### PR TITLE
feat(bigframe): per-group D'Agostino-Pearson normality test (scipy.stats.normaltest)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -16,6 +16,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | per-group paired inference: paired t-test / Cohen's dz / mean-diff 95% CI (1M rows, 1000 keys) | | ~16 | ~103 | **0.15x — wins 6.6x** | one-pass over d=x-y + t_two_tail/t_quantile vs groupby.apply ttest_rel |
 | per-group two-proportion z-test + Wald CI (1M rows, 1000 keys, 2 groups, binary outcome) | | ~17 | ~457 | **0.04x — wins 28x** | one-pass counts + local normal Phi vs groupby.apply |
 | per-group variance homogeneity: Bartlett + Levene (1M rows, 1000 keys, 4 groups) | | ~38 | ~749 | **0.05x — wins 20x** | one/two-pass moments + chi2_sf/f_sf vs groupby.apply |
+| per-group normality: D'Agostino-Pearson normaltest (K2, p, skew/kurt z) (1M rows, 1000 keys) | | ~20 | ~88 | **0.22x — wins 4.4x** | one moment pass + D'Agostino transform vs groupby.apply |
 | two-sample tests: welch/cohens_d/glass/pooled_sd/point_biserial + mannwhitney_u/cles/rank_biserial/ks (1M rows, 1000 keys, 2 groups) | | ~18 | ~430 | **0.04x — wins 24x** | one-pass moments / group-split histogram; pandas = scipy + groupby.apply |
 | col_sum (8-accumulator ILP) | | 1.44 | 0.55 | **2.6x** | 3.9x |
 | col_mean (via 8-acc sum) | | 2.05 | 1.00 | **2.1x** | 2.3x |

--- a/stdlib/data/bigframe_stats.sio
+++ b/stdlib/data/bigframe_stats.sio
@@ -938,3 +938,81 @@ pub fn bf_hedges_g_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64) 
 pub fn bf_cohens_d_ci_lo_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_effsize(src, key_col, grp_col, val_col, 1) }
 /// Per-group COHEN'S d 95% CI UPPER bound, broadcast. NATIVE + lean_single.
 pub fn bf_cohens_d_ci_hi_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_effsize(src, key_col, grp_col, val_col, 2) }
+
+/// Per-group D'AGOSTINO-PEARSON NORMALITY test (scipy.stats.normaltest), columns key, value. One
+/// pass accumulates n/Σx/Σx²/Σx³/Σx⁴ per key -> central moments -> the skewness (D'Agostino) and
+/// kurtosis (Anscombe-Glynn) z-scores; K² = Z_skew² + Z_kurt² ~ χ²(2). modes: 0 = K² statistic,
+/// 1 = p-value χ²_sf(K²,2), 2 = skewness z-score, 3 = kurtosis z-score. Needs n>7. Returns 0 for
+/// n<8 or zero variance. O(n). NATIVE + lean_single only.
+fn bf_group_normaltest(src: &BigFrame, key_col: i64, val_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cn: [f64; 1024] = [0.0; 1024]
+    var s1: [f64; 1024] = [0.0; 1024]
+    var s2: [f64; 1024] = [0.0; 1024]
+    var s3: [f64; 1024] = [0.0; 1024]
+    var s4: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 { let v = read_f64(vp, i); let v2 = v * v; cn[k] = cn[k] + 1.0; s1[k] = s1[k] + v; s2[k] = s2[k] + v2; s3[k] = s3[k] + v2 * v; s4[k] = s4[k] + v2 * v2 }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        let nn = cn[g]
+        if nn > 7.0 {
+            let xb = s1[g] / nn
+            let m2 = s2[g] / nn - xb * xb
+            if m2 > 0.0 {
+                let m3 = s3[g] / nn - 3.0 * xb * s2[g] / nn + 2.0 * xb * xb * xb
+                let m4 = s4[g] / nn - 4.0 * xb * s3[g] / nn + 6.0 * xb * xb * s2[g] / nn - 3.0 * xb * xb * xb * xb
+                let g1 = m3 / (m2 * bfs_sqrt(m2, sc))
+                let b2 = m4 / (m2 * m2)
+                // skewness z (D'Agostino)
+                let Y = g1 * bfs_sqrt((nn + 1.0) * (nn + 3.0) / (6.0 * (nn - 2.0)), sc)
+                let bb = 3.0 * (nn * nn + 27.0 * nn - 70.0) * (nn + 1.0) * (nn + 3.0) / ((nn - 2.0) * (nn + 5.0) * (nn + 7.0) * (nn + 9.0))
+                let W2 = 0.0 - 1.0 + bfs_sqrt(2.0 * (bb - 1.0), sc)
+                let delta = 1.0 / bfs_sqrt(0.5 * ln(W2), sc)
+                let alpha = bfs_sqrt(2.0 / (W2 - 1.0), sc)
+                let Ya = Y / alpha
+                let Zs = delta * ln(Ya + bfs_sqrt(Ya * Ya + 1.0, sc))
+                // kurtosis z (Anscombe-Glynn)
+                let E = 3.0 * (nn - 1.0) / (nn + 1.0)
+                let vark = 24.0 * nn * (nn - 2.0) * (nn - 3.0) / ((nn + 1.0) * (nn + 1.0) * (nn + 3.0) * (nn + 5.0))
+                let Xk = (b2 - E) / bfs_sqrt(vark, sc)
+                let b1 = (6.0 * (nn * nn - 5.0 * nn + 2.0) / ((nn + 7.0) * (nn + 9.0))) * bfs_sqrt(6.0 * (nn + 3.0) * (nn + 5.0) / (nn * (nn - 2.0) * (nn - 3.0)), sc)
+                let A = 6.0 + (8.0 / b1) * (2.0 / b1 + bfs_sqrt(1.0 + 4.0 / (b1 * b1), sc))
+                let base = (1.0 - 2.0 / A) / (1.0 + Xk * bfs_sqrt(2.0 / (A - 4.0), sc))
+                var cbrt = 0.0
+                if base > 0.0 { cbrt = exp(ln(base) / 3.0) } else { if base < 0.0 { cbrt = 0.0 - exp(ln(0.0 - base) / 3.0) } }
+                let Zk = ((1.0 - 2.0 / (9.0 * A)) - cbrt) / bfs_sqrt(2.0 / (9.0 * A), sc)
+                let K2 = Zs * Zs + Zk * Zk
+                if mode == 0 { res[g] = K2 }
+                else { if mode == 1 { res[g] = chi2_sf(K2, 2.0) }
+                else { if mode == 2 { res[g] = Zs } else { res[g] = Zk } } }
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group D'AGOSTINO-PEARSON K² normality statistic, broadcast. NATIVE + lean_single.
+pub fn bf_normaltest_stat_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_normaltest(src, key_col, val_col, 0) }
+/// Per-group NORMALITY TEST P-VALUE (χ²_sf(K²,2)), broadcast. Uses stats::chi_square. NATIVE + lean_single.
+pub fn bf_normaltest_pvalue_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_normaltest(src, key_col, val_col, 1) }
+/// Per-group SKEWNESS Z-SCORE (D'Agostino), broadcast. NATIVE + lean_single.
+pub fn bf_skew_zscore_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_normaltest(src, key_col, val_col, 2) }
+/// Per-group KURTOSIS Z-SCORE (Anscombe-Glynn), broadcast. NATIVE + lean_single.
+pub fn bf_kurt_zscore_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_normaltest(src, key_col, val_col, 3) }

--- a/tests/stdlib/data/test_bigframe_stats.sio
+++ b/tests/stdlib/data/test_bigframe_stats.sio
@@ -194,6 +194,37 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let dhi2 = bf_cohens_d_ci_hi_by(&df,0,1,2)
     if !aeq(bf_get(&dhi2,0,0), 5.324921) { print("FAIL cohens_d_ci_hi\n"); return 58 }
 
+    // ===== normality test (D'Agostino K^2) on a 20-value key =====
+    var nf = bf_new(2, 24)
+    var nr0:[f64;64]=[0.0;64]; nr0[0]=0.0; nr0[1]=2.0; bf_push_row(&!nf,&nr0,2)
+    var nr1:[f64;64]=[0.0;64]; nr1[0]=0.0; nr1[1]=3.0; bf_push_row(&!nf,&nr1,2)
+    var nr2:[f64;64]=[0.0;64]; nr2[0]=0.0; nr2[1]=3.0; bf_push_row(&!nf,&nr2,2)
+    var nr3:[f64;64]=[0.0;64]; nr3[0]=0.0; nr3[1]=4.0; bf_push_row(&!nf,&nr3,2)
+    var nr4:[f64;64]=[0.0;64]; nr4[0]=0.0; nr4[1]=4.0; bf_push_row(&!nf,&nr4,2)
+    var nr5:[f64;64]=[0.0;64]; nr5[0]=0.0; nr5[1]=4.0; bf_push_row(&!nf,&nr5,2)
+    var nr6:[f64;64]=[0.0;64]; nr6[0]=0.0; nr6[1]=5.0; bf_push_row(&!nf,&nr6,2)
+    var nr7:[f64;64]=[0.0;64]; nr7[0]=0.0; nr7[1]=5.0; bf_push_row(&!nf,&nr7,2)
+    var nr8:[f64;64]=[0.0;64]; nr8[0]=0.0; nr8[1]=5.0; bf_push_row(&!nf,&nr8,2)
+    var nr9:[f64;64]=[0.0;64]; nr9[0]=0.0; nr9[1]=5.0; bf_push_row(&!nf,&nr9,2)
+    var nr10:[f64;64]=[0.0;64]; nr10[0]=0.0; nr10[1]=6.0; bf_push_row(&!nf,&nr10,2)
+    var nr11:[f64;64]=[0.0;64]; nr11[0]=0.0; nr11[1]=6.0; bf_push_row(&!nf,&nr11,2)
+    var nr12:[f64;64]=[0.0;64]; nr12[0]=0.0; nr12[1]=6.0; bf_push_row(&!nf,&nr12,2)
+    var nr13:[f64;64]=[0.0;64]; nr13[0]=0.0; nr13[1]=7.0; bf_push_row(&!nf,&nr13,2)
+    var nr14:[f64;64]=[0.0;64]; nr14[0]=0.0; nr14[1]=7.0; bf_push_row(&!nf,&nr14,2)
+    var nr15:[f64;64]=[0.0;64]; nr15[0]=0.0; nr15[1]=8.0; bf_push_row(&!nf,&nr15,2)
+    var nr16:[f64;64]=[0.0;64]; nr16[0]=0.0; nr16[1]=9.0; bf_push_row(&!nf,&nr16,2)
+    var nr17:[f64;64]=[0.0;64]; nr17[0]=0.0; nr17[1]=10.0; bf_push_row(&!nf,&nr17,2)
+    var nr18:[f64;64]=[0.0;64]; nr18[0]=0.0; nr18[1]=12.0; bf_push_row(&!nf,&nr18,2)
+    var nr19:[f64;64]=[0.0;64]; nr19[0]=0.0; nr19[1]=15.0; bf_push_row(&!nf,&nr19,2)
+    let nk = bf_normaltest_stat_by(&nf,0,1)
+    if !aeq(bf_get(&nk,0,0), 8.023499) { print("FAIL normaltest_stat\n"); return 59 }
+    let np2 = bf_normaltest_pvalue_by(&nf,0,1)
+    if !aeq(bf_get(&np2,0,0), 0.018110) { print("FAIL normaltest_p\n"); return 60 }
+    let nzs = bf_skew_zscore_by(&nf,0,1)
+    if !aeq(bf_get(&nzs,0,0), 2.369690) { print("FAIL skew_zscore\n"); return 61 }
+    let nzk = bf_kurt_zscore_by(&nf,0,1)
+    if !aeq(bf_get(&nzk,0,0), 1.551794) { print("FAIL kurt_zscore\n"); return 62 }
+
     print("BIGFRAME_STATS_GATE_OK\n")
     return 0
 }


### PR DESCRIPTION
Adds a normality test to **data::bigframe_stats** (columns key, value) from a single moment pass, reusing stats::chi_square:
- `bf_normaltest_stat_by` / `bf_normaltest_pvalue_by` — K²=Z_skew²+Z_kurt² ~ χ²(2)
- `bf_skew_zscore_by` / `bf_kurt_zscore_by` — D'Agostino skewness + Anscombe-Glynn kurtosis z-scores

One pass over n/Σx/Σx²/Σx³/Σx⁴ → central moments → the two z-transforms (cube root via sign·exp(ln|·|/3)). Needs n>7.

| verb | Sounio | pandas groupby.apply | ratio |
|---|---|---|---|
| normaltest | 20 ms | 88 ms | **0.22x (4.4x)** |

**Verified:** gate 59–62 vs an independent numpy D'Agostino implementation on a 20-value sample: K²=8.0235, p=0.0181, skew z=2.3697, kurt z=1.5518. Benchmarks reproduced.

Generated with Claude Code