### PR TITLE
feat(bigframe): per-group paired-sample inference (paired t-test / Cohen's dz / mean-diff CI)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -13,6 +13,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | per-group correlation inference: pearson_pvalue / pearson CI (Fisher z) / spearman_rho+p (1M rows, 1000 keys, 2 cols) | | ~20-41 | ~150-267 | **0.13-0.15x — wins 7-8x** | one-pass co-moments (Pearson) or rank-LUT co-moment (Spearman) + t_two_tail vs groupby.apply |
 | per-group OLS inference: slope/intercept SE+p-value, F-test p, slope 95% CI (1M rows, 1000 keys) | | ~21 | ~92 | **0.23x — wins 4.4x** | one-pass co-moments + t_two_tail/f_sf/t_quantile vs groupby.apply linregress |
 | per-group one-sample inference: mean 95% CI + one-sample t-test (1M rows, 1000 keys) | | ~16 | ~89 | **0.18x — wins 5.5x** | one-pass mean/SD + t_quantile/t_two_tail vs groupby.apply |
+| per-group paired inference: paired t-test / Cohen's dz / mean-diff 95% CI (1M rows, 1000 keys) | | ~16 | ~103 | **0.15x — wins 6.6x** | one-pass over d=x-y + t_two_tail/t_quantile vs groupby.apply ttest_rel |
 | two-sample tests: welch/cohens_d/glass/pooled_sd/point_biserial + mannwhitney_u/cles/rank_biserial/ks (1M rows, 1000 keys, 2 groups) | | ~18 | ~430 | **0.04x — wins 24x** | one-pass moments / group-split histogram; pandas = scipy + groupby.apply |
 | col_sum (8-accumulator ILP) | | 1.44 | 0.55 | **2.6x** | 3.9x |
 | col_mean (via 8-acc sum) | | 2.05 | 1.00 | **2.1x** | 2.3x |

--- a/stdlib/data/bigframe_stats.sio
+++ b/stdlib/data/bigframe_stats.sio
@@ -640,3 +640,64 @@ pub fn bf_mean_ci_hi_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame 
 pub fn bf_one_sample_t_by(src: &BigFrame, key_col: i64, val_col: i64, mu0: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_onesample(src, key_col, val_col, mu0, 2) }
 /// Per-group ONE-SAMPLE t-test two-sided P-VALUE (H0: mean=mu0), broadcast. Uses stats::student_t. NATIVE + lean_single.
 pub fn bf_one_sample_ttest_pvalue_by(src: &BigFrame, key_col: i64, val_col: i64, mu0: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_onesample(src, key_col, val_col, mu0, 3) }
+
+/// Per-group PAIRED-SAMPLE inference (columns key, x, y): tests the within-pair difference d=x−y
+/// per key. One pass accumulates n/Σd/Σd²; the paired t-test reduces to a one-sample t on d.
+/// modes: 0 = paired t ((mean_d)/SEM_d), 1 = two-sided p-value (df=n−1), 2 = Cohen's dz
+/// (mean_d/SD_d, paired effect size), 3 = mean-difference 95% CI lower, 4 = CI upper. SD uses
+/// ddof=1. Returns 0 for n<2 or zero difference-variance. O(n). NATIVE + lean_single only.
+fn bf_group_paired(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cn:  [f64; 1024] = [0.0; 1024]
+    var sd:  [f64; 1024] = [0.0; 1024]
+    var sq:  [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || x_col < 0 || x_col >= nc || y_col < 0 || y_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let xp = bf_col_ptr(src, x_col) as *mut f64
+    let yp = bf_col_ptr(src, y_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 { let d = read_f64(xp, i) - read_f64(yp, i); cn[k] = cn[k] + 1.0; sd[k] = sd[k] + d; sq[k] = sq[k] + d * d }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        let m = cn[g]
+        if m > 1.0 {
+            let md = sd[g] / m
+            var vr = (sq[g] - sd[g] * sd[g] / m) / (m - 1.0); if vr < 0.0 { vr = 0.0 }
+            let sdd = bfs_sqrt(vr, sc)
+            let sem = bfs_sqrt(vr / m, sc)
+            let df = m - 1.0
+            if mode == 2 { if sdd > 0.0 { res[g] = md / sdd } }
+            else { if sem > 0.0 {
+                if mode == 0 { res[g] = md / sem }
+                else { if mode == 1 { res[g] = t_two_tail(md / sem, df) }
+                else { if mode == 3 { res[g] = md - t_quantile(0.975, df) * sem }
+                else { res[g] = md + t_quantile(0.975, df) * sem } } }
+            } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group PAIRED t STATISTIC (of d=x−y), broadcast. NATIVE + lean_single.
+pub fn bf_paired_t_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_paired(src, key_col, x_col, y_col, 0) }
+/// Per-group PAIRED t-test two-sided P-VALUE (H0: mean(x−y)=0), broadcast. Uses stats::student_t. NATIVE + lean_single.
+pub fn bf_paired_ttest_pvalue_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_paired(src, key_col, x_col, y_col, 1) }
+/// Per-group PAIRED COHEN'S dz effect size (mean_d/SD_d), broadcast. NATIVE + lean_single.
+pub fn bf_cohens_dz_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_paired(src, key_col, x_col, y_col, 2) }
+/// Per-group MEAN-DIFFERENCE 95% CI LOWER bound (paired), broadcast. Uses stats::student_t. NATIVE + lean_single.
+pub fn bf_mean_diff_ci_lo_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_paired(src, key_col, x_col, y_col, 3) }
+/// Per-group MEAN-DIFFERENCE 95% CI UPPER bound (paired), broadcast. Uses stats::student_t. NATIVE + lean_single.
+pub fn bf_mean_diff_ci_hi_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_paired(src, key_col, x_col, y_col, 4) }

--- a/tests/stdlib/data/test_bigframe_stats.sio
+++ b/tests/stdlib/data/test_bigframe_stats.sio
@@ -134,6 +134,24 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let osq = bf_one_sample_ttest_pvalue_by(&uf,0,1,6.0)
     if !aeq(bf_get(&osq,0,0), 0.227452) { print("FAIL one_sample_ttest_p\n"); return 41 }
 
+    // ===== paired-sample inference (key, x, y): d=x-y =====
+    // K0: x={5,6,7,8,9} y={4,4,7,6,10}. mean_d=0.8 t=1.37199 p=0.24198 dz=0.61357 CI[-0.81893,2.41893].
+    var pf = bf_new(3, 8)
+    var px: [f64;6] = [5.0,6.0,7.0,8.0,9.0,0.0]
+    var py: [f64;6] = [4.0,4.0,7.0,6.0,10.0,0.0]
+    var jp: i64 = 0
+    while jp < 5 { var row:[f64;64]=[0.0;64]; row[0]=0.0; row[1]=px[jp]; row[2]=py[jp]; bf_push_row(&!pf,&row,3); jp=jp+1 }
+    let pt = bf_paired_t_by(&pf,0,1,2)
+    if !aeq(bf_get(&pt,0,0), 1.371989) { print("FAIL paired_t\n"); return 42 }
+    let ptp = bf_paired_ttest_pvalue_by(&pf,0,1,2)
+    if !aeq(bf_get(&ptp,0,0), 0.241981) { print("FAIL paired_ttest_p\n"); return 43 }
+    let dz = bf_cohens_dz_by(&pf,0,1,2)
+    if !aeq(bf_get(&dz,0,0), 0.613572) { print("FAIL cohens_dz\n"); return 44 }
+    let dlo = bf_mean_diff_ci_lo_by(&pf,0,1,2)
+    if !aeq(bf_get(&dlo,0,0), 0.0 - 0.818932) { print("FAIL mean_diff_ci_lo\n"); return 45 }
+    let dhi = bf_mean_diff_ci_hi_by(&pf,0,1,2)
+    if !aeq(bf_get(&dhi,0,0), 2.418932) { print("FAIL mean_diff_ci_hi\n"); return 46 }
+
     print("BIGFRAME_STATS_GATE_OK\n")
     return 0
 }


### PR DESCRIPTION
Adds paired inference to **data::bigframe_stats** (columns key, x, y): tests d=x−y per key (scipy.stats.ttest_rel), reusing stats::student_t.

- `bf_paired_t_by` / `bf_paired_ttest_pvalue_by` (H0: mean(x−y)=0, df=n−1)
- `bf_cohens_dz_by` (paired effect size mean_d/SD_d)
- `bf_mean_diff_ci_lo_by` / `bf_mean_diff_ci_hi_by` (95% t-interval for the mean difference)

| verb | Sounio | pandas groupby.apply | ratio |
|---|---|---|---|
| paired_ttest_p | 16 ms | 103 ms | **0.15× (6.6×)** |

**Verified:** gate 42–46 vs numpy on x={5,6,7,8,9} y={4,4,7,6,10}: paired t=1.3720, p=0.2420, Cohen's dz=0.6136, mean-diff CI [−0.8189, 2.4189]. Benchmarks reproduced. Appends to bigframe_stats.sio; stats package imported read-only.

Generated with Claude Code