### PR TITLE
feat(bigframe): per-group OLS regression + one-sample inference (SE / p-values / CIs / F-test)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -11,6 +11,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | per-group p-values: ttest_pvalue / mannwhitney_pvalue (tie-corrected) / ks_pvalue (1M rows, 1000 keys, 2 groups) | | ~18 | ~460 | **0.04x — wins 25x** | one-pass stat + tested stats:: CDF vs scipy/pandas groupby.apply |
 | per-group K-sample: anova_pvalue / kruskal_pvalue (tie-corrected) (1M rows, 1000 keys, 4 groups) | | ~22 | ~460 | **0.03-0.12x — wins 8-33x** | one-pass SSB/SSW or rank-sums + tested stats:: CDF vs groupby.apply |
 | per-group correlation inference: pearson_pvalue / pearson CI (Fisher z) / spearman_rho+p (1M rows, 1000 keys, 2 cols) | | ~20-41 | ~150-267 | **0.13-0.15x — wins 7-8x** | one-pass co-moments (Pearson) or rank-LUT co-moment (Spearman) + t_two_tail vs groupby.apply |
+| per-group OLS inference: slope/intercept SE+p-value, F-test p, slope 95% CI (1M rows, 1000 keys) | | ~21 | ~92 | **0.23x — wins 4.4x** | one-pass co-moments + t_two_tail/f_sf/t_quantile vs groupby.apply linregress |
 | two-sample tests: welch/cohens_d/glass/pooled_sd/point_biserial + mannwhitney_u/cles/rank_biserial/ks (1M rows, 1000 keys, 2 groups) | | ~18 | ~430 | **0.04x — wins 24x** | one-pass moments / group-split histogram; pandas = scipy + groupby.apply |
 | col_sum (8-accumulator ILP) | | 1.44 | 0.55 | **2.6x** | 3.9x |
 | col_mean (via 8-acc sum) | | 2.05 | 1.00 | **2.1x** | 2.3x |

--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -12,6 +12,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | per-group K-sample: anova_pvalue / kruskal_pvalue (tie-corrected) (1M rows, 1000 keys, 4 groups) | | ~22 | ~460 | **0.03-0.12x — wins 8-33x** | one-pass SSB/SSW or rank-sums + tested stats:: CDF vs groupby.apply |
 | per-group correlation inference: pearson_pvalue / pearson CI (Fisher z) / spearman_rho+p (1M rows, 1000 keys, 2 cols) | | ~20-41 | ~150-267 | **0.13-0.15x — wins 7-8x** | one-pass co-moments (Pearson) or rank-LUT co-moment (Spearman) + t_two_tail vs groupby.apply |
 | per-group OLS inference: slope/intercept SE+p-value, F-test p, slope 95% CI (1M rows, 1000 keys) | | ~21 | ~92 | **0.23x — wins 4.4x** | one-pass co-moments + t_two_tail/f_sf/t_quantile vs groupby.apply linregress |
+| per-group one-sample inference: mean 95% CI + one-sample t-test (1M rows, 1000 keys) | | ~16 | ~89 | **0.18x — wins 5.5x** | one-pass mean/SD + t_quantile/t_two_tail vs groupby.apply |
 | two-sample tests: welch/cohens_d/glass/pooled_sd/point_biserial + mannwhitney_u/cles/rank_biserial/ks (1M rows, 1000 keys, 2 groups) | | ~18 | ~430 | **0.04x — wins 24x** | one-pass moments / group-split histogram; pandas = scipy + groupby.apply |
 | col_sum (8-accumulator ILP) | | 1.44 | 0.55 | **2.6x** | 3.9x |
 | col_mean (via 8-acc sum) | | 2.05 | 1.00 | **2.1x** | 2.3x |

--- a/stdlib/data/bigframe_stats.sio
+++ b/stdlib/data/bigframe_stats.sio
@@ -508,3 +508,79 @@ fn bf_group_spearman(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, vmax:
 pub fn bf_spearman_rho_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_spearman(src, key_col, x_col, y_col, vmax, 0) }
 /// Per-group SPEARMAN two-sided P-VALUE (t-approximation), broadcast. Uses stats::student_t. NATIVE + lean_single.
 pub fn bf_spearman_pvalue_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_spearman(src, key_col, x_col, y_col, vmax, 1) }
+
+/// Per-group SIMPLE OLS REGRESSION inference (columns key, x, y): fits y = a + b·x per key in one
+/// co-moment pass and reports the standard errors, t-tests, F-test and CI that scipy.stats.linregress
+/// gives. Sxx/Syy/Sxy are the centred sums; MSE = SSE/(n−2). modes: 0 = slope SE, 1 = slope p-value
+/// (t = b/SE(b), df=n−2), 2 = intercept SE, 3 = intercept p-value, 4 = overall F-test p-value
+/// (f_sf(t_slope², 1, n−2)), 5 = slope 95% CI lower, 6 = slope 95% CI upper (b ± t_.975·SE). Uses the
+/// tested stats::student_t / stats::fisher_f. Returns 0 for keys with n<3 or zero x-variance.
+/// O(n). NATIVE + lean_single only.
+fn bf_group_ols(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cn:  [f64; 1024] = [0.0; 1024]
+    var sx:  [f64; 1024] = [0.0; 1024]
+    var sy:  [f64; 1024] = [0.0; 1024]
+    var sxx: [f64; 1024] = [0.0; 1024]
+    var syy: [f64; 1024] = [0.0; 1024]
+    var sxy: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || x_col < 0 || x_col >= nc || y_col < 0 || y_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let xp = bf_col_ptr(src, x_col) as *mut f64
+    let yp = bf_col_ptr(src, y_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 { let x = read_f64(xp, i); let y = read_f64(yp, i); cn[k] = cn[k] + 1.0; sx[k] = sx[k] + x; sy[k] = sy[k] + y; sxx[k] = sxx[k] + x * x; syy[k] = syy[k] + y * y; sxy[k] = sxy[k] + x * y }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        let m = cn[g]
+        if m > 2.0 {
+            let mx = sx[g] / m; let my = sy[g] / m
+            let Sxx = sxx[g] - sx[g] * sx[g] / m
+            let Syy = syy[g] - sy[g] * sy[g] / m
+            let Sxy = sxy[g] - sx[g] * sy[g] / m
+            if Sxx > 0.0 {
+                let slope = Sxy / Sxx
+                let icpt = my - slope * mx
+                var sse = Syy - Sxy * Sxy / Sxx; if sse < 0.0 { sse = 0.0 }
+                let df = m - 2.0
+                let mse = sse / df
+                let se_s = bfs_sqrt(mse / Sxx, sc)
+                if mode == 0 { res[g] = se_s }
+                else { if mode == 1 { if se_s > 0.0 { res[g] = t_two_tail(slope / se_s, df) } }
+                else { if mode == 2 { res[g] = bfs_sqrt(mse * (1.0 / m + mx * mx / Sxx), sc) }
+                else { if mode == 3 { let se_i = bfs_sqrt(mse * (1.0 / m + mx * mx / Sxx), sc); if se_i > 0.0 { res[g] = t_two_tail(icpt / se_i, df) } }
+                else { if mode == 4 { if se_s > 0.0 { let ts = slope / se_s; res[g] = f_sf(ts * ts, 1.0, df) } }
+                else { let tc = t_quantile(0.975, df); if mode == 5 { res[g] = slope - tc * se_s } else { res[g] = slope + tc * se_s } } } } } }
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group OLS SLOPE STANDARD ERROR, broadcast. NATIVE + lean_single.
+pub fn bf_ols_slope_se_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_ols(src, key_col, x_col, y_col, 0) }
+/// Per-group OLS SLOPE two-sided P-VALUE (H0: slope=0), broadcast. Uses stats::student_t. NATIVE + lean_single.
+pub fn bf_ols_slope_pvalue_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_ols(src, key_col, x_col, y_col, 1) }
+/// Per-group OLS INTERCEPT STANDARD ERROR, broadcast. NATIVE + lean_single.
+pub fn bf_ols_intercept_se_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_ols(src, key_col, x_col, y_col, 2) }
+/// Per-group OLS INTERCEPT two-sided P-VALUE (H0: intercept=0), broadcast. Uses stats::student_t. NATIVE + lean_single.
+pub fn bf_ols_intercept_pvalue_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_ols(src, key_col, x_col, y_col, 3) }
+/// Per-group OLS OVERALL F-TEST P-VALUE (model significance), broadcast. Uses stats::fisher_f. NATIVE + lean_single.
+pub fn bf_ols_f_pvalue_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_ols(src, key_col, x_col, y_col, 4) }
+/// Per-group OLS SLOPE 95% CI LOWER bound (b − t_.975·SE), broadcast. Uses stats::student_t. NATIVE + lean_single.
+pub fn bf_ols_slope_ci_lo_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_ols(src, key_col, x_col, y_col, 5) }
+/// Per-group OLS SLOPE 95% CI UPPER bound (b + t_.975·SE), broadcast. Uses stats::student_t. NATIVE + lean_single.
+pub fn bf_ols_slope_ci_hi_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_ols(src, key_col, x_col, y_col, 6) }

--- a/stdlib/data/bigframe_stats.sio
+++ b/stdlib/data/bigframe_stats.sio
@@ -584,3 +584,59 @@ pub fn bf_ols_f_pvalue_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) 
 pub fn bf_ols_slope_ci_lo_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_ols(src, key_col, x_col, y_col, 5) }
 /// Per-group OLS SLOPE 95% CI UPPER bound (b + t_.975·SE), broadcast. Uses stats::student_t. NATIVE + lean_single.
 pub fn bf_ols_slope_ci_hi_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_ols(src, key_col, x_col, y_col, 6) }
+
+/// Per-group ONE-SAMPLE inference on a value column (columns key, value). One pass gives n/mean/SD;
+/// per key it forms the standard error and defers the tail/quantile to stats::student_t. modes:
+/// 0 = 95% CI lower for the mean (mean − t_.975(n−1)·SEM), 1 = 95% CI upper, 2 = one-sample t vs
+/// param mu0 ((mean−mu0)/SEM), 3 = its two-sided p-value (df=n−1). Sample SD uses ddof=1. Returns
+/// 0 for keys with n<2 or zero variance. O(n). NATIVE + lean_single only.
+fn bf_group_onesample(src: &BigFrame, key_col: i64, val_col: i64, param: f64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cn:  [f64; 1024] = [0.0; 1024]
+    var sv:  [f64; 1024] = [0.0; 1024]
+    var sq:  [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 { let v = read_f64(vp, i); cn[k] = cn[k] + 1.0; sv[k] = sv[k] + v; sq[k] = sq[k] + v * v }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        let m = cn[g]
+        if m > 1.0 {
+            let mean = sv[g] / m
+            var vr = (sq[g] - sv[g] * sv[g] / m) / (m - 1.0); if vr < 0.0 { vr = 0.0 }
+            let sem = bfs_sqrt(vr / m, sc)
+            let df = m - 1.0
+            if sem > 0.0 {
+                if mode == 0 { res[g] = mean - t_quantile(0.975, df) * sem }
+                else { if mode == 1 { res[g] = mean + t_quantile(0.975, df) * sem }
+                else { if mode == 2 { res[g] = (mean - param) / sem }
+                else { res[g] = t_two_tail((mean - param) / sem, df) } } }
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group 95% CI LOWER bound for the mean (t-interval), broadcast. Uses stats::student_t. NATIVE + lean_single.
+pub fn bf_mean_ci_lo_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_onesample(src, key_col, val_col, 0.0, 0) }
+/// Per-group 95% CI UPPER bound for the mean (t-interval), broadcast. Uses stats::student_t. NATIVE + lean_single.
+pub fn bf_mean_ci_hi_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_onesample(src, key_col, val_col, 0.0, 1) }
+/// Per-group ONE-SAMPLE t STATISTIC vs mu0 ((mean−mu0)/SEM), broadcast. NATIVE + lean_single.
+pub fn bf_one_sample_t_by(src: &BigFrame, key_col: i64, val_col: i64, mu0: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_onesample(src, key_col, val_col, mu0, 2) }
+/// Per-group ONE-SAMPLE t-test two-sided P-VALUE (H0: mean=mu0), broadcast. Uses stats::student_t. NATIVE + lean_single.
+pub fn bf_one_sample_ttest_pvalue_by(src: &BigFrame, key_col: i64, val_col: i64, mu0: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_onesample(src, key_col, val_col, mu0, 3) }

--- a/tests/stdlib/data/test_bigframe_stats.sio
+++ b/tests/stdlib/data/test_bigframe_stats.sio
@@ -119,6 +119,21 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let ohi = bf_ols_slope_ci_hi_by(&of,0,1,2)
     if !aeq(bf_get(&ohi,0,0), 1.500132) { print("FAIL ols_ci_hi\n"); return 37 }
 
+    // ===== one-sample inference (key, value): mean CI + one-sample t-test =====
+    // K0: value={2,4,4,4,5,5,7,9}, mean=5, sem=0.75593. CI[3.2125,6.7875]; t vs mu0=6 -> p=0.22745.
+    var uf = bf_new(2, 8)
+    var uv: [f64;9] = [2.0,4.0,4.0,4.0,5.0,5.0,7.0,9.0,0.0]
+    var ju: i64 = 0
+    while ju < 8 { var row:[f64;64]=[0.0;64]; row[0]=0.0; row[1]=uv[ju]; bf_push_row(&!uf,&row,2); ju=ju+1 }
+    let mlo = bf_mean_ci_lo_by(&uf,0,1)
+    if !aeq(bf_get(&mlo,0,0), 3.212512) { print("FAIL mean_ci_lo\n"); return 38 }
+    let mhi = bf_mean_ci_hi_by(&uf,0,1)
+    if !aeq(bf_get(&mhi,0,0), 6.787488) { print("FAIL mean_ci_hi\n"); return 39 }
+    let ost = bf_one_sample_t_by(&uf,0,1,6.0)
+    if !aeq(bf_get(&ost,0,0), 0.0 - 1.322876) { print("FAIL one_sample_t\n"); return 40 }
+    let osq = bf_one_sample_ttest_pvalue_by(&uf,0,1,6.0)
+    if !aeq(bf_get(&osq,0,0), 0.227452) { print("FAIL one_sample_ttest_p\n"); return 41 }
+
     print("BIGFRAME_STATS_GATE_OK\n")
     return 0
 }

--- a/tests/stdlib/data/test_bigframe_stats.sio
+++ b/tests/stdlib/data/test_bigframe_stats.sio
@@ -97,6 +97,28 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let sp = bf_spearman_pvalue_by(&cf,0,1,2,16)
     if !aeq(bf_get(&sp,0,0), 0.037383) { print("FAIL spearman_p K0\n"); return 30 }
 
+    // ===== OLS regression inference (key, x, y): y=a+b*x per key =====
+    // K0: x={1,2,3,4,5} y={2,4,5,4,5}. slope=0.6 icpt=2.2 R2=0.6.
+    var of = bf_new(3, 8)
+    var ox: [f64;6] = [1.0,2.0,3.0,4.0,5.0,0.0]
+    var oy: [f64;6] = [2.0,4.0,5.0,4.0,5.0,0.0]
+    var jo: i64 = 0
+    while jo < 5 { var row:[f64;64]=[0.0;64]; row[0]=0.0; row[1]=ox[jo]; row[2]=oy[jo]; bf_push_row(&!of,&row,3); jo=jo+1 }
+    let ose = bf_ols_slope_se_by(&of,0,1,2)
+    if !aeq(bf_get(&ose,0,0), 0.282843) { print("FAIL ols_slope_se\n"); return 31 }
+    let osp = bf_ols_slope_pvalue_by(&of,0,1,2)
+    if !aeq(bf_get(&osp,0,0), 0.124027) { print("FAIL ols_slope_p\n"); return 32 }
+    let oie = bf_ols_intercept_se_by(&of,0,1,2)
+    if !aeq(bf_get(&oie,0,0), 0.938083) { print("FAIL ols_intercept_se\n"); return 33 }
+    let oip = bf_ols_intercept_pvalue_by(&of,0,1,2)
+    if !aeq(bf_get(&oip,0,0), 0.100743) { print("FAIL ols_intercept_p\n"); return 34 }
+    let ofp = bf_ols_f_pvalue_by(&of,0,1,2)
+    if !aeq(bf_get(&ofp,0,0), 0.124027) { print("FAIL ols_f_p (==slope_p)\n"); return 35 }
+    let olo = bf_ols_slope_ci_lo_by(&of,0,1,2)
+    if !aeq(bf_get(&olo,0,0), 0.0 - 0.300132) { print("FAIL ols_ci_lo\n"); return 36 }
+    let ohi = bf_ols_slope_ci_hi_by(&of,0,1,2)
+    if !aeq(bf_get(&ohi,0,0), 1.500132) { print("FAIL ols_ci_hi\n"); return 37 }
+
     print("BIGFRAME_STATS_GATE_OK\n")
     return 0
 }


### PR DESCRIPTION
Extends **data::bigframe_stats** to what `scipy.stats.linregress` gives — per group, at 1M-row scale, reusing the tested stats:: CDFs. One co-moment pass per key → slope/intercept, their SEs and t-tests, the overall F-test, and the slope 95% CI:

- `bf_ols_slope_se_by` / `bf_ols_slope_pvalue_by` (t=b/SE(b), df=n−2 → t_two_tail)
- `bf_ols_intercept_se_by` / `bf_ols_intercept_pvalue_by`
- `bf_ols_f_pvalue_by` (model significance, f_sf(t²,1,n−2))
- `bf_ols_slope_ci_lo_by` / `bf_ols_slope_ci_hi_by` (b ± t_.975·SE, via t_quantile)

| verb | Sounio | pandas groupby.apply linregress | ratio |
|---|---|---|---|
| ols_slope_pvalue | 21 ms | 92 ms | **0.23× (4.4×)** |

**Verified:** gate 31–37 vs numpy — slope SE 0.2828, slope p 0.1240, intercept SE 0.9381 p 0.1007, F p 0.1240 (= slope p, the simple-regression identity), slope 95% CI [−0.3001, 1.5001]. Uses inlined Newton bfs_sqrt. Benchmarks reproduced. Appends to bigframe_stats.sio; stats package imported read-only.

Generated with Claude Code