### PR TITLE
feat(bigframe): scaled-histogram robust statistics for fixed-precision floats (10 verbs, all win 5-7x)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -132,6 +132,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | bowley_skew / moors_kurt / robust_cv / p95p05 | | ~14 | ~185 | **0.07x — wins 13x** | robust shape from octiles/quartiles |
 | trimmed_mean(t) / winsorized_mean(t) | | ~13.9 | ~126 | **0.11x — wins 9x** | histogram rank-window split |
 | median_scaled / q1/q3/iqr/percentile_scaled (FIXED-PRECISION float, 1M rows, 1000 keys, 2dp, range 0-6.99) | | ~229 | ~265 | **0.86x — wins** | scaled histogram (round v*100); flips the general-float bf_median_by 5.36x LOSS to a win for narrow fixed-precision ranges |
+| trimean/midhinge/bowley/moors/robust_cv/decile_range/p95p05 + trimmed/winsorized_scaled (FIXED-PRECISION float, 1M rows, 1000 keys) | | ~245 | ~1600 | **0.15x — wins 7x** | scaled histogram; pandas float robust-stats = per-group lambda (1.1-1.8s) |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -7804,3 +7804,133 @@ pub fn bf_q3_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i
 pub fn bf_iqr_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile_scaled(src, key_col, val_col, scaled_max, scale, 0.0, 3) }
 /// Per-group interpolated PERCENTILE q (0..1) of fixed-precision float values, broadcast. Scaled histogram. NATIVE + lean_single.
 pub fn bf_percentile_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64, q: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile_scaled(src, key_col, val_col, scaled_max, scale, q, 4) }
+
+/// Per-group ROBUST LOCATION / SHAPE for FIXED-PRECISION FLOAT values via a scaled histogram
+/// (round(v·scale) in 0..scaled_max, dense keys 0..1023). The float-domain sibling of
+/// bf_group_robustloc_dense: percentiles come from bf_qpos_from_hist in scaled units; location/
+/// spread modes divide back by scale, while ratio / dimensionless modes need no division (scale
+/// cancels). EXACT for genuinely fixed-precision, narrow-range, v>=0 data. modes: 0=percentile
+/// (param), 1=trimean, 2=midhinge, 3=P95/P05, 4=Bowley skew, 5=Moors kurtosis, 6=robust CV
+/// (IQR/median), 7=decile range (P90−P10). Broadcast. O(n + G·scaled_range). NATIVE + lean_single.
+fn bf_group_robustloc_scaled(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64, param: f64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cnt: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || scaled_max < 0 || scale <= 0.0 { return out }
+    let vm1 = scaled_max + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let hist = heap_alloc(1024 * vm1 * 8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let s = (read_f64(vp, i) * scale + 0.5) as i64
+        if k >= 0 && k < 1024 && s >= 0 && s < vm1 { write_i64(hist, k * vm1 + s, read_i64(hist, k * vm1 + s) + 1); cnt[k] = cnt[k] + 1.0 }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if cnt[g] > 0.0 {
+            let sz = cnt[g] as i64
+            let base = g * vm1
+            if mode == 0 { res[g] = bf_qpos_from_hist(hist, base, vm1, sz, param) / scale }
+            else { if mode == 1 { res[g] = (bf_qpos_from_hist(hist, base, vm1, sz, 0.25) + 2.0 * bf_qpos_from_hist(hist, base, vm1, sz, 0.5) + bf_qpos_from_hist(hist, base, vm1, sz, 0.75)) / (4.0 * scale) }
+            else { if mode == 2 { res[g] = (bf_qpos_from_hist(hist, base, vm1, sz, 0.25) + bf_qpos_from_hist(hist, base, vm1, sz, 0.75)) / (2.0 * scale) }
+            else { if mode == 3 { let b = bf_qpos_from_hist(hist, base, vm1, sz, 0.05); if b > 0.0 { res[g] = bf_qpos_from_hist(hist, base, vm1, sz, 0.95) / b } }
+            else { if mode == 4 { let q1 = bf_qpos_from_hist(hist, base, vm1, sz, 0.25); let q2 = bf_qpos_from_hist(hist, base, vm1, sz, 0.5); let q3 = bf_qpos_from_hist(hist, base, vm1, sz, 0.75); let d = q3 - q1; if d != 0.0 { res[g] = (q3 + q1 - 2.0 * q2) / d } }
+            else { if mode == 5 { let e1 = bf_qpos_from_hist(hist, base, vm1, sz, 0.125); let e2 = bf_qpos_from_hist(hist, base, vm1, sz, 0.25); let e3 = bf_qpos_from_hist(hist, base, vm1, sz, 0.375); let e5 = bf_qpos_from_hist(hist, base, vm1, sz, 0.625); let e6 = bf_qpos_from_hist(hist, base, vm1, sz, 0.75); let e7 = bf_qpos_from_hist(hist, base, vm1, sz, 0.875); let d = e6 - e2; if d != 0.0 { res[g] = (e7 - e5 + e3 - e1) / d } }
+            else { if mode == 6 { let q2 = bf_qpos_from_hist(hist, base, vm1, sz, 0.5); if q2 != 0.0 { res[g] = (bf_qpos_from_hist(hist, base, vm1, sz, 0.75) - bf_qpos_from_hist(hist, base, vm1, sz, 0.25)) / q2 } }
+            else { res[g] = (bf_qpos_from_hist(hist, base, vm1, sz, 0.9) - bf_qpos_from_hist(hist, base, vm1, sz, 0.1)) / scale } } } } } } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, read_f64(vp, i)) } i = i + 1 }
+    heap_free(hist as *mut i8)
+    out
+}
+/// Per-group TRIMEAN of fixed-precision float values ((q25+2·median+q75)/4), broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_trimean_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_robustloc_scaled(src, key_col, val_col, scaled_max, scale, 0.0, 1) }
+/// Per-group MIDHINGE of fixed-precision float values ((q25+q75)/2), broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_midhinge_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_robustloc_scaled(src, key_col, val_col, scaled_max, scale, 0.0, 2) }
+/// Per-group P95/P05 RATIO of fixed-precision float values (scale-free), broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_p95p05_ratio_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_robustloc_scaled(src, key_col, val_col, scaled_max, scale, 0.0, 3) }
+/// Per-group BOWLEY (quartile) SKEWNESS of fixed-precision float values (dimensionless), broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_bowley_skew_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_robustloc_scaled(src, key_col, val_col, scaled_max, scale, 0.0, 4) }
+/// Per-group MOORS (octile) KURTOSIS of fixed-precision float values (dimensionless), broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_moors_kurt_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_robustloc_scaled(src, key_col, val_col, scaled_max, scale, 0.0, 5) }
+/// Per-group ROBUST CV (IQR/median, scale-free) of fixed-precision float values, broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_robust_cv_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_robustloc_scaled(src, key_col, val_col, scaled_max, scale, 0.0, 6) }
+/// Per-group DECILE RANGE (P90−P10) of fixed-precision float values, broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_decile_range_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_robustloc_scaled(src, key_col, val_col, scaled_max, scale, 0.0, 7) }
+
+/// Per-group TRIMMED / WINSORIZED MEAN for FIXED-PRECISION FLOAT values via a scaled histogram
+/// (round(v·scale) in 0..scaled_max). Float sibling of bf_group_trimstat_dense: symmetric trim
+/// of floor(trim·n) items by rank; the accumulated scaled sums are divided back by scale. mode
+/// 0 trimmed mean, mode 1 Winsorized mean. Broadcast. O(n + G·scaled_range). NATIVE + lean_single.
+fn bf_group_trimstat_scaled(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64, trim: f64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cnt: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || scaled_max < 0 || scale <= 0.0 { return out }
+    let vm1 = scaled_max + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let hist = heap_alloc(1024 * vm1 * 8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let s = (read_f64(vp, i) * scale + 0.5) as i64
+        if k >= 0 && k < 1024 && s >= 0 && s < vm1 { write_i64(hist, k * vm1 + s, read_i64(hist, k * vm1 + s) + 1); cnt[k] = cnt[k] + 1.0 }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if cnt[g] > 0.0 {
+            let sz = cnt[g] as i64
+            let lo = (trim * cnt[g]) as i64
+            let hi = sz - lo
+            if hi > lo {
+                let base = g * vm1
+                var v: i64 = 0
+                var c: i64 = 0
+                var sumt = 0.0
+                var nt: i64 = 0
+                var vlo = 0.0
+                var vhi = 0.0
+                while v < vm1 {
+                    let f = read_i64(hist, base + v)
+                    if f > 0 {
+                        let cend = c + f
+                        if c <= lo && lo < cend { vlo = v as f64 }
+                        if c <= hi - 1 && hi - 1 < cend { vhi = v as f64 }
+                        var a = c; if lo > a { a = lo }
+                        var b = cend; if hi < b { b = hi }
+                        if b > a { let ci = b - a; sumt = sumt + (v as f64) * (ci as f64); nt = nt + ci }
+                        c = cend
+                    }
+                    v = v + 1
+                }
+                if mode == 0 { if nt > 0 { res[g] = sumt / ((nt as f64) * scale) } }
+                else { res[g] = (vlo * (lo as f64) + sumt + vhi * ((sz - hi) as f64)) / (cnt[g] * scale) }
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, read_f64(vp, i)) } i = i + 1 }
+    heap_free(hist as *mut i8)
+    out
+}
+/// Per-group TRIMMED MEAN of fixed-precision float values (drop floor(trim·n) per tail), broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_trimmed_mean_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64, trim: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_trimstat_scaled(src, key_col, val_col, scaled_max, scale, trim, 0) }
+/// Per-group WINSORIZED MEAN of fixed-precision float values (clamp tails to boundary), broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_winsorized_mean_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64, trim: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_trimstat_scaled(src, key_col, val_col, scaled_max, scale, trim, 1) }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -1780,6 +1780,33 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     if !approx_eq(bf_get(&siq,0,0), 2.50) { print("FAIL iqr_scaled\n"); return 649 }  // 5.00-2.50
     let spc = bf_percentile_scaled_by(&fpf,0,1,700,100.0,0.5)
     if !approx_eq(bf_get(&spc,0,0), 3.75) { print("FAIL percentile_scaled\n"); return 650 }
+    // ===== BATCH 17: robust location/shape + trimmed/winsorized for FIXED-PRECISION floats =====
+    // reuse fpf {1.25,2.50,3.75,5.00,6.25}, scale=100, scaled_max=700.
+    let strm = bf_trimean_scaled_by(&fpf,0,1,700,100.0)
+    if !approx_eq(bf_get(&strm,0,0), 3.75) { print("FAIL trimean_scaled\n"); return 651 }
+    let smh = bf_midhinge_scaled_by(&fpf,0,1,700,100.0)
+    if !approx_eq(bf_get(&smh,0,0), 3.75) { print("FAIL midhinge_scaled\n"); return 652 }
+    let s95 = bf_p95p05_ratio_scaled_by(&fpf,0,1,700,100.0)
+    if !approx_eq(bf_get(&s95,0,0), 4.0) { print("FAIL p95p05_scaled\n"); return 653 }      // scale-free
+    let sbw = bf_bowley_skew_scaled_by(&fpf,0,1,700,100.0)
+    if !approx_eq(bf_get(&sbw,0,0), 0.0) { print("FAIL bowley_scaled\n"); return 654 }
+    let smk = bf_moors_kurt_scaled_by(&fpf,0,1,700,100.0)
+    if !approx_eq(bf_get(&smk,0,0), 1.0) { print("FAIL moors_scaled\n"); return 655 }
+    let srcv = bf_robust_cv_scaled_by(&fpf,0,1,700,100.0)
+    if !approx_eq(bf_get(&srcv,0,0), 0.6666666667) { print("FAIL robust_cv_scaled\n"); return 656 }
+    let sdr = bf_decile_range_scaled_by(&fpf,0,1,700,100.0)
+    if !approx_eq(bf_get(&sdr,0,0), 4.0) { print("FAIL decile_range_scaled\n"); return 657 } // 5.75-1.75... check
+    // trimmed/winsorized on a float outlier frame: g0 = {1.0,2.0,3.0,4.0,50.0}, scale=100, scaled_max=5000.
+    var tff = bf_new(2, 8)
+    var tg0:[f64;64]=[0.0;64]; tg0[0]=0.0; tg0[1]=1.0;  bf_push_row(&!tff,&tg0,2)
+    var tg1:[f64;64]=[0.0;64]; tg1[0]=0.0; tg1[1]=2.0;  bf_push_row(&!tff,&tg1,2)
+    var tg2:[f64;64]=[0.0;64]; tg2[0]=0.0; tg2[1]=3.0;  bf_push_row(&!tff,&tg2,2)
+    var tg3:[f64;64]=[0.0;64]; tg3[0]=0.0; tg3[1]=4.0;  bf_push_row(&!tff,&tg3,2)
+    var tg4:[f64;64]=[0.0;64]; tg4[0]=0.0; tg4[1]=50.0; bf_push_row(&!tff,&tg4,2)
+    let stm = bf_trimmed_mean_scaled_by(&tff,0,1,5000,100.0,0.2)
+    if !approx_eq(bf_get(&stm,0,0), 3.0) { print("FAIL trimmed_scaled\n"); return 658 }
+    let swm = bf_winsorized_mean_scaled_by(&tff,0,1,5000,100.0,0.2)
+    if !approx_eq(bf_get(&swm,0,0), 3.0) { print("FAIL winsorized_scaled\n"); return 659 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What
Extends the fixed-precision-float mitigation (`bf_median_scaled_by`, #1389) to the full **robust order-statistic family** for float input — the float sibling of the batch-15 dense-integer verbs.

**Robust location / shape** (`bf_group_robustloc_scaled`):
- `bf_trimean_scaled_by` / `bf_midhinge_scaled_by`
- `bf_p95p05_ratio_scaled_by` / `bf_decile_range_scaled_by`
- `bf_bowley_skew_scaled_by` / `bf_moors_kurt_scaled_by` / `bf_robust_cv_scaled_by`

**Trimmed / Winsorized means** (`bf_group_trimstat_scaled`):
- `bf_trimmed_mean_scaled_by(trim)` / `bf_winsorized_mean_scaled_by(trim)`

## Numbers (1M rows, 1000 keys, 2-decimal floats, reproduced locally)
| verb | Sounio | pandas 3.0.3 | ratio |
|---|---|---|---|
| trimean / midhinge / bowley / moors / ... | ~245 ms | ~1600 ms | **0.15× (7×)** |
| trimmed_mean / winsorized_mean | ~225 ms | ~1137 ms | **0.20× (5×)** |

pandas' float robust stats go through `groupby.transform(lambda)` at **1.1–1.8 seconds** per op; the scaled histogram does them in ~245ms.

## Scope (honest)
- Exact for genuinely **fixed-precision, narrow-range, v ≥ 0** data (measurement beachhead).
- Location/spread modes divide back by scale; ratio/dimensionless modes (bowley/moors/robust_cv/p95p05) need no division (scale cancels).
- Still **not** the general-float unblock — see the `select_f64` escalation (#1390 → #1359).

## Verified
- Gate return codes **651–659** → `BIGFRAME_OPS_GATE_OK`, exit 0
- all vs `{1.25, 2.50, 3.75, 5.00, 6.25}`; trimmed/winsorized vs `{1,2,3,4,50}` (both = 3, outlier dropped)
- benchmarks reproduced myself

Files: `stdlib/data/bigframe_ops.sio`, its gate test, `scripts/bench/RESULTS.md` (my disjoint lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)