### PR TITLE
feat(bigframe): per-group chi-square tests (goodness-of-fit + test-of-independence p-value)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -17,6 +17,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | per-group two-proportion z-test + Wald CI (1M rows, 1000 keys, 2 groups, binary outcome) | | ~17 | ~457 | **0.04x — wins 28x** | one-pass counts + local normal Phi vs groupby.apply |
 | per-group variance homogeneity: Bartlett + Levene (1M rows, 1000 keys, 4 groups) | | ~38 | ~749 | **0.05x — wins 20x** | one/two-pass moments + chi2_sf/f_sf vs groupby.apply |
 | per-group normality: D'Agostino-Pearson normaltest (K2, p, skew/kurt z) (1M rows, 1000 keys) | | ~20 | ~88 | **0.22x — wins 4.4x** | one moment pass + D'Agostino transform vs groupby.apply |
+| per-group chi-square: goodness-of-fit + test-of-independence p-value (1M rows, 1000 keys) | | ~26 | ~3004 | **0.01x — wins 114x** | 1D/joint histogram + chi2_sf vs groupby.apply crosstab |
 | two-sample tests: welch/cohens_d/glass/pooled_sd/point_biserial + mannwhitney_u/cles/rank_biserial/ks (1M rows, 1000 keys, 2 groups) | | ~18 | ~430 | **0.04x — wins 24x** | one-pass moments / group-split histogram; pandas = scipy + groupby.apply |
 | col_sum (8-accumulator ILP) | | 1.44 | 0.55 | **2.6x** | 3.9x |
 | col_mean (via 8-acc sum) | | 2.05 | 1.00 | **2.1x** | 2.3x |

--- a/stdlib/data/bigframe_stats.sio
+++ b/stdlib/data/bigframe_stats.sio
@@ -1016,3 +1016,123 @@ pub fn bf_normaltest_pvalue_by(src: &BigFrame, key_col: i64, val_col: i64) -> Bi
 pub fn bf_skew_zscore_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_normaltest(src, key_col, val_col, 2) }
 /// Per-group KURTOSIS Z-SCORE (Anscombe-Glynn), broadcast. NATIVE + lean_single.
 pub fn bf_kurt_zscore_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_normaltest(src, key_col, val_col, 3) }
+
+/// Per-group CHI-SQUARE GOODNESS-OF-FIT vs uniform (columns key, integer category 0..vmax). A 1D
+/// histogram per key; with K = #categories present and E = n/K, χ² = Σ(Oᵢ−E)²/E, df = K−1.
+/// modes: 0 = χ² statistic, 1 = p-value χ²_sf(χ², K−1). Returns 0 for K<2. O(n + G·vrange).
+/// NATIVE + lean_single only.
+fn bf_group_chi2gof(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cn: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || vmax < 0 { return out }
+    let vm1 = vmax + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let hist = heap_alloc(1024 * vm1 * 8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let v = read_f64(vp, i) as i64
+        if k >= 0 && k < 1024 && v >= 0 && v < vm1 { write_i64(hist, k * vm1 + v, read_i64(hist, k * vm1 + v) + 1); cn[k] = cn[k] + 1.0 }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if cn[g] > 0.0 {
+            let base = g * vm1
+            var K = 0.0; var v: i64 = 0
+            while v < vm1 { if read_i64(hist, base + v) > 0 { K = K + 1.0 } v = v + 1 }
+            if K > 1.0 {
+                let E = cn[g] / K
+                var chi = 0.0; v = 0
+                while v < vm1 { if read_i64(hist, base + v) > 0 { let o = read_i64(hist, base + v) as f64; chi = chi + (o - E) * (o - E) / E } v = v + 1 }
+                if mode == 0 { res[g] = chi } else { res[g] = chi2_sf(chi, K - 1.0) }
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(hist as *mut i8)
+    out
+}
+/// Per-group CHI-SQUARE GOODNESS-OF-FIT statistic (vs uniform), broadcast. NATIVE + lean_single.
+pub fn bf_chi2_gof_stat_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_chi2gof(src, key_col, val_col, vmax, 0) }
+/// Per-group CHI-SQUARE GOODNESS-OF-FIT P-VALUE, broadcast. Uses stats::chi_square. NATIVE + lean_single.
+pub fn bf_chi2_gof_pvalue_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_chi2gof(src, key_col, val_col, vmax, 1) }
+
+/// Per-group CHI-SQUARE TEST OF INDEPENDENCE P-VALUE (columns key, integer categories x 0..xmax,
+/// y 0..ymax) via a per-key joint histogram. The Pearson χ² over cells with Eᵢⱼ = rowᵢ·colⱼ/N and
+/// df = (r−1)(c−1) (r,c = #present rows/cols) is reduced through stats::chi_square::chi2_sf — the
+/// p-value companion to the existing bf_chi2_dense_by statistic. Broadcast. O(n + G·xrange·yrange).
+/// NATIVE + lean_single only.
+fn bf_group_chi2ind(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, xmax: i64, ymax: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cn: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || x_col < 0 || x_col >= nc || y_col < 0 || y_col >= nc || n <= 0 || xmax < 0 || ymax < 0 { return out }
+    let xm1 = xmax + 1
+    let ym1 = ymax + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let xp = bf_col_ptr(src, x_col) as *mut f64
+    let yp = bf_col_ptr(src, y_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let joint = heap_alloc(1024 * xm1 * ym1 * 8) as *mut i64
+    let rs = heap_alloc(1024 * xm1 * 8) as *mut f64
+    let cs = heap_alloc(1024 * ym1 * 8) as *mut f64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let x = read_f64(xp, i) as i64
+        let y = read_f64(yp, i) as i64
+        if k >= 0 && k < 1024 && x >= 0 && x < xm1 && y >= 0 && y < ym1 {
+            let ji = (k * xm1 + x) * ym1 + y; write_i64(joint, ji, read_i64(joint, ji) + 1)
+            let ri = k * xm1 + x; write_f64(rs, ri, read_f64(rs, ri) + 1.0)
+            let ci = k * ym1 + y; write_f64(cs, ci, read_f64(cs, ci) + 1.0)
+            cn[k] = cn[k] + 1.0
+        }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        let N = cn[g]
+        if N > 0.0 {
+            var r = 0.0; var x: i64 = 0
+            while x < xm1 { if read_f64(rs, g * xm1 + x) > 0.0 { r = r + 1.0 } x = x + 1 }
+            var c = 0.0; var y: i64 = 0
+            while y < ym1 { if read_f64(cs, g * ym1 + y) > 0.0 { c = c + 1.0 } y = y + 1 }
+            if r > 1.0 && c > 1.0 {
+                var chi = 0.0
+                x = 0
+                while x < xm1 {
+                    let rx = read_f64(rs, g * xm1 + x)
+                    if rx > 0.0 {
+                        y = 0
+                        while y < ym1 {
+                            let cy = read_f64(cs, g * ym1 + y)
+                            if cy > 0.0 { let E = rx * cy / N; let o = read_i64(joint, (g * xm1 + x) * ym1 + y) as f64; chi = chi + (o - E) * (o - E) / E }
+                            y = y + 1
+                        }
+                    }
+                    x = x + 1
+                }
+                res[g] = chi2_sf(chi, (r - 1.0) * (c - 1.0))
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(joint as *mut i8); heap_free(rs as *mut i8); heap_free(cs as *mut i8)
+    out
+}
+/// Per-group CHI-SQUARE TEST-OF-INDEPENDENCE P-VALUE, broadcast (companion to bf_chi2_dense_by). NATIVE + lean_single.
+pub fn bf_chi2_contingency_pvalue_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, xmax: i64, ymax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_chi2ind(src, key_col, x_col, y_col, xmax, ymax) }

--- a/tests/stdlib/data/test_bigframe_stats.sio
+++ b/tests/stdlib/data/test_bigframe_stats.sio
@@ -225,6 +225,34 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let nzk = bf_kurt_zscore_by(&nf,0,1)
     if !aeq(bf_get(&nzk,0,0), 1.551794) { print("FAIL kurt_zscore\n"); return 62 }
 
+    // ===== chi-square: goodness-of-fit + test of independence =====
+    var gof = bf_new(2, 16)
+    var gr0:[f64;64]=[0.0;64]; gr0[0]=0.0; gr0[1]=0.0; bf_push_row(&!gof,&gr0,2)
+    var gr1:[f64;64]=[0.0;64]; gr1[0]=0.0; gr1[1]=0.0; bf_push_row(&!gof,&gr1,2)
+    var gr2:[f64;64]=[0.0;64]; gr2[0]=0.0; gr2[1]=0.0; bf_push_row(&!gof,&gr2,2)
+    var gr3:[f64;64]=[0.0;64]; gr3[0]=0.0; gr3[1]=1.0; bf_push_row(&!gof,&gr3,2)
+    var gr4:[f64;64]=[0.0;64]; gr4[0]=0.0; gr4[1]=2.0; bf_push_row(&!gof,&gr4,2)
+    var gr5:[f64;64]=[0.0;64]; gr5[0]=0.0; gr5[1]=2.0; bf_push_row(&!gof,&gr5,2)
+    var gr6:[f64;64]=[0.0;64]; gr6[0]=0.0; gr6[1]=2.0; bf_push_row(&!gof,&gr6,2)
+    var gr7:[f64;64]=[0.0;64]; gr7[0]=0.0; gr7[1]=2.0; bf_push_row(&!gof,&gr7,2)
+    var gr8:[f64;64]=[0.0;64]; gr8[0]=0.0; gr8[1]=3.0; bf_push_row(&!gof,&gr8,2)
+    var gr9:[f64;64]=[0.0;64]; gr9[0]=0.0; gr9[1]=3.0; bf_push_row(&!gof,&gr9,2)
+    let cgs = bf_chi2_gof_stat_by(&gof,0,1,3)
+    if !aeq(bf_get(&cgs,0,0), 2.0) { print("FAIL chi2_gof_stat\n"); return 63 }
+    let cgp = bf_chi2_gof_pvalue_by(&gof,0,1,3)
+    if !aeq(bf_get(&cgp,0,0), 0.572406) { print("FAIL chi2_gof_p\n"); return 64 }
+    var cof = bf_new(3, 16)
+    var cr0:[f64;64]=[0.0;64]; cr0[0]=0.0; cr0[1]=0.0; cr0[2]=0.0; bf_push_row(&!cof,&cr0,3)
+    var cr1:[f64;64]=[0.0;64]; cr1[0]=0.0; cr1[1]=0.0; cr1[2]=0.0; bf_push_row(&!cof,&cr1,3)
+    var cr2:[f64;64]=[0.0;64]; cr2[0]=0.0; cr2[1]=0.0; cr2[2]=0.0; bf_push_row(&!cof,&cr2,3)
+    var cr3:[f64;64]=[0.0;64]; cr3[0]=0.0; cr3[1]=0.0; cr3[2]=1.0; bf_push_row(&!cof,&cr3,3)
+    var cr4:[f64;64]=[0.0;64]; cr4[0]=0.0; cr4[1]=1.0; cr4[2]=0.0; bf_push_row(&!cof,&cr4,3)
+    var cr5:[f64;64]=[0.0;64]; cr5[0]=0.0; cr5[1]=1.0; cr5[2]=1.0; bf_push_row(&!cof,&cr5,3)
+    var cr6:[f64;64]=[0.0;64]; cr6[0]=0.0; cr6[1]=1.0; cr6[2]=1.0; bf_push_row(&!cof,&cr6,3)
+    var cr7:[f64;64]=[0.0;64]; cr7[0]=0.0; cr7[1]=1.0; cr7[2]=1.0; bf_push_row(&!cof,&cr7,3)
+    let cip = bf_chi2_contingency_pvalue_by(&cof,0,1,2,1,1)
+    if !aeq(bf_get(&cip,0,0), 0.157299) { print("FAIL chi2_contingency_p\n"); return 65 }
+
     print("BIGFRAME_STATS_GATE_OK\n")
     return 0
 }


### PR DESCRIPTION
Adds the chi-square **p-value** bridge to data::bigframe_stats (the gap: #1416 shipped the chi2/Cramér's V statistics but no p-value, since the statistic doesn't expose the dof):
- `bf_chi2_gof_stat_by` / `bf_chi2_gof_pvalue_by` — goodness-of-fit vs uniform (1D histogram, E=n/K, df=K−1)
- `bf_chi2_contingency_pvalue_by` — test of independence (per-key joint histogram, Pearson χ² over cells with E=row·col/N, df=(r−1)(c−1)); companion to the existing `bf_chi2_dense_by`

| verb | Sounio | pandas groupby.apply+crosstab | ratio |
|---|---|---|---|
| chi2_contingency_p | 26 ms | 3004 ms | **0.01x (114x)** |

**Verified:** gate 63–65 vs numpy: GoF {3,1,4,2} χ²=2.0 p=0.5724; 2×2 [[3,1],[1,3]] χ²=2.0 df=1 p=0.1573. Benchmarks reproduced.

Generated with Claude Code