### PR TITLE
feat(bigframe): scaled-histogram geometric + inequality + diversity for fixed-precision floats (10 verbs, all win)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -133,6 +133,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | trimmed_mean(t) / winsorized_mean(t) | | ~13.9 | ~126 | **0.11x — wins 9x** | histogram rank-window split |
 | median_scaled / q1/q3/iqr/percentile_scaled (FIXED-PRECISION float, 1M rows, 1000 keys, 2dp, range 0-6.99) | | ~229 | ~265 | **0.86x — wins** | scaled histogram (round v*100); flips the general-float bf_median_by 5.36x LOSS to a win for narrow fixed-precision ranges |
 | trimean/midhinge/bowley/moors/robust_cv/decile_range/p95p05 + trimmed/winsorized_scaled (FIXED-PRECISION float, 1M rows, 1000 keys) | | ~245 | ~1600 | **0.15x — wins 7x** | scaled histogram; pandas float robust-stats = per-group lambda (1.1-1.8s) |
+| geomean/geostd + gini_coef/theil/atkinson/hoover + entropy/perplexity/inv_simpson/gini_impurity (FIXED-PRECISION float, 1M rows) | | ~22 | ~180 | **0.12x — wins 8x** | scaled histogram/LUT; pandas float = per-group lambda |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -7934,3 +7934,197 @@ fn bf_group_trimstat_scaled(src: &BigFrame, key_col: i64, val_col: i64, scaled_m
 pub fn bf_trimmed_mean_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64, trim: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_trimstat_scaled(src, key_col, val_col, scaled_max, scale, trim, 0) }
 /// Per-group WINSORIZED MEAN of fixed-precision float values (clamp tails to boundary), broadcast. Scaled histogram. NATIVE + lean_single.
 pub fn bf_winsorized_mean_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64, trim: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_trimstat_scaled(src, key_col, val_col, scaled_max, scale, trim, 1) }
+
+/// Per-group GEOMETRIC statistics for FIXED-PRECISION FLOAT values via a scaled ln-LUT (dense
+/// keys 0..1023, buckets round(v·scale) in 1..scaled_max). Float sibling of bf_group_geostat_dense.
+/// mode 0 = geometric mean (÷scale, since geomean(v·scale)=scale·geomean(v)); mode 1 = geometric
+/// std (scale-free: std(ln(v·scale))=std(ln v)). Broadcast. O(n + scaled_range). NATIVE + lean_single.
+fn bf_group_geostat_scaled(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var nn:  [f64; 1024] = [0.0; 1024]
+    var sl:  [f64; 1024] = [0.0; 1024]
+    var sl2: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || scaled_max < 0 || scale <= 0.0 { return out }
+    let vm1 = scaled_max + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    let lut = heap_alloc(vm1 * 8) as *mut f64
+    var v: i64 = 1
+    while v < vm1 { write_f64(lut, v, bf_ln(v as f64, sc)) v = v + 1 }
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let s = (read_f64(vp, i) * scale + 0.5) as i64
+        if k >= 0 && k < 1024 && s >= 1 && s < vm1 { let l = read_f64(lut, s); nn[k] = nn[k] + 1.0; sl[k] = sl[k] + l; sl2[k] = sl2[k] + l * l }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        let m = nn[g]
+        if m > 0.0 {
+            if mode == 0 { res[g] = bf_exp(sl[g] / m, sc) / scale }
+            else {
+                var vv = 0.0
+                if m > 1.0 { vv = (sl2[g] - sl[g] * sl[g] / m) / (m - 1.0) }
+                if vv < 0.0 { vv = 0.0 }
+                res[g] = bf_exp(bf_sqrt(vv, sc), sc)
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(lut as *mut i8)
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group GEOMETRIC MEAN of fixed-precision float values, broadcast. Scaled ln-LUT + exp. NATIVE + lean_single.
+pub fn bf_geomean_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_geostat_scaled(src, key_col, val_col, scaled_max, scale, 0) }
+/// Per-group GEOMETRIC STD DEV of fixed-precision float values (scale-free), broadcast. Scaled ln-LUT. NATIVE + lean_single.
+pub fn bf_geostd_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_geostat_scaled(src, key_col, val_col, scaled_max, scale, 1) }
+
+/// Per-group INEQUALITY indices for FIXED-PRECISION FLOAT values via a scaled histogram (buckets
+/// round(v·scale)). Float sibling of bf_group_inequality_dense. All four indices are scale-free
+/// (ratios / normalized), so no division is needed. modes 0=Gini 1=Theil-T 2=Atkinson(eps=1)
+/// 3=Hoover. Broadcast. O(n + G·scaled_range). NATIVE + lean_single only.
+fn bf_group_inequality_scaled(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cnt: [f64; 1024] = [0.0; 1024]
+    var sv:  [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || scaled_max < 0 || scale <= 0.0 { return out }
+    let vm1 = scaled_max + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let hist = heap_alloc(1024 * vm1 * 8) as *mut i64
+    let sc = heap_alloc(8) as *mut i64
+    let lut = heap_alloc(vm1 * 8) as *mut f64
+    var v: i64 = 1
+    while v < vm1 { write_f64(lut, v, bf_ln(v as f64, sc)) v = v + 1 }
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let s = (read_f64(vp, i) * scale + 0.5) as i64
+        if k >= 0 && k < 1024 && s >= 0 && s < vm1 { write_i64(hist, k * vm1 + s, read_i64(hist, k * vm1 + s) + 1); cnt[k] = cnt[k] + 1.0; sv[k] = sv[k] + (s as f64) }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if cnt[g] > 0.0 && sv[g] > 0.0 {
+            let nf = cnt[g]
+            let sumx = sv[g]
+            let mu = sumx / nf
+            let lnmu = bf_ln(mu, sc)
+            let base = g * vm1
+            var vv: i64 = 0
+            var c = 0.0
+            var gini = 0.0
+            var theil = 0.0
+            var hoov = 0.0
+            var slf = 0.0
+            var haszero = false
+            while vv < vm1 {
+                let f = read_i64(hist, base + vv)
+                if f > 0 {
+                    let ff = f as f64
+                    let xf = vv as f64
+                    gini = gini + xf * ff * (2.0 * c + ff - nf)
+                    hoov = hoov + ff * bf_fabs(xf - mu)
+                    if vv >= 1 { theil = theil + ff * (xf / mu) * (read_f64(lut, vv) - lnmu); slf = slf + ff * read_f64(lut, vv) } else { haszero = true }
+                    c = c + ff
+                }
+                vv = vv + 1
+            }
+            if mode == 0 { res[g] = gini / (nf * sumx) }
+            else { if mode == 1 { res[g] = theil / nf }
+            else { if mode == 2 { var gm = 0.0; if !haszero { gm = bf_exp(slf / nf, sc) }; res[g] = 1.0 - gm / mu }
+            else { res[g] = hoov / (2.0 * sumx) } } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(hist as *mut i8)
+    heap_free(lut as *mut i8)
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group GINI COEFFICIENT of fixed-precision float values (inequality/heterogeneity), broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_gini_coef_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_inequality_scaled(src, key_col, val_col, scaled_max, scale, 0) }
+/// Per-group THEIL-T INDEX of fixed-precision float values, broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_theil_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_inequality_scaled(src, key_col, val_col, scaled_max, scale, 1) }
+/// Per-group ATKINSON INDEX (eps=1) of fixed-precision float values, broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_atkinson1_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_inequality_scaled(src, key_col, val_col, scaled_max, scale, 2) }
+/// Per-group HOOVER / ROBIN-HOOD INDEX of fixed-precision float values, broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_hoover_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_inequality_scaled(src, key_col, val_col, scaled_max, scale, 3) }
+
+/// Per-group VALUE-DISTRIBUTION DIVERSITY for FIXED-PRECISION FLOAT values via a scaled histogram
+/// (buckets round(v·scale) = the natural fixed-precision categories). Float sibling of the entropy
+/// engine; all outputs are frequency-based hence scale-free. modes 0=Shannon entropy (nats),
+/// 1=perplexity (exp H), 2=inverse Simpson (1/Σp²), 3=Gini-Simpson impurity (1−Σp²). Broadcast.
+/// O(n + G·scaled_range). NATIVE + lean_single only.
+fn bf_group_diversity_scaled(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cnt: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || scaled_max < 0 || scale <= 0.0 { return out }
+    let vm1 = scaled_max + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let hist = heap_alloc(1024 * vm1 * 8) as *mut i64
+    let sc = heap_alloc(8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let s = (read_f64(vp, i) * scale + 0.5) as i64
+        if k >= 0 && k < 1024 && s >= 0 && s < vm1 { write_i64(hist, k * vm1 + s, read_i64(hist, k * vm1 + s) + 1); cnt[k] = cnt[k] + 1.0 }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if cnt[g] > 0.0 {
+            let nf = cnt[g]
+            let base = g * vm1
+            var v: i64 = 0
+            var hh = 0.0
+            var sq = 0.0
+            while v < vm1 {
+                let f = read_i64(hist, base + v)
+                if f > 0 { let pp = (f as f64) / nf; hh = hh - pp * bf_ln(pp, sc); sq = sq + pp * pp }
+                v = v + 1
+            }
+            if mode == 0 { res[g] = hh }
+            else { if mode == 1 { res[g] = bf_exp(hh, sc) }
+            else { if mode == 2 { if sq > 0.0 { res[g] = 1.0 / sq } }
+            else { res[g] = 1.0 - sq } } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, read_f64(vp, i)) } i = i + 1 }
+    heap_free(hist as *mut i8)
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group SHANNON ENTROPY of the fixed-precision value distribution (nats), broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_entropy_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_diversity_scaled(src, key_col, val_col, scaled_max, scale, 0) }
+/// Per-group PERPLEXITY (exp Shannon = effective # distinct readings) of fixed-precision values, broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_perplexity_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_diversity_scaled(src, key_col, val_col, scaled_max, scale, 1) }
+/// Per-group INVERSE SIMPSON index of the fixed-precision value distribution, broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_inv_simpson_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_diversity_scaled(src, key_col, val_col, scaled_max, scale, 2) }
+/// Per-group GINI-SIMPSON IMPURITY (1−Σp²) of the fixed-precision value distribution, broadcast. Scaled histogram. NATIVE + lean_single.
+pub fn bf_gini_impurity_scaled_by(src: &BigFrame, key_col: i64, val_col: i64, scaled_max: i64, scale: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_diversity_scaled(src, key_col, val_col, scaled_max, scale, 3) }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -1807,6 +1807,34 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     if !approx_eq(bf_get(&stm,0,0), 3.0) { print("FAIL trimmed_scaled\n"); return 658 }
     let swm = bf_winsorized_mean_scaled_by(&tff,0,1,5000,100.0,0.2)
     if !approx_eq(bf_get(&swm,0,0), 3.0) { print("FAIL winsorized_scaled\n"); return 659 }
+    // ===== BATCH 18: geometric + inequality + diversity for FIXED-PRECISION floats =====
+    // reuse fpf {1.25,2.50,3.75,5.00,6.25}, scale=100, scaled_max=700.
+    let sgm = bf_geomean_scaled_by(&fpf,0,1,700,100.0)
+    if !approx_eq(bf_get(&sgm,0,0), 3.25646386) { print("FAIL geomean_scaled\n"); return 660 }
+    let sgs = bf_geostd_scaled_by(&fpf,0,1,700,100.0)
+    if !approx_eq(bf_get(&sgs,0,0), 1.88798371) { print("FAIL geostd_scaled\n"); return 661 }
+    let sgc = bf_gini_coef_scaled_by(&fpf,0,1,700,100.0)
+    if !approx_eq(bf_get(&sgc,0,0), 0.26666667) { print("FAIL gini_coef_scaled\n"); return 662 }
+    let sth = bf_theil_scaled_by(&fpf,0,1,700,100.0)
+    if !approx_eq(bf_get(&sth,0,0), 0.11968759) { print("FAIL theil_scaled\n"); return 663 }
+    let sat = bf_atkinson1_scaled_by(&fpf,0,1,700,100.0)
+    if !approx_eq(bf_get(&sat,0,0), 0.13160964) { print("FAIL atkinson_scaled\n"); return 664 }
+    let sho = bf_hoover_scaled_by(&fpf,0,1,700,100.0)
+    if !approx_eq(bf_get(&sho,0,0), 0.2) { print("FAIL hoover_scaled\n"); return 665 }
+    // diversity frame dvf = {1.00,1.00,2.00,3.00}, scale=100, scaled_max=400. p=[1/2,1/4,1/4].
+    var dvf = bf_new(2, 8)
+    var dv0:[f64;64]=[0.0;64]; dv0[0]=0.0; dv0[1]=1.00; bf_push_row(&!dvf,&dv0,2)
+    var dv1:[f64;64]=[0.0;64]; dv1[0]=0.0; dv1[1]=1.00; bf_push_row(&!dvf,&dv1,2)
+    var dv2:[f64;64]=[0.0;64]; dv2[0]=0.0; dv2[1]=2.00; bf_push_row(&!dvf,&dv2,2)
+    var dv3:[f64;64]=[0.0;64]; dv3[0]=0.0; dv3[1]=3.00; bf_push_row(&!dvf,&dv3,2)
+    let sen2 = bf_entropy_scaled_by(&dvf,0,1,400,100.0)
+    if !approx_eq(bf_get(&sen2,0,0), 1.03972077) { print("FAIL entropy_scaled\n"); return 666 }
+    let spx = bf_perplexity_scaled_by(&dvf,0,1,400,100.0)
+    if !approx_eq(bf_get(&spx,0,0), 2.82842712) { print("FAIL perplexity_scaled\n"); return 667 }
+    let sis = bf_inv_simpson_scaled_by(&dvf,0,1,400,100.0)
+    if !approx_eq(bf_get(&sis,0,0), 2.66666667) { print("FAIL inv_simpson_scaled\n"); return 668 }
+    let sgi = bf_gini_impurity_scaled_by(&dvf,0,1,400,100.0)
+    if !approx_eq(bf_get(&sgi,0,0), 0.625) { print("FAIL gini_impurity_scaled\n"); return 669 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What
Extends the fixed-precision-float mitigation to the **geometric / inequality / diversity** families for float input (siblings of the dense-integer verbs).

**Geometric** (`bf_group_geostat_scaled`, ln-LUT + exp): `bf_geomean_scaled_by` / `bf_geostd_scaled_by` — lognormal biomarkers.

**Inequality** (`bf_group_inequality_scaled`, all scale-free): `bf_gini_coef_scaled_by` / `bf_theil_scaled_by` / `bf_atkinson1_scaled_by` / `bf_hoover_scaled_by`.

**Diversity** (`bf_group_diversity_scaled`, over the fixed-precision grid): `bf_entropy_scaled_by` / `bf_perplexity_scaled_by` / `bf_inv_simpson_scaled_by` / `bf_gini_impurity_scaled_by`.

## Numbers (1M rows, 1000 keys, 2-decimal floats, reproduced locally)
| verb | Sounio | pandas 3.0.3 | ratio |
|---|---|---|---|
| geomean | 21 ms | 161 ms | **0.13×** |
| gini_coef | 23 ms | 136 ms | **0.17×** |
| entropy | 22 ms | 237 ms | **0.09×** |

## Scope
- Scale handling: geomean ÷scale; geostd, inequality (ratios) and diversity (frequency-based) are scale-free.
- Exact for genuinely fixed-precision, narrow-range, v ≥ 0 data.

## Verified
- Gate return codes **660–669** → `BIGFRAME_OPS_GATE_OK`, exit 0
- geomean/geostd/gini/theil/atkinson/hoover vs `{1.25,…,6.25}`; entropy/perplexity/inv_simpson/gini_impurity vs `{1.00,1.00,2.00,3.00}`
- benchmarks reproduced myself

Files: `stdlib/data/bigframe_ops.sio`, its gate test, `scripts/bench/RESULTS.md` (my disjoint lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)