### PR TITLE
feat(bigframe): batch 14 — power means + Hill/Rényi/Tsallis diversity + quantile-ratio (10 verbs, all win)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -125,6 +125,9 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | geomean_dense / geostd_dense | | ~13.8 | ~159 | **0.09x — wins 11x** | ln-LUT + exp |
 | gini_coef_dense (inequality) | | ~17.4 | ~125 | **0.14x — wins 7x** | histogram ascending walk |
 | theil_dense / atkinson1 / hoover (inequality) | | ~17.4 | ~230 | **0.08x — wins 13x** | histogram + ln-LUT + exp |
+| power_mean_dense(p) / lehmer_mean(p) / contraharmonic (1M rows, 1000 keys) | | ~13.6 | ~175 | **0.08x — wins 13x** | v^p lookup-table; pandas = per-group lambda |
+| hill_number(q) / renyi(a) / tsallis(q) / perplexity / kl_uniform | | ~64 | ~247 | **0.26x — wins 4x** | histogram + bf_pow per bucket |
+| p90p10_ratio / quartile_dispersion | | ~13.6 | ~227 | **0.06x — wins 16x** | histogram + interpolated percentiles |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -7431,3 +7431,186 @@ pub fn bf_theil_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) 
 pub fn bf_atkinson1_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_inequality_dense(src, key_col, val_col, vmax, 2) }
 /// Per-group HOOVER / ROBIN-HOOD INDEX (share of total to redistribute for equality), broadcast. Dense histogram. NATIVE + lean_single.
 pub fn bf_hoover_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_inequality_dense(src, key_col, val_col, vmax, 3) }
+
+/// Power b^e for b>0 via exp(e·ln b) (composes bf_ln + bf_exp; ~1e-12 rel). Returns 0.0 for
+/// b<=0 as a domain sentinel. Needs a scratch i64 `sc`. NATIVE + lean_single only.
+fn bf_pow(b: f64, e: f64, sc: *mut i64) -> f64 with Mut, Div, Panic {
+    if b <= 0.0 { return 0.0 }
+    bf_exp(e * bf_ln(b, sc), sc)
+}
+
+/// Per-group POWER-MEAN family via v^p lookup tables (dense integer values 1..vmax). mode 0 =
+/// Hölder/power mean of order p ((Σvᵖ/n)^(1/p)); mode 1 = Lehmer mean L_p (Σvᵖ/Σvᵖ⁻¹). ln/exp
+/// are evaluated once per distinct value; a single pass sums the tabulated powers. Broadcast.
+/// O(n + vrange). NATIVE + lean_single only.
+fn bf_group_powermean_dense(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, p: f64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var nn:  [f64; 1024] = [0.0; 1024]
+    var svp: [f64; 1024] = [0.0; 1024]
+    var svq: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || vmax < 0 { return out }
+    let vm1 = vmax + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    let lvp = heap_alloc(vm1 * 8) as *mut f64
+    let lvq = heap_alloc(vm1 * 8) as *mut f64
+    var v: i64 = 1
+    while v < vm1 { write_f64(lvp, v, bf_pow(v as f64, p, sc)); write_f64(lvq, v, bf_pow(v as f64, p - 1.0, sc)) v = v + 1 }
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let vi = read_f64(vp, i) as i64
+        if k >= 0 && k < 1024 && vi >= 1 && vi < vm1 { nn[k] = nn[k] + 1.0; svp[k] = svp[k] + read_f64(lvp, vi); svq[k] = svq[k] + read_f64(lvq, vi) }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        let m = nn[g]
+        if m > 0.0 {
+            if mode == 0 { res[g] = bf_pow(svp[g] / m, 1.0 / p, sc) }
+            else { if svq[g] != 0.0 { res[g] = svp[g] / svq[g] } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, res[k]) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(lvp as *mut i8)
+    heap_free(lvq as *mut i8)
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group POWER (Hölder) MEAN of order p, broadcast: (Σvᵖ/n)^(1/p). p=1 arithmetic, p=2 RMS,
+/// p→0 geometric, p=−1 harmonic. Dense v^p LUT. NATIVE + lean_single only.
+pub fn bf_power_mean_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, p: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_powermean_dense(src, key_col, val_col, vmax, p, 0) }
+/// Per-group LEHMER MEAN L_p (Σvᵖ/Σvᵖ⁻¹), broadcast. p=0 harmonic, p=1 arithmetic, p=2 contraharmonic. Dense LUT. NATIVE + lean_single.
+pub fn bf_lehmer_mean_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, p: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_powermean_dense(src, key_col, val_col, vmax, p, 1) }
+/// Per-group CONTRAHARMONIC MEAN (Σv²/Σv = Lehmer L_2), broadcast. Dense LUT. NATIVE + lean_single only.
+pub fn bf_contraharmonic_mean_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_powermean_dense(src, key_col, val_col, vmax, 2.0, 1) }
+
+/// Per-group DIVERSITY / GENERALIZED-ENTROPY family via a value histogram (dense keys 0..1023 +
+/// values 0..vmax). From the value distribution pᵢ=fᵢ/n it forms Σpᵢ^q (q=order) and Shannon H;
+/// modes: 0 = Hill number qD ((Σpᵢ^q)^(1/(1−q)); q→1 ⇒ exp H), 1 = Rényi entropy (ln(Σpᵢ^q)/(1−q);
+/// q→1 ⇒ H), 2 = Tsallis entropy ((1−Σpᵢ^q)/(q−1); q→1 ⇒ H), 3 = KL divergence from uniform
+/// (ln k − H). Broadcast. O(n + G·vrange). NATIVE + lean_single only.
+fn bf_group_diversity_dense(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, q: f64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cnt: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || vmax < 0 { return out }
+    let vm1 = vmax + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let hist = heap_alloc(1024 * vm1 * 8) as *mut i64
+    let sc = heap_alloc(8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let vi = read_f64(vp, i) as i64
+        if k >= 0 && k < 1024 && vi >= 0 && vi < vm1 { write_i64(hist, k * vm1 + vi, read_i64(hist, k * vm1 + vi) + 1); cnt[k] = cnt[k] + 1.0 }
+        i = i + 1
+    }
+    let isone = q > 0.999999999 && q < 1.000000001
+    var g: i64 = 0
+    while g < 1024 {
+        if cnt[g] > 0.0 {
+            let nf = cnt[g]
+            let base = g * vm1
+            var v: i64 = 0
+            var spq = 0.0
+            var hh = 0.0
+            var nd = 0.0
+            while v < vm1 {
+                let f = read_i64(hist, base + v)
+                if f > 0 {
+                    let pp = (f as f64) / nf
+                    nd = nd + 1.0
+                    hh = hh - pp * bf_ln(pp, sc)
+                    if !isone { spq = spq + bf_pow(pp, q, sc) }
+                }
+                v = v + 1
+            }
+            if mode == 0 { if isone { res[g] = bf_exp(hh, sc) } else { res[g] = bf_pow(spq, 1.0 / (1.0 - q), sc) } }
+            else { if mode == 1 { if isone { res[g] = hh } else { res[g] = bf_ln(spq, sc) / (1.0 - q) } }
+            else { if mode == 2 { if isone { res[g] = hh } else { res[g] = (1.0 - spq) / (q - 1.0) } }
+            else { if nd > 1.0 { res[g] = bf_ln(nd, sc) - hh } else { res[g] = 0.0 } } } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, res[k]) } else { write_f64(op, i, read_f64(vp, i)) } i = i + 1 }
+    heap_free(hist as *mut i8)
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group HILL NUMBER of order q (effective #categories, qD), broadcast. Dense histogram. q=0 richness, q=1 exp(Shannon), q=2 inv-Simpson. NATIVE + lean_single.
+pub fn bf_hill_number_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, q: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_diversity_dense(src, key_col, val_col, vmax, q, 0) }
+/// Per-group RÉNYI ENTROPY of order α, broadcast. Dense histogram. α=1 ⇒ Shannon, α=2 ⇒ collision entropy. NATIVE + lean_single.
+pub fn bf_renyi_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, alpha: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_diversity_dense(src, key_col, val_col, vmax, alpha, 1) }
+/// Per-group TSALLIS ENTROPY of order q, broadcast. Dense histogram. q→1 ⇒ Shannon. NATIVE + lean_single only.
+pub fn bf_tsallis_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, q: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_diversity_dense(src, key_col, val_col, vmax, q, 2) }
+/// Per-group PERPLEXITY (Hill number of order 1 = exp(Shannon entropy) = effective vocabulary size), broadcast. Dense histogram. NATIVE + lean_single.
+pub fn bf_perplexity_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_diversity_dense(src, key_col, val_col, vmax, 1.0, 0) }
+/// Per-group KL DIVERGENCE from the uniform distribution (ln k − H, how concentrated vs even), broadcast. Dense histogram. NATIVE + lean_single.
+pub fn bf_kl_uniform_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_diversity_dense(src, key_col, val_col, vmax, 2.0, 3) }
+
+/// Per-group QUANTILE-RATIO dispersion via a value histogram (dense keys 0..1023 + values
+/// 0..vmax). mode 0 = P90/P10 decile ratio; mode 1 = quartile coefficient of dispersion
+/// (q75−q25)/(q75+q25). Percentiles use bf_qpos_from_hist (linear interpolation). Broadcast.
+/// O(n + G·vrange). NATIVE + lean_single only.
+fn bf_group_qratio_dense(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cnt: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || vmax < 0 { return out }
+    let vm1 = vmax + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let hist = heap_alloc(1024 * vm1 * 8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let vi = read_f64(vp, i) as i64
+        if k >= 0 && k < 1024 && vi >= 0 && vi < vm1 { write_i64(hist, k * vm1 + vi, read_i64(hist, k * vm1 + vi) + 1); cnt[k] = cnt[k] + 1.0 }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if cnt[g] > 0.0 {
+            let sz = cnt[g] as i64
+            let base = g * vm1
+            if mode == 0 {
+                let p10 = bf_qpos_from_hist(hist, base, vm1, sz, 0.10)
+                let p90 = bf_qpos_from_hist(hist, base, vm1, sz, 0.90)
+                if p10 > 0.0 { res[g] = p90 / p10 }
+            } else {
+                let q1 = bf_qpos_from_hist(hist, base, vm1, sz, 0.25)
+                let q3 = bf_qpos_from_hist(hist, base, vm1, sz, 0.75)
+                let den = q3 + q1
+                if den != 0.0 { res[g] = (q3 - q1) / den }
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, res[k]) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(hist as *mut i8)
+    out
+}
+/// Per-group P90/P10 DECILE RATIO (dispersion), broadcast. Dense histogram + interpolated percentiles. NATIVE + lean_single.
+pub fn bf_p90p10_ratio_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_qratio_dense(src, key_col, val_col, vmax, 0) }
+/// Per-group QUARTILE COEFFICIENT OF DISPERSION ((q75−q25)/(q75+q25)), broadcast. Dense histogram. NATIVE + lean_single only.
+pub fn bf_quartile_dispersion_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_qratio_dense(src, key_col, val_col, vmax, 1) }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -1699,6 +1699,40 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     if !approx_eq(bf_get(&atk,0,0), 0.1339745962) { print("FAIL atkinson1\n"); return 622 }
     let hov = bf_hoover_dense_by(&iqf,0,1,3)
     if !approx_eq(bf_get(&hov,0,0), 0.25) { print("FAIL hoover\n"); return 623 }
+    // ===== BATCH 14: power means + Hill/Renyi/Tsallis diversity + quantile-ratio (uses bf_pow) =====
+    // power/lehmer on lgf {2,4,8}
+    let pm2 = bf_power_mean_dense_by(&lgf,0,1,8,2.0)
+    if !approx_eq(bf_get(&pm2,0,0), 5.2915026221) { print("FAIL power_mean2\n"); return 624 }  // RMS
+    let pm1 = bf_power_mean_dense_by(&lgf,0,1,8,1.0)
+    if !approx_eq(bf_get(&pm1,0,0), 4.6666666667) { print("FAIL power_mean1\n"); return 625 }  // arithmetic
+    let lh2 = bf_lehmer_mean_dense_by(&lgf,0,1,8,2.0)
+    if !approx_eq(bf_get(&lh2,0,0), 6.0) { print("FAIL lehmer2\n"); return 626 }
+    let cha = bf_contraharmonic_mean_dense_by(&lgf,0,1,8)
+    if !approx_eq(bf_get(&cha,0,0), 6.0) { print("FAIL contraharmonic\n"); return 627 }
+    // diversity on dbf {2,2,3,0}
+    let h2 = bf_hill_number_dense_by(&dbf,0,1,5,2.0)
+    if !approx_eq(bf_get(&h2,0,0), 2.6666666667) { print("FAIL hill2\n"); return 628 }
+    let h0 = bf_hill_number_dense_by(&dbf,0,1,5,0.0)
+    if !approx_eq(bf_get(&h0,0,0), 3.0) { print("FAIL hill0\n"); return 629 }               // richness
+    let re2 = bf_renyi_dense_by(&dbf,0,1,5,2.0)
+    if !approx_eq(bf_get(&re2,0,0), 0.9808292530) { print("FAIL renyi_alpha2\n"); return 630 }
+    let ts2 = bf_tsallis_dense_by(&dbf,0,1,5,2.0)
+    if !approx_eq(bf_get(&ts2,0,0), 0.625) { print("FAIL tsallis2\n"); return 631 }
+    let ppx = bf_perplexity_dense_by(&dbf,0,1,5)
+    if !approx_eq(bf_get(&ppx,0,0), 2.8284271247) { print("FAIL perplexity\n"); return 632 } // exp(Shannon)=2sqrt2
+    let klu = bf_kl_uniform_dense_by(&dbf,0,1,5)
+    if !approx_eq(bf_get(&klu,0,0), 0.0588915178) { print("FAIL kl_uniform\n"); return 633 } // ln3-H
+    // quantile-ratio frame g0 = {10,20,30,40,50}, vmax=50.
+    var qrf = bf_new(2, 8)
+    var qr0:[f64;64]=[0.0;64]; qr0[0]=0.0; qr0[1]=10.0; bf_push_row(&!qrf,&qr0,2)
+    var qr1:[f64;64]=[0.0;64]; qr1[0]=0.0; qr1[1]=20.0; bf_push_row(&!qrf,&qr1,2)
+    var qr2:[f64;64]=[0.0;64]; qr2[0]=0.0; qr2[1]=30.0; bf_push_row(&!qrf,&qr2,2)
+    var qr3:[f64;64]=[0.0;64]; qr3[0]=0.0; qr3[1]=40.0; bf_push_row(&!qrf,&qr3,2)
+    var qr4:[f64;64]=[0.0;64]; qr4[0]=0.0; qr4[1]=50.0; bf_push_row(&!qrf,&qr4,2)
+    let pr = bf_p90p10_ratio_dense_by(&qrf,0,1,50)
+    if !approx_eq(bf_get(&pr,0,0), 3.2857142857) { print("FAIL p90p10\n"); return 634 }       // 46/14
+    let qd = bf_quartile_dispersion_dense_by(&qrf,0,1,50)
+    if !approx_eq(bf_get(&qd,0,0), 0.3333333333) { print("FAIL quartile_disp\n"); return 635 } // (40-20)/(40+20)
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What
New `bf_pow` helper (`b^e = exp(e·ln b)`, ~1e-12) unlocks 3 engines and 10 grouped verbs — all beating pandas **4–16×** at 1M rows.

**Power-mean family** (`bf_group_powermean_dense`, v^p LUT):
- `bf_power_mean_dense_by(p)` (Hölder mean) / `bf_lehmer_mean_dense_by(p)` / `bf_contraharmonic_mean_dense_by`

**Diversity / generalized entropy** (`bf_group_diversity_dense`, histogram + `bf_pow`):
- `bf_hill_number_dense_by(q)` (q=0 richness, q=1 exp-Shannon, q=2 inv-Simpson)
- `bf_renyi_dense_by(α)` / `bf_tsallis_dense_by(q)`
- `bf_perplexity_dense_by` (Hill q=1 — fills the batch-12 gap) / `bf_kl_uniform_dense_by` (ln k − H)

**Quantile-ratio dispersion** (`bf_group_qratio_dense`, histogram + interpolated percentiles):
- `bf_p90p10_ratio_dense_by` / `bf_quartile_dispersion_dense_by`

## Numbers (1M rows, 1000 dense keys, values 1..101, reproduced locally)
| verb | Sounio | pandas 3.0.3 | ratio |
|---|---|---|---|
| power_mean / lehmer / contraharmonic | 13.6 ms | 175 ms | **0.08× (13×)** |
| hill / renyi / tsallis / perplexity / kl_uniform | 64 ms | 247 ms | **0.26× (4×)** |
| p90p10 / quartile_dispersion | 13.6 ms | 227 ms | **0.06× (16×)** |

## Verified
- Gate return codes **624–635** → `BIGFRAME_OPS_GATE_OK`, exit 0
- power_mean(2)=RMS, lehmer(2)=contraharmonic vs `{2,4,8}`
- hill(2)=inv-Simpson, hill(0)=richness, renyi(2), tsallis(2), perplexity=exp(H), kl_uniform vs `{2,2,3,0}`
- p90p10=46/14, quartile-dispersion vs `{10,20,30,40,50}`
- benchmarks reproduced myself

Files: `stdlib/data/bigframe_ops.sio`, its gate test, `scripts/bench/RESULTS.md` (my disjoint lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)