### PR TITLE
feat(bigframe): batch 15 — robust location/shape + trimmed/winsorized means (10 verbs, all win)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -128,6 +128,9 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | power_mean_dense(p) / lehmer_mean(p) / contraharmonic (1M rows, 1000 keys) | | ~13.6 | ~175 | **0.08x — wins 13x** | v^p lookup-table; pandas = per-group lambda |
 | hill_number(q) / renyi(a) / tsallis(q) / perplexity / kl_uniform | | ~64 | ~247 | **0.26x — wins 4x** | histogram + bf_pow per bucket |
 | p90p10_ratio / quartile_dispersion | | ~13.6 | ~227 | **0.06x — wins 16x** | histogram + interpolated percentiles |
+| percentile(q) / trimean / midhinge / decile_range (1M rows, 1000 keys) | | ~13.6 | ~176 | **0.08x — wins 13x** | histogram interpolated percentiles; pandas = lambda |
+| bowley_skew / moors_kurt / robust_cv / p95p05 | | ~14 | ~185 | **0.07x — wins 13x** | robust shape from octiles/quartiles |
+| trimmed_mean(t) / winsorized_mean(t) | | ~13.9 | ~126 | **0.11x — wins 9x** | histogram rank-window split |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -7614,3 +7614,135 @@ fn bf_group_qratio_dense(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, 
 pub fn bf_p90p10_ratio_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_qratio_dense(src, key_col, val_col, vmax, 0) }
 /// Per-group QUARTILE COEFFICIENT OF DISPERSION ((q75−q25)/(q75+q25)), broadcast. Dense histogram. NATIVE + lean_single only.
 pub fn bf_quartile_dispersion_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_qratio_dense(src, key_col, val_col, vmax, 1) }
+
+/// Per-group ROBUST LOCATION / SHAPE statistics from interpolated percentiles (dense keys
+/// 0..1023 + integer values 0..vmax). All modes reduce a per-group value histogram through
+/// bf_qpos_from_hist (linear-interpolated quantiles). modes: 0=percentile(param q), 1=trimean
+/// ((q25+2·q50+q75)/4), 2=midhinge ((q25+q75)/2), 3=P95/P05 ratio, 4=Bowley/quartile skewness
+/// ((q75+q25−2·q50)/(q75−q25)), 5=Moors/octile kurtosis ((E7−E5+E3−E1)/(E6−E2)), 6=robust CV
+/// (IQR/median), 7=decile range (P90−P10). Broadcast. O(n + G·vrange). NATIVE + lean_single.
+fn bf_group_robustloc_dense(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, param: f64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cnt: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || vmax < 0 { return out }
+    let vm1 = vmax + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let hist = heap_alloc(1024 * vm1 * 8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let vi = read_f64(vp, i) as i64
+        if k >= 0 && k < 1024 && vi >= 0 && vi < vm1 { write_i64(hist, k * vm1 + vi, read_i64(hist, k * vm1 + vi) + 1); cnt[k] = cnt[k] + 1.0 }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if cnt[g] > 0.0 {
+            let sz = cnt[g] as i64
+            let base = g * vm1
+            if mode == 0 { res[g] = bf_qpos_from_hist(hist, base, vm1, sz, param) }
+            else { if mode == 1 { res[g] = (bf_qpos_from_hist(hist, base, vm1, sz, 0.25) + 2.0 * bf_qpos_from_hist(hist, base, vm1, sz, 0.5) + bf_qpos_from_hist(hist, base, vm1, sz, 0.75)) / 4.0 }
+            else { if mode == 2 { res[g] = (bf_qpos_from_hist(hist, base, vm1, sz, 0.25) + bf_qpos_from_hist(hist, base, vm1, sz, 0.75)) / 2.0 }
+            else { if mode == 3 { let b = bf_qpos_from_hist(hist, base, vm1, sz, 0.05); if b > 0.0 { res[g] = bf_qpos_from_hist(hist, base, vm1, sz, 0.95) / b } }
+            else { if mode == 4 { let q1 = bf_qpos_from_hist(hist, base, vm1, sz, 0.25); let q2 = bf_qpos_from_hist(hist, base, vm1, sz, 0.5); let q3 = bf_qpos_from_hist(hist, base, vm1, sz, 0.75); let d = q3 - q1; if d != 0.0 { res[g] = (q3 + q1 - 2.0 * q2) / d } }
+            else { if mode == 5 { let e1 = bf_qpos_from_hist(hist, base, vm1, sz, 0.125); let e2 = bf_qpos_from_hist(hist, base, vm1, sz, 0.25); let e3 = bf_qpos_from_hist(hist, base, vm1, sz, 0.375); let e5 = bf_qpos_from_hist(hist, base, vm1, sz, 0.625); let e6 = bf_qpos_from_hist(hist, base, vm1, sz, 0.75); let e7 = bf_qpos_from_hist(hist, base, vm1, sz, 0.875); let d = e6 - e2; if d != 0.0 { res[g] = (e7 - e5 + e3 - e1) / d } }
+            else { if mode == 6 { let q2 = bf_qpos_from_hist(hist, base, vm1, sz, 0.5); if q2 != 0.0 { res[g] = (bf_qpos_from_hist(hist, base, vm1, sz, 0.75) - bf_qpos_from_hist(hist, base, vm1, sz, 0.25)) / q2 } }
+            else { res[g] = bf_qpos_from_hist(hist, base, vm1, sz, 0.9) - bf_qpos_from_hist(hist, base, vm1, sz, 0.1) } } } } } } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, res[k]) } else { write_f64(op, i, read_f64(vp, i)) } i = i + 1 }
+    heap_free(hist as *mut i8)
+    out
+}
+/// Per-group interpolated PERCENTILE at fraction q (0..1), broadcast. Dense histogram. NATIVE + lean_single only.
+pub fn bf_percentile_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, q: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_robustloc_dense(src, key_col, val_col, vmax, q, 0) }
+/// Per-group TUKEY TRIMEAN ((q25 + 2·median + q75)/4, a robust center), broadcast. Dense histogram. NATIVE + lean_single.
+pub fn bf_trimean_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_robustloc_dense(src, key_col, val_col, vmax, 0.0, 1) }
+/// Per-group MIDHINGE ((q25 + q75)/2), broadcast. Dense histogram. NATIVE + lean_single only.
+pub fn bf_midhinge_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_robustloc_dense(src, key_col, val_col, vmax, 0.0, 2) }
+/// Per-group P95/P05 RATIO (wide dispersion ratio), broadcast. Dense histogram. NATIVE + lean_single only.
+pub fn bf_p95p05_ratio_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_robustloc_dense(src, key_col, val_col, vmax, 0.0, 3) }
+/// Per-group BOWLEY (quartile) SKEWNESS ((q75+q25−2·median)/IQR, robust skew in [−1,1]), broadcast. Dense histogram. NATIVE + lean_single.
+pub fn bf_bowley_skew_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_robustloc_dense(src, key_col, val_col, vmax, 0.0, 4) }
+/// Per-group MOORS (octile) KURTOSIS ((E7−E5+E3−E1)/(E6−E2), robust tail weight), broadcast. Dense histogram. NATIVE + lean_single.
+pub fn bf_moors_kurt_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_robustloc_dense(src, key_col, val_col, vmax, 0.0, 5) }
+/// Per-group ROBUST CV (IQR / median, a robust coefficient of variation), broadcast. Dense histogram. NATIVE + lean_single.
+pub fn bf_robust_cv_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_robustloc_dense(src, key_col, val_col, vmax, 0.0, 6) }
+/// Per-group DECILE RANGE (P90 − P10, absolute robust spread), broadcast. Dense histogram. NATIVE + lean_single only.
+pub fn bf_decile_range_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_robustloc_dense(src, key_col, val_col, vmax, 0.0, 7) }
+
+/// Per-group TRIMMED / WINSORIZED MEAN via a value histogram (dense keys 0..1023 + values
+/// 0..vmax). Symmetric trim of floor(trim·n) items from each tail (by rank). An ascending
+/// bucket walk splits each value's rank span [c, c+f) against the kept window [lo, hi); mode 0
+/// averages the kept values, mode 1 replaces trimmed tails with the boundary values (Winsor).
+/// Broadcast. O(n + G·vrange). NATIVE + lean_single only.
+fn bf_group_trimstat_dense(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, trim: f64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cnt: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || vmax < 0 { return out }
+    let vm1 = vmax + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let hist = heap_alloc(1024 * vm1 * 8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let vi = read_f64(vp, i) as i64
+        if k >= 0 && k < 1024 && vi >= 0 && vi < vm1 { write_i64(hist, k * vm1 + vi, read_i64(hist, k * vm1 + vi) + 1); cnt[k] = cnt[k] + 1.0 }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if cnt[g] > 0.0 {
+            let sz = cnt[g] as i64
+            let lo = (trim * cnt[g]) as i64
+            let hi = sz - lo
+            if hi > lo {
+                let base = g * vm1
+                var v: i64 = 0
+                var c: i64 = 0
+                var sumt = 0.0
+                var nt: i64 = 0
+                var vlo = 0.0
+                var vhi = 0.0
+                while v < vm1 {
+                    let f = read_i64(hist, base + v)
+                    if f > 0 {
+                        let cend = c + f
+                        if c <= lo && lo < cend { vlo = v as f64 }
+                        if c <= hi - 1 && hi - 1 < cend { vhi = v as f64 }
+                        var a = c; if lo > a { a = lo }
+                        var b = cend; if hi < b { b = hi }
+                        if b > a { let ci = b - a; sumt = sumt + (v as f64) * (ci as f64); nt = nt + ci }
+                        c = cend
+                    }
+                    v = v + 1
+                }
+                if mode == 0 { if nt > 0 { res[g] = sumt / (nt as f64) } }
+                else { res[g] = (vlo * (lo as f64) + sumt + vhi * ((sz - hi) as f64)) / cnt[g] }
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, res[k]) } else { write_f64(op, i, read_f64(vp, i)) } i = i + 1 }
+    heap_free(hist as *mut i8)
+    out
+}
+/// Per-group TRIMMED MEAN (drop floor(trim·n) from each tail, average the rest), broadcast. Dense histogram. NATIVE + lean_single.
+pub fn bf_trimmed_mean_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, trim: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_trimstat_dense(src, key_col, val_col, vmax, trim, 0) }
+/// Per-group WINSORIZED MEAN (clamp floor(trim·n) tail items to the boundary values, then mean), broadcast. Dense histogram. NATIVE + lean_single.
+pub fn bf_winsorized_mean_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, trim: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_trimstat_dense(src, key_col, val_col, vmax, trim, 1) }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -1733,6 +1733,35 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     if !approx_eq(bf_get(&pr,0,0), 3.2857142857) { print("FAIL p90p10\n"); return 634 }       // 46/14
     let qd = bf_quartile_dispersion_dense_by(&qrf,0,1,50)
     if !approx_eq(bf_get(&qd,0,0), 0.3333333333) { print("FAIL quartile_disp\n"); return 635 } // (40-20)/(40+20)
+    // ===== BATCH 15: robust location/shape + trimmed/winsorized (histogram percentiles) =====
+    // reuse qrf {10,20,30,40,50}.
+    let pctl = bf_percentile_dense_by(&qrf,0,1,50,0.5)
+    if !approx_eq(bf_get(&pctl,0,0), 30.0) { print("FAIL percentile\n"); return 636 }
+    let trm = bf_trimean_dense_by(&qrf,0,1,50)
+    if !approx_eq(bf_get(&trm,0,0), 30.0) { print("FAIL trimean\n"); return 637 }
+    let mh = bf_midhinge_dense_by(&qrf,0,1,50)
+    if !approx_eq(bf_get(&mh,0,0), 30.0) { print("FAIL midhinge\n"); return 638 }
+    let p95 = bf_p95p05_ratio_dense_by(&qrf,0,1,50)
+    if !approx_eq(bf_get(&p95,0,0), 4.0) { print("FAIL p95p05\n"); return 639 }              // 48/12
+    let bws = bf_bowley_skew_dense_by(&qrf,0,1,50)
+    if !approx_eq(bf_get(&bws,0,0), 0.0) { print("FAIL bowley\n"); return 640 }               // symmetric
+    let mrk = bf_moors_kurt_dense_by(&qrf,0,1,50)
+    if !approx_eq(bf_get(&mrk,0,0), 1.0) { print("FAIL moors\n"); return 641 }
+    let rcv = bf_robust_cv_dense_by(&qrf,0,1,50)
+    if !approx_eq(bf_get(&rcv,0,0), 0.6666666667) { print("FAIL robust_cv\n"); return 642 }   // 20/30
+    let dcr = bf_decile_range_dense_by(&qrf,0,1,50)
+    if !approx_eq(bf_get(&dcr,0,0), 32.0) { print("FAIL decile_range\n"); return 643 }        // 46-14
+    // trimmed/winsorized on a frame with an outlier: g0 = {1,2,3,4,100}, vmax=100.
+    var trf = bf_new(2, 8)
+    var tf0:[f64;64]=[0.0;64]; tf0[0]=0.0; tf0[1]=1.0;   bf_push_row(&!trf,&tf0,2)
+    var tf1:[f64;64]=[0.0;64]; tf1[0]=0.0; tf1[1]=2.0;   bf_push_row(&!trf,&tf1,2)
+    var tf2:[f64;64]=[0.0;64]; tf2[0]=0.0; tf2[1]=3.0;   bf_push_row(&!trf,&tf2,2)
+    var tf3:[f64;64]=[0.0;64]; tf3[0]=0.0; tf3[1]=4.0;   bf_push_row(&!trf,&tf3,2)
+    var tf4:[f64;64]=[0.0;64]; tf4[0]=0.0; tf4[1]=100.0; bf_push_row(&!trf,&tf4,2)
+    let tmn = bf_trimmed_mean_dense_by(&trf,0,1,100,0.2)
+    if !approx_eq(bf_get(&tmn,0,0), 3.0) { print("FAIL trimmed_mean\n"); return 644 }         // mean{2,3,4}
+    let wmn = bf_winsorized_mean_dense_by(&trf,0,1,100,0.2)
+    if !approx_eq(bf_get(&wmn,0,0), 3.0) { print("FAIL winsorized_mean\n"); return 645 }      // mean{2,2,3,4,4}
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What
Two histogram engines over interpolated percentiles (reuse `bf_qpos_from_hist`) — 10 grouped robust-statistics verbs, all beating pandas **9–14×** at 1M rows.

**Robust location / shape** (`bf_group_robustloc_dense`):
- `bf_percentile_dense_by(q)` (general interpolated percentile)
- `bf_trimean_dense_by` / `bf_midhinge_dense_by` (robust centers)
- `bf_p95p05_ratio_dense_by` / `bf_decile_range_dense_by` (spread)
- `bf_bowley_skew_dense_by` (quartile skewness) / `bf_moors_kurt_dense_by` (octile kurtosis)
- `bf_robust_cv_dense_by` (IQR/median)

**Trimmed / Winsorized means** (`bf_group_trimstat_dense`, rank-window split):
- `bf_trimmed_mean_dense_by(trim)` / `bf_winsorized_mean_dense_by(trim)`

## Numbers (1M rows, 1000 dense keys, values 1..101, reproduced locally)
| verb | Sounio | pandas 3.0.3 | ratio |
|---|---|---|---|
| percentile / trimean / midhinge / decile_range | 13.6 ms | 176 ms | **0.08× (13×)** |
| bowley_skew / moors_kurt / robust_cv / p95p05 | 14 ms | 185 ms | **0.07× (13×)** |
| trimmed_mean / winsorized_mean | 13.9 ms | 126 ms | **0.11× (9×)** |

## Verified
- Gate return codes **636–645** → `BIGFRAME_OPS_GATE_OK`, exit 0
- percentile/trimean/midhinge/p95p05/bowley/moors/robust_cv/decile_range vs `{10,20,30,40,50}`
- trimmed/winsorized vs `{1,2,3,4,100}` (both = 3, dropping/clamping the outlier)
- all cross-checked against numpy percentile; benchmarks reproduced myself

Files: `stdlib/data/bigframe_ops.sio`, its gate test, `scripts/bench/RESULTS.md` (my disjoint lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)