### PR TITLE
feat(bigframe): per-group two-proportion z-test + Wald CI

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -14,6 +14,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | per-group OLS inference: slope/intercept SE+p-value, F-test p, slope 95% CI (1M rows, 1000 keys) | | ~21 | ~92 | **0.23x — wins 4.4x** | one-pass co-moments + t_two_tail/f_sf/t_quantile vs groupby.apply linregress |
 | per-group one-sample inference: mean 95% CI + one-sample t-test (1M rows, 1000 keys) | | ~16 | ~89 | **0.18x — wins 5.5x** | one-pass mean/SD + t_quantile/t_two_tail vs groupby.apply |
 | per-group paired inference: paired t-test / Cohen's dz / mean-diff 95% CI (1M rows, 1000 keys) | | ~16 | ~103 | **0.15x — wins 6.6x** | one-pass over d=x-y + t_two_tail/t_quantile vs groupby.apply ttest_rel |
+| per-group two-proportion z-test + Wald CI (1M rows, 1000 keys, 2 groups, binary outcome) | | ~17 | ~457 | **0.04x — wins 28x** | one-pass counts + local normal Phi vs groupby.apply |
 | two-sample tests: welch/cohens_d/glass/pooled_sd/point_biserial + mannwhitney_u/cles/rank_biserial/ks (1M rows, 1000 keys, 2 groups) | | ~18 | ~430 | **0.04x — wins 24x** | one-pass moments / group-split histogram; pandas = scipy + groupby.apply |
 | col_sum (8-accumulator ILP) | | 1.44 | 0.55 | **2.6x** | 3.9x |
 | col_mean (via 8-acc sum) | | 2.05 | 1.00 | **2.1x** | 2.3x |

--- a/stdlib/data/bigframe_stats.sio
+++ b/stdlib/data/bigframe_stats.sio
@@ -701,3 +701,67 @@ pub fn bf_cohens_dz_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> 
 pub fn bf_mean_diff_ci_lo_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_paired(src, key_col, x_col, y_col, 3) }
 /// Per-group MEAN-DIFFERENCE 95% CI UPPER bound (paired), broadcast. Uses stats::student_t. NATIVE + lean_single.
 pub fn bf_mean_diff_ci_hi_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_paired(src, key_col, x_col, y_col, 4) }
+
+/// Per-group TWO-PROPORTION z-test (columns key, group∈{0,1}, binary outcome 0/1). One pass counts
+/// n and #successes per (key,group); per key it compares p1 vs p0. modes: 0 = proportion difference
+/// p1−p0, 1 = pooled two-proportion z ((p1−p0)/√(p̄(1−p̄)(1/n1+1/n0))), 2 = its two-sided p-value
+/// (normal approx via the local A&S Φ), 3 = Wald 95% CI lower for the difference, 4 = CI upper.
+/// Returns 0 for keys missing a group or with a degenerate pooled proportion. O(n). NATIVE + lean_single.
+fn bf_group_twoprop(src: &BigFrame, key_col: i64, grp_col: i64, out_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var n0: [f64; 1024] = [0.0; 1024]
+    var x0: [f64; 1024] = [0.0; 1024]
+    var n1: [f64; 1024] = [0.0; 1024]
+    var x1: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || grp_col < 0 || grp_col >= nc || out_col < 0 || out_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let gp = bf_col_ptr(src, grp_col) as *mut f64
+    let vp = bf_col_ptr(src, out_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 {
+            let g = read_f64(gp, i) as i64
+            let v = read_f64(vp, i)
+            if g == 1 { n1[k] = n1[k] + 1.0; if v > 0.0 { x1[k] = x1[k] + 1.0 } }
+            else { if g == 0 { n0[k] = n0[k] + 1.0; if v > 0.0 { x0[k] = x0[k] + 1.0 } } }
+        }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if n0[g] > 0.0 && n1[g] > 0.0 {
+            let p0 = x0[g] / n0[g]; let p1 = x1[g] / n1[g]; let diff = p1 - p0
+            if mode == 0 { res[g] = diff }
+            else { if mode == 3 || mode == 4 {
+                let seW = bfs_sqrt(p1 * (1.0 - p1) / n1[g] + p0 * (1.0 - p0) / n0[g], sc)
+                if mode == 3 { res[g] = diff - 1.959963985 * seW } else { res[g] = diff + 1.959963985 * seW }
+            } else {
+                let pp = (x0[g] + x1[g]) / (n0[g] + n1[g])
+                let se = bfs_sqrt(pp * (1.0 - pp) * (1.0 / n1[g] + 1.0 / n0[g]), sc)
+                if se > 0.0 { let z = diff / se; if mode == 1 { res[g] = z } else { var za = z; if za < 0.0 { za = 0.0 - za }; res[g] = 2.0 * (1.0 - bfs_ncdf(za)) } }
+            } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group PROPORTION DIFFERENCE (p1−p0), broadcast. NATIVE + lean_single.
+pub fn bf_prop_diff_by(src: &BigFrame, key_col: i64, grp_col: i64, out_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_twoprop(src, key_col, grp_col, out_col, 0) }
+/// Per-group TWO-PROPORTION z STATISTIC (pooled), broadcast. NATIVE + lean_single.
+pub fn bf_prop_z_by(src: &BigFrame, key_col: i64, grp_col: i64, out_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_twoprop(src, key_col, grp_col, out_col, 1) }
+/// Per-group TWO-PROPORTION z-test two-sided P-VALUE, broadcast. NATIVE + lean_single.
+pub fn bf_prop_ztest_pvalue_by(src: &BigFrame, key_col: i64, grp_col: i64, out_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_twoprop(src, key_col, grp_col, out_col, 2) }
+/// Per-group PROPORTION-DIFFERENCE Wald 95% CI LOWER, broadcast. NATIVE + lean_single.
+pub fn bf_prop_diff_ci_lo_by(src: &BigFrame, key_col: i64, grp_col: i64, out_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_twoprop(src, key_col, grp_col, out_col, 3) }
+/// Per-group PROPORTION-DIFFERENCE Wald 95% CI UPPER, broadcast. NATIVE + lean_single.
+pub fn bf_prop_diff_ci_hi_by(src: &BigFrame, key_col: i64, grp_col: i64, out_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_twoprop(src, key_col, grp_col, out_col, 4) }

--- a/tests/stdlib/data/test_bigframe_stats.sio
+++ b/tests/stdlib/data/test_bigframe_stats.sio
@@ -152,6 +152,24 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let dhi = bf_mean_diff_ci_hi_by(&pf,0,1,2)
     if !aeq(bf_get(&dhi,0,0), 2.418932) { print("FAIL mean_diff_ci_hi\n"); return 46 }
 
+    // ===== two-proportion z-test (key, group, binary outcome) =====
+    // K0 g0: 2/5 success (p0=0.4); g1: 4/5 (p1=0.8). diff=0.4 z=1.29099 p=0.19671 waldCI[-0.15436,0.95436].
+    var zf = bf_new(3, 16)
+    var zg: [f64;11] = [0.0,0.0,0.0,0.0,0.0,1.0,1.0,1.0,1.0,1.0,0.0]
+    var zo: [f64;11] = [1.0,1.0,0.0,0.0,0.0,1.0,1.0,1.0,1.0,0.0,0.0]
+    var jz: i64 = 0
+    while jz < 10 { var row:[f64;64]=[0.0;64]; row[0]=0.0; row[1]=zg[jz]; row[2]=zo[jz]; bf_push_row(&!zf,&row,3); jz=jz+1 }
+    let pd = bf_prop_diff_by(&zf,0,1,2)
+    if !aeq(bf_get(&pd,0,0), 0.4) { print("FAIL prop_diff\n"); return 47 }
+    let pz = bf_prop_z_by(&zf,0,1,2)
+    if !aeq(bf_get(&pz,0,0), 1.290994) { print("FAIL prop_z\n"); return 48 }
+    let pzp = bf_prop_ztest_pvalue_by(&zf,0,1,2)
+    if !aeq(bf_get(&pzp,0,0), 0.196706) { print("FAIL prop_ztest_p\n"); return 49 }
+    let zlo = bf_prop_diff_ci_lo_by(&zf,0,1,2)
+    if !aeq(bf_get(&zlo,0,0), 0.0 - 0.154362) { print("FAIL prop_ci_lo\n"); return 50 }
+    let zhi = bf_prop_diff_ci_hi_by(&zf,0,1,2)
+    if !aeq(bf_get(&zhi,0,0), 0.954362) { print("FAIL prop_ci_hi\n"); return 51 }
+
     print("BIGFRAME_STATS_GATE_OK\n")
     return 0
 }


### PR DESCRIPTION
Adds two-proportion inference to **data::bigframe_stats** (columns key, group in {0,1}, binary outcome 0/1):
- `bf_prop_diff_by` (p1-p0) / `bf_prop_z_by` (pooled z) / `bf_prop_ztest_pvalue_by` (two-sided) / `bf_prop_diff_ci_lo_by` / `bf_prop_diff_ci_hi_by` (Wald 95% CI)

| verb | Sounio | pandas groupby.apply | ratio |
|---|---|---|---|
| prop_ztest_p | 17 ms | 457 ms | **0.04x (28x)** |

**Verified:** gate 47-51 vs numpy (g0 2/5 vs g1 4/5): diff 0.4, z 1.2910, p 0.1967, Wald CI [-0.1544, 0.9544]. Uses the module's local A&S normal CDF. Benchmarks reproduced. Appends to bigframe_stats.sio.

Generated with Claude Code