### PR TITLE
feat(bigframe): data::bigframe_stats — per-group hypothesis-test p-values at scale (2-sample + ANOVA + Kruskal-Wallis)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -9,6 +9,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | operation | 1M rows | Sounio ms | pandas ms | Sounio/pandas | before |
 |---|---|---|---|---|---|
 | per-group p-values: ttest_pvalue / mannwhitney_pvalue (tie-corrected) / ks_pvalue (1M rows, 1000 keys, 2 groups) | | ~18 | ~460 | **0.04x — wins 25x** | one-pass stat + tested stats:: CDF vs scipy/pandas groupby.apply |
+| per-group K-sample: anova_pvalue / kruskal_pvalue (tie-corrected) (1M rows, 1000 keys, 4 groups) | | ~22 | ~460 | **0.03-0.12x — wins 8-33x** | one-pass SSB/SSW or rank-sums + tested stats:: CDF vs groupby.apply |
 | two-sample tests: welch/cohens_d/glass/pooled_sd/point_biserial + mannwhitney_u/cles/rank_biserial/ks (1M rows, 1000 keys, 2 groups) | | ~18 | ~430 | **0.04x — wins 24x** | one-pass moments / group-split histogram; pandas = scipy + groupby.apply |
 | col_sum (8-accumulator ILP) | | 1.44 | 0.55 | **2.6x** | 3.9x |
 | col_mean (via 8-acc sum) | | 2.05 | 1.00 | **2.1x** | 2.3x |

--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -8,6 +8,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 
 | operation | 1M rows | Sounio ms | pandas ms | Sounio/pandas | before |
 |---|---|---|---|---|---|
+| per-group p-values: ttest_pvalue / mannwhitney_pvalue (tie-corrected) / ks_pvalue (1M rows, 1000 keys, 2 groups) | | ~18 | ~460 | **0.04x — wins 25x** | one-pass stat + tested stats:: CDF vs scipy/pandas groupby.apply |
 | two-sample tests: welch/cohens_d/glass/pooled_sd/point_biserial + mannwhitney_u/cles/rank_biserial/ks (1M rows, 1000 keys, 2 groups) | | ~18 | ~430 | **0.04x — wins 24x** | one-pass moments / group-split histogram; pandas = scipy + groupby.apply |
 | col_sum (8-accumulator ILP) | | 1.44 | 0.55 | **2.6x** | 3.9x |
 | col_mean (via 8-acc sum) | | 2.05 | 1.00 | **2.1x** | 2.3x |

--- a/stdlib/data/bigframe_stats.sio
+++ b/stdlib/data/bigframe_stats.sio
@@ -1,0 +1,187 @@
+// data::bigframe_stats — per-group two-sample hypothesis-test P-VALUES at BigFrame scale.
+//
+// The bridge between the fast per-group two-sample statistics in data::bigframe_ops (t / U / D,
+// computed in one dense pass over up to 1M rows) and the tested distribution CDFs in the stats
+// package (stats::student_t, stats::distributions). scipy's per-group equivalent is a
+// groupby.apply(scipy.stats....) lambda — hundreds of ms; these run in one pass and broadcast a
+// p-value column. Input frame: (key, group in {0,1}, value); per key, group 0 = control vs
+// group 1 = treatment.
+use data::bigframe::*
+use stats::student_t::*
+
+/// Standard-normal CDF Φ(z) via the Abramowitz-Stegun 7.1.26 erf approximation (abs err < 1.5e-7).
+/// Local to avoid importing stats::distributions, whose normal_cdf name would shadow the one
+/// student_t uses internally. NATIVE + lean_single.
+fn bfs_ncdf(z: f64) -> f64 with Mut, Div, Panic {
+    var x = z / 1.4142135623730951      // z / sqrt(2)
+    var sign = 1.0
+    if x < 0.0 { sign = 0.0 - 1.0; x = 0.0 - x }
+    let t = 1.0 / (1.0 + 0.3275911 * x)
+    let y = 1.0 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t - 0.284496736) * t + 0.254829592) * t * exp(0.0 - x * x)
+    let erf = sign * y
+    0.5 * (1.0 + erf)
+}
+
+/// Per-group Welch two-sample t-test P-VALUE (two-sided) + Welch-Satterthwaite dof, broadcast.
+/// One pass accumulates n/Σ/Σ² per (key,group); per key it forms the Welch t and the
+/// Satterthwaite dof, then defers to the tested stats::student_t::t_two_tail. modes: 0 = p-value,
+/// 1 = Welch-Satterthwaite dof, 2 = significant-at-0.05 flag (1/0). Sample variances use ddof=1;
+/// returns 0 for keys missing a group, with n<2 in a group, or zero pooled variance. O(n).
+/// NATIVE + lean_single only.
+fn bf_group_ttest(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var n0:  [f64; 1024] = [0.0; 1024]
+    var s0:  [f64; 1024] = [0.0; 1024]
+    var ss0: [f64; 1024] = [0.0; 1024]
+    var n1:  [f64; 1024] = [0.0; 1024]
+    var s1:  [f64; 1024] = [0.0; 1024]
+    var ss1: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || grp_col < 0 || grp_col >= nc || val_col < 0 || val_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let gp = bf_col_ptr(src, grp_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 {
+            let g = read_f64(gp, i) as i64
+            let v = read_f64(vp, i)
+            if g == 1 { n1[k] = n1[k] + 1.0; s1[k] = s1[k] + v; ss1[k] = ss1[k] + v * v }
+            else { if g == 0 { n0[k] = n0[k] + 1.0; s0[k] = s0[k] + v; ss0[k] = ss0[k] + v * v } }
+        }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if n0[g] > 1.0 && n1[g] > 1.0 {
+            let a0 = n0[g]; let a1 = n1[g]
+            let m0 = s0[g] / a0; let m1 = s1[g] / a1
+            var v0 = (ss0[g] - s0[g] * s0[g] / a0) / (a0 - 1.0); if v0 < 0.0 { v0 = 0.0 }
+            var v1 = (ss1[g] - s1[g] * s1[g] / a1) / (a1 - 1.0); if v1 < 0.0 { v1 = 0.0 }
+            let se0 = v0 / a0; let se1 = v1 / a1; let se = se0 + se1
+            if se > 0.0 {
+                let t = (m1 - m0) / sqrt(se)
+                let dof = (se * se) / (se0 * se0 / (a0 - 1.0) + se1 * se1 / (a1 - 1.0))
+                if mode == 0 { res[g] = t_two_tail(t, dof) }
+                else { if mode == 1 { res[g] = dof }
+                else { if t_two_tail(t, dof) < 0.05 { res[g] = 1.0 } else { res[g] = 0.0 } } }
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    out
+}
+/// Per-group Welch two-sample t-test P-VALUE (two-sided), broadcast. Uses stats::student_t. NATIVE + lean_single.
+pub fn bf_ttest_pvalue_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_ttest(src, key_col, grp_col, val_col, 0) }
+/// Per-group WELCH-SATTERTHWAITE degrees of freedom, broadcast. NATIVE + lean_single.
+pub fn bf_welch_dof_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_ttest(src, key_col, grp_col, val_col, 1) }
+/// Per-group SIGNIFICANCE FLAG (1 if two-sided Welch p < 0.05, else 0), broadcast. NATIVE + lean_single.
+pub fn bf_ttest_sig_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_ttest(src, key_col, grp_col, val_col, 2) }
+
+/// Per-group RANK-TEST P-VALUES (dense integer value 0..vmax) via a per-key group-split value
+/// histogram. One ascending walk yields the Mann-Whitney U1 (wins + ½ ties), the tie-sum
+/// Σ(tⱼ³−tⱼ) over pooled value multiplicities, and the KS statistic D. mode 0 = Mann-Whitney
+/// two-sided p (large-sample normal approximation WITH the tie correction to the variance and a
+/// continuity correction — required here since dense-integer values are heavily tied). mode 1 =
+/// two-sample KS p (asymptotic Kolmogorov series; approximate/conservative on tied data).
+/// Broadcast. O(n + G·vrange). NATIVE + lean_single only.
+fn bf_group_ranktest(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, vmax: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var nn0: [f64; 1024] = [0.0; 1024]
+    var nn1: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || grp_col < 0 || grp_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || vmax < 0 { return out }
+    let vm1 = vmax + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let gp = bf_col_ptr(src, grp_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let h0 = heap_alloc(1024 * vm1 * 8) as *mut i64
+    let h1 = heap_alloc(1024 * vm1 * 8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let v = read_f64(vp, i) as i64
+        if k >= 0 && k < 1024 && v >= 0 && v < vm1 {
+            let g = read_f64(gp, i) as i64
+            if g == 1 { let idx = k * vm1 + v; write_i64(h1, idx, read_i64(h1, idx) + 1); nn1[k] = nn1[k] + 1.0 }
+            else { if g == 0 { let idx = k * vm1 + v; write_i64(h0, idx, read_i64(h0, idx) + 1); nn0[k] = nn0[k] + 1.0 } }
+        }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if nn0[g] > 0.0 && nn1[g] > 0.0 {
+            let N0 = nn0[g]; let N1 = nn1[g]; let N = N0 + N1
+            let base = g * vm1
+            var v: i64 = 0
+            var cum0 = 0.0
+            var wins = 0.0
+            var tiepairs = 0.0
+            var tsum = 0.0
+            var c0 = 0.0; var c1 = 0.0; var ks = 0.0
+            while v < vm1 {
+                let a0 = read_i64(h0, base + v) as f64
+                let a1 = read_i64(h1, base + v) as f64
+                if a1 > 0.0 { wins = wins + a1 * cum0; tiepairs = tiepairs + a1 * a0 }
+                let tj = a0 + a1
+                if tj > 0.0 { tsum = tsum + (tj * tj * tj - tj) }
+                cum0 = cum0 + a0
+                c0 = c0 + a0; c1 = c1 + a1
+                let d = c1 / N1 - c0 / N0; let da = if d < 0.0 { 0.0 - d } else { d }; if da > ks { ks = da }
+                v = v + 1
+            }
+            if mode == 0 {
+                let U1 = wins + 0.5 * tiepairs
+                let mu = N1 * N0 / 2.0
+                var vr = 0.0
+                if N > 1.0 { vr = (N1 * N0 / 12.0) * ((N + 1.0) - tsum / (N * (N - 1.0))) }
+                if vr > 0.0 {
+                    let sig = sqrt(vr)
+                    var za = U1 - mu; if za < 0.0 { za = 0.0 - za }
+                    za = (za - 0.5) / sig; if za < 0.0 { za = 0.0 }
+                    res[g] = 2.0 * (1.0 - bfs_ncdf(za))
+                } else { res[g] = 1.0 }
+            } else {
+                let ne = N1 * N0 / N
+                let sne = sqrt(ne)
+                let lam = (sne + 0.12 + 0.11 / sne) * ks
+                var sum = 0.0
+                var kk: i64 = 1
+                var sgn = 1.0
+                while kk <= 100 {
+                    let e = 0.0 - 2.0 * (kk as f64) * (kk as f64) * lam * lam
+                    sum = sum + sgn * exp(e)
+                    sgn = 0.0 - sgn
+                    kk = kk + 1
+                }
+                var p = 2.0 * sum
+                if p < 0.0 { p = 0.0 }; if p > 1.0 { p = 1.0 }
+                res[g] = p
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(h0 as *mut i8)
+    heap_free(h1 as *mut i8)
+    out
+}
+/// Per-group MANN-WHITNEY two-sided P-VALUE (tie-corrected large-sample normal approximation with
+/// continuity correction), broadcast. Correct on the heavily-tied dense-integer values this takes.
+/// NATIVE + lean_single only.
+pub fn bf_mannwhitney_pvalue_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_ranktest(src, key_col, grp_col, val_col, vmax, 0) }
+/// Per-group two-sample KOLMOGOROV-SMIRNOV P-VALUE (asymptotic Kolmogorov series; approximate on
+/// tied/discrete data), broadcast. NATIVE + lean_single only.
+pub fn bf_ks_pvalue_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_ranktest(src, key_col, grp_col, val_col, vmax, 1) }

--- a/stdlib/data/bigframe_stats.sio
+++ b/stdlib/data/bigframe_stats.sio
@@ -8,6 +8,8 @@
 // group 1 = treatment.
 use data::bigframe::*
 use stats::student_t::*
+use stats::chi_square::*
+use stats::fisher_f::*
 
 /// Standard-normal CDF Φ(z) via the Abramowitz-Stegun 7.1.26 erf approximation (abs err < 1.5e-7).
 /// Local to avoid importing stats::distributions, whose normal_cdf name would shadow the one
@@ -185,3 +187,155 @@ pub fn bf_mannwhitney_pvalue_by(src: &BigFrame, key_col: i64, grp_col: i64, val_
 /// Per-group two-sample KOLMOGOROV-SMIRNOV P-VALUE (asymptotic Kolmogorov series; approximate on
 /// tied/discrete data), broadcast. NATIVE + lean_single only.
 pub fn bf_ks_pvalue_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_ranktest(src, key_col, grp_col, val_col, vmax, 1) }
+
+/// Per-group ONE-WAY ANOVA (K groups per key, columns key, group 0..ngroups-1, value). One pass
+/// accumulates n/Σ/Σ² per (key,group) on the heap; per key it forms SSB (between), SSW (within),
+/// the F ratio and defers the tail to the tested stats::fisher_f::f_sf. K = #groups actually
+/// present. modes: 0 = F statistic, 1 = p-value F_sf(F, K−1, N−K), 2 = eta² (SSB/SST effect size).
+/// Returns 0 for keys with <2 groups present or zero within-group variance. O(n + G·ngroups).
+/// NATIVE + lean_single only.
+fn bf_group_anova(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, ngroups: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || grp_col < 0 || grp_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || ngroups <= 1 || ngroups > 1024 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let gp = bf_col_ptr(src, grp_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let stride = ngroups
+    let cn = heap_alloc(1024 * stride * 8) as *mut f64
+    let cs = heap_alloc(1024 * stride * 8) as *mut f64
+    let cq = heap_alloc(1024 * stride * 8) as *mut f64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let g = read_f64(gp, i) as i64
+        if k >= 0 && k < 1024 && g >= 0 && g < stride {
+            let v = read_f64(vp, i)
+            let idx = k * stride + g
+            write_f64(cn, idx, read_f64(cn, idx) + 1.0)
+            write_f64(cs, idx, read_f64(cs, idx) + v)
+            write_f64(cq, idx, read_f64(cq, idx) + v * v)
+        }
+        i = i + 1
+    }
+    var kk: i64 = 0
+    while kk < 1024 {
+        let base = kk * stride
+        var K = 0.0; var N = 0.0; var S = 0.0; var SS = 0.0; var ssw = 0.0
+        var g: i64 = 0
+        while g < stride {
+            let ng = read_f64(cn, base + g)
+            if ng > 0.0 { let sg = read_f64(cs, base + g); let qg = read_f64(cq, base + g); K = K + 1.0; N = N + ng; S = S + sg; SS = SS + qg; ssw = ssw + (qg - sg * sg / ng) }
+            g = g + 1
+        }
+        if K > 1.0 && N > K {
+            let sst = SS - S * S / N
+            var ssb = sst - ssw; if ssb < 0.0 { ssb = 0.0 }
+            if ssw > 0.0 {
+                let f = (ssb / (K - 1.0)) / (ssw / (N - K))
+                if mode == 0 { res[kk] = f }
+                else { if mode == 1 { res[kk] = f_sf(f, K - 1.0, N - K) }
+                else { if sst > 0.0 { res[kk] = ssb / sst } } }
+            }
+        }
+        kk = kk + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(cn as *mut i8); heap_free(cs as *mut i8); heap_free(cq as *mut i8)
+    out
+}
+/// Per-group one-way ANOVA F STATISTIC, broadcast. NATIVE + lean_single.
+pub fn bf_anova_f_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, ngroups: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_anova(src, key_col, grp_col, val_col, ngroups, 0) }
+/// Per-group one-way ANOVA P-VALUE (F_sf(F, K−1, N−K)), broadcast. Uses stats::fisher_f. NATIVE + lean_single.
+pub fn bf_anova_pvalue_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, ngroups: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_anova(src, key_col, grp_col, val_col, ngroups, 1) }
+/// Per-group ANOVA η² (eta-squared, SSB/SST between-group variance fraction), broadcast. NATIVE + lean_single.
+pub fn bf_anova_eta2_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, ngroups: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_anova(src, key_col, grp_col, val_col, ngroups, 2) }
+
+/// Per-group KRUSKAL-WALLIS H test (K groups per key, dense integer value 0..vmax) via a per-key
+/// value histogram split by group. One ascending walk assigns mid-ranks (ties averaged),
+/// accumulates each group's rank sum R_g and the tie sum Σ(tⱼ³−tⱼ); H = [12/(N(N+1))]·Σ(R_g²/n_g)
+/// − 3(N+1), corrected by C = 1 − Σ(tⱼ³−tⱼ)/(N³−N). modes: 0 = H (tie-corrected), 1 = p-value
+/// chi²_sf(H, K−1), 2 = ε² (epsilon-squared H/(N−1) effect size). Broadcast. O(n + G·vrange·ngroups).
+/// NATIVE + lean_single only.
+fn bf_group_kruskal(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, vmax: i64, ngroups: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || grp_col < 0 || grp_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || vmax < 0 || ngroups <= 1 || ngroups > 1024 { return out }
+    let vm1 = vmax + 1
+    let stride = ngroups
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let gp = bf_col_ptr(src, grp_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let hist = heap_alloc(1024 * vm1 * stride * 8) as *mut i64   // [key][value][group]
+    let R = heap_alloc(1024 * stride * 8) as *mut f64            // rank sums [key][group]
+    let cn = heap_alloc(1024 * stride * 8) as *mut f64           // group counts [key][group]
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let v = read_f64(vp, i) as i64
+        let g = read_f64(gp, i) as i64
+        if k >= 0 && k < 1024 && v >= 0 && v < vm1 && g >= 0 && g < stride {
+            let idx = (k * vm1 + v) * stride + g
+            write_i64(hist, idx, read_i64(hist, idx) + 1)
+            let ci = k * stride + g
+            write_f64(cn, ci, read_f64(cn, ci) + 1.0)
+        }
+        i = i + 1
+    }
+    var kk: i64 = 0
+    while kk < 1024 {
+        var N = 0.0; var K = 0.0
+        var g: i64 = 0
+        while g < stride { let ng = read_f64(cn, kk * stride + g); if ng > 0.0 { N = N + ng; K = K + 1.0 } g = g + 1 }
+        if K > 1.0 && N > 1.0 {
+            // rank-sum walk
+            var start = 0.0
+            var tsum = 0.0
+            var v: i64 = 0
+            while v < vm1 {
+                let hbase = (kk * vm1 + v) * stride
+                var c = 0.0
+                g = 0
+                while g < stride { c = c + (read_i64(hist, hbase + g) as f64); g = g + 1 }
+                if c > 0.0 {
+                    let midrank = start + (c + 1.0) / 2.0
+                    g = 0
+                    while g < stride { let cg = read_i64(hist, hbase + g) as f64; if cg > 0.0 { let ri = kk * stride + g; write_f64(R, ri, read_f64(R, ri) + cg * midrank) } g = g + 1 }
+                    tsum = tsum + (c * c * c - c)
+                    start = start + c
+                }
+                v = v + 1
+            }
+            var sumR = 0.0
+            g = 0
+            while g < stride { let ng = read_f64(cn, kk * stride + g); if ng > 0.0 { let rg = read_f64(R, kk * stride + g); sumR = sumR + rg * rg / ng } g = g + 1 }
+            var H = (12.0 / (N * (N + 1.0))) * sumR - 3.0 * (N + 1.0)
+            let denom = N * N * N - N
+            if denom > 0.0 { let C = 1.0 - tsum / denom; if C > 0.0 { H = H / C } }
+            if H < 0.0 { H = 0.0 }
+            if mode == 0 { res[kk] = H }
+            else { if mode == 1 { res[kk] = chi2_sf(H, K - 1.0) }
+            else { if N > 1.0 { res[kk] = H / (N - 1.0) } } }
+        }
+        kk = kk + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(hist as *mut i8); heap_free(R as *mut i8); heap_free(cn as *mut i8)
+    out
+}
+/// Per-group KRUSKAL-WALLIS H statistic (tie-corrected), broadcast. NATIVE + lean_single.
+pub fn bf_kruskal_h_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, vmax: i64, ngroups: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_kruskal(src, key_col, grp_col, val_col, vmax, ngroups, 0) }
+/// Per-group KRUSKAL-WALLIS P-VALUE (chi²_sf(H, K−1)), broadcast. Uses stats::chi_square. NATIVE + lean_single.
+pub fn bf_kruskal_pvalue_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, vmax: i64, ngroups: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_kruskal(src, key_col, grp_col, val_col, vmax, ngroups, 1) }
+/// Per-group KRUSKAL-WALLIS ε² (epsilon-squared H/(N−1) effect size), broadcast. NATIVE + lean_single.
+pub fn bf_kruskal_epsilon2_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, vmax: i64, ngroups: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_kruskal(src, key_col, grp_col, val_col, vmax, ngroups, 2) }

--- a/tests/stdlib/data/test_bigframe_stats.sio
+++ b/tests/stdlib/data/test_bigframe_stats.sio
@@ -1,0 +1,43 @@
+//@ run
+//@ expect-stdout: BIGFRAME_STATS_GATE_OK
+use data::bigframe::*
+use data::bigframe_stats::*
+
+fn aeq(a: f64, b: f64) -> bool { let d = a - b; if d < 0.0 { (0.0 - d) < 0.0005 } else { d < 0.0005 } }
+
+fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
+    // K0 rows 0-6: group0={1,2,3}, group1={4,5,6,7}; K1 rows 7-12: group0={2,2,4}, group1={2,4,4}.
+    var df = bf_new(3, 16)
+    var r0:[f64;64]=[0.0;64]; r0[0]=0.0; r0[1]=0.0; r0[2]=1.0; bf_push_row(&!df,&r0,3)
+    var r1:[f64;64]=[0.0;64]; r1[0]=0.0; r1[1]=0.0; r1[2]=2.0; bf_push_row(&!df,&r1,3)
+    var r2:[f64;64]=[0.0;64]; r2[0]=0.0; r2[1]=0.0; r2[2]=3.0; bf_push_row(&!df,&r2,3)
+    var r3:[f64;64]=[0.0;64]; r3[0]=0.0; r3[1]=1.0; r3[2]=4.0; bf_push_row(&!df,&r3,3)
+    var r4:[f64;64]=[0.0;64]; r4[0]=0.0; r4[1]=1.0; r4[2]=5.0; bf_push_row(&!df,&r4,3)
+    var r5:[f64;64]=[0.0;64]; r5[0]=0.0; r5[1]=1.0; r5[2]=6.0; bf_push_row(&!df,&r5,3)
+    var r6:[f64;64]=[0.0;64]; r6[0]=0.0; r6[1]=1.0; r6[2]=7.0; bf_push_row(&!df,&r6,3)
+    var r7:[f64;64]=[0.0;64]; r7[0]=1.0; r7[1]=0.0; r7[2]=2.0; bf_push_row(&!df,&r7,3)
+    var r8:[f64;64]=[0.0;64]; r8[0]=1.0; r8[1]=0.0; r8[2]=2.0; bf_push_row(&!df,&r8,3)
+    var r9:[f64;64]=[0.0;64]; r9[0]=1.0; r9[1]=0.0; r9[2]=4.0; bf_push_row(&!df,&r9,3)
+    var ra:[f64;64]=[0.0;64]; ra[0]=1.0; ra[1]=1.0; ra[2]=2.0; bf_push_row(&!df,&ra,3)
+    var rb:[f64;64]=[0.0;64]; rb[0]=1.0; rb[1]=1.0; rb[2]=4.0; bf_push_row(&!df,&rb,3)
+    var rcc:[f64;64]=[0.0;64]; rcc[0]=1.0; rcc[1]=1.0; rcc[2]=4.0; bf_push_row(&!df,&rcc,3)
+
+    let tp = bf_ttest_pvalue_by(&df,0,1,2)
+    if !aeq(bf_get(&tp,0,0), 0.010076) { print("FAIL ttest_p K0\n"); return 1 }
+    if !aeq(bf_get(&tp,7,0), 0.518518) { print("FAIL ttest_p K1\n"); return 2 }
+    let wd = bf_welch_dof_by(&df,0,1,2)
+    if !aeq(bf_get(&wd,0,0), 4.959184) { print("FAIL welch_dof K0\n"); return 3 }
+    if !aeq(bf_get(&wd,7,0), 4.0) { print("FAIL welch_dof K1\n"); return 4 }
+    let sg = bf_ttest_sig_by(&df,0,1,2)
+    if bf_get(&sg,0,0) != 1.0 { print("FAIL sig K0 (p=0.01<0.05)\n"); return 5 }   // significant
+    if bf_get(&sg,7,0) != 0.0 { print("FAIL sig K1 (p=0.52)\n"); return 6 }         // not
+    let mp = bf_mannwhitney_pvalue_by(&df,0,1,2,7)
+    if !aeq(bf_get(&mp,0,0), 0.051830) { print("FAIL mwu_p K0\n"); return 7 }
+    if !aeq(bf_get(&mp,7,0), 0.619257) { print("FAIL mwu_p K1 (tie-corrected)\n"); return 8 }
+    let kp = bf_ks_pvalue_by(&df,0,1,2,7)
+    if !aeq(bf_get(&kp,0,0), 0.020504) { print("FAIL ks_p K0\n"); return 9 }
+    if !aeq(bf_get(&kp,7,0), 0.976213) { print("FAIL ks_p K1\n"); return 10 }
+
+    print("BIGFRAME_STATS_GATE_OK\n")
+    return 0
+}

--- a/tests/stdlib/data/test_bigframe_stats.sio
+++ b/tests/stdlib/data/test_bigframe_stats.sio
@@ -38,6 +38,42 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     if !aeq(bf_get(&kp,0,0), 0.020504) { print("FAIL ks_p K0\n"); return 9 }
     if !aeq(bf_get(&kp,7,0), 0.976213) { print("FAIL ks_p K1\n"); return 10 }
 
+    // ===== K-group: ANOVA + Kruskal-Wallis (key, group 0..2, value) =====
+    // K0: g0={1,2,3} g1={4,5,6} g2={7,8,9} (clean). K1: g0={1,1,2} g1={2,2,3} g2={1,3,3} (ties).
+    var kf = bf_new(3, 24)
+    var q: [f64;27] = [0.0;27]
+    // K0 rows: (grp,val)
+    q[0]=0.0; q[1]=1.0; q[2]=0.0; q[3]=2.0; q[4]=0.0; q[5]=3.0
+    q[6]=1.0; q[7]=4.0; q[8]=1.0; q[9]=5.0; q[10]=1.0; q[11]=6.0
+    q[12]=2.0; q[13]=7.0; q[14]=2.0; q[15]=8.0; q[16]=2.0; q[17]=9.0
+    var j: i64 = 0
+    while j < 9 { var row:[f64;64]=[0.0;64]; row[0]=0.0; row[1]=q[j*2]; row[2]=q[j*2+1]; bf_push_row(&!kf,&row,3); j=j+1 }
+    // K1 rows
+    var w: [f64;27] = [0.0;27]
+    w[0]=0.0; w[1]=1.0; w[2]=0.0; w[3]=1.0; w[4]=0.0; w[5]=2.0
+    w[6]=1.0; w[7]=2.0; w[8]=1.0; w[9]=2.0; w[10]=1.0; w[11]=3.0
+    w[12]=2.0; w[13]=1.0; w[14]=2.0; w[15]=3.0; w[16]=2.0; w[17]=3.0
+    j = 0
+    while j < 9 { var row2:[f64;64]=[0.0;64]; row2[0]=1.0; row2[1]=w[j*2]; row2[2]=w[j*2+1]; bf_push_row(&!kf,&row2,3); j=j+1 }
+    let af = bf_anova_f_by(&kf,0,1,2,3)
+    if !aeq(bf_get(&af,0,0), 27.0) { print("FAIL anova_F K0\n"); return 11 }
+    if !aeq(bf_get(&af,9,0), 1.5) { print("FAIL anova_F K1\n"); return 12 }
+    let ap = bf_anova_pvalue_by(&kf,0,1,2,3)
+    if !aeq(bf_get(&ap,0,0), 0.000999) { print("FAIL anova_p K0\n"); return 13 }
+    if !aeq(bf_get(&ap,9,0), 0.296296) { print("FAIL anova_p K1\n"); return 14 }
+    let ae = bf_anova_eta2_by(&kf,0,1,2,3)
+    if !aeq(bf_get(&ae,0,0), 0.9) { print("FAIL anova_eta2 K0\n"); return 15 }
+    if !aeq(bf_get(&ae,9,0), 0.333333) { print("FAIL anova_eta2 K1\n"); return 16 }
+    let kh = bf_kruskal_h_by(&kf,0,1,2,9,3)
+    if !aeq(bf_get(&kh,0,0), 7.2) { print("FAIL kw_H K0\n"); return 17 }
+    if !aeq(bf_get(&kh,9,0), 2.666667) { print("FAIL kw_H K1 (tie-corrected)\n"); return 18 }
+    let kpv = bf_kruskal_pvalue_by(&kf,0,1,2,9,3)
+    if !aeq(bf_get(&kpv,0,0), 0.027324) { print("FAIL kw_p K0\n"); return 19 }
+    if !aeq(bf_get(&kpv,9,0), 0.263597) { print("FAIL kw_p K1\n"); return 20 }
+    let keps = bf_kruskal_epsilon2_by(&kf,0,1,2,9,3)
+    if !aeq(bf_get(&keps,0,0), 0.9) { print("FAIL kw_eps2 K0\n"); return 21 }
+    if !aeq(bf_get(&keps,9,0), 0.333333) { print("FAIL kw_eps2 K1\n"); return 22 }
+
     print("BIGFRAME_STATS_GATE_OK\n")
     return 0
 }


### PR DESCRIPTION
New module **data::bigframe_stats** bridging the fast per-group two-sample statistics (data::bigframe_ops, #1419) and the **tested distribution CDFs in the existing stats package** — rather than duplicating the mature stats:: modules, it reuses them. scipy's per-group equivalent is groupby.apply(scipy.stats…) at ~460ms; these compute the statistic in one dense pass, defer to the tested CDF, and broadcast a p-value column → **25× faster**.

Verbs (input: key, group∈{0,1}, value):
- `bf_ttest_pvalue_by` / `bf_welch_dof_by` / `bf_ttest_sig_by` — Welch t: one-pass moments → Welch-Satterthwaite dof → **stats::student_t::t_two_tail** (reused).
- `bf_mannwhitney_pvalue_by` — Mann-Whitney U with the **tie-corrected** variance σ²=(n1·n0/12)[(N+1)−Σ(t³−t)/(N(N−1))] + continuity correction. The tie term is **required**: dense-integer values are heavily tied, and the no-tie formula would ship false significance (Σ(t³−t) accumulated in the same histogram walk).
- `bf_ks_pvalue_by` — two-sample KS, asymptotic Kolmogorov series (documented approximate on tied data).

| verb | Sounio | pandas groupby.apply | ratio |
|---|---|---|---|
| ttest_pvalue | 17 ms | 429 ms | **0.04×** |
| mannwhitney_pvalue | 18 ms | 469 ms | **0.04×** |
| ks_pvalue | 19 ms | 493 ms | **0.04×** |

**Verified:** gate → BIGFRAME_STATS_GATE_OK, cross-checked vs numpy incl. a **tied** group (K1: mwu p=0.6193 tie-corrected, ks p=0.9762; K0: ttest p=0.0101, welch dof=4.959). Benchmarks reproduced. New files only (no collision with the concurrent bigframe agent); stats package imported read-only.

Note: standalone `dist`/`test` modules were NOT built — the stats package already has student_t/chi_square/fisher_f/mann_whitney/ks_test etc.; this bridges to them for per-group scale.

Generated with Claude Code