### PR TITLE
test(madaros): Wave11 tip-green lock (k95 + global ref + receipt)

### DIFF
--- a/artifacts/compiler/madaros_wave11_tip_green_receipt.v1.json
+++ b/artifacts/compiler/madaros_wave11_tip_green_receipt.v1.json
@@ -1,0 +1,104 @@
+{
+  "schema": "madaros_wave11_tip_green_receipt.v1",
+  "status": "pass",
+  "wave": "wave11",
+  "role": "tip_green_regression_lock",
+  "supersedes": "madaros_wave10_tip_green_receipt.v1",
+  "engine": "madaros_default",
+  "engine_line": "Madaros v0.80.0 -- the Sounio self-hosted compiler",
+  "lean_single_pin": false,
+  "commit": "bbb4a84aaea8acf01e9886b2343188347de5ede1",
+  "commit_short": "bbb4a84aa",
+  "utc": "2026-07-21T11:46:14Z",
+  "raw_elf": "bin/madaros-linux-x86_64",
+  "raw_elf_sha256": "b652756cf8537beaca539c2d082c742ef97ed61406d4a68df2459323b02de07a",
+  "souc": "bin/souc",
+  "gates": [
+    {
+      "name": "dual",
+      "status": "pass",
+      "rc": 0,
+      "duration_s": 3,
+      "expected_token": "MADAROS_DUAL_IMPORT_GATE_OK"
+    },
+    {
+      "name": "order_spread",
+      "status": "pass",
+      "rc": 0,
+      "duration_s": 3,
+      "expected_token": "MADAROS_ORDER_SPREAD_NATIVE_GATE_OK"
+    },
+    {
+      "name": "knowledge_method",
+      "status": "pass",
+      "rc": 0,
+      "duration_s": 4,
+      "expected_token": "MADAROS_KNOWLEDGE_METHOD_RESIDUAL_GATE_OK"
+    },
+    {
+      "name": "global_array",
+      "status": "pass",
+      "rc": 0,
+      "duration_s": 10,
+      "expected_token": "GLOBAL_ARRAY_INIT_GATE_OK"
+    },
+    {
+      "name": "named_path",
+      "status": "pass",
+      "rc": 0,
+      "duration_s": 0,
+      "expected_token": "NAMED_PATH_IMPORT_GATE_PASS"
+    },
+    {
+      "name": "unsplit_oct",
+      "status": "pass",
+      "rc": 0,
+      "duration_s": 1,
+      "expected_token": "MADAROS_UNSPLIT_OCT_MUL_GATE_OK"
+    },
+    {
+      "name": "epistemic_trust",
+      "status": "pass",
+      "rc": 0,
+      "duration_s": 9,
+      "expected_token": "EPISTEMIC_TRUST_GATE_OK"
+    },
+    {
+      "name": "global_array_ref",
+      "status": "pass",
+      "rc": 0,
+      "duration_s": 0,
+      "expected_token": "MADAROS_GLOBAL_ARRAY_REF_GATE_OK"
+    }
+  ],
+  "claims": [
+    "dual_gum_knowledge_import_native",
+    "order_spread4_cpc_n4_native",
+    "knowledge_method_form_parity",
+    "global_array_init_i64_f64_i8",
+    "named_path_import_print_f64_default_and_opt",
+    "unsplit_oct_mul_no_reentry",
+    "gum_k95_f64_i64_cast_fixed",
+    "epistemic_trust_section_a_native",
+    "global_array_ref_mut_bss_defect_b"
+  ],
+  "claims_not_made": [
+    "all_stdlib_dual_pairs",
+    "language_knowledge_t_generic_import",
+    "multi_module_irmodule_memory_wall_closed",
+    "cd_exact_generic_i64_elf",
+    "full_root2_census_closed",
+    "f64_param_bitcast_all_call_shapes",
+    "linalg_full_native_parity"
+  ],
+  "measurement": {
+    "tip_sha": "bbb4a84aa",
+    "wave10_tip_green": "pass",
+    "epistemic_trust": "pass",
+    "dual": "pass",
+    "global_array_ref": "pass",
+    "red_count_at_measurement": 0,
+    "note": "origin/main tip measured green; wave11 locks k95 + Defect B global ref + tip receipt"
+  },
+  "verdict": "pass"
+}

--- a/docs/audit/MADAROS_WAVE11_TIP_GREEN_2026-07-21.md
+++ b/docs/audit/MADAROS_WAVE11_TIP_GREEN_2026-07-21.md
@@ -1,0 +1,102 @@
+# Madaros Wave11 tip-green measurement + regression lock
+
+**Date:** 2026-07-21  
+**Role:** Wave11 Agent F (implementer)  
+**Branch:** `fix/madaros-wave11-tip-green`  
+**Tip measured:** `origin/main` @ `bbb4a84aa` (Madaros v0.80.0)  
+**Engine:** default `bin/souc` → Madaros (no lean_single pin)
+
+## Mission
+
+1. Run Wave10 tip-green + epistemic trust + dual on `origin/main`
+2. Document RED if any
+3. Ship a fix for a red residual **or** extend tip-green with Wave10/11 locks (k95, global ref, tip receipt)
+4. PR `fix/madaros-wave11-tip-green`
+
+## Measurement on origin/main (`bbb4a84aa`)
+
+| Gate | Script | Result | Notes |
+|------|--------|--------|-------|
+| dual | `scripts/madaros_dual_import_gate.sh` | **GREEN** | `MADAROS_DUAL_IMPORT_GATE_OK` |
+| wave10 tip-green (6-in-1) | `scripts/dev/madaros_wave10_tip_green_gate.sh` | **GREEN** | all six sub-gates pass |
+| epistemic trust | `scripts/epistemic_trust_gate.sh` | **GREEN** | Section A + **k95i=2776** |
+| global array ref | `scripts/ci/madaros_global_array_ref_gate.sh` | **GREEN** | Defect B / wave10e |
+
+**RED count: 0.** No science/compiler residual in this Agent F scope that is not already owned by deeper open tracks (`claims_not_made` below).
+
+### Epistemic trust detail (k95)
+
+Finite-dof coverage factor on Type-A-dominant budget:
+
+- **PASS:** `k95i=2776` (= `t95(4)`)
+- Collapse value that would reintroduce D1 bitcast (`k95i=1960`) was **not** observed
+
+Wave10 tip-green still lists `gum_k95_f64_i64_cast_fixed` under `claims_not_made` even though Section A of the trust gate already gates it. Wave11 promotes that claim into the tip-green orchestrator.
+
+### Global array ref detail (Defect B)
+
+`tests/run-pass/global_array_ref_mut.sio` → `GLOBAL_ARRAY_REF_MUT_OK` under default Madaros. Fixed wave10e (#1364) but not previously locked inside tip-green (Wave10 only locked **init**, not **ref mutation**).
+
+## Ship (because tip was green)
+
+| Artefact | Role |
+|----------|------|
+| `scripts/dev/madaros_wave11_tip_green_gate.sh` | 8-gate orchestrator + tip receipt writer |
+| `scripts/ci/madaros_global_array_ref_gate.sh` | emit `MADAROS_GLOBAL_ARRAY_REF_GATE_OK` sentinel |
+| `artifacts/compiler/madaros_wave11_tip_green_receipt.v1.json` | machine-readable green tip receipt |
+| this audit note | measurement + claim boundary |
+
+```bash
+bash scripts/dev/madaros_wave11_tip_green_gate.sh
+# MADAROS_WAVE11_TIP_GREEN_GATE_OK
+# receipt: artifacts/compiler/madaros_wave11_tip_green_receipt.v1.json
+```
+
+### Gates locked by Wave11
+
+1. dual  
+2. order_spread  
+3. knowledge_method  
+4. global_array (init)  
+5. named_path  
+6. unsplit_oct  
+7. **epistemic_trust** (includes k95i=2776) — **new**  
+8. **global_array_ref** (Defect B) — **new**
+
+Wave10 tip-green remains as a historical subset (`scripts/dev/madaros_wave10_tip_green_gate.sh`). Wave11 supersedes it for tip regression lock.
+
+## Claims
+
+- dual gum+knowledge import native
+- order_spread N=4 CPC native
+- knowledge method form parity
+- global array init (i64/f64/i8)
+- named path import `print_f64` default and `-O`
+- unsplit `oct_mul` no re-entry
+- **gum k95 f64→i64 cast fixed** (promoted from Wave10 non-claim)
+- **epistemic trust Section A native**
+- **global array `&!`/`&` BSS ref mutation** (Defect B)
+
+## Explicit non-claims
+
+- all stdlib dual pairs
+- language-level `Knowledge<T>` generic import
+- multi-module IrModule memory wall closed
+- `cd_exact_generic_i64` ELF
+- full Root-2 census closed
+- f64-param bitcast free for *all* call shapes beyond the gated witnesses
+- full linalg native parity
+
+## Re-run commands
+
+```bash
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+unset SOUNIO_SOUC_ENGINE
+ulimit -s unlimited 2>/dev/null || true
+
+bash scripts/madaros_dual_import_gate.sh
+bash scripts/epistemic_trust_gate.sh
+bash scripts/dev/madaros_wave10_tip_green_gate.sh
+bash scripts/ci/madaros_global_array_ref_gate.sh
+bash scripts/dev/madaros_wave11_tip_green_gate.sh
+```

--- a/scripts/ci/madaros_global_array_ref_gate.sh
+++ b/scripts/ci/madaros_global_array_ref_gate.sh
@@ -35,3 +35,4 @@ if grep -q 'FAIL ' <<<"$out"; then
   exit 1
 fi
 echo "PASS madaros_global_array_ref_gate"
+echo "MADAROS_GLOBAL_ARRAY_REF_GATE_OK"

--- a/scripts/dev/madaros_wave11_tip_green_gate.sh
+++ b/scripts/dev/madaros_wave11_tip_green_gate.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# scripts/dev/madaros_wave11_tip_green_gate.sh
+#
+# Wave11 tip-green regression lock for origin/main Madaros science/compiler.
+# Supersedes Wave10 tip-green by keeping the six Wave10 locks and promoting
+# two Wave10 closeouts that were still listed under claims_not_made / outside
+# the tip-green orchestrator:
+#
+#   Wave10 retained:
+#     1. dual            — scripts/madaros_dual_import_gate.sh
+#     2. order_spread    — scripts/madaros_order_spread_native_gate.sh
+#     3. knowledge_method— scripts/madaros_knowledge_method_residual_gate.sh
+#     4. global_array    — scripts/dev/madaros_global_array_init_gate.sh
+#     5. named_path      — scripts/dev/named_path_import_print_f64_gate.sh
+#     6. unsplit_oct     — scripts/madaros_unsplit_oct_mul_gate.sh
+#
+#   Wave11 promotions:
+#     7. epistemic_trust — scripts/epistemic_trust_gate.sh
+#                          (Section A + finite-dof gum k95i=2776 = t95(4))
+#     8. global_array_ref— scripts/ci/madaros_global_array_ref_gate.sh
+#                          (Defect B / wave10e: BSS global &!/& mutation)
+#
+# Exit 0 only when every sub-gate exits 0 and emits its expected sentinel.
+# Writes a machine-readable tip receipt:
+#   artifacts/compiler/madaros_wave11_tip_green_receipt.v1.json
+#
+# Does not rebuild Madaros. Does not pin lean_single. Uses default bin/souc.
+# Soft stack raised for multi-module dual/knowledge lowers.
+#
+# Usage:
+#   bash scripts/dev/madaros_wave11_tip_green_gate.sh
+#   SOUC=./bin/souc bash scripts/dev/madaros_wave11_tip_green_gate.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
+unset SOUNIO_SOUC_ENGINE || true
+# Multi-module dual/knowledge lowers need a large stack; prefer unlimited.
+ulimit -s unlimited 2>/dev/null || ulimit -s 131072 2>/dev/null || true
+
+SOUC="${SOUC:-$ROOT/bin/souc}"
+export SOUC
+
+RECEIPT_DIR="$ROOT/artifacts/compiler"
+RECEIPT="$RECEIPT_DIR/madaros_wave11_tip_green_receipt.v1.json"
+LOG_DIR="$(mktemp -d /tmp/madaros_wave11_tip_green.XXXXXX)"
+trap 'rm -rf "$LOG_DIR"' EXIT
+
+COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+COMMIT_SHORT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Prefer raw Madaros ELF for sha identity (wrapper scripts are not ELFs).
+RAW=""
+for cand in \
+  "${MADAROS_RAW_BIN:-}" \
+  "$ROOT/artifacts/self-hosted/madaros" \
+  "$ROOT/bin/madaros-linux-x86_64"
+do
+  [[ -n "$cand" && -x "$cand" ]] || continue
+  if [[ "$(head -c2 "$cand" 2>/dev/null)" != '#!' ]]; then
+    RAW="$cand"
+    break
+  fi
+done
+RAW_SHA256="missing"
+if [[ -n "$RAW" ]]; then
+  RAW_SHA256="$(sha256sum "$RAW" | awk '{print $1}')"
+fi
+
+ENGINE_LINE="$("$SOUC" --version 2>&1 | head -1 || echo unknown)"
+
+echo "== madaros_wave11_tip_green_gate =="
+echo "git_sha=$COMMIT_SHORT"
+echo "engine=$ENGINE_LINE"
+echo "raw_elf=${RAW:-none}"
+echo "raw_elf_sha256=$RAW_SHA256"
+echo "souc=$SOUC"
+echo "log_dir=$LOG_DIR"
+echo
+
+# name|script|expected_token (optional; empty = any rc==0)
+GATES=(
+  "dual|scripts/madaros_dual_import_gate.sh|MADAROS_DUAL_IMPORT_GATE_OK"
+  "order_spread|scripts/madaros_order_spread_native_gate.sh|MADAROS_ORDER_SPREAD_NATIVE_GATE_OK"
+  "knowledge_method|scripts/madaros_knowledge_method_residual_gate.sh|MADAROS_KNOWLEDGE_METHOD_RESIDUAL_GATE_OK"
+  "global_array|scripts/dev/madaros_global_array_init_gate.sh|GLOBAL_ARRAY_INIT_GATE_OK"
+  "named_path|scripts/dev/named_path_import_print_f64_gate.sh|NAMED_PATH_IMPORT_GATE_PASS"
+  "unsplit_oct|scripts/madaros_unsplit_oct_mul_gate.sh|MADAROS_UNSPLIT_OCT_MUL_GATE_OK"
+  "epistemic_trust|scripts/epistemic_trust_gate.sh|EPISTEMIC_TRUST_GATE_OK"
+  "global_array_ref|scripts/ci/madaros_global_array_ref_gate.sh|MADAROS_GLOBAL_ARRAY_REF_GATE_OK"
+)
+
+declare -a RESULT_NAMES=()
+declare -a RESULT_STATUS=()
+declare -a RESULT_RC=()
+declare -a RESULT_DURATION=()
+declare -a RESULT_TOKEN=()
+
+fail=0
+idx=0
+total=${#GATES[@]}
+
+run_one() {
+  local name="$1" script="$2" token="$3"
+  local log="$LOG_DIR/${name}.log"
+  local start end dur rc
+  idx=$((idx + 1))
+  echo "---------- [$idx/$total] $name ----------"
+  echo "script=$script"
+  if [[ ! -f "$ROOT/$script" ]]; then
+    echo "RED  $name reason=missing_script path=$script"
+    RESULT_NAMES+=("$name")
+    RESULT_STATUS+=("missing_script")
+    RESULT_RC+=(127)
+    RESULT_DURATION+=(0)
+    RESULT_TOKEN+=("$token")
+    fail=1
+    return
+  fi
+  start=$(date +%s)
+  set +e
+  bash "$ROOT/$script" >"$log" 2>&1
+  rc=$?
+  set -e
+  end=$(date +%s)
+  dur=$((end - start))
+
+  local status="pass"
+  if [[ $rc -ne 0 ]]; then
+    status="fail"
+    fail=1
+  elif [[ -n "$token" ]] && ! grep -qF "$token" "$log"; then
+    status="token_missing"
+    fail=1
+    # Force non-zero classification even if sub-gate exited 0 without sentinel.
+    rc=2
+  fi
+
+  # Extra k95 invariant when the epistemic trust log is present: refuse a silent
+  # reintroduction of the D1 bitcast collapse (k95i=1960) even if the outer
+  # sentinel were ever weakened.
+  if [[ "$name" == "epistemic_trust" && "$status" == "pass" ]]; then
+    if ! grep -qF 'k95i=2776' "$log"; then
+      status="k95_token_missing"
+      fail=1
+      rc=3
+    elif grep -qE 'k95i=1960|want 2776' "$log" && ! grep -qF 'PASS: k95i=2776' "$log"; then
+      status="k95_collapse"
+      fail=1
+      rc=4
+    fi
+  fi
+
+  if [[ "$status" == "pass" ]]; then
+    echo "GREEN $name rc=$rc ${dur}s token=$token"
+  else
+    echo "RED   $name status=$status rc=$rc ${dur}s token=$token"
+    echo "----- tail $name -----"
+    tail -40 "$log" || true
+    echo "----- end tail -----"
+  fi
+
+  RESULT_NAMES+=("$name")
+  RESULT_STATUS+=("$status")
+  RESULT_RC+=("$rc")
+  RESULT_DURATION+=("$dur")
+  RESULT_TOKEN+=("$token")
+}
+
+for entry in "${GATES[@]}"; do
+  IFS='|' read -r gname gscript gtoken <<<"$entry"
+  run_one "$gname" "$gscript" "$gtoken"
+  echo
+done
+
+OVERALL="pass"
+[[ $fail -eq 0 ]] || OVERALL="fail"
+
+# Build gates JSON array without requiring jq.
+gates_json="["
+for i in "${!RESULT_NAMES[@]}"; do
+  [[ $i -gt 0 ]] && gates_json+=","
+  gates_json+=$(printf '\n    {"name":"%s","status":"%s","rc":%s,"duration_s":%s,"expected_token":"%s"}' \
+    "${RESULT_NAMES[$i]}" \
+    "${RESULT_STATUS[$i]}" \
+    "${RESULT_RC[$i]}" \
+    "${RESULT_DURATION[$i]}" \
+    "${RESULT_TOKEN[$i]}")
+done
+gates_json+=$'\n  ]'
+
+# Prefer repo-relative paths in the receipt so committed snapshots are portable.
+relpath_under_root() {
+  local p="$1"
+  [[ -z "$p" ]] && { printf ''; return; }
+  python3 - "$ROOT" "$p" <<'PY'
+import os, sys
+root = os.path.realpath(sys.argv[1])
+path = os.path.realpath(sys.argv[2])
+if path == root:
+    print(".")
+elif path.startswith(root + os.sep):
+    print(os.path.relpath(path, root))
+else:
+    print(sys.argv[2])
+PY
+}
+
+RAW_REL="$(relpath_under_root "${RAW:-}")"
+SOUC_REL="$(relpath_under_root "$SOUC")"
+
+mkdir -p "$RECEIPT_DIR"
+cat >"$RECEIPT" <<EOF
+{
+  "schema": "madaros_wave11_tip_green_receipt.v1",
+  "status": "$OVERALL",
+  "wave": "wave11",
+  "role": "tip_green_regression_lock",
+  "supersedes": "madaros_wave10_tip_green_receipt.v1",
+  "engine": "madaros_default",
+  "engine_line": $(printf '%s' "$ENGINE_LINE" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().rstrip("\n")))'),
+  "lean_single_pin": false,
+  "commit": "$COMMIT",
+  "commit_short": "$COMMIT_SHORT",
+  "utc": "$UTC",
+  "raw_elf": $(printf '%s' "$RAW_REL" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().rstrip("\n")))'),
+  "raw_elf_sha256": "$RAW_SHA256",
+  "souc": $(printf '%s' "$SOUC_REL" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().rstrip("\n")))'),
+  "gates": $gates_json,
+  "claims": [
+    "dual_gum_knowledge_import_native",
+    "order_spread4_cpc_n4_native",
+    "knowledge_method_form_parity",
+    "global_array_init_i64_f64_i8",
+    "named_path_import_print_f64_default_and_opt",
+    "unsplit_oct_mul_no_reentry",
+    "gum_k95_f64_i64_cast_fixed",
+    "epistemic_trust_section_a_native",
+    "global_array_ref_mut_bss_defect_b"
+  ],
+  "claims_not_made": [
+    "all_stdlib_dual_pairs",
+    "language_knowledge_t_generic_import",
+    "multi_module_irmodule_memory_wall_closed",
+    "cd_exact_generic_i64_elf",
+    "full_root2_census_closed",
+    "f64_param_bitcast_all_call_shapes",
+    "linalg_full_native_parity"
+  ],
+  "measurement": {
+    "wave10_tip_green": "pass",
+    "epistemic_trust": "pass_or_see_gates",
+    "dual": "pass_or_see_gates",
+    "red_count_at_ship": "see_gates"
+  },
+  "verdict": "$OVERALL"
+}
+EOF
+
+echo "===== SUMMARY ====="
+for i in "${!RESULT_NAMES[@]}"; do
+  printf '  %-18s %-14s rc=%-3s %ss\n' \
+    "${RESULT_NAMES[$i]}" \
+    "${RESULT_STATUS[$i]}" \
+    "${RESULT_RC[$i]}" \
+    "${RESULT_DURATION[$i]}"
+done
+echo "overall=$OVERALL"
+echo "receipt: $RECEIPT"
+
+if [[ $fail -eq 0 ]]; then
+  echo "MADAROS_WAVE11_TIP_GREEN_GATE_OK"
+  exit 0
+fi
+echo "MADAROS_WAVE11_TIP_GREEN_GATE_FAIL" >&2
+exit 1


### PR DESCRIPTION
## Summary

Wave11 Agent F (implementer) — measure tip residuals + extend tip-green regression lock.

### Tip measurement on `origin/main` (`bbb4a84aa`, Madaros v0.80.0)

| Gate | Script | Result |
|------|--------|--------|
| dual | `scripts/madaros_dual_import_gate.sh` | **GREEN** |
| wave10 tip-green (6-in-1) | `scripts/dev/madaros_wave10_tip_green_gate.sh` | **GREEN** |
| epistemic trust (+ k95i=2776) | `scripts/epistemic_trust_gate.sh` | **GREEN** |
| global array ref (Defect B) | `scripts/ci/madaros_global_array_ref_gate.sh` | **GREEN** |

**RED count: 0.** No science/compiler residual left for Agent F that is not already owned by deeper open tracks (`claims_not_made`).

Evidence note: `docs/audit/MADAROS_WAVE11_TIP_GREEN_2026-07-21.md`.

### Ship (extend tip-green — tip was already green)

Because all measured gates were green, ship the Wave11 regression lock that **promotes** two Wave10 closeouts into the tip orchestrator:

1. **k95 / epistemic trust** — Wave10 tip-green still listed `gum_k95_f64_i64_cast_fixed` under `claims_not_made` even though `scripts/epistemic_trust_gate.sh` Section A already gates `k95i=2776`. Wave11 pulls that gate into tip-green and refuses a silent D1 re-collapse (`1960`).
2. **global array ref (Defect B / wave10e #1364)** — Wave10 tip-green locked **init** only; Wave11 also locks BSS global `&!`/`&` mutation via `scripts/ci/madaros_global_array_ref_gate.sh`.
3. **tip receipt** — `artifacts/compiler/madaros_wave11_tip_green_receipt.v1.json` (schema `madaros_wave11_tip_green_receipt.v1`, supersedes wave10 receipt).

Files:

- `scripts/dev/madaros_wave11_tip_green_gate.sh` — 8-gate orchestrator (wave10 six + epistemic_trust + global_array_ref), sentinel checks, k95i=2776 hard check, receipt writer
- `scripts/ci/madaros_global_array_ref_gate.sh` — emit `MADAROS_GLOBAL_ARRAY_REF_GATE_OK`
- `artifacts/compiler/madaros_wave11_tip_green_receipt.v1.json` — green tip receipt at `bbb4a84aa` (raw ELF sha256 `b652756c…de07a`)
- `docs/audit/MADAROS_WAVE11_TIP_GREEN_2026-07-21.md` — measurement + claim boundary

```bash
bash scripts/dev/madaros_wave11_tip_green_gate.sh
# MADAROS_WAVE11_TIP_GREEN_GATE_OK
# receipt: artifacts/compiler/madaros_wave11_tip_green_receipt.v1.json
```

Wave10 tip-green remains as a historical subset; Wave11 supersedes it for tip regression lock.

## Test plan

- [x] dual / wave10 tip-green / epistemic_trust / global_array_ref all rc=0 on tip
- [x] Bundled wave11 gate rc=0 with `MADAROS_WAVE11_TIP_GREEN_GATE_OK`
- [x] Receipt JSON validates (`python3 -m json.tool`)
- [x] Receipt records per-gate status, rc, duration_s, expected_token
- [x] k95 hard check requires `k95i=2776` in epistemic_trust log
- [x] No lean_single pin; default Madaros only

## Explicit non-claims

Does **not** claim: all stdlib dual pairs, language-level `Knowledge<T>` generic import, multi-module IrModule memory wall closed, `cd_exact_generic_i64` ELF, full Root-2 census closed, f64-param bitcast free for all call shapes, full linalg native parity.