### PR TITLE
feat(bigframe): two-sample statistical tests (Welch t / Mann-Whitney U / KS / effect sizes), 10 verbs, all win ~24x

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -8,6 +8,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 
 | operation | 1M rows | Sounio ms | pandas ms | Sounio/pandas | before |
 |---|---|---|---|---|---|
+| two-sample tests: welch/cohens_d/glass/pooled_sd/point_biserial + mannwhitney_u/cles/rank_biserial/ks (1M rows, 1000 keys, 2 groups) | | ~18 | ~430 | **0.04x — wins 24x** | one-pass moments / group-split histogram; pandas = scipy + groupby.apply |
 | col_sum (8-accumulator ILP) | | 1.44 | 0.55 | **2.6x** | 3.9x |
 | col_mean (via 8-acc sum) | | 2.05 | 1.00 | **2.1x** | 2.3x |
 | filter_count (`bf_count_gt`, raw scan) | | 1.84 | 0.74 | **2.5x** | 12.1x |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -8765,3 +8765,150 @@ fn bf_group_wmad_dense(src: &BigFrame, key_col: i64, val_col: i64, wt_col: i64, 
 pub fn bf_weighted_mad_dense_by(src: &BigFrame, key_col: i64, val_col: i64, wt_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_wmad_dense(src, key_col, val_col, wt_col, vmax, 1.0, 0) }
 /// Per-group WEIGHTED NORMALIZED MAD (1.4826·wMAD ≈ robust σ) of dense integer values, broadcast. NATIVE + lean_single.
 pub fn bf_weighted_madn_dense_by(src: &BigFrame, key_col: i64, val_col: i64, wt_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_wmad_dense(src, key_col, val_col, wt_col, vmax, 1.0, 1) }
+
+/// Per-group TWO-SAMPLE moment statistics (columns key, group∈{0,1}, value). Per key the two
+/// subgroups (group 0 = control, group 1 = treatment) are compared: n/Σ/Σ² are accumulated per
+/// (key,group) in one pass, then a contrast statistic is broadcast to every row of the key.
+/// Sample variances use ddof=1. modes: 0=mean difference (m1−m0), 1=Welch t, 2=Cohen's d,
+/// 3=Glass's Δ (÷sd of group 0), 4=pooled SD, 5=point-biserial r. Returns 0 for keys missing a
+/// group or with undefined denominators. O(n). NATIVE + lean_single only.
+fn bf_group_twosample_moment(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var n0:  [f64; 1024] = [0.0; 1024]
+    var s0:  [f64; 1024] = [0.0; 1024]
+    var ss0: [f64; 1024] = [0.0; 1024]
+    var n1:  [f64; 1024] = [0.0; 1024]
+    var s1:  [f64; 1024] = [0.0; 1024]
+    var ss1: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || grp_col < 0 || grp_col >= nc || val_col < 0 || val_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let gp = bf_col_ptr(src, grp_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 {
+            let g = read_f64(gp, i) as i64
+            let v = read_f64(vp, i)
+            if g == 1 { n1[k] = n1[k] + 1.0; s1[k] = s1[k] + v; ss1[k] = ss1[k] + v * v }
+            else { if g == 0 { n0[k] = n0[k] + 1.0; s0[k] = s0[k] + v; ss0[k] = ss0[k] + v * v } }
+        }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if n0[g] > 0.0 && n1[g] > 0.0 {
+            let a0 = n0[g]; let a1 = n1[g]
+            let m0 = s0[g] / a0; let m1 = s1[g] / a1
+            let diff = m1 - m0
+            var v0 = 0.0; if a0 > 1.0 { v0 = (ss0[g] - s0[g] * s0[g] / a0) / (a0 - 1.0); if v0 < 0.0 { v0 = 0.0 } }
+            var v1 = 0.0; if a1 > 1.0 { v1 = (ss1[g] - s1[g] * s1[g] / a1) / (a1 - 1.0); if v1 < 0.0 { v1 = 0.0 } }
+            if mode == 0 { res[g] = diff }
+            else { if mode == 1 { let den = bf_sqrt(v1 / a1 + v0 / a0, sc); if den > 0.0 { res[g] = diff / den } }
+            else { if mode == 2 { let dof = a1 + a0 - 2.0; if dof > 0.0 { let psd = bf_sqrt(((a1 - 1.0) * v1 + (a0 - 1.0) * v0) / dof, sc); if psd > 0.0 { res[g] = diff / psd } } }
+            else { if mode == 3 { let sd0 = bf_sqrt(v0, sc); if sd0 > 0.0 { res[g] = diff / sd0 } }
+            else { if mode == 4 { let dof = a1 + a0 - 2.0; if dof > 0.0 { res[g] = bf_sqrt(((a1 - 1.0) * v1 + (a0 - 1.0) * v0) / dof, sc) } }
+            else { let N = a0 + a1; let sT = s0[g] + s1[g]; let ssT = ss0[g] + ss1[g]; var vpop = ssT / N - (sT / N) * (sT / N); if vpop < 0.0 { vpop = 0.0 }; let sdT = bf_sqrt(vpop, sc); if sdT > 0.0 { res[g] = diff / sdT * bf_sqrt(a1 * a0 / (N * N), sc) } } } } } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group MEAN DIFFERENCE (m1 − m0) between the two subgroups, broadcast. NATIVE + lean_single.
+pub fn bf_mean_diff_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_twosample_moment(src, key_col, grp_col, val_col, 0) }
+/// Per-group WELCH t-STATISTIC ((m1−m0)/√(v1/n1+v0/n0), unequal-variance), broadcast. NATIVE + lean_single.
+pub fn bf_ttest_welch_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_twosample_moment(src, key_col, grp_col, val_col, 1) }
+/// Per-group COHEN'S d effect size ((m1−m0)/pooled SD), broadcast. NATIVE + lean_single.
+pub fn bf_cohens_d_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_twosample_moment(src, key_col, grp_col, val_col, 2) }
+/// Per-group GLASS'S Δ effect size ((m1−m0)/sd of the control group 0), broadcast. NATIVE + lean_single.
+pub fn bf_glass_delta_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_twosample_moment(src, key_col, grp_col, val_col, 3) }
+/// Per-group POOLED STANDARD DEVIATION of the two subgroups, broadcast. NATIVE + lean_single.
+pub fn bf_pooled_sd_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_twosample_moment(src, key_col, grp_col, val_col, 4) }
+/// Per-group POINT-BISERIAL CORRELATION between the binary group and the value, broadcast. NATIVE + lean_single.
+pub fn bf_point_biserial_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_twosample_moment(src, key_col, grp_col, val_col, 5) }
+
+/// Per-group TWO-SAMPLE RANK / ECDF statistics (columns key, group∈{0,1}, integer value 0..vmax)
+/// via per-key group-split value histograms. One ascending walk yields the Mann-Whitney U1
+/// (wins + ½·ties over all group1×group0 pairs), the common-language effect size CLES =
+/// U1/(n1·n0), the rank-biserial correlation (2·CLES−1) and the Kolmogorov-Smirnov D
+/// (maxᵥ|ECDF1−ECDF0|). Broadcast. modes 0=U 1=CLES 2=rank-biserial 3=KS. O(n + G·vrange).
+/// NATIVE + lean_single only.
+fn bf_group_twosample_rank(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, vmax: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var n0:  [f64; 1024] = [0.0; 1024]
+    var n1:  [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || grp_col < 0 || grp_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || vmax < 0 { return out }
+    let vm1 = vmax + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let gp = bf_col_ptr(src, grp_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let h0 = heap_alloc(1024 * vm1 * 8) as *mut i64
+    let h1 = heap_alloc(1024 * vm1 * 8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let v = read_f64(vp, i) as i64
+        if k >= 0 && k < 1024 && v >= 0 && v < vm1 {
+            let g = read_f64(gp, i) as i64
+            if g == 1 { let idx = k * vm1 + v; write_i64(h1, idx, read_i64(h1, idx) + 1); n1[k] = n1[k] + 1.0 }
+            else { if g == 0 { let idx = k * vm1 + v; write_i64(h0, idx, read_i64(h0, idx) + 1); n0[k] = n0[k] + 1.0 } }
+        }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if n0[g] > 0.0 && n1[g] > 0.0 {
+            let N0 = n0[g]; let N1 = n1[g]
+            let base = g * vm1
+            var v: i64 = 0
+            var cum0 = 0.0
+            var wins = 0.0
+            var ties = 0.0
+            var c0 = 0.0
+            var c1 = 0.0
+            var ks = 0.0
+            while v < vm1 {
+                let a0 = read_i64(h0, base + v) as f64
+                let a1 = read_i64(h1, base + v) as f64
+                if a1 > 0.0 { wins = wins + a1 * cum0; ties = ties + a1 * a0 }
+                cum0 = cum0 + a0
+                c0 = c0 + a0; c1 = c1 + a1
+                let d = bf_fabs(c1 / N1 - c0 / N0); if d > ks { ks = d }
+                v = v + 1
+            }
+            let U1 = wins + 0.5 * ties
+            if mode == 0 { res[g] = U1 }
+            else { if mode == 1 { res[g] = U1 / (N1 * N0) }
+            else { if mode == 2 { res[g] = 2.0 * U1 / (N1 * N0) - 1.0 }
+            else { res[g] = ks } } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(h0 as *mut i8)
+    heap_free(h1 as *mut i8)
+    out
+}
+/// Per-group MANN-WHITNEY U (U1 = wins + ½·ties for group 1 vs group 0), broadcast. NATIVE + lean_single.
+pub fn bf_mannwhitney_u_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_twosample_rank(src, key_col, grp_col, val_col, vmax, 0) }
+/// Per-group COMMON-LANGUAGE EFFECT SIZE (CLES = P(X₁>X₀) = U1/(n1·n0)), broadcast. NATIVE + lean_single.
+pub fn bf_cles_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_twosample_rank(src, key_col, grp_col, val_col, vmax, 1) }
+/// Per-group RANK-BISERIAL CORRELATION (2·CLES − 1, in [−1,1]), broadcast. NATIVE + lean_single.
+pub fn bf_rank_biserial_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_twosample_rank(src, key_col, grp_col, val_col, vmax, 2) }
+/// Per-group KOLMOGOROV-SMIRNOV D (maxᵥ|ECDF₁−ECDF₀|), broadcast. NATIVE + lean_single.
+pub fn bf_ks_stat_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_twosample_rank(src, key_col, grp_col, val_col, vmax, 3) }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -1968,6 +1968,44 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     if !approx_eq(bf_get(&wmad,0,0), 1.0) { print("FAIL wmad\n"); return 708 }              // wmedian of |v-2|
     let wmadn = bf_weighted_madn_dense_by(&wtf,0,1,2,4)
     if !approx_eq(bf_get(&wmadn,0,0), 1.4826) { print("FAIL wmadn\n"); return 709 }
+    // ===== BATCH 23: two-sample statistical tests (key, group, value) =====
+    // K0 rows 0-6: group0={1,2,3}, group1={4,5,6,7}; K1 rows 7-12: group0={2,2,4}, group1={2,4,4}.
+    var stt = bf_new(3, 16)
+    var st_a:[f64;64]=[0.0;64]; st_a[0]=0.0; st_a[1]=0.0; st_a[2]=1.0; bf_push_row(&!stt,&st_a,3)
+    var st_b:[f64;64]=[0.0;64]; st_b[0]=0.0; st_b[1]=0.0; st_b[2]=2.0; bf_push_row(&!stt,&st_b,3)
+    var st_c:[f64;64]=[0.0;64]; st_c[0]=0.0; st_c[1]=0.0; st_c[2]=3.0; bf_push_row(&!stt,&st_c,3)
+    var st_d:[f64;64]=[0.0;64]; st_d[0]=0.0; st_d[1]=1.0; st_d[2]=4.0; bf_push_row(&!stt,&st_d,3)
+    var st_e:[f64;64]=[0.0;64]; st_e[0]=0.0; st_e[1]=1.0; st_e[2]=5.0; bf_push_row(&!stt,&st_e,3)
+    var st_f:[f64;64]=[0.0;64]; st_f[0]=0.0; st_f[1]=1.0; st_f[2]=6.0; bf_push_row(&!stt,&st_f,3)
+    var st_g:[f64;64]=[0.0;64]; st_g[0]=0.0; st_g[1]=1.0; st_g[2]=7.0; bf_push_row(&!stt,&st_g,3)
+    var st_h:[f64;64]=[0.0;64]; st_h[0]=1.0; st_h[1]=0.0; st_h[2]=2.0; bf_push_row(&!stt,&st_h,3)
+    var st_i:[f64;64]=[0.0;64]; st_i[0]=1.0; st_i[1]=0.0; st_i[2]=2.0; bf_push_row(&!stt,&st_i,3)
+    var st_j:[f64;64]=[0.0;64]; st_j[0]=1.0; st_j[1]=0.0; st_j[2]=4.0; bf_push_row(&!stt,&st_j,3)
+    var st_k:[f64;64]=[0.0;64]; st_k[0]=1.0; st_k[1]=1.0; st_k[2]=2.0; bf_push_row(&!stt,&st_k,3)
+    var st_l:[f64;64]=[0.0;64]; st_l[0]=1.0; st_l[1]=1.0; st_l[2]=4.0; bf_push_row(&!stt,&st_l,3)
+    var st_m:[f64;64]=[0.0;64]; st_m[0]=1.0; st_m[1]=1.0; st_m[2]=4.0; bf_push_row(&!stt,&st_m,3)
+    let mdf2 = bf_mean_diff_by(&stt,0,1,2)
+    if !approx_eq(bf_get(&mdf2,0,0), 3.5) { print("FAIL mean_diff\n"); return 710 }
+    let twe = bf_ttest_welch_by(&stt,0,1,2)
+    if !approx_eq(bf_get(&twe,0,0), 4.04145188) { print("FAIL welch\n"); return 711 }
+    let tcd = bf_cohens_d_by(&stt,0,1,2)
+    if !approx_eq(bf_get(&tcd,0,0), 2.95803989) { print("FAIL cohens_d\n"); return 712 }
+    let tgd = bf_glass_delta_by(&stt,0,1,2)
+    if !approx_eq(bf_get(&tgd,0,0), 3.5) { print("FAIL glass\n"); return 713 }
+    let tps = bf_pooled_sd_by(&stt,0,1,2)
+    if !approx_eq(bf_get(&tps,0,0), 1.18321596) { print("FAIL pooled_sd\n"); return 714 }
+    let tpb = bf_point_biserial_by(&stt,0,1,2)
+    if !approx_eq(bf_get(&tpb,0,0), 0.86602540) { print("FAIL point_biserial\n"); return 715 }
+    let tmu = bf_mannwhitney_u_by(&stt,0,1,2,7)
+    if !approx_eq(bf_get(&tmu,0,0), 12.0) { print("FAIL mwu_k0\n"); return 716 }
+    if !approx_eq(bf_get(&tmu,7,0), 6.0) { print("FAIL mwu_k1\n"); return 717 }        // ties
+    let tcl = bf_cles_by(&stt,0,1,2,7)
+    if !approx_eq(bf_get(&tcl,7,0), 0.66666667) { print("FAIL cles_k1\n"); return 718 }
+    let trb = bf_rank_biserial_by(&stt,0,1,2,7)
+    if !approx_eq(bf_get(&trb,7,0), 0.33333333) { print("FAIL rankbis_k1\n"); return 719 }
+    let tks = bf_ks_stat_by(&stt,0,1,2,7)
+    if !approx_eq(bf_get(&tks,0,0), 1.0) { print("FAIL ks_k0\n"); return 720 }
+    if !approx_eq(bf_get(&tks,7,0), 0.33333333) { print("FAIL ks_k1\n"); return 721 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
New per-group **two-sample test** class (columns key, group∈{0,1}, value). pandas needs scipy + groupby.apply(lambda) → these win **20–25×**.

**Moment-based** (bf_group_twosample_moment): bf_mean_diff_by / bf_ttest_welch_by (unequal-variance t) / bf_cohens_d_by / bf_glass_delta_by / bf_pooled_sd_by / bf_point_biserial_by

**Rank / ECDF** (bf_group_twosample_rank, group-split value histogram): bf_mannwhitney_u_by (U1 = wins + ½ ties) / bf_cles_by (P(X1>X0)) / bf_rank_biserial_by (2·CLES−1) / bf_ks_stat_by (max|ECDF1−ECDF0|)

Mann-Whitney / CLES / KS handle **ties exactly** via the group-split histogram (verified on a key with ties: U1=6, CLES=0.667, KS=0.333). Sample variances ddof=1; point-biserial uses population SD.

| verb | Sounio | pandas 3.0.3 | ratio |
|---|---|---|---|
| welch t | 16 ms | 450 ms | **0.04×** |
| mannwhitney_u | 20 ms | 395 ms | **0.05×** |
| ks | 18 ms | 438 ms | **0.04×** |

**Verified:** gate return codes 710–721 → BIGFRAME_OPS_GATE_OK, exit 0, cross-checked vs numpy (Welch 4.0415, Cohen's d 2.958, pooled_sd 1.1832, point-biserial 0.8660, MWU 12/6, KS 1.0/0.333). Benchmarks reproduced. My 3-file lane.

Generated with Claude Code