### PR TITLE
fix(madaros): wave11 multi-mod BSS offset remapping + Defect A live-path suppress

### DIFF
--- a/docs/audit/MADAROS_NATIVE_V2_F64_REMAINING_BUGS_2026-07-20.md
+++ b/docs/audit/MADAROS_NATIVE_V2_F64_REMAINING_BUGS_2026-07-20.md
@@ -64,6 +64,32 @@ Residual / future: carrying init words on the AST/Program (no process-global tab
 would be more robust under capacity pressure (`GLOBAL_VAR_INIT_*` is still 128 slots)
 and re-parse-heavy probe paths; not required for the measured science vertical.
 
+## Defect A′ — multi-mod BSS offset collision (two modules with BSS scalars) — **FIXED (wave11, 2026-07-21)**
+
+When **two imported modules** each own a module-level f64/i64 BSS global, each is
+lowered with **module-local** BSS offset 0. Multi-mod merge used to append functions
+**without** relocating `param_count` / `IrLoadGlobal`/`IrStoreGlobal` immediates by
+`acc.bss_total_size`, so both slots and both loads shared `BSS_BASE+0`. Last init wins:
+
+```
+// a.sio: let A_CONST: f64 = 1.5
+// b.sio: let B_CONST: f64 = 2.5
+// was: both get_*_bits() → 2.5 bits | now: 1.5 and 2.5 distinct
+```
+
+**Fix (wave11 Agent D, PR #1382):** `ir_merge_place_and_remap_function` /
+`ir_merge_modules_into` add `bss_offset_delta = dst.bss_total_size` to BSS slot
+offsets and global load/store immediates (and absolute `BSS_BASE+off` `IrLoadImm`),
+then `dst.bss_total_size += src.bss_total_size`. Complements Wave11e Defect A
+suppress (`GLOBAL_VAR_INIT` accumulate) — both are required for multi-import science
+with per-module constants.
+
+Gate: `tests/run-pass/imported_module_f64_const.sio` (A then B, both nonzero and
+distinct) via `scripts/ci/madaros_imported_f64_const_gate.sh`.
+
+Status: **CLOSED wave11** (source fix; prebuilt lag may still show collision until
+`madaros-prebuilt-refresh` ships this source).
+
 ## Defect B — passing a global array by `&!` ref — **FIXED (wave10e, 2026-07-21)**
 
 Passing **any module-level global array** by `&!` reference used to silently
@@ -103,8 +129,9 @@ by ref.
 
 ## Migration status
 
-SPECIAL: green on Madaros. STATS: Defect A closed Wave11e (lognormal_pdf const). LINALG: Defect B
-(global `&!` array ref) is fixed wave10e — remaining linalg blockers are
+SPECIAL: green on Madaros. STATS: Defect A closed Wave11e (lognormal_pdf const);
+Defect A′ multi-mod BSS remap closed wave11 (A_CONST/B_CONST distinct). LINALG:
+Defect B (global `&!` array ref) is fixed wave10e — remaining linalg blockers are
 independent of that ref path. After the compiler fixes ship in the prebuilt
-(madaros-prebuilt-refresh), the SPECIAL gate can drop
-`SOUNIO_SOUC_ENGINE=lean_single`; STATS stays on lean_single until A lands.
+(madaros-prebuilt-refresh), the SPECIAL/STATS gates can drop
+`SOUNIO_SOUC_ENGINE=lean_single` where they still pin it.

--- a/scripts/ci/madaros_imported_f64_const_gate.sh
+++ b/scripts/ci/madaros_imported_f64_const_gate.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Gate: imported-module f64 constants survive multi-module native lower (Defect A).
+# Gate: imported-module f64 constants survive multi-module Madaros.
+# Defect A (Wave11e suppress GLOBAL_VAR_INIT) + Defect A′ (Wave11 multi-mod BSS remap).
 # docs/audit/MADAROS_NATIVE_V2_F64_REMAINING_BUGS_2026-07-20.md
 set -euo pipefail
 
@@ -10,17 +11,18 @@ export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
 SOUC="${SOUC:-$ROOT/bin/souc}"
 MIN="$ROOT/tests/run-pass/imported_f64_global_const.sio"
 SCI="$ROOT/tests/run-pass/imported_f64_lognormal_science.sio"
+BSS="$ROOT/tests/run-pass/imported_module_f64_const.sio"
 
 if [[ ! -x "$SOUC" ]]; then
   echo "FAIL: souc not executable at $SOUC" >&2
   exit 2
 fi
-if [[ ! -f "$MIN" || ! -f "$SCI" ]]; then
+if [[ ! -f "$MIN" || ! -f "$SCI" || ! -f "$BSS" ]]; then
   echo "FAIL: missing witness files" >&2
   exit 2
 fi
 
-echo "== madaros_imported_f64_const_gate: minimal multi-mod =="
+echo "== madaros_imported_f64_const_gate: minimal multi-mod (Defect A) =="
 out_min="$("$SOUC" run "$MIN" 2>&1)" || {
   echo "$out_min"
   echo "FAIL: minimal witness compile/run non-zero" >&2
@@ -52,4 +54,30 @@ if grep -q 'FAIL ' <<<"$out_sci"; then
   exit 1
 fi
 
+echo "== madaros_imported_f64_const_gate: multi-mod BSS remap (Defect A′) =="
+out_bss="$("$SOUC" run "$BSS" 2>&1)" || {
+  echo "$out_bss"
+  echo "FAIL: multi-mod BSS witness compile/run non-zero" >&2
+  exit 1
+}
+echo "$out_bss"
+if ! grep -q 'IMPORTED_F64_CONST_OK' <<<"$out_bss"; then
+  echo "FAIL: missing IMPORTED_F64_CONST_OK" >&2
+  exit 1
+fi
+if grep -q 'FAIL ' <<<"$out_bss"; then
+  echo "FAIL: assertion marker in BSS multi-mod output" >&2
+  exit 1
+fi
+# Distinct A/B bits (last-init-wins collision would print B for both).
+if ! grep -q '4609434218613702656' <<<"$out_bss"; then
+  echo "FAIL: missing A_CONST bits 1.5" >&2
+  exit 1
+fi
+if ! grep -q '4612811918334230528' <<<"$out_bss"; then
+  echo "FAIL: missing B_CONST bits 2.5" >&2
+  exit 1
+fi
+
 echo "MADAROS_IMPORTED_F64_CONST_GATE_OK"
+echo "PASS madaros_imported_f64_const_gate"

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -1219,16 +1219,34 @@ fn ir_merge_modules_into(dst: &! IrModule, src: &IrModule) with Mut, Panic, Div 
     let transition_plan_offset = (*dst).epistemic.transition_plan_count
     let observed_transition_offset = (*dst).epistemic.observed_transition_count
     let rollback_certificate_offset = (*dst).epistemic.rollback_certificate_count
+    // Wave11: relocate src BSS past dst BSS (same residual as lower_array path).
+    let bss_offset_delta = (*dst).bss_total_size
 
     var fi: i64 = 0
     while fi < (*src).fn_count && (*dst).fn_count < IR_MAX_FUNCS {
         var func = (*src).functions[fi]
         func.compile_strategy = (*src).functions[fi].compile_strategy
+        if func.compile_strategy == IR_STRATEGY_BSS_GLOBAL {
+            if bss_offset_delta != 0 {
+                func.param_count = func.param_count + bss_offset_delta
+            }
+        }
         var ii: i64 = 0
         while ii < func.instr_count {
             if func.instrs[ii].op == IrOpcode::IrCall {
                 if func.instrs[ii].fn_id >= 0 {
                     func.instrs[ii].fn_id = func.instrs[ii].fn_id + fn_offset
+                }
+            }
+            if bss_offset_delta != 0 {
+                if func.instrs[ii].op == IrOpcode::IrLoadGlobal || func.instrs[ii].op == IrOpcode::IrStoreGlobal {
+                    func.instrs[ii].imm_i64 = func.instrs[ii].imm_i64 + bss_offset_delta
+                }
+                if func.instrs[ii].op == IrOpcode::IrLoadImm {
+                    let imm = func.instrs[ii].imm_i64
+                    if imm >= BSS_BASE_LINUX && imm < BSS_BASE_LINUX + 268435456 {
+                        func.instrs[ii].imm_i64 = imm + bss_offset_delta
+                    }
                 }
             }
             let _epi_lid = ir_merge_adjusted_label_id(
@@ -1252,11 +1270,19 @@ fn ir_merge_modules_into(dst: &! IrModule, src: &IrModule) with Mut, Panic, Div 
             ii = ii + 1
         }
         func.compile_strategy = (*src).functions[fi].compile_strategy
+        if func.compile_strategy == IR_STRATEGY_BSS_GLOBAL {
+            // strategy re-copy may have clobbered param_count; re-apply delta from src base.
+            if bss_offset_delta != 0 {
+                func.param_count = (*src).functions[fi].param_count + bss_offset_delta
+            }
+        }
         let dst_idx = (*dst).fn_count
         (*dst).functions[dst_idx as usize] = func
         (*dst).fn_count = dst_idx + 1
         fi = fi + 1
     }
+
+    (*dst).bss_total_size = (*dst).bss_total_size + (*src).bss_total_size
 
     var si: i64 = 0
     while si < (*src).string_count && (*dst).string_count < IR_MAX_STRINGS {
@@ -1438,6 +1464,10 @@ fn ir_merge_remap_existing_call_targets(func: IrFunction, src: &IrModule, dst: &
 // New: one local + one slot write. Remap call targets + prepare map +
 // epistemic label shifts in a single instr pass. Scalar field stores only
 // on the owned local (no IrInstr by-value; A8/A14 safe).
+// Wave11: also remap BSS offsets. Each module lowers BSS slots with
+// module-local param_count/imm starting at 0. Without +bss_offset_delta
+// (= dst.bss_total_size at merge time), two imported modules' f64 globals
+// collide at BSS+0 — last init wins (A_CONST and B_CONST both read as 2.5).
 fn ir_merge_place_and_remap_function(
     dst: &! IrModule,
     src: &IrModule,
@@ -1455,7 +1485,8 @@ fn ir_merge_place_and_remap_function(
     alternative_set_offset: i64,
     transition_plan_offset: i64,
     observed_transition_offset: i64,
-    rollback_certificate_offset: i64
+    rollback_certificate_offset: i64,
+    bss_offset_delta: i64
 ) with Mut, Panic, Div {
     if src_fi < 0 || src_fi >= (*src).fn_count {
         return
@@ -1466,6 +1497,12 @@ fn ir_merge_place_and_remap_function(
     // One full-function materialization from the dependency module.
     var func = (*src).functions[src_fi as usize]
     func.compile_strategy = (*src).functions[src_fi as usize].compile_strategy
+    // BSS slot: param_count holds the module-local BSS byte offset.
+    if func.compile_strategy == IR_STRATEGY_BSS_GLOBAL {
+        if bss_offset_delta != 0 {
+            func.param_count = func.param_count + bss_offset_delta
+        }
+    }
     var ii: i64 = 0
     while ii < func.instr_count {
         let op = func.instrs[ii as usize].op
@@ -1488,6 +1525,20 @@ fn ir_merge_place_and_remap_function(
                             func.instrs[ii as usize].fn_id = mapped_id
                         }
                     }
+                }
+            }
+        }
+        // Relative BSS offsets in global load/store (codegen adds BSS_BASE).
+        if bss_offset_delta != 0 {
+            if op == IrOpcode::IrLoadGlobal || op == IrOpcode::IrStoreGlobal {
+                func.instrs[ii as usize].imm_i64 = func.instrs[ii as usize].imm_i64 + bss_offset_delta
+            }
+            // Aggregate path bakes BSS_BASE+local_off as IrLoadImm absolute.
+            // Remap addresses in the BSS window; skip unrelated immediates.
+            if op == IrOpcode::IrLoadImm {
+                let imm = func.instrs[ii as usize].imm_i64
+                if imm >= BSS_BASE_LINUX && imm < BSS_BASE_LINUX + 268435456 {
+                    func.instrs[ii as usize].imm_i64 = imm + bss_offset_delta
                 }
             }
         }
@@ -5101,6 +5152,7 @@ fn module_frontend_lower_programs_array_direct_box(
                         let transition_plan_offset = (*acc_box).epistemic.transition_plan_count
                         let observed_transition_offset = (*acc_box).epistemic.observed_transition_count
                         let rollback_certificate_offset = (*acc_box).epistemic.rollback_certificate_count
+                        let bss_offset_delta = (*acc_box).bss_total_size
                         // Functions with index < acc_fn_before existed before this dep merge;
                         // a fn_remap target below this marks a DEDUP reuse (skip re-placing).
                         let acc_fn_before = (*acc_box).fn_count
@@ -5158,6 +5210,7 @@ fn module_frontend_lower_programs_array_direct_box(
                             // skip re-placing it. Only place newly-appended functions.
                             if dst_fi >= acc_fn_before {
                                 // Wave10: single-pass place+remap (one IrFunction local).
+                                // Wave11: bss_offset_delta relocates dep BSS past acc BSS.
                                 ir_merge_place_and_remap_function(
                                     &! (*acc_box),
                                     &(*dep_box),
@@ -5175,11 +5228,14 @@ fn module_frontend_lower_programs_array_direct_box(
                                     alternative_set_offset,
                                     transition_plan_offset,
                                     observed_transition_offset,
-                                    rollback_certificate_offset
+                                    rollback_certificate_offset,
+                                    bss_offset_delta
                                 )
                             }
                             mfi = mfi + 1
                         }
+                        // Grow acc BSS by the dep module's local BSS footprint.
+                        (*acc_box).bss_total_size = (*acc_box).bss_total_size + (*dep_box).bss_total_size
                         var si: i64 = 0
                         while si < (*dep_box).string_count && (*acc_box).string_count < IR_MAX_STRINGS {
                             (*acc_box).string_table[(*acc_box).string_count as usize] = (*dep_box).string_table[si as usize]

--- a/tests/run-pass/imported_module_f64_const.sio
+++ b/tests/run-pass/imported_module_f64_const.sio
@@ -1,0 +1,55 @@
+//@ run-pass
+//@ expect-stdout: IMPORTED_F64_CONST_OK
+
+// Wave11 multi-mod residual (Agent D / PR #1382):
+// 1) Defect A (Wave11e): GLOBAL_VAR_INIT must accumulate (suppress on live path).
+// 2) Defect A′: BSS offset collision — each module lowers BSS at local offset 0;
+//    merge must relocate dep BSS by +acc.bss_total_size. Without remap, A_CONST
+//    and B_CONST both live at BSS+0 → last init wins (both read 2.5).
+//
+// Expected IEEE754 bits (big-endian u64 of f64):
+//   1.5 → 4609434218613702656
+//   2.5 → 4612811918334230528
+
+use imported_module_f64_const_a::{get_a_bits, get_a}
+use imported_module_f64_const_b::{get_b_bits, get_b}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let a_bits = get_a_bits()
+    let b_bits = get_b_bits()
+    print_int(a_bits)
+    print("\n")
+    print_int(b_bits)
+    print("\n")
+
+    // Direct value path (not only bits via helper).
+    let a_v = get_a()
+    let b_v = get_b()
+    if a_bits != 4609434218613702656 {
+        print("FAIL A_CONST bits\n")
+        return 1
+    }
+    if b_bits != 4612811918334230528 {
+        print("FAIL B_CONST bits\n")
+        return 1
+    }
+    if f64_to_bits(a_v) != 4609434218613702656 {
+        print("FAIL get_a value\n")
+        return 1
+    }
+    if f64_to_bits(b_v) != 4612811918334230528 {
+        print("FAIL get_b value\n")
+        return 1
+    }
+    // Range check so a last-module-wins wipe (A→0 or A←B) cannot pass.
+    if a_v < 1.4 || a_v > 1.6 {
+        print("FAIL A range\n")
+        return 1
+    }
+    if b_v < 2.4 || b_v > 2.6 {
+        print("FAIL B range\n")
+        return 1
+    }
+    print("IMPORTED_F64_CONST_OK\n")
+    0
+}

--- a/tests/run-pass/imported_module_f64_const_a.sio
+++ b/tests/run-pass/imported_module_f64_const_a.sio
@@ -1,0 +1,13 @@
+//@ ignore
+// Leaf import for multi-mod BSS (Defect A′): A_CONST = 1.5.
+// Loaded before module B so a last-init-wins wipe would zero or replace A.
+
+let A_CONST: f64 = 1.5
+
+pub fn get_a_bits() -> i64 with Mut, Div, Panic {
+    f64_to_bits(A_CONST)
+}
+
+pub fn get_a() -> f64 {
+    A_CONST
+}

--- a/tests/run-pass/imported_module_f64_const_b.sio
+++ b/tests/run-pass/imported_module_f64_const_b.sio
@@ -1,0 +1,13 @@
+//@ ignore
+// Second leaf import for multi-mod BSS (Defect A′): B_CONST = 2.5.
+// Parsed after A; without BSS remap both collide at BSS+0 (last init wins).
+
+let B_CONST: f64 = 2.5
+
+pub fn get_b_bits() -> i64 with Mut, Div, Panic {
+    f64_to_bits(B_CONST)
+}
+
+pub fn get_b() -> f64 {
+    B_CONST
+}


### PR DESCRIPTION
## Summary

Wave11 Agent D — highest remaining I×F residual after wave10 that is **not** cd_exact (A), global-list multi-stmt (B), or dep-into-acc (C).

Two cooperating multi-module bugs for imported module-level f64 constants:

1. **Defect A (GLOBAL_VAR_INIT wipe)** — `module_loader` preflight set `GLOBAL_VAR_INIT_SUPPRESS_RESET`, but live `souc run` goes through **`module_frontend_compile_imported_to_file`**, which re-parses every dep without the bracket → only last-parsed module’s inits survive → `DE_LN_SQRT_2PI` → 0 → `lognormal_pdf(1,0,1)=1.0`.
2. **Defect A′ (BSS offset collision)** — each module lowers BSS at **local offset 0**; merge appended slots/`IrLoadGlobal` without `+acc.bss_total_size` → two modules’ scalars share `BSS+0` → last init wins (`A_CONST` and `B_CONST` both read `2.5`).

## Fix

| Path | Change |
|---|---|
| `ir_merge_place_and_remap_function` / `ir_merge_modules_into` | `bss_offset_delta = dst.bss_total_size` on BSS slot `param_count`, `IrLoadGlobal`/`IrStoreGlobal` imm, absolute `BSS_BASE+off` `IrLoadImm`; then `dst.bss_total_size += src.bss_total_size` |
| `module_frontend_compile_imported_to_file` + `load_multimodule_ir_to_box_traced` | `ast_multimodule_global_init_begin/end` so GLOBAL_VAR_INIT accumulates across loads |
| `module_loader` residual | same begin on `load_multimodule_ir_traced`; preflight comment updated |

## Evidence (rebuilt Madaros)

```text
# stock origin/main prebuilt
A_bits=B_bits=4612811918334230528  # both 2.5 — FAIL A_CONST

# artifacts/self-hosted/madaros-w11d-bss (this PR source)
4609434218613702656   # 1.5
4612811918334230528   # 2.5
IMPORTED_F64_CONST_OK
IMPORTED_F64_DENS_OK  # lognormal_pdf range
PASS madaros_imported_f64_const_gate
```

Commands:

```bash
export MADAROS_RAW_BIN=$PWD/artifacts/self-hosted/madaros-w11d-bss
export SOUNIO_STDLIB_PATH=$PWD/stdlib
bash scripts/ci/madaros_imported_f64_const_gate.sh
# → PASS madaros_imported_f64_const_gate
```

**Prebuilt lag:** `bin/madaros-linux-x86_64` on `main` still red until a madaros-prebuilt-refresh ships this source (same pattern as wave10e Defect B).

## Gate / tests

- `tests/run-pass/imported_module_f64_const{,_a,_b}.sio` — A then B both own BSS; both must be correct and distinct
- `scripts/ci/madaros_imported_f64_const_gate.sh` — witness + dens/lognormal science probe
- docs: `docs/audit/MADAROS_NATIVE_V2_F64_REMAINING_BUGS_2026-07-20.md` — Defect A closed; Defect A′ filed closed

## Scope / non-goals

- Does **not** own cd_exact E011, global-list multi-stmt, or dep-into-acc
- Bare cross-module `use m::{CONST}` Ident of a global from main (without same-module helper) may still be fragile; gate uses same-module `get_*` / `lognormal_pdf` (science path)
- No prebuilt ELF in this PR (keep PR small; refresh separately)

## AI disclosure

Implementation and measurement by Wave11 Agent D under human direction. GAIDeT-ICMJE 2025.