### PR TITLE
fix(check): unblock cd_exact_generic_i64 multi-module E011/E008

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -1463,6 +1463,54 @@ fn checker_lower_named_type_with_args_mut(c: *mut Checker, path: AstPath, type_a
             }
         }
     }
+    // Generic struct type application: `S<T>` / `S<F>` must monomorphize to the
+    // mangled name `S__T` / `S__F` — matching the by-value lower_named_type_with_args
+    // and checker_check_struct_lit_inplace paths. Without this the *mut spine (the
+    // path that actually runs during check) dropped type_args and returned bare
+    // `ty_named(S)`, so a body `return S { .. }` typed as `S__F` failed E008
+    // (expected S / found S__F) and field element methods on F failed E011.
+    // See Wave11 cd_exact_generic_i64 / ExactRing residual.
+    match type_args {
+        Some(args) => {
+            let tmpl_idx = struct_table_find((*c).structs, name)
+            if tmpl_idx >= 0 {
+                let tmpl = struct_table_get((*c).structs, tmpl_idx)
+                if tmpl.is_generic_template {
+                    let lowered_args = checker_lower_type_expr_list_mut(c, *args)
+                    let tmpl_name = tmpl.name
+                    let tmpl_fields = field_info_list_clone(&tmpl.fields)
+                    let tmpl_tp_buf = TypeParamBuf { names: tmpl.type_param_names, count: tmpl.type_param_count }
+                    let tmpl_is_linear = tmpl.is_linear
+                    let tmpl_visibility_kind = tmpl.visibility_kind
+                    let tmpl_defining_module_id = tmpl.defining_module_id
+                    let tmpl_visibility = tmpl.visibility
+                    let tmpl_defining_module = tmpl.defining_module
+                    let mangled = mangle_generic_name(&tmpl_name, &lowered_args)
+                    let existing_idx = struct_table_find((*c).structs, mangled)
+                    if existing_idx >= 0 {
+                        return ty_named(mangled)
+                    }
+                    let mono_fields = monomorphize_fields(tmpl_fields, tmpl_tp_buf, &lowered_args)
+                    let mono_info = StructInfo {
+                        name: mangled,
+                        fields: mono_fields.0,
+                        field_count: mono_fields.1,
+                        is_linear: tmpl_is_linear,
+                        type_param_count: 0,
+                        type_param_names: [Name { buf: [0; 128], len: 0 }; 8],
+                        is_generic_template: false,
+                        visibility_kind: tmpl_visibility_kind,
+                        defining_module_id: tmpl_defining_module_id,
+                        visibility: tmpl_visibility,
+                        defining_module: tmpl_defining_module,
+                    }
+                    struct_table_add((*c).structs, mono_info)
+                    return ty_named(mangled)
+                }
+            }
+        }
+        None => {}
+    }
     checker_lower_named_type_mut(c, path)
 }
 

--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -22,8 +22,8 @@ use check::refinement::*
 use check::units::*
 use check::env::*
 use check::traits::*
-use check::mod::{check_program, check_program_epistemic_into, check_modules_verdict_boot4_with_visibility}
-use check::specializer::{specialize_generics}
+use check::mod::{check_program, check_program_epistemic_into, check_items_verdict_boot4, check_modules_verdict_boot4_with_visibility}
+use check::specializer::{specialize_generics, spec_last_instantiated, spec_append_item_lists}
 use check::ownership::*
 use check::lint::*
 use check::layout::*
@@ -2083,11 +2083,37 @@ fn compiler_visibility_preflight(source_path: string) -> bool with IO, Mut, Pani
     print("run_check_mode: about to check ")
     print_int(closure.node_count)
     print(" modules\n")
-    let verdict = check_modules_verdict_boot4_with_visibility(
-        &!programs,
-        closure.node_count,
-        true
-    )
+    // WP-A3 specialized multi-module typecheck (same design as
+    // module_frontend_specialized_typecheck on the IR-merge/compile path):
+    // merge all modules' items, monomorphize turbofish instantiations, then
+    // check the specialized list. Without this pass, generic template bodies
+    // that construct `S {..}` / call trait methods on a type parameter F
+    // emit spurious E008 (`expected S / found S__F`) and E011 (no method on
+    // F) — blocking `cd_exact_generic_i64` and related ExactRing engines.
+    // Fall back to the plain multi-module checker when no generic was
+    // actually instantiated so ordinary multi-module code stays identical.
+    var merged: Option<Box<ItemList>> = None
+    var mi: i64 = closure.node_count - 1
+    while mi >= 0 {
+        merged = spec_append_item_lists(programs[mi as usize].items, merged)
+        mi = mi - 1
+    }
+    let specialized = specialize_generics(merged)
+    var verdict: i64 = 0
+    if spec_last_instantiated() {
+        if str_eq(read_env("SOUNIO_MM_SPEC_TRACE"), "1") {
+            print("run_check_mode: specialized-typecheck over merged ")
+            print_int(closure.node_count)
+            print(" modules\n")
+        }
+        verdict = check_items_verdict_boot4(specialized)
+    } else {
+        verdict = check_modules_verdict_boot4_with_visibility(
+            &!programs,
+            closure.node_count,
+            true
+        )
+    }
     print("run_check_mode: verdict=")
     print_int(verdict)
     print("\n")


### PR DESCRIPTION
## Summary

Wave11 Agent A — unblocks `tests/run-pass/cd_exact_generic_i64.sio` under default Madaros typecheck.

### Root cause

Multi-module `souc check` / visibility preflight used bare `check_modules_verdict_boot4` **without** the WP-A3 generic specializer that the IR-merge compile path already runs (`module_frontend_specialized_typecheck`). Generic template bodies for ExactRing engines therefore saw:

| Error | Site | Symptom |
|---|---|---|
| **E008** | `cd_zero_exact` return | `expected CDElementExact` / `found CDElementExact__F` |
| **E011** | `er_add` / `er_mul` / `er_is_zero` / … | no method named for type param `F` |

Contributing bug: the *mut inplace type lowerer (`checker_lower_named_type_with_args_mut`) dropped type args on generic structs, while struct-lit check monomorphized to `S__F`.

Importing the type name into the caller only *masked* E008/E011 by binding `CDElementExact` as `ty_unknown` in the shared env (wildcard compatible) — not a real fix.

### Fix

1. **`self-hosted/compiler/main.sio`** — `compiler_visibility_preflight` merges module items, runs `specialize_generics`, and typechecks the specialized list when instantiations occurred (same design as WP-A3 IR path); falls back to plain multi-module check otherwise.
2. **`self-hosted/check/check.sio`** — port generic-struct type application monomorphization into the *mut inplace lowerer so `S<F>` → `S__F`.

## Evidence

Rebuilt Madaros (`artifacts/self-hosted/madaros`, lock `/tmp/sounio-w11-cdexact.lock`):

```
./bin/souc check tests/run-pass/cd_exact_generic_i64.sio
# run_check_mode: verdict=0
# check: OK

bash scripts/madaros_dual_import_gate.sh
# MADAROS_DUAL_IMPORT_GATE_OK

./bin/souc check tests/run-pass/a14_transitive_min.sio  # OK
./bin/souc run tests/run-pass/a14_transitive_min.sio    # rc=0

./bin/souc check tests/ui/type/unknown_method_multimodule.sio
# still error[E011] (negative control)
```

## Residual (not this PR)

`souc run` / full native compile of `cd_exact_generic_i64` still SEGV at `lower_array: dep_begin 1` after typecheck ok — pre-existing multi-module body-lower memory wall (KNOWN_LIMITATIONS). Typecheck E011 unblock is the scoped acceptance.

## Test plan

- [x] `souc check tests/run-pass/cd_exact_generic_i64.sio` green
- [x] dual_import gate green
- [x] a14_transitive check+run green
- [x] unknown method multimodule still E011
- [ ] Prefer compile+run ZD PROVED (blocked by lower residual)