### PR TITLE
feat(bigframe): per-group variance-homogeneity tests (Bartlett + Levene)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -15,6 +15,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | per-group one-sample inference: mean 95% CI + one-sample t-test (1M rows, 1000 keys) | | ~16 | ~89 | **0.18x — wins 5.5x** | one-pass mean/SD + t_quantile/t_two_tail vs groupby.apply |
 | per-group paired inference: paired t-test / Cohen's dz / mean-diff 95% CI (1M rows, 1000 keys) | | ~16 | ~103 | **0.15x — wins 6.6x** | one-pass over d=x-y + t_two_tail/t_quantile vs groupby.apply ttest_rel |
 | per-group two-proportion z-test + Wald CI (1M rows, 1000 keys, 2 groups, binary outcome) | | ~17 | ~457 | **0.04x — wins 28x** | one-pass counts + local normal Phi vs groupby.apply |
+| per-group variance homogeneity: Bartlett + Levene (1M rows, 1000 keys, 4 groups) | | ~38 | ~749 | **0.05x — wins 20x** | one/two-pass moments + chi2_sf/f_sf vs groupby.apply |
 | two-sample tests: welch/cohens_d/glass/pooled_sd/point_biserial + mannwhitney_u/cles/rank_biserial/ks (1M rows, 1000 keys, 2 groups) | | ~18 | ~430 | **0.04x — wins 24x** | one-pass moments / group-split histogram; pandas = scipy + groupby.apply |
 | col_sum (8-accumulator ILP) | | 1.44 | 0.55 | **2.6x** | 3.9x |
 | col_mean (via 8-acc sum) | | 2.05 | 1.00 | **2.1x** | 2.3x |

--- a/stdlib/data/bigframe_stats.sio
+++ b/stdlib/data/bigframe_stats.sio
@@ -765,3 +765,119 @@ pub fn bf_prop_ztest_pvalue_by(src: &BigFrame, key_col: i64, grp_col: i64, out_c
 pub fn bf_prop_diff_ci_lo_by(src: &BigFrame, key_col: i64, grp_col: i64, out_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_twoprop(src, key_col, grp_col, out_col, 3) }
 /// Per-group PROPORTION-DIFFERENCE Wald 95% CI UPPER, broadcast. NATIVE + lean_single.
 pub fn bf_prop_diff_ci_hi_by(src: &BigFrame, key_col: i64, grp_col: i64, out_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_twoprop(src, key_col, grp_col, out_col, 4) }
+
+/// Per-group BARTLETT test of equal variances (columns key, group 0..ngroups−1, value). One pass
+/// gives n/Σ/Σ² per (key,group); B = [(N−K)ln s²_p − Σ(nᵢ−1)ln s²ᵢ] / C with the standard
+/// correction C. modes: 0 = B statistic, 1 = p-value χ²_sf(B, K−1). Sensitive to normality
+/// (use Levene otherwise). Returns 0 if any present group has zero variance or K<2. O(n + G·ngroups).
+/// NATIVE + lean_single only.
+fn bf_group_bartlett(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, ngroups: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || grp_col < 0 || grp_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || ngroups <= 1 || ngroups > 1024 { return out }
+    let stride = ngroups
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let gp = bf_col_ptr(src, grp_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let cn = heap_alloc(1024 * stride * 8) as *mut f64
+    let cs = heap_alloc(1024 * stride * 8) as *mut f64
+    let cq = heap_alloc(1024 * stride * 8) as *mut f64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let g = read_f64(gp, i) as i64
+        if k >= 0 && k < 1024 && g >= 0 && g < stride { let v = read_f64(vp, i); let idx = k * stride + g; write_f64(cn, idx, read_f64(cn, idx) + 1.0); write_f64(cs, idx, read_f64(cs, idx) + v); write_f64(cq, idx, read_f64(cq, idx) + v * v) }
+        i = i + 1
+    }
+    var kk: i64 = 0
+    while kk < 1024 {
+        let base = kk * stride
+        var K = 0.0; var N = 0.0; var sumdf = 0.0; var suml = 0.0; var sumrec = 0.0; var bad = false
+        var g: i64 = 0
+        while g < stride {
+            let ng = read_f64(cn, base + g)
+            if ng > 1.0 { let sg = read_f64(cs, base + g); let qg = read_f64(cq, base + g); var v = (qg - sg * sg / ng) / (ng - 1.0); if v <= 0.0 { bad = true } else { K = K + 1.0; N = N + ng; sumdf = sumdf + (ng - 1.0) * v; suml = suml + (ng - 1.0) * ln(v); sumrec = sumrec + 1.0 / (ng - 1.0) } }
+            else { if ng > 0.0 { bad = true } }
+            g = g + 1
+        }
+        if K > 1.0 && !bad && N > K {
+            let sp = sumdf / (N - K)
+            let bnum = (N - K) * ln(sp) - suml
+            let C = 1.0 + (sumrec - 1.0 / (N - K)) / (3.0 * (K - 1.0))
+            let B = bnum / C
+            if mode == 0 { res[kk] = B } else { res[kk] = chi2_sf(B, K - 1.0) }
+        }
+        kk = kk + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(cn as *mut i8); heap_free(cs as *mut i8); heap_free(cq as *mut i8)
+    out
+}
+/// Per-group BARTLETT statistic (equal-variance test), broadcast. NATIVE + lean_single.
+pub fn bf_bartlett_stat_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, ngroups: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_bartlett(src, key_col, grp_col, val_col, ngroups, 0) }
+/// Per-group BARTLETT P-VALUE (χ²_sf(B, K−1)), broadcast. Uses stats::chi_square. NATIVE + lean_single.
+pub fn bf_bartlett_pvalue_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, ngroups: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_bartlett(src, key_col, grp_col, val_col, ngroups, 1) }
+
+/// Per-group LEVENE test of equal variances (mean-based; columns key, group 0..ngroups−1, value).
+/// Two passes: group means, then the ANOVA F on the absolute deviations z=|x−mean_g| (robust to
+/// non-normality). modes: 0 = W statistic, 1 = p-value F_sf(W, K−1, N−K). Returns 0 for K<2 or
+/// zero within-group deviation spread. O(n + G·ngroups). NATIVE + lean_single only.
+fn bf_group_levene(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, ngroups: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || grp_col < 0 || grp_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || ngroups <= 1 || ngroups > 1024 { return out }
+    let stride = ngroups
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let gp = bf_col_ptr(src, grp_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let cn = heap_alloc(1024 * stride * 8) as *mut f64
+    let cs = heap_alloc(1024 * stride * 8) as *mut f64
+    let zs = heap_alloc(1024 * stride * 8) as *mut f64
+    let zq = heap_alloc(1024 * stride * 8) as *mut f64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let g = read_f64(gp, i) as i64
+        if k >= 0 && k < 1024 && g >= 0 && g < stride { let v = read_f64(vp, i); let idx = k * stride + g; write_f64(cn, idx, read_f64(cn, idx) + 1.0); write_f64(cs, idx, read_f64(cs, idx) + v) }
+        i = i + 1
+    }
+    i = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let g = read_f64(gp, i) as i64
+        if k >= 0 && k < 1024 && g >= 0 && g < stride { let idx = k * stride + g; let ng = read_f64(cn, idx); if ng > 0.0 { let mean = read_f64(cs, idx) / ng; var z = read_f64(vp, i) - mean; if z < 0.0 { z = 0.0 - z }; write_f64(zs, idx, read_f64(zs, idx) + z); write_f64(zq, idx, read_f64(zq, idx) + z * z) } }
+        i = i + 1
+    }
+    var kk: i64 = 0
+    while kk < 1024 {
+        let base = kk * stride
+        var K = 0.0; var N = 0.0; var totz = 0.0; var ssb = 0.0; var ssw = 0.0
+        var g: i64 = 0
+        while g < stride { let ng = read_f64(cn, base + g); if ng > 0.0 { let zsum = read_f64(zs, base + g); K = K + 1.0; N = N + ng; totz = totz + zsum; ssb = ssb + zsum * zsum / ng; ssw = ssw + (read_f64(zq, base + g) - zsum * zsum / ng) } g = g + 1 }
+        if K > 1.0 && N > K {
+            let SSB = ssb - totz * totz / N
+            if ssw > 0.0 {
+                let W = (SSB / (K - 1.0)) / (ssw / (N - K))
+                if mode == 0 { res[kk] = W } else { res[kk] = f_sf(W, K - 1.0, N - K) }
+            }
+        }
+        kk = kk + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(cn as *mut i8); heap_free(cs as *mut i8); heap_free(zs as *mut i8); heap_free(zq as *mut i8)
+    out
+}
+/// Per-group LEVENE statistic (mean-based equal-variance test), broadcast. NATIVE + lean_single.
+pub fn bf_levene_stat_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, ngroups: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_levene(src, key_col, grp_col, val_col, ngroups, 0) }
+/// Per-group LEVENE P-VALUE (F_sf(W, K−1, N−K)), broadcast. Uses stats::fisher_f. NATIVE + lean_single.
+pub fn bf_levene_pvalue_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, ngroups: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_levene(src, key_col, grp_col, val_col, ngroups, 1) }

--- a/tests/stdlib/data/test_bigframe_stats.sio
+++ b/tests/stdlib/data/test_bigframe_stats.sio
@@ -170,6 +170,22 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let zhi = bf_prop_diff_ci_hi_by(&zf,0,1,2)
     if !aeq(bf_get(&zhi,0,0), 0.954362) { print("FAIL prop_ci_hi\n"); return 51 }
 
+    // ===== variance homogeneity: Bartlett + Levene (key, group 0..2, value) =====
+    // K0: g0={2,4,6} g1={1,2,3} g2={10,20,30}. Bartlett B=7.6493 p=0.02182; Levene W=2.7810 p=0.13975.
+    var vf = bf_new(3, 16)
+    var vgg: [f64;10] = [0.0,0.0,0.0,1.0,1.0,1.0,2.0,2.0,2.0,0.0]
+    var vvv: [f64;10] = [2.0,4.0,6.0,1.0,2.0,3.0,10.0,20.0,30.0,0.0]
+    var jv: i64 = 0
+    while jv < 9 { var row:[f64;64]=[0.0;64]; row[0]=0.0; row[1]=vgg[jv]; row[2]=vvv[jv]; bf_push_row(&!vf,&row,3); jv=jv+1 }
+    let bst = bf_bartlett_stat_by(&vf,0,1,2,3)
+    if !aeq(bf_get(&bst,0,0), 7.649312) { print("FAIL bartlett_stat\n"); return 52 }
+    let bpv = bf_bartlett_pvalue_by(&vf,0,1,2,3)
+    if !aeq(bf_get(&bpv,0,0), 0.021822) { print("FAIL bartlett_p\n"); return 53 }
+    let lst = bf_levene_stat_by(&vf,0,1,2,3)
+    if !aeq(bf_get(&lst,0,0), 2.780952) { print("FAIL levene_stat\n"); return 54 }
+    let lpv = bf_levene_pvalue_by(&vf,0,1,2,3)
+    if !aeq(bf_get(&lpv,0,0), 0.139749) { print("FAIL levene_p\n"); return 55 }
+
     print("BIGFRAME_STATS_GATE_OK\n")
     return 0
 }


### PR DESCRIPTION
Adds equal-variance tests to **data::bigframe_stats** (columns key, group, value), reusing stats:: CDFs:
- `bf_bartlett_stat_by` / `bf_bartlett_pvalue_by` — Bartlett (one-pass, chi2_sf(B,K−1))
- `bf_levene_stat_by` / `bf_levene_pvalue_by` — Levene mean-based (ANOVA F on z=|x−mean_g|, robust to non-normality)

| verb | Sounio | pandas groupby.apply | ratio |
|---|---|---|---|
| levene_pvalue | 38 ms | 749 ms | **0.05x (20x)** |

**Verified:** gate 52–55 vs numpy on g0={2,4,6}/g1={1,2,3}/g2={10,20,30}: Bartlett B=7.6493 p=0.0218, Levene W=2.7810 p=0.1397. Benchmarks reproduced. Appends to bigframe_stats.sio.

Generated with Claude Code