### PR TITLE
fix(madaros): Root-2 inline method-chain residual

### DIFF
--- a/artifacts/compiler/madaros_knowledge_method_residual_receipt.v1.json
+++ b/artifacts/compiler/madaros_knowledge_method_residual_receipt.v1.json
@@ -3,18 +3,23 @@
   "status": "pass",
   "engine": "madaros_default",
   "lean_single_pin": false,
-  "commit": "45ad6e084426461b942d3fa0fbae2819e60d7668",
+  "commit": "1b289fda30ae8e2af26d667979a403812373706a",
   "verdict": "FIXED_ALREADY",
   "claims": [
     "epistemic_method_form_multimodule_import",
     "epistemic_measured_val_add_mul_std_method_path",
+    "epistemic_inline_method_chain_multimodule",
     "free_vs_method_numeric_parity",
     "legacy_method_witness_now_required_green"
   ],
   "claims_not_made": [
     "language_knowledge_t_generic_import",
-    "gum_k95_f64_i64_cast_fixed",
     "full_root2_census_closed",
-    "enum_ctor_path"
+    "enum_ctor_path",
+    "arbitrary_depth_method_chain_census"
+  ],
+  "closed_elsewhere": [
+    "gum_k95_f64_i64_cast_fixed (Wave10: scripts/epistemic_trust_gate.sh Section A; #1252+#983)",
+    "root2_inline_method_chain (lower_method_recv_type MethodCall/Call; scripts/madaros_root2_method_gate.sh)"
   ]
 }

--- a/artifacts/compiler/madaros_root2_method_receipt.v1.json
+++ b/artifacts/compiler/madaros_root2_method_receipt.v1.json
@@ -2,17 +2,20 @@
   "schema": "madaros_root2_method_receipt.v1",
   "status": "pass",
   "engine": "madaros_default",
-  "commit": "45ad6e084426461b942d3fa0fbae2819e60d7668",
+  "commit": "1b289fda30ae8e2af26d667979a403812373706a",
   "claims": [
     "same_module_self_ref_method_call",
     "same_module_associated_type_method",
     "same_module_method_on_method_return",
+    "same_module_inline_method_chain",
     "multimodule_associated_type_method_import",
     "multimodule_instance_method_call",
+    "multimodule_inline_method_chain",
     "epistemic_method_form_multimodule"
   ],
   "claims_not_made": [
     "full_root2_census_closed",
-    "enum_ctor_path"
+    "enum_ctor_path",
+    "arbitrary_depth_method_chain_census"
   ]
 }

--- a/artifacts/compiler/madaros_root2_multimodule_method_receipt.v1.json
+++ b/artifacts/compiler/madaros_root2_multimodule_method_receipt.v1.json
@@ -2,14 +2,17 @@
   "schema": "madaros_root2_multimodule_method_receipt.v1",
   "status": "pass",
   "engine": "madaros_default",
-  "commit": "45ad6e084426461b942d3fa0fbae2819e60d7668",
+  "commit": "1b289fda30ae8e2af26d667979a403812373706a",
   "claims": [
     "multimodule_instance_method_call",
     "multimodule_method_f64_print",
+    "multimodule_inline_method_chain",
+    "same_module_inline_method_chain",
     "epistemic_measured_val_add_std_import"
   ],
   "claims_not_made": [
     "enum_ctor_path",
-    "full_root2_census_closed"
+    "full_root2_census_closed",
+    "arbitrary_depth_method_chain_census"
   ]
 }

--- a/docs/audit/MADAROS_ROOT2_METHOD_CHAIN_2026-07-21.md
+++ b/docs/audit/MADAROS_ROOT2_METHOD_CHAIN_2026-07-21.md
@@ -1,0 +1,77 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-root2-method-chain-2026-07-21
+authority: repo_only
+audience: users
+last_validated: 2026-07-21
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-root2-method-chain-2026-07-21
+-->
+
+# Madaros Root 2 — inline method-chain residual closeout — 2026-07-21
+
+## Claim
+
+> Under **default Madaros**, **inline method chains** on both same-module types and
+> **imported** science-path types compile and run correctly:
+>
+> - `E::of(3.0).get()`
+> - `a.add(&b).get()` / `a.add(&b).add(&c).get()`
+> - multi-module `Epistemic::certain(1.0).val()`, `a.add(&b).val()`,
+>   `a.add(&b).add(&c).val()`, `print(a.add(&b).std())`
+
+Stepwise bind (`let t = a.add(&b); t.get()`) was already green after #1219 / #1227.
+Inline chains were the remaining Root-2 method residual measured post-#1392.
+
+## Root cause
+
+`lower_method_recv_type` only typed **Ident** and **Index** receivers. A receiver
+that was itself an `ExprMethodCall` or `ExprCall` returned the empty name, so the
+outer call mangled to bare `"get"` / `"add"` / `"val"`. The seed lower then
+invented a body-less function and **SEGV'd at `lower_array: seed_begin`**.
+
+## Fix
+
+In `self-hosted/ir/lower.sio` → `lower_method_recv_type`:
+
+| Receiver kind | Resolution |
+|---|---|
+| `ExprMethodCall` | Recurse for inner recv type → mangle → `return_struct_name_for_fn_id`; fallback to inner recv type (Self-returning methods) |
+| `ExprCall` | `expr_call_return_struct_name_ref` (associated `Type::method` constructors) |
+| `ExprIdent` / `ExprIndex` | unchanged |
+
+Does **not** touch Wave13 paths (`module_frontend.sio`, `parser/items.sio`).
+
+## Gate
+
+```bash
+bash scripts/madaros_root2_method_gate.sh
+# → MADAROS_ROOT2_METHOD_GATE_OK
+
+bash scripts/madaros_root2_multimodule_method_gate.sh
+# → MADAROS_ROOT2_MULTIMODULE_METHOD_GATE_OK
+```
+
+Requires current-source Madaros (chain fixtures fail on pre-fix stock ELFs).
+
+## Fixtures
+
+| File | Sentinel |
+|---|---|
+| `tests/run-pass/madaros_root2_method_chain.sio` | `ROOT2_METHOD_CHAIN_OK` |
+| `tests/run-pass/madaros_root2_multimodule_method_chain.sio` | `ROOT2_MULTIMODULE_METHOD_CHAIN_OK` |
+
+## Measured (current-source Madaros)
+
+```
+ROOT2_METHOD_CHAIN_OK
+ROOT2_MULTIMODULE_METHOD_CHAIN_OK
+MADAROS_ROOT2_METHOD_GATE_OK
+MADAROS_ROOT2_MULTIMODULE_METHOD_GATE_OK
+```
+
+## claims_not_made
+
+- Full Root-2 census closed  
+- Enum ctor path  
+- Arbitrary-depth method-chain census beyond the fixtures above  
+- Stock prebuilt ELF without rebuild (chain residual needs the lower fix in the running Madaros)

--- a/docs/audit/MADAROS_ROOT2_METHOD_CHAIN_2026-07-21.md
+++ b/docs/audit/MADAROS_ROOT2_METHOD_CHAIN_2026-07-21.md
@@ -2,7 +2,7 @@
 topic_id: repo.docs.audit.madaros-root2-method-chain-2026-07-21
 authority: repo_only
 audience: users
-last_validated: 2026-07-21
+last_validated: 2026-03-07
 validated_by: A2
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-root2-method-chain-2026-07-21
 -->

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,25 +19,25 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1076
-- Repo-backed topics: 926
+- Total governed topics: 1078
+- Repo-backed topics: 928
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 242
-- Authority count `repo_only`: 646
+- Authority count `historical`: 243
+- Authority count `repo_only`: 647
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 665 topics
+- A2: 666 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 276 topics
+- A6: 277 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -179,6 +179,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-raw-references-codegen-2026-06-24 | repo_only | docs/audit/MADAROS_RAW_REFERENCES_CODEGEN_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-root2-enum-fncount-2026-06-20 | repo_only | docs/audit/MADAROS_ROOT2_ENUM_FNCOUNT_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-root2-method-associated-2026-07-19 | repo_only | docs/audit/MADAROS_ROOT2_METHOD_ASSOCIATED_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-root2-method-chain-2026-07-21 | repo_only | docs/audit/MADAROS_ROOT2_METHOD_CHAIN_2026-07-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-root2-multimodule-method-2026-07-19 | repo_only | docs/audit/MADAROS_ROOT2_MULTIMODULE_METHOD_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-root2-readonly-probe-2026-06-21 | repo_only | docs/audit/MADAROS_ROOT2_READONLY_PROBE_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-selfhost-tier1-module-resolver-2026-06-24 | repo_only | docs/audit/MADAROS_SELFHOST_TIER1_MODULE_RESOLVER_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -798,6 +799,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.probe-result-deep-ffn | historical | docs/research/PROBE-RESULT-deep-ffn.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.probe-result-h256-scale | historical | docs/research/PROBE-RESULT-h256-scale.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.probe-result-lstm-adding | historical | docs/research/PROBE-RESULT-lstm-adding.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.probe-result-multiseed | historical | docs/research/PROBE-RESULT-multiseed.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.probe-usage | historical | docs/research/probe-usage.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.program-registry-mercyful-learning | historical | docs/research/PROGRAM-REGISTRY-mercyful-learning.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.proof-checker-family-matrix-2026-06-23 | historical | docs/research/proof-checker-family-matrix-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -3604,6 +3604,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-root2-method-chain-2026-07-21",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_ROOT2_METHOD_CHAIN_2026-07-21.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-root2-readonly-probe-2026-06-21",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_ROOT2_READONLY_PROBE_2026-06-21.md",

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -3581,9 +3581,9 @@
       "related_artifacts": []
     },
     {
-      "topic_id": "repo.docs.audit.madaros-root2-multimodule-method-2026-07-19",
+      "topic_id": "repo.docs.audit.madaros-root2-method-chain-2026-07-21",
       "collection": "repo",
-      "repo_doc_path": "docs/audit/MADAROS_ROOT2_MULTIMODULE_METHOD_2026-07-19.md",
+      "repo_doc_path": "docs/audit/MADAROS_ROOT2_METHOD_CHAIN_2026-07-21.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",
@@ -3604,9 +3604,9 @@
       "related_artifacts": []
     },
     {
-      "topic_id": "repo.docs.audit.madaros-root2-method-chain-2026-07-21",
+      "topic_id": "repo.docs.audit.madaros-root2-multimodule-method-2026-07-19",
       "collection": "repo",
-      "repo_doc_path": "docs/audit/MADAROS_ROOT2_METHOD_CHAIN_2026-07-21.md",
+      "repo_doc_path": "docs/audit/MADAROS_ROOT2_MULTIMODULE_METHOD_2026-07-19.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",
@@ -17686,6 +17686,28 @@
       "topic_id": "repo.docs.research.probe-result-lstm-adding",
       "collection": "repo",
       "repo_doc_path": "docs/research/PROBE-RESULT-lstm-adding.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.research.probe-result-multiseed",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/PROBE-RESULT-multiseed.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "researchers",

--- a/scripts/madaros_knowledge_method_residual_gate.sh
+++ b/scripts/madaros_knowledge_method_residual_gate.sh
@@ -69,6 +69,13 @@ if [[ -f tests/run-pass/madaros_root2_multimodule_method.sio ]]; then
     ROOT2_MULTIMODULE_METHOD_OK
 fi
 
+# Inline method chain on imported Epistemic (Root-2 chain residual closeout)
+if [[ -f tests/run-pass/madaros_root2_multimodule_method_chain.sio ]]; then
+  run_ok "root2 multimodule method chain regression" \
+    tests/run-pass/madaros_root2_multimodule_method_chain.sio \
+    ROOT2_MULTIMODULE_METHOD_CHAIN_OK
+fi
+
 mkdir -p "$ROOT/artifacts/compiler"
 COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
 STATUS=fail
@@ -84,16 +91,19 @@ cat >"$ROOT/artifacts/compiler/madaros_knowledge_method_residual_receipt.v1.json
   "claims": [
     "epistemic_method_form_multimodule_import",
     "epistemic_measured_val_add_mul_std_method_path",
+    "epistemic_inline_method_chain_multimodule",
     "free_vs_method_numeric_parity",
     "legacy_method_witness_now_required_green"
   ],
   "claims_not_made": [
     "language_knowledge_t_generic_import",
     "full_root2_census_closed",
-    "enum_ctor_path"
+    "enum_ctor_path",
+    "arbitrary_depth_method_chain_census"
   ],
   "closed_elsewhere": [
-    "gum_k95_f64_i64_cast_fixed (Wave10: scripts/epistemic_trust_gate.sh Section A; #1252+#983)"
+    "gum_k95_f64_i64_cast_fixed (Wave10: scripts/epistemic_trust_gate.sh Section A; #1252+#983)",
+    "root2_inline_method_chain (lower_method_recv_type MethodCall/Call; scripts/madaros_root2_method_gate.sh)"
   ]
 }
 EOF

--- a/scripts/madaros_root2_method_gate.sh
+++ b/scripts/madaros_root2_method_gate.sh
@@ -45,6 +45,15 @@ run_ok "knowledge method form" \
   tests/run-pass/madaros_knowledge_method_form.sio \
   KNOWLEDGE_METHOD_FORM_OK
 
+# Inline method chain (was residual: SEGV at seed lower for non-Ident receivers)
+run_ok "same-module method chain" \
+  tests/run-pass/madaros_root2_method_chain.sio \
+  ROOT2_METHOD_CHAIN_OK
+
+run_ok "multi-module method chain" \
+  tests/run-pass/madaros_root2_multimodule_method_chain.sio \
+  ROOT2_MULTIMODULE_METHOD_CHAIN_OK
+
 mkdir -p "$ROOT/artifacts/compiler"
 COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
 STATUS=fail
@@ -59,13 +68,16 @@ cat >"$ROOT/artifacts/compiler/madaros_root2_method_receipt.v1.json" <<EOF
     "same_module_self_ref_method_call",
     "same_module_associated_type_method",
     "same_module_method_on_method_return",
+    "same_module_inline_method_chain",
     "multimodule_associated_type_method_import",
     "multimodule_instance_method_call",
+    "multimodule_inline_method_chain",
     "epistemic_method_form_multimodule"
   ],
   "claims_not_made": [
     "full_root2_census_closed",
-    "enum_ctor_path"
+    "enum_ctor_path",
+    "arbitrary_depth_method_chain_census"
   ]
 }
 EOF

--- a/scripts/madaros_root2_multimodule_method_gate.sh
+++ b/scripts/madaros_root2_multimodule_method_gate.sh
@@ -36,6 +36,15 @@ run_ok "same-module method+associated (regression)" \
   tests/run-pass/madaros_root2_method_associated.sio \
   ROOT2_METHOD_ASSOCIATED_OK
 
+# Inline method chain on imported Epistemic (science path; was residual SEGV)
+run_ok "multi-module Epistemic method chain" \
+  tests/run-pass/madaros_root2_multimodule_method_chain.sio \
+  ROOT2_MULTIMODULE_METHOD_CHAIN_OK
+
+run_ok "same-module method chain (regression)" \
+  tests/run-pass/madaros_root2_method_chain.sio \
+  ROOT2_METHOD_CHAIN_OK
+
 mkdir -p "$ROOT/artifacts/compiler"
 COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
 STATUS=fail
@@ -49,11 +58,14 @@ cat >"$ROOT/artifacts/compiler/madaros_root2_multimodule_method_receipt.v1.json"
   "claims": [
     "multimodule_instance_method_call",
     "multimodule_method_f64_print",
+    "multimodule_inline_method_chain",
+    "same_module_inline_method_chain",
     "epistemic_measured_val_add_std_import"
   ],
   "claims_not_made": [
     "enum_ctor_path",
-    "full_root2_census_closed"
+    "full_root2_census_closed",
+    "arbitrary_depth_method_chain_census"
   ]
 }
 EOF

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -10291,14 +10291,48 @@ impl Lowerer {
         (lo3, dst)
     }
 
-    // Receiver struct type for a method call, when the receiver is a simple local
-    // (e.g. `c.method()` -> type of `c`). Used to mangle the call to the same name the
-    // impl method was registered under. Empty when the type can't be determined here.
+    // Receiver struct type for a method call. Used to mangle the call to the same
+    // name the impl method was registered under. Empty when the type can't be
+    // determined here. Covers:
+    //   - local idents (`c.method()`)
+    //   - chained method receivers (`a.add(&b).get()`) via return_struct_name
+    //   - associated/free call receivers (`E::of(3.0).get()`)
+    //   - primitive index receivers (`a.c[i].er_add(...)`)
     fn lower_method_recv_type(self, left: &Option<Box<Expr>>) -> Name with Mut, Panic, Div, Alloc {
         match *left {
             Some(recv) => {
                 if (*recv).kind == ExprKind::ExprIdent {
                     return self.lookup_local_struct_type((*recv).name)
+                }
+                // Root 2 chain residual: method call on a method result.
+                // `a.add(&b).get()` — outer mangling needs the inner method's
+                // return_struct_name (E), not an empty name that invents bare "get".
+                if (*recv).kind == ExprKind::ExprMethodCall {
+                    let inner_recv = self.lower_method_recv_type(&(*recv).left)
+                    let inner_call = if inner_recv.len > 0 {
+                        ir_mangle_method_name(inner_recv, (*recv).name)
+                    } else {
+                        (*recv).name
+                    }
+                    let fn_id = lowerer_lookup_fn_id_by_name_ref(&self, inner_call)
+                    let ret = self.return_struct_name_for_fn_id(fn_id)
+                    if ret.len > 0 {
+                        return ret
+                    }
+                    // Self-returning methods often omit a distinct return name in
+                    // edge stubs; reuse the receiver type when known.
+                    if inner_recv.len > 0 {
+                        return inner_recv
+                    }
+                    return ir_empty_name()
+                }
+                // Associated / free call as receiver: `E::of(3.0).get()`.
+                if (*recv).kind == ExprKind::ExprCall {
+                    let ret = self.expr_call_return_struct_name_ref(&(*recv))
+                    if ret.len > 0 {
+                        return ret
+                    }
+                    return ir_empty_name()
                 }
                 // Primitive-receiver fallback for a non-ident scalar receiver such
                 // as an array element `a.c[i]` (the imported cd_exact lane calls

--- a/tests/run-pass/madaros_root2_associated_import.sio
+++ b/tests/run-pass/madaros_root2_associated_import.sio
@@ -7,7 +7,7 @@ use epistemic::knowledge::{Epistemic}
 fn main() -> i32 with IO, Mut, Div, Panic {
     let e = Epistemic::measured(10.0, 0.5)
     let c = Epistemic::certain(1.0)
-    // Associated construction only — instance methods still multi-module residual.
+    // Associated construction only; instance methods gated in multimodule_method*.sio.
     print("ROOT2_ASSOCIATED_IMPORT_OK\n")
     return 0
 }

--- a/tests/run-pass/madaros_root2_method_associated.sio
+++ b/tests/run-pass/madaros_root2_method_associated.sio
@@ -1,7 +1,8 @@
 //@ run-pass
 // Madaros Root 2: associated Type::method + same-module &self methods,
 // including method call on the result of another method (`s = a.add(&b); s.get()`).
-// Multi-module instance method (x.method() across use) remains residual — see gate.
+// Inline chains live in madaros_root2_method_chain.sio; multi-module instance
+// methods in madaros_root2_multimodule_method.sio / _method_chain.sio.
 
 pub struct E {
     v: f64,

--- a/tests/run-pass/madaros_root2_method_chain.sio
+++ b/tests/run-pass/madaros_root2_method_chain.sio
@@ -1,0 +1,43 @@
+//@ run-pass
+//@ requires: madaros
+// Madaros Root 2 residual: chained method calls on same-module types.
+// Stepwise `let t = a.add(&b); t.get()` was green after #1219; inline
+// `a.add(&b).get()` / `E::of(x).get()` SEGV'd at seed lower because
+// lower_method_recv_type only typed Ident/Index receivers.
+
+pub struct E {
+    v: f64,
+}
+
+impl E {
+    pub fn of(v: f64) -> E {
+        E { v: v }
+    }
+    pub fn get(self: &E) -> f64 {
+        self.v
+    }
+    pub fn add(self: &E, other: &E) -> E {
+        E { v: self.v + other.v }
+    }
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // Associated call as receiver
+    let v0 = E::of(3.0).get()
+    if v0 < 2.9 || v0 > 3.1 { print("FAIL_ASSOC\n"); return 1 }
+
+    let a = E::of(3.0)
+    let b = E::of(4.0)
+    let c = E::of(5.0)
+
+    // Method result as receiver (f64 return)
+    let v1 = a.add(&b).get()
+    if v1 < 6.9 || v1 > 7.1 { print("FAIL_CHAIN_GET\n"); return 2 }
+
+    // Method result as receiver (struct return), then get
+    let v2 = a.add(&b).add(&c).get()
+    if v2 < 11.9 || v2 > 12.1 { print("FAIL_CHAIN_ADD\n"); return 3 }
+
+    print("ROOT2_METHOD_CHAIN_OK\n")
+    return 0
+}

--- a/tests/run-pass/madaros_root2_multimodule_method_chain.sio
+++ b/tests/run-pass/madaros_root2_multimodule_method_chain.sio
@@ -1,0 +1,32 @@
+//@ run-pass
+//@ requires: madaros
+// Madaros Root 2 residual: chained instance methods on imported Epistemic
+// (science-path multi-module). Stepwise bind was green; inline chain SEGV'd
+// at seed lower (lower_method_recv_type empty on MethodCall receivers).
+
+use epistemic::knowledge::{Epistemic}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let a = Epistemic::measured(3.0, 0.1)
+    let b = Epistemic::measured(4.0, 0.2)
+    let c = Epistemic::measured(5.0, 0.3)
+
+    // Associated construction + immediate method
+    let v0 = Epistemic::certain(1.0).val()
+    if v0 < 0.999 || v0 > 1.001 { print("FAIL_ASSOC_VAL\n"); return 1 }
+
+    // Method result as receiver (f64)
+    let v1 = a.add(&b).val()
+    if v1 < 6.9 || v1 > 7.1 { print("FAIL_CHAIN_VAL\n"); return 2 }
+
+    // Two struct-returning methods chained
+    let v2 = a.add(&b).add(&c).val()
+    if v2 < 11.9 || v2 > 12.1 { print("FAIL_CHAIN_ADD\n"); return 3 }
+
+    // print of chained method f64 (expr_result_is_float_ref path)
+    print(a.add(&b).std())
+    print("\n")
+
+    print("ROOT2_MULTIMODULE_METHOD_CHAIN_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Summary

Closes a real **Root-2 multimodule method residual** measured after #1392: **inline method chains** (`a.add(&b).get()`, `E::of(x).get()`, multi-mod `a.add(&b).add(&c).val()`) compile-SEGV at `lower_array: seed_begin` under Madaros. Stepwise bind was already green (#1219/#1227).

### Root cause

`lower_method_recv_type` only typed **Ident** and **Index** receivers. A receiver that is itself an `ExprMethodCall` or `ExprCall` returned the empty name → outer call mangled to bare `"get"`/`"add"`/`"val"` → body-less fn → SEGV.

### Fix (`self-hosted/ir/lower.sio`)

| Receiver | Resolution |
|---|---|
| `ExprMethodCall` | recurse → mangle → `return_struct_name_for_fn_id` (Self fallback) |
| `ExprCall` | `expr_call_return_struct_name_ref` (associated constructors) |
| Ident / Index | unchanged |

Does **not** touch Wave13 paths (`module_frontend.sio`, `parser/items.sio`, specializer DCE).

## Claim boundary

**Claims (required green under default Madaros / refreshed prebuilt):**

- same-module stepwise methods + associated (`ROOT2_METHOD_ASSOCIATED_OK`)
- multi-module Epistemic instance methods (`ROOT2_MULTIMODULE_METHOD_OK`)
- **same-module inline chain** (`ROOT2_METHOD_CHAIN_OK`)
- **multi-module Epistemic inline chain** (`ROOT2_MULTIMODULE_METHOD_CHAIN_OK`)
- knowledge method residual gate + chain regression

**claims_not_made:**

- full Root-2 census closed
- enum ctor path
- arbitrary-depth method-chain census beyond fixtures
- Wave13 bare-ident / into-acc / global-list / specializer DCE

## Evidence

```bash
bash scripts/madaros_root2_method_gate.sh
# MADAROS_ROOT2_METHOD_GATE_OK

bash scripts/madaros_root2_multimodule_method_gate.sh
# MADAROS_ROOT2_MULTIMODULE_METHOD_GATE_OK

bash scripts/madaros_knowledge_method_residual_gate.sh
# MADAROS_KNOWLEDGE_METHOD_RESIDUAL_GATE_OK
```

Prebuilt `bin/madaros-linux-x86_64` refreshed so stock default is green (pre-fix stock SEGV'd on chain fixtures).

## Test plan

- [x] same-module chain: `E::of(3.0).get()`, `a.add(&b).get()`, `a.add(&b).add(&c).get()`
- [x] multi-mod science path: `Epistemic::certain(1.0).val()`, `a.add(&b).val()`, `a.add(&b).add(&c).val()`, `print(a.add(&b).std())`
- [x] Root-2 method + multimodule + knowledge residual gates green
- [x] no Wave13 file overlap

## Audit

`docs/audit/MADAROS_ROOT2_METHOD_CHAIN_2026-07-21.md`