### PR TITLE
feat(bigframe): per-group F-test (variance ratio) + one-proportion z-test + Wilson CI

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -18,6 +18,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | per-group variance homogeneity: Bartlett + Levene (1M rows, 1000 keys, 4 groups) | | ~38 | ~749 | **0.05x — wins 20x** | one/two-pass moments + chi2_sf/f_sf vs groupby.apply |
 | per-group normality: D'Agostino-Pearson normaltest (K2, p, skew/kurt z) (1M rows, 1000 keys) | | ~20 | ~88 | **0.22x — wins 4.4x** | one moment pass + D'Agostino transform vs groupby.apply |
 | per-group chi-square: goodness-of-fit + test-of-independence p-value (1M rows, 1000 keys) | | ~26 | ~3004 | **0.01x — wins 114x** | 1D/joint histogram + chi2_sf vs groupby.apply crosstab |
+| per-group F-test (variance ratio) + one-proportion z-test + Wilson CI (1M rows, 1000 keys) | | ~17 | ~407 | **0.04x — wins 24x** | one-pass moments/counts + f_sf/f_cdf/Phi vs groupby.apply |
 | two-sample tests: welch/cohens_d/glass/pooled_sd/point_biserial + mannwhitney_u/cles/rank_biserial/ks (1M rows, 1000 keys, 2 groups) | | ~18 | ~430 | **0.04x — wins 24x** | one-pass moments / group-split histogram; pandas = scipy + groupby.apply |
 | col_sum (8-accumulator ILP) | | 1.44 | 0.55 | **2.6x** | 3.9x |
 | col_mean (via 8-acc sum) | | 2.05 | 1.00 | **2.1x** | 2.3x |

--- a/stdlib/data/bigframe_stats.sio
+++ b/stdlib/data/bigframe_stats.sio
@@ -1136,3 +1136,105 @@ fn bf_group_chi2ind(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, xmax: 
 }
 /// Per-group CHI-SQUARE TEST-OF-INDEPENDENCE P-VALUE, broadcast (companion to bf_chi2_dense_by). NATIVE + lean_single.
 pub fn bf_chi2_contingency_pvalue_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, xmax: i64, ymax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_chi2ind(src, key_col, x_col, y_col, xmax, ymax) }
+
+/// Per-group TWO-SAMPLE F-TEST for equal variances (columns key, group∈{0,1}, value). One pass over
+/// n/Σ/Σ² per (key,group); F = s²₁/s²₀, df=(n1−1, n0−1). modes: 0 = F ratio, 1 = two-sided p-value
+/// (2·min(F_cdf, F_sf)). Sample variances ddof=1. Returns 0 for n<2 in a group or zero denominator
+/// variance. O(n). NATIVE + lean_single only.
+fn bf_group_varftest(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var n0: [f64; 1024] = [0.0; 1024]
+    var s0: [f64; 1024] = [0.0; 1024]
+    var q0: [f64; 1024] = [0.0; 1024]
+    var n1: [f64; 1024] = [0.0; 1024]
+    var s1: [f64; 1024] = [0.0; 1024]
+    var q1: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || grp_col < 0 || grp_col >= nc || val_col < 0 || val_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let gp = bf_col_ptr(src, grp_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 { let g = read_f64(gp, i) as i64; let v = read_f64(vp, i); if g == 1 { n1[k] = n1[k] + 1.0; s1[k] = s1[k] + v; q1[k] = q1[k] + v * v } else { if g == 0 { n0[k] = n0[k] + 1.0; s0[k] = s0[k] + v; q0[k] = q0[k] + v * v } } }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if n0[g] > 1.0 && n1[g] > 1.0 {
+            let v0 = (q0[g] - s0[g] * s0[g] / n0[g]) / (n0[g] - 1.0)
+            let v1 = (q1[g] - s1[g] * s1[g] / n1[g]) / (n1[g] - 1.0)
+            if v0 > 0.0 && v1 > 0.0 {
+                let F = v1 / v0
+                if mode == 0 { res[g] = F }
+                else { let hi = f_sf(F, n1[g] - 1.0, n0[g] - 1.0); let lo = f_cdf(F, n1[g] - 1.0, n0[g] - 1.0); var mn = hi; if lo < mn { mn = lo }; res[g] = 2.0 * mn }
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    out
+}
+/// Per-group VARIANCE RATIO F = s²₁/s²₀, broadcast. NATIVE + lean_single.
+pub fn bf_var_ratio_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_varftest(src, key_col, grp_col, val_col, 0) }
+/// Per-group F-TEST two-sided P-VALUE for equal variances, broadcast. Uses stats::fisher_f. NATIVE + lean_single.
+pub fn bf_var_ftest_pvalue_by(src: &BigFrame, key_col: i64, grp_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_varftest(src, key_col, grp_col, val_col, 1) }
+
+/// Per-group ONE-PROPORTION inference (columns key, binary outcome 0/1). One pass counts n and
+/// #successes; p̂ = x/n. modes: 0 = z vs param p0 ((p̂−p0)/√(p0(1−p0)/n)), 1 = its two-sided
+/// p-value, 2 = Wilson 95% CI lower, 3 = Wilson 95% CI upper (CI ignores p0). Returns 0 for n<1.
+/// O(n). NATIVE + lean_single only.
+fn bf_group_oneprop(src: &BigFrame, key_col: i64, out_col: i64, p0: f64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cn: [f64; 1024] = [0.0; 1024]
+    var cx: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || out_col < 0 || out_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, out_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 { cn[k] = cn[k] + 1.0; if read_f64(vp, i) > 0.0 { cx[k] = cx[k] + 1.0 } }
+        i = i + 1
+    }
+    let zc = 1.959963985
+    var g: i64 = 0
+    while g < 1024 {
+        let m = cn[g]
+        if m > 0.0 {
+            let ph = cx[g] / m
+            if mode == 0 || mode == 1 {
+                let se = bfs_sqrt(p0 * (1.0 - p0) / m, sc)
+                if se > 0.0 { let z = (ph - p0) / se; if mode == 0 { res[g] = z } else { var za = z; if za < 0.0 { za = 0.0 - za }; res[g] = 2.0 * (1.0 - bfs_ncdf(za)) } }
+            } else {
+                let cen = ph + zc * zc / (2.0 * m)
+                let hw = zc * bfs_sqrt(ph * (1.0 - ph) / m + zc * zc / (4.0 * m * m), sc)
+                let den = 1.0 + zc * zc / m
+                if mode == 2 { res[g] = (cen - hw) / den } else { res[g] = (cen + hw) / den }
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group ONE-PROPORTION z-test two-sided P-VALUE (H0: p=p0), broadcast. NATIVE + lean_single.
+pub fn bf_one_prop_ztest_pvalue_by(src: &BigFrame, key_col: i64, out_col: i64, p0: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_oneprop(src, key_col, out_col, p0, 1) }
+/// Per-group WILSON 95% CI LOWER for a proportion, broadcast. NATIVE + lean_single.
+pub fn bf_wilson_ci_lo_by(src: &BigFrame, key_col: i64, out_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_oneprop(src, key_col, out_col, 0.5, 2) }
+/// Per-group WILSON 95% CI UPPER for a proportion, broadcast. NATIVE + lean_single.
+pub fn bf_wilson_ci_hi_by(src: &BigFrame, key_col: i64, out_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_oneprop(src, key_col, out_col, 0.5, 3) }

--- a/tests/stdlib/data/test_bigframe_stats.sio
+++ b/tests/stdlib/data/test_bigframe_stats.sio
@@ -253,6 +253,50 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let cip = bf_chi2_contingency_pvalue_by(&cof,0,1,2,1,1)
     if !aeq(bf_get(&cip,0,0), 0.157299) { print("FAIL chi2_contingency_p\n"); return 65 }
 
+    // ===== F-test (variance ratio) + one-proportion z-test + Wilson CI =====
+    var ff = bf_new(3, 16)
+    var fr0:[f64;64]=[0.0;64]; fr0[0]=0.0; fr0[1]=0.0; fr0[2]=1.0; bf_push_row(&!ff,&fr0,3)
+    var fr1:[f64;64]=[0.0;64]; fr1[0]=0.0; fr1[1]=0.0; fr1[2]=2.0; bf_push_row(&!ff,&fr1,3)
+    var fr2:[f64;64]=[0.0;64]; fr2[0]=0.0; fr2[1]=0.0; fr2[2]=3.0; bf_push_row(&!ff,&fr2,3)
+    var fr3:[f64;64]=[0.0;64]; fr3[0]=0.0; fr3[1]=0.0; fr3[2]=4.0; bf_push_row(&!ff,&fr3,3)
+    var fr4:[f64;64]=[0.0;64]; fr4[0]=0.0; fr4[1]=0.0; fr4[2]=5.0; bf_push_row(&!ff,&fr4,3)
+    var fr5:[f64;64]=[0.0;64]; fr5[0]=0.0; fr5[1]=1.0; fr5[2]=2.0; bf_push_row(&!ff,&fr5,3)
+    var fr6:[f64;64]=[0.0;64]; fr6[0]=0.0; fr6[1]=1.0; fr6[2]=4.0; bf_push_row(&!ff,&fr6,3)
+    var fr7:[f64;64]=[0.0;64]; fr7[0]=0.0; fr7[1]=1.0; fr7[2]=6.0; bf_push_row(&!ff,&fr7,3)
+    var fr8:[f64;64]=[0.0;64]; fr8[0]=0.0; fr8[1]=1.0; fr8[2]=8.0; bf_push_row(&!ff,&fr8,3)
+    var fr9:[f64;64]=[0.0;64]; fr9[0]=0.0; fr9[1]=1.0; fr9[2]=10.0; bf_push_row(&!ff,&fr9,3)
+    let vr = bf_var_ratio_by(&ff,0,1,2)
+    if !aeq(bf_get(&vr,0,0), 4.0) { print("FAIL var_ratio\n"); return 66 }
+    let vfp = bf_var_ftest_pvalue_by(&ff,0,1,2)
+    if !aeq(bf_get(&vfp,0,0), 0.208) { print("FAIL var_ftest_p\n"); return 67 }
+    var opf = bf_new(2, 24)
+    var pr0:[f64;64]=[0.0;64]; pr0[0]=0.0; pr0[1]=1.0; bf_push_row(&!opf,&pr0,2)
+    var pr1:[f64;64]=[0.0;64]; pr1[0]=0.0; pr1[1]=1.0; bf_push_row(&!opf,&pr1,2)
+    var pr2:[f64;64]=[0.0;64]; pr2[0]=0.0; pr2[1]=1.0; bf_push_row(&!opf,&pr2,2)
+    var pr3:[f64;64]=[0.0;64]; pr3[0]=0.0; pr3[1]=1.0; bf_push_row(&!opf,&pr3,2)
+    var pr4:[f64;64]=[0.0;64]; pr4[0]=0.0; pr4[1]=1.0; bf_push_row(&!opf,&pr4,2)
+    var pr5:[f64;64]=[0.0;64]; pr5[0]=0.0; pr5[1]=1.0; bf_push_row(&!opf,&pr5,2)
+    var pr6:[f64;64]=[0.0;64]; pr6[0]=0.0; pr6[1]=1.0; bf_push_row(&!opf,&pr6,2)
+    var pr7:[f64;64]=[0.0;64]; pr7[0]=0.0; pr7[1]=1.0; bf_push_row(&!opf,&pr7,2)
+    var pr8:[f64;64]=[0.0;64]; pr8[0]=0.0; pr8[1]=1.0; bf_push_row(&!opf,&pr8,2)
+    var pr9:[f64;64]=[0.0;64]; pr9[0]=0.0; pr9[1]=1.0; bf_push_row(&!opf,&pr9,2)
+    var pr10:[f64;64]=[0.0;64]; pr10[0]=0.0; pr10[1]=1.0; bf_push_row(&!opf,&pr10,2)
+    var pr11:[f64;64]=[0.0;64]; pr11[0]=0.0; pr11[1]=1.0; bf_push_row(&!opf,&pr11,2)
+    var pr12:[f64;64]=[0.0;64]; pr12[0]=0.0; pr12[1]=1.0; bf_push_row(&!opf,&pr12,2)
+    var pr13:[f64;64]=[0.0;64]; pr13[0]=0.0; pr13[1]=0.0; bf_push_row(&!opf,&pr13,2)
+    var pr14:[f64;64]=[0.0;64]; pr14[0]=0.0; pr14[1]=0.0; bf_push_row(&!opf,&pr14,2)
+    var pr15:[f64;64]=[0.0;64]; pr15[0]=0.0; pr15[1]=0.0; bf_push_row(&!opf,&pr15,2)
+    var pr16:[f64;64]=[0.0;64]; pr16[0]=0.0; pr16[1]=0.0; bf_push_row(&!opf,&pr16,2)
+    var pr17:[f64;64]=[0.0;64]; pr17[0]=0.0; pr17[1]=0.0; bf_push_row(&!opf,&pr17,2)
+    var pr18:[f64;64]=[0.0;64]; pr18[0]=0.0; pr18[1]=0.0; bf_push_row(&!opf,&pr18,2)
+    var pr19:[f64;64]=[0.0;64]; pr19[0]=0.0; pr19[1]=0.0; bf_push_row(&!opf,&pr19,2)
+    let opz = bf_one_prop_ztest_pvalue_by(&opf,0,1,0.5)
+    if !aeq(bf_get(&opz,0,0), 0.179712) { print("FAIL one_prop_z_p\n"); return 68 }
+    let wlo = bf_wilson_ci_lo_by(&opf,0,1)
+    if !aeq(bf_get(&wlo,0,0), 0.432854) { print("FAIL wilson_lo\n"); return 69 }
+    let whi = bf_wilson_ci_hi_by(&opf,0,1)
+    if !aeq(bf_get(&whi,0,0), 0.818808) { print("FAIL wilson_hi\n"); return 70 }
+
     print("BIGFRAME_STATS_GATE_OK\n")
     return 0
 }


### PR DESCRIPTION
Rounds out the hypothesis-test surface in **data::bigframe_stats**:
- `bf_var_ratio_by` / `bf_var_ftest_pvalue_by` — two-sample F-test for equal variances (F=s1²/s0², two-sided via stats::fisher_f)
- `bf_one_prop_ztest_pvalue_by(p0)` — one-proportion z-test
- `bf_wilson_ci_lo_by` / `bf_wilson_ci_hi_by` — Wilson 95% CI for a proportion

| verb | Sounio | pandas groupby.apply | ratio |
|---|---|---|---|
| var_ftest | 17 ms | 407 ms | **0.04x (24x)** |

**Verified:** gate 66–70 vs numpy: F-test g0={1..5} g1={2..10} F=4.0 p=0.208; one-proportion 13/20 vs 0.5 z p=0.1797, Wilson CI [0.4329, 0.8188]. Benchmarks reproduced.

Generated with Claude Code