### PR TITLE
feat(bigframe): scaled-histogram quantiles for fixed-precision floats (interim float-median win, narrow range)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -131,6 +131,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | percentile(q) / trimean / midhinge / decile_range (1M rows, 1000 keys) | | ~13.6 | ~176 | **0.08x — wins 13x** | histogram interpolated percentiles; pandas = lambda |
 | bowley_skew / moors_kurt / robust_cv / p95p05 | | ~14 | ~185 | **0.07x — wins 13x** | robust shape from octiles/quartiles |
 | trimmed_mean(t) / winsorized_mean(t) | | ~13.9 | ~126 | **0.11x — wins 9x** | histogram rank-window split |
+| median_scaled / q1/q3/iqr/percentile_scaled (FIXED-PRECISION float, 1M rows, 1000 keys, 2dp, range 0-6.99) | | ~229 | ~265 | **0.86x — wins** | scaled histogram (round v*100); flips the general-float bf_median_by 5.36x LOSS to a win for narrow fixed-precision ranges |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -7746,3 +7746,61 @@ fn bf_group_trimstat_dense(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64
 pub fn bf_trimmed_mean_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, trim: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_trimstat_dense(src, key_col, val_col, vmax, trim, 0) }
 /// Per-group WINSORIZED MEAN (clamp floor(trim·n) tail items to the boundary values, then mean), broadcast. Dense histogram. NATIVE + lean_single.
 pub fn bf_winsorized_mean_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, trim: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_trimstat_dense(src, key_col, val_col, vmax, trim, 1) }
+
+/// Per-group interpolated QUANTILES for FIXED-PRECISION FLOAT values, via a scaled value
+/// histogram (dense keys 0..1023). Each value is mapped to an integer bucket round(v·scale)
+/// in 0..scaled_max, counted, and reduced through bf_qpos_from_hist; the percentile is divided
+/// back by scale. EXACT when the data is genuinely fixed-precision at `scale` (e.g. scale=100
+/// for 2-decimal readings) and v>=0. This is the float-domain analog of bf_median_dense_by and
+/// the stdlib mitigation for the general-float order-statistic loss (see the CODEX-2 select_f64
+/// dispatch): it holds only for NARROW ranges -- histogram memory is 1024·(scaled_max+1)·8, so
+/// keep scaled_max <= a few thousand. modes 0=median 1=q25 2=q75 3=IQR 4=percentile(param).
+/// O(n + G·scaled_range). NATIVE + lean_single only.
+fn bf_group_quantile_scaled(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64, param: f64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cnt: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || scaled_max < 0 || scale <= 0.0 { return out }
+    let vm1 = scaled_max + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let hist = heap_alloc(1024 * vm1 * 8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let s = (read_f64(vp, i) * scale + 0.5) as i64
+        if k >= 0 && k < 1024 && s >= 0 && s < vm1 { write_i64(hist, k * vm1 + s, read_i64(hist, k * vm1 + s) + 1); cnt[k] = cnt[k] + 1.0 }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if cnt[g] > 0.0 {
+            let sz = cnt[g] as i64
+            let base = g * vm1
+            if mode == 0 { res[g] = bf_qpos_from_hist(hist, base, vm1, sz, 0.5) / scale }
+            else { if mode == 1 { res[g] = bf_qpos_from_hist(hist, base, vm1, sz, 0.25) / scale }
+            else { if mode == 2 { res[g] = bf_qpos_from_hist(hist, base, vm1, sz, 0.75) / scale }
+            else { if mode == 3 { res[g] = (bf_qpos_from_hist(hist, base, vm1, sz, 0.75) - bf_qpos_from_hist(hist, base, vm1, sz, 0.25)) / scale }
+            else { res[g] = bf_qpos_from_hist(hist, base, vm1, sz, param) / scale } } } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, read_f64(vp, i)) } i = i + 1 }
+    heap_free(hist as *mut i8)
+    out
+}
+/// Per-group MEDIAN of fixed-precision float values (scale = 10^decimals; e.g. 100 for 2 dp), broadcast. Exact for narrow fixed-precision ranges. NATIVE + lean_single.
+pub fn bf_median_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile_scaled(src, key_col, val_col, scaled_max, scale, 0.0, 0) }
+/// Per-group Q25 of fixed-precision float values, broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_q1_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile_scaled(src, key_col, val_col, scaled_max, scale, 0.0, 1) }
+/// Per-group Q75 of fixed-precision float values, broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_q3_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile_scaled(src, key_col, val_col, scaled_max, scale, 0.0, 2) }
+/// Per-group IQR of fixed-precision float values, broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_iqr_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile_scaled(src, key_col, val_col, scaled_max, scale, 0.0, 3) }
+/// Per-group interpolated PERCENTILE q (0..1) of fixed-precision float values, broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_percentile_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64, q: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile_scaled(src, key_col, val_col, scaled_max, scale, q, 4) }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -1762,6 +1762,24 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     if !approx_eq(bf_get(&tmn,0,0), 3.0) { print("FAIL trimmed_mean\n"); return 644 }         // mean{2,3,4}
     let wmn = bf_winsorized_mean_dense_by(&trf,0,1,100,0.2)
     if !approx_eq(bf_get(&wmn,0,0), 3.0) { print("FAIL winsorized_mean\n"); return 645 }      // mean{2,2,3,4,4}
+    // ===== BATCH 16: fixed-precision FLOAT quantiles via scaled histogram (2-decimal) =====
+    // g0 = {1.25, 2.50, 3.75, 5.00, 6.25}, scale=100, scaled_max=700.
+    var fpf = bf_new(2, 8)
+    var fp0:[f64;64]=[0.0;64]; fp0[0]=0.0; fp0[1]=1.25; bf_push_row(&!fpf,&fp0,2)
+    var fp1:[f64;64]=[0.0;64]; fp1[0]=0.0; fp1[1]=2.50; bf_push_row(&!fpf,&fp1,2)
+    var fp2:[f64;64]=[0.0;64]; fp2[0]=0.0; fp2[1]=3.75; bf_push_row(&!fpf,&fp2,2)
+    var fp3:[f64;64]=[0.0;64]; fp3[0]=0.0; fp3[1]=5.00; bf_push_row(&!fpf,&fp3,2)
+    var fp4:[f64;64]=[0.0;64]; fp4[0]=0.0; fp4[1]=6.25; bf_push_row(&!fpf,&fp4,2)
+    let sme = bf_median_scaled_by(&fpf,0,1,700,100.0)
+    if !approx_eq(bf_get(&sme,0,0), 3.75) { print("FAIL median_scaled\n"); return 646 }
+    let sq1 = bf_q1_scaled_by(&fpf,0,1,700,100.0)
+    if !approx_eq(bf_get(&sq1,0,0), 2.50) { print("FAIL q1_scaled\n"); return 647 }
+    let sq3 = bf_q3_scaled_by(&fpf,0,1,700,100.0)
+    if !approx_eq(bf_get(&sq3,0,0), 5.00) { print("FAIL q3_scaled\n"); return 648 }
+    let siq = bf_iqr_scaled_by(&fpf,0,1,700,100.0)
+    if !approx_eq(bf_get(&siq,0,0), 2.50) { print("FAIL iqr_scaled\n"); return 649 }  // 5.00-2.50
+    let spc = bf_percentile_scaled_by(&fpf,0,1,700,100.0,0.5)
+    if !approx_eq(bf_get(&spc,0,0), 3.75) { print("FAIL percentile_scaled\n"); return 650 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What
`bf_median_scaled_by` / `bf_q1_scaled_by` / `bf_q3_scaled_by` / `bf_iqr_scaled_by` / `bf_percentile_scaled_by` — grouped order statistics for **fixed-precision float** values via a scaled value histogram (`round(v·scale)` → bucket → `bf_qpos_from_hist` → `÷scale`).

## Why
The general-float `bf_median_by` pays a per-group quickselect that loses **~5.4×** to pandas at 1M rows. I confirmed a pure-Sounio radix f64 select is **no faster** (~697ms vs quickselect ~760ms) — the `read_f64`/`write_f64` builtin call overhead is the wall, which is exactly why the `select_f64` compiler-intrinsic dispatch (#1359) exists and can only be closed by CODEX-2.

For the common **measurement** case — fixed-precision readings (e.g. 2-decimal), narrow range — the scaled histogram avoids selection entirely and **flips the loss to a win**:

| verb | Sounio | pandas 3.0.3 | ratio |
|---|---|---|---|
| median_scaled (2dp, range 0–6.99) | 229 ms | 265 ms | **0.86× — wins** |

## Scope (honest)
- **Exact** only when the data is genuinely fixed-precision at `scale` and `v ≥ 0`.
- Holds only for **narrow ranges** — histogram memory is `1024·(scaled_max+1)·8`, so keep `scaled_max` ≲ a few thousand.
- This is the measurement-beachhead mitigation, **not** the general-float unblock — that still needs the `select_f64`/`sort_f64` intrinsic (#1359, CODEX-2).

## Verified
- Gate return codes **646–650** → `BIGFRAME_OPS_GATE_OK`, exit 0
- median/q1/q3/iqr/percentile exact vs `{1.25, 2.50, 3.75, 5.00, 6.25}`
- benchmark reproduced myself

Files: `stdlib/data/bigframe_ops.sio`, its gate test, `scripts/bench/RESULTS.md` (my disjoint lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)