### PR TITLE
feat(bigframe): per-group correlation inference — Pearson (r/p/Fisher-CI) + Spearman (rho/p)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -10,6 +10,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 |---|---|---|---|---|---|
 | per-group p-values: ttest_pvalue / mannwhitney_pvalue (tie-corrected) / ks_pvalue (1M rows, 1000 keys, 2 groups) | | ~18 | ~460 | **0.04x — wins 25x** | one-pass stat + tested stats:: CDF vs scipy/pandas groupby.apply |
 | per-group K-sample: anova_pvalue / kruskal_pvalue (tie-corrected) (1M rows, 1000 keys, 4 groups) | | ~22 | ~460 | **0.03-0.12x — wins 8-33x** | one-pass SSB/SSW or rank-sums + tested stats:: CDF vs groupby.apply |
+| per-group correlation inference: pearson_pvalue / pearson CI (Fisher z) / spearman_rho+p (1M rows, 1000 keys, 2 cols) | | ~20-41 | ~150-267 | **0.13-0.15x — wins 7-8x** | one-pass co-moments (Pearson) or rank-LUT co-moment (Spearman) + t_two_tail vs groupby.apply |
 | two-sample tests: welch/cohens_d/glass/pooled_sd/point_biserial + mannwhitney_u/cles/rank_biserial/ks (1M rows, 1000 keys, 2 groups) | | ~18 | ~430 | **0.04x — wins 24x** | one-pass moments / group-split histogram; pandas = scipy + groupby.apply |
 | col_sum (8-accumulator ILP) | | 1.44 | 0.55 | **2.6x** | 3.9x |
 | col_mean (via 8-acc sum) | | 2.05 | 1.00 | **2.1x** | 2.3x |

--- a/stdlib/data/bigframe_stats.sio
+++ b/stdlib/data/bigframe_stats.sio
@@ -339,3 +339,172 @@ pub fn bf_kruskal_h_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64,
 pub fn bf_kruskal_pvalue_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, vmax: i64, ngroups: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_kruskal(src, key_col, grp_col, val_col, vmax, ngroups, 1) }
 /// Per-group KRUSKAL-WALLIS ε² (epsilon-squared H/(N−1) effect size), broadcast. NATIVE + lean_single.
 pub fn bf_kruskal_epsilon2_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, vmax: i64, ngroups: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_kruskal(src, key_col, grp_col, val_col, vmax, ngroups, 2) }
+
+/// Newton sqrt with a bit-trick seed (the builtin sqrt is wrong for args > ~1e6, and the Pearson
+/// denominator reaches ~1e10 at 1M-row scale). Needs a scratch i64 `sc`. NATIVE + lean_single.
+fn bfs_sqrt(x: f64, sc: *mut i64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    let b = f64_to_bits(x)
+    let seed = (b + 4607182418800017408) >> 1
+    write_i64(sc, 0, seed)
+    var y = read_f64(sc as *mut f64, 0)
+    if y < 0.0 { y = 0.0 - y }
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y
+}
+
+/// Per-group PEARSON CORRELATION inference (columns key, x, y). One pass accumulates the
+/// co-moments n/Σx/Σy/Σx²/Σy²/Σxy; per key it forms r and, via the exact t-transform and Fisher
+/// z, its p-value and 95% CI. modes: 0 = r, 1 = two-sided p (t = r·√((n−2)/(1−r²)), df=n−2, via
+/// stats::student_t::t_two_tail), 2 = CI lower, 3 = CI upper (Fisher z ± 1.96/√(n−3), back-tanh).
+/// Returns 0 for keys with n<3 (n<4 for CI) or a degenerate column. O(n). NATIVE + lean_single.
+fn bf_group_pearson(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cn:  [f64; 1024] = [0.0; 1024]
+    var sx:  [f64; 1024] = [0.0; 1024]
+    var sy:  [f64; 1024] = [0.0; 1024]
+    var sxx: [f64; 1024] = [0.0; 1024]
+    var syy: [f64; 1024] = [0.0; 1024]
+    var sxy: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || x_col < 0 || x_col >= nc || y_col < 0 || y_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let xp = bf_col_ptr(src, x_col) as *mut f64
+    let yp = bf_col_ptr(src, y_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 { let x = read_f64(xp, i); let y = read_f64(yp, i); cn[k] = cn[k] + 1.0; sx[k] = sx[k] + x; sy[k] = sy[k] + y; sxx[k] = sxx[k] + x * x; syy[k] = syy[k] + y * y; sxy[k] = sxy[k] + x * y }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        let m = cn[g]
+        if m > 2.0 {
+            let dx = m * sxx[g] - sx[g] * sx[g]
+            let dy = m * syy[g] - sy[g] * sy[g]
+            if dx > 0.0 && dy > 0.0 {
+                var r = (m * sxy[g] - sx[g] * sy[g]) / bfs_sqrt(dx * dy, sc)
+                if r > 1.0 { r = 1.0 }; if r < 0.0 - 1.0 { r = 0.0 - 1.0 }
+                if mode == 0 { res[g] = r }
+                else { if mode == 1 {
+                    if r > 0.0 - 1.0 && r < 1.0 { let t = r * bfs_sqrt((m - 2.0) / (1.0 - r * r), sc); res[g] = t_two_tail(t, m - 2.0) }
+                } else {
+                    if m > 3.0 && r > 0.0 - 1.0 && r < 1.0 {
+                        let zf = 0.5 * ln((1.0 + r) / (1.0 - r))
+                        let se = 1.0 / bfs_sqrt(m - 3.0, sc)
+                        var zc = zf - 1.959963985 * se
+                        if mode == 3 { zc = zf + 1.959963985 * se }
+                        let e2 = exp(2.0 * zc)
+                        res[g] = (e2 - 1.0) / (e2 + 1.0)
+                    }
+                } }
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group PEARSON r, broadcast. NATIVE + lean_single.
+pub fn bf_pearson_r_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_pearson(src, key_col, x_col, y_col, 0) }
+/// Per-group PEARSON two-sided P-VALUE, broadcast. Uses stats::student_t. NATIVE + lean_single.
+pub fn bf_pearson_pvalue_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_pearson(src, key_col, x_col, y_col, 1) }
+/// Per-group PEARSON 95% CI LOWER bound (Fisher z), broadcast. NATIVE + lean_single.
+pub fn bf_pearson_ci_lo_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_pearson(src, key_col, x_col, y_col, 2) }
+/// Per-group PEARSON 95% CI UPPER bound (Fisher z), broadcast. NATIVE + lean_single.
+pub fn bf_pearson_ci_hi_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_pearson(src, key_col, x_col, y_col, 3) }
+
+/// Per-group SPEARMAN RANK CORRELATION inference (columns key, integer x/y in 0..vmax). Per key,
+/// value histograms of x and y give mid-rank lookup tables (ties averaged); a co-moment pass over
+/// the row ranks yields ρ = Pearson-on-ranks. modes: 0 = ρ, 1 = two-sided p (t = ρ·√((n−2)/(1−ρ²)),
+/// df=n−2, via stats::student_t::t_two_tail). Broadcast. O(n + G·vrange). NATIVE + lean_single only.
+fn bf_group_spearman(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, vmax: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cn:  [f64; 1024] = [0.0; 1024]
+    var srx: [f64; 1024] = [0.0; 1024]
+    var sry: [f64; 1024] = [0.0; 1024]
+    var sxx: [f64; 1024] = [0.0; 1024]
+    var syy: [f64; 1024] = [0.0; 1024]
+    var sxy: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || x_col < 0 || x_col >= nc || y_col < 0 || y_col >= nc || n <= 0 || vmax < 0 { return out }
+    let vm1 = vmax + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let xp = bf_col_ptr(src, x_col) as *mut f64
+    let yp = bf_col_ptr(src, y_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    let hx = heap_alloc(1024 * vm1 * 8) as *mut i64
+    let hy = heap_alloc(1024 * vm1 * 8) as *mut i64
+    let mrx = heap_alloc(1024 * vm1 * 8) as *mut f64
+    let mry = heap_alloc(1024 * vm1 * 8) as *mut f64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let x = read_f64(xp, i) as i64
+        let y = read_f64(yp, i) as i64
+        if k >= 0 && k < 1024 && x >= 0 && x < vm1 && y >= 0 && y < vm1 { let ix = k * vm1 + x; write_i64(hx, ix, read_i64(hx, ix) + 1); let iy = k * vm1 + y; write_i64(hy, iy, read_i64(hy, iy) + 1); cn[k] = cn[k] + 1.0 }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if cn[g] > 0.0 {
+            let base = g * vm1
+            var sxr = 0.0; var v: i64 = 0
+            while v < vm1 { let c = read_i64(hx, base + v) as f64; if c > 0.0 { write_f64(mrx, base + v, sxr + (c + 1.0) / 2.0); sxr = sxr + c } v = v + 1 }
+            var syr = 0.0; v = 0
+            while v < vm1 { let c = read_i64(hy, base + v) as f64; if c > 0.0 { write_f64(mry, base + v, syr + (c + 1.0) / 2.0); syr = syr + c } v = v + 1 }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let x = read_f64(xp, i) as i64
+        let y = read_f64(yp, i) as i64
+        if k >= 0 && k < 1024 && x >= 0 && x < vm1 && y >= 0 && y < vm1 {
+            let rx = read_f64(mrx, k * vm1 + x); let ry = read_f64(mry, k * vm1 + y)
+            srx[k] = srx[k] + rx; sry[k] = sry[k] + ry; sxx[k] = sxx[k] + rx * rx; syy[k] = syy[k] + ry * ry; sxy[k] = sxy[k] + rx * ry
+        }
+        i = i + 1
+    }
+    g = 0
+    while g < 1024 {
+        let m = cn[g]
+        if m > 2.0 {
+            let dx = m * sxx[g] - srx[g] * srx[g]
+            let dy = m * syy[g] - sry[g] * sry[g]
+            if dx > 0.0 && dy > 0.0 {
+                var rho = (m * sxy[g] - srx[g] * sry[g]) / bfs_sqrt(dx * dy, sc)
+                if rho > 1.0 { rho = 1.0 }; if rho < 0.0 - 1.0 { rho = 0.0 - 1.0 }
+                if mode == 0 { res[g] = rho }
+                else { if rho > 0.0 - 1.0 && rho < 1.0 { let t = rho * bfs_sqrt((m - 2.0) / (1.0 - rho * rho), sc); res[g] = t_two_tail(t, m - 2.0) } }
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(sc as *mut i8); heap_free(hx as *mut i8); heap_free(hy as *mut i8); heap_free(mrx as *mut i8); heap_free(mry as *mut i8)
+    out
+}
+/// Per-group SPEARMAN ρ (rank correlation), broadcast. NATIVE + lean_single.
+pub fn bf_spearman_rho_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_spearman(src, key_col, x_col, y_col, vmax, 0) }
+/// Per-group SPEARMAN two-sided P-VALUE (t-approximation), broadcast. Uses stats::student_t. NATIVE + lean_single.
+pub fn bf_spearman_pvalue_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_spearman(src, key_col, x_col, y_col, vmax, 1) }

--- a/tests/stdlib/data/test_bigframe_stats.sio
+++ b/tests/stdlib/data/test_bigframe_stats.sio
@@ -74,6 +74,29 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     if !aeq(bf_get(&keps,0,0), 0.9) { print("FAIL kw_eps2 K0\n"); return 21 }
     if !aeq(bf_get(&keps,9,0), 0.333333) { print("FAIL kw_eps2 K1\n"); return 22 }
 
+    // ===== correlation inference: Pearson (r/p/CI) + Spearman (rho/p) =====
+    // K0 x={1,2,3,4,5} y={1,2,4,16,8}; K1(ties) x={1,2,3,4} y={5,5,7,9}. vmax=16.
+    var cf = bf_new(3, 16)
+    var cx: [f64;10] = [1.0,2.0,3.0,4.0,5.0,1.0,2.0,3.0,4.0,0.0]
+    var cy: [f64;10] = [1.0,2.0,4.0,16.0,8.0,5.0,5.0,7.0,9.0,0.0]
+    var ck: [f64;10] = [0.0,0.0,0.0,0.0,0.0,1.0,1.0,1.0,1.0,0.0]
+    var j: i64 = 0
+    while j < 9 { var row:[f64;64]=[0.0;64]; row[0]=ck[j]; row[1]=cx[j]; row[2]=cy[j]; bf_push_row(&!cf,&row,3); j=j+1 }
+    let pr = bf_pearson_r_by(&cf,0,1,2)
+    if !aeq(bf_get(&pr,0,0), 0.725866) { print("FAIL pearson_r K0\n"); return 23 }
+    if !aeq(bf_get(&pr,5,0), 0.943880) { print("FAIL pearson_r K1\n"); return 24 }
+    let pp = bf_pearson_pvalue_by(&cf,0,1,2)
+    if !aeq(bf_get(&pp,0,0), 0.165019) { print("FAIL pearson_p K0\n"); return 25 }
+    let plo = bf_pearson_ci_lo_by(&cf,0,1,2)
+    if !aeq(bf_get(&plo,0,0), 0.0 - 0.434937) { print("FAIL pearson_ci_lo K0\n"); return 26 }
+    let phi = bf_pearson_ci_hi_by(&cf,0,1,2)
+    if !aeq(bf_get(&phi,0,0), 0.980325) { print("FAIL pearson_ci_hi K0\n"); return 27 }
+    let sr = bf_spearman_rho_by(&cf,0,1,2,16)
+    if !aeq(bf_get(&sr,0,0), 0.9) { print("FAIL spearman_rho K0\n"); return 28 }
+    if !aeq(bf_get(&sr,5,0), 0.948683) { print("FAIL spearman_rho K1 (ties)\n"); return 29 }
+    let sp = bf_spearman_pvalue_by(&cf,0,1,2,16)
+    if !aeq(bf_get(&sp,0,0), 0.037383) { print("FAIL spearman_p K0\n"); return 30 }
+
     print("BIGFRAME_STATS_GATE_OK\n")
     return 0
 }


### PR DESCRIPTION
Extends **data::bigframe_stats** to correlation inference (columns key, x, y), reusing stats::student_t::t_two_tail.

**Pearson** (bf_group_pearson, one-pass co-moments): `bf_pearson_r_by` / `bf_pearson_pvalue_by` (t=r√((n−2)/(1−r²)), df=n−2) / `bf_pearson_ci_lo_by` / `bf_pearson_ci_hi_by` (95% Fisher-z CI).

**Spearman** (bf_group_spearman, per-key x/y histograms → mid-rank LUTs → rank co-moment): `bf_spearman_rho_by` (ties averaged) / `bf_spearman_pvalue_by`.

Inlines a Newton `bfs_sqrt` — builtin sqrt is wrong for args > ~1e6 and the Pearson denominator hits ~1e10 at scale (verified sqrt(1e12)=1279996). Fisher CI uses builtin ln/exp (verified accurate).

| verb | Sounio | pandas groupby.apply | ratio |
|---|---|---|---|
| pearson_pvalue | 20 ms | 149 ms | **0.13×** |
| spearman_rho | 41 ms | 267 ms | **0.15×** |

**Verified:** gate 23–30 vs numpy incl. a **tied** key (Spearman ρ=0.9487 mid-ranks): pearson r=0.7259 p=0.1650 CI[−0.4349,0.9803]; spearman ρ=0.9 p=0.0374. Benchmarks reproduced. Appends to bigframe_stats.sio (my bridge lane); stats package imported read-only.

Generated with Claude Code