### PR TITLE
feat(bigframe): per-group 2-sample effect sizes — Hedges' g + Cohen's d 95% CI

### DIFF
--- a/stdlib/data/bigframe_stats.sio
+++ b/stdlib/data/bigframe_stats.sio
@@ -881,3 +881,60 @@ fn bf_group_levene(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, ngr
 pub fn bf_levene_stat_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, ngroups: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_levene(src, key_col, grp_col, val_col, ngroups, 0) }
 /// Per-group LEVENE P-VALUE (F_sf(W, K−1, N−K)), broadcast. Uses stats::fisher_f. NATIVE + lean_single.
 pub fn bf_levene_pvalue_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, ngroups: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_levene(src, key_col, grp_col, val_col, ngroups, 1) }
+
+/// Per-group additional TWO-SAMPLE EFFECT SIZES (columns key, group∈{0,1}, value). One pass over
+/// n/Σ/Σ² per (key,group) gives Cohen's d; modes: 0 = Hedges' g (bias-corrected d, ×J=1−3/(4N−9)),
+/// 1 = Cohen's d 95% CI lower, 2 = CI upper (d ± 1.96·SE(d), SE²=(n1+n0)/(n1n0)+d²/(2(n1+n0−2))).
+/// Returns 0 for keys missing a group or zero pooled variance. O(n). NATIVE + lean_single only.
+fn bf_group_effsize(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var n0: [f64; 1024] = [0.0; 1024]
+    var s0: [f64; 1024] = [0.0; 1024]
+    var q0: [f64; 1024] = [0.0; 1024]
+    var n1: [f64; 1024] = [0.0; 1024]
+    var s1: [f64; 1024] = [0.0; 1024]
+    var q1: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || grp_col < 0 || grp_col >= nc || val_col < 0 || val_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let gp = bf_col_ptr(src, grp_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 { let g = read_f64(gp, i) as i64; let v = read_f64(vp, i); if g == 1 { n1[k] = n1[k] + 1.0; s1[k] = s1[k] + v; q1[k] = q1[k] + v * v } else { if g == 0 { n0[k] = n0[k] + 1.0; s0[k] = s0[k] + v; q0[k] = q0[k] + v * v } } }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if n0[g] > 1.0 && n1[g] > 1.0 {
+            let a0 = n0[g]; let a1 = n1[g]
+            var v0 = (q0[g] - s0[g] * s0[g] / a0) / (a0 - 1.0); if v0 < 0.0 { v0 = 0.0 }
+            var v1 = (q1[g] - s1[g] * s1[g] / a1) / (a1 - 1.0); if v1 < 0.0 { v1 = 0.0 }
+            let dof = a1 + a0 - 2.0
+            let psd = bfs_sqrt(((a1 - 1.0) * v1 + (a0 - 1.0) * v0) / dof, sc)
+            if psd > 0.0 {
+                let d = (s1[g] / a1 - s0[g] / a0) / psd
+                let nn = a1 + a0
+                if mode == 0 { res[g] = d * (1.0 - 3.0 / (4.0 * nn - 9.0)) }
+                else { let se = bfs_sqrt(nn / (a1 * a0) + d * d / (2.0 * dof), sc); if mode == 1 { res[g] = d - 1.959963985 * se } else { res[g] = d + 1.959963985 * se } }
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group HEDGES' g (bias-corrected Cohen's d), broadcast. NATIVE + lean_single.
+pub fn bf_hedges_g_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_effsize(src, key_col, grp_col, val_col, 0) }
+/// Per-group COHEN'S d 95% CI LOWER bound, broadcast. NATIVE + lean_single.
+pub fn bf_cohens_d_ci_lo_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_effsize(src, key_col, grp_col, val_col, 1) }
+/// Per-group COHEN'S d 95% CI UPPER bound, broadcast. NATIVE + lean_single.
+pub fn bf_cohens_d_ci_hi_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_effsize(src, key_col, grp_col, val_col, 2) }

--- a/tests/stdlib/data/test_bigframe_stats.sio
+++ b/tests/stdlib/data/test_bigframe_stats.sio
@@ -186,6 +186,14 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let lpv = bf_levene_pvalue_by(&vf,0,1,2,3)
     if !aeq(bf_get(&lpv,0,0), 0.139749) { print("FAIL levene_p\n"); return 55 }
 
+    // ===== 2-sample effect sizes: Hedges g + Cohen's d CI (reuse df: g0={1,2,3} g1={4,5,6,7}) =====
+    let hg = bf_hedges_g_by(&df,0,1,2)
+    if !aeq(bf_get(&hg,0,0), 2.490981) { print("FAIL hedges_g\n"); return 56 }
+    let dlo2 = bf_cohens_d_ci_lo_by(&df,0,1,2)
+    if !aeq(bf_get(&dlo2,0,0), 0.591158) { print("FAIL cohens_d_ci_lo\n"); return 57 }
+    let dhi2 = bf_cohens_d_ci_hi_by(&df,0,1,2)
+    if !aeq(bf_get(&dhi2,0,0), 5.324921) { print("FAIL cohens_d_ci_hi\n"); return 58 }
+
     print("BIGFRAME_STATS_GATE_OK\n")
     return 0
 }


### PR DESCRIPTION
Completes the two-sample effect-size surface in **data::bigframe_stats**:
- `bf_hedges_g_by` — bias-corrected Cohen's d (×J = 1 − 3/(4N−9))
- `bf_cohens_d_ci_lo_by` / `bf_cohens_d_ci_hi_by` — Cohen's d 95% CI (d ± 1.96·SE(d))

Same one-pass moment engine as the merged `bf_cohens_d_by` (~0.04× vs groupby.apply). Gate 56–58 vs numpy on g0={1,2,3} g1={4,5,6,7}: Cohen's d=2.9580, Hedges g=2.4910, d 95% CI [0.5912, 5.3249].

Generated with Claude Code