### PR TITLE
feat(bigframe): data::bigframe_ml — per-group ML metrics at scale (sklearn.metrics analog)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -8,6 +8,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 
 | operation | 1M rows | Sounio ms | pandas ms | Sounio/pandas | before |
 |---|---|---|---|---|---|
+| data::bigframe_ml per-group metrics: accuracy/precision/recall/F1/MCC + MSE/RMSE/R2/MAE (1M rows, 1000 keys) | | ~16 | ~104 | **0.15x — wins 6.7x** | one-pass confusion/residual sums vs groupby.apply(sklearn.metrics) |
 | per-group p-values: ttest_pvalue / mannwhitney_pvalue (tie-corrected) / ks_pvalue (1M rows, 1000 keys, 2 groups) | | ~18 | ~460 | **0.04x — wins 25x** | one-pass stat + tested stats:: CDF vs scipy/pandas groupby.apply |
 | per-group K-sample: anova_pvalue / kruskal_pvalue (tie-corrected) (1M rows, 1000 keys, 4 groups) | | ~22 | ~460 | **0.03-0.12x — wins 8-33x** | one-pass SSB/SSW or rank-sums + tested stats:: CDF vs groupby.apply |
 | per-group correlation inference: pearson_pvalue / pearson CI (Fisher z) / spearman_rho+p (1M rows, 1000 keys, 2 cols) | | ~20-41 | ~150-267 | **0.13-0.15x — wins 7-8x** | one-pass co-moments (Pearson) or rank-LUT co-moment (Spearman) + t_two_tail vs groupby.apply |

--- a/stdlib/data/bigframe_ml.sio
+++ b/stdlib/data/bigframe_ml.sio
@@ -1,0 +1,145 @@
+// data::bigframe_ml — per-group machine-learning metrics at BigFrame scale (the sklearn.metrics
+// analog). sklearn scores ONE array of predictions; these score PER GROUP over up to 1M rows in a
+// single pass and broadcast the metric column -- a structural win sklearn's groupby.apply cannot
+// match. Inputs: (key, y_true, y_pred) columns.
+use data::bigframe::*
+
+/// Newton sqrt (builtin sqrt is wrong for args > ~1e6; the MCC denominator can be large). NATIVE + lean_single.
+fn ml_sqrt(x: f64, sc: *mut i64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    let b = f64_to_bits(x)
+    write_i64(sc, 0, (b + 4607182418800017408) >> 1)
+    var y = read_f64(sc as *mut f64, 0)
+    if y < 0.0 { y = 0.0 - y }
+    y = 0.5 * (y + x / y); y = 0.5 * (y + x / y); y = 0.5 * (y + x / y); y = 0.5 * (y + x / y); y = 0.5 * (y + x / y); y = 0.5 * (y + x / y)
+    y
+}
+
+/// Per-group BINARY CLASSIFICATION metrics (columns key, y_true∈{0,1}, y_pred∈{0,1}). One pass
+/// accumulates the confusion counts TP/FP/FN/TN per key. modes: 0 accuracy, 1 precision, 2 recall
+/// (sensitivity), 3 specificity, 4 F1, 5 Matthews correlation coefficient, 6 balanced accuracy.
+/// Broadcast. O(n). NATIVE + lean_single only.
+fn bf_group_clfmetric(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var tp: [f64; 1024] = [0.0; 1024]
+    var fp: [f64; 1024] = [0.0; 1024]
+    var fnn: [f64; 1024] = [0.0; 1024]
+    var tn: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || yt_col < 0 || yt_col >= nc || yp_col < 0 || yp_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let ytp = bf_col_ptr(src, yt_col) as *mut f64
+    let ypp = bf_col_ptr(src, yp_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 {
+            let a = read_f64(ytp, i) > 0.5
+            let b = read_f64(ypp, i) > 0.5
+            if a { if b { tp[k] = tp[k] + 1.0 } else { fnn[k] = fnn[k] + 1.0 } } else { if b { fp[k] = fp[k] + 1.0 } else { tn[k] = tn[k] + 1.0 } }
+        }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        let T = tp[g]; let P = fp[g]; let F = fnn[g]; let N = tn[g]
+        let tot = T + P + F + N
+        if tot > 0.0 {
+            if mode == 0 { res[g] = (T + N) / tot }
+            else { if mode == 1 { if T + P > 0.0 { res[g] = T / (T + P) } }
+            else { if mode == 2 { if T + F > 0.0 { res[g] = T / (T + F) } }
+            else { if mode == 3 { if N + P > 0.0 { res[g] = N / (N + P) } }
+            else { if mode == 4 { let d = 2.0 * T + P + F; if d > 0.0 { res[g] = 2.0 * T / d } }
+            else { if mode == 5 { let den = ml_sqrt((T + P) * (T + F) * (N + P) * (N + F), sc); if den > 0.0 { res[g] = (T * N - P * F) / den } }
+            else { var rc = 0.0; var sp = 0.0; if T + F > 0.0 { rc = T / (T + F) }; if N + P > 0.0 { sp = N / (N + P) }; res[g] = (rc + sp) / 2.0 } } } } } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group ACCURACY, broadcast. NATIVE + lean_single.
+pub fn bf_accuracy_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_clfmetric(src, key_col, yt_col, yp_col, 0) }
+/// Per-group PRECISION, broadcast. NATIVE + lean_single.
+pub fn bf_precision_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_clfmetric(src, key_col, yt_col, yp_col, 1) }
+/// Per-group RECALL (sensitivity / TPR), broadcast. NATIVE + lean_single.
+pub fn bf_recall_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_clfmetric(src, key_col, yt_col, yp_col, 2) }
+/// Per-group SPECIFICITY (TNR), broadcast. NATIVE + lean_single.
+pub fn bf_specificity_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_clfmetric(src, key_col, yt_col, yp_col, 3) }
+/// Per-group F1 SCORE, broadcast. NATIVE + lean_single.
+pub fn bf_f1_score_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_clfmetric(src, key_col, yt_col, yp_col, 4) }
+/// Per-group MATTHEWS CORRELATION COEFFICIENT, broadcast. NATIVE + lean_single.
+pub fn bf_mcc_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_clfmetric(src, key_col, yt_col, yp_col, 5) }
+/// Per-group BALANCED ACCURACY, broadcast. NATIVE + lean_single.
+pub fn bf_balanced_accuracy_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_clfmetric(src, key_col, yt_col, yp_col, 6) }
+
+/// Per-group REGRESSION metrics (columns key, y_true, y_pred). One pass accumulates the residual
+/// sums. modes: 0 MSE, 1 RMSE, 2 MAE, 3 R², 4 MAPE, 5 explained variance. Broadcast. O(n).
+/// NATIVE + lean_single only.
+fn bf_group_regmetric(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cn:  [f64; 1024] = [0.0; 1024]
+    var sse: [f64; 1024] = [0.0; 1024]
+    var sae: [f64; 1024] = [0.0; 1024]
+    var syt: [f64; 1024] = [0.0; 1024]
+    var sq:  [f64; 1024] = [0.0; 1024]
+    var smp: [f64; 1024] = [0.0; 1024]
+    var sr:  [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || yt_col < 0 || yt_col >= nc || yp_col < 0 || yp_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let ytp = bf_col_ptr(src, yt_col) as *mut f64
+    let ypp = bf_col_ptr(src, yp_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 {
+            let t = read_f64(ytp, i); let p = read_f64(ypp, i); let r = t - p
+            var ar = r; if ar < 0.0 { ar = 0.0 - ar }
+            cn[k] = cn[k] + 1.0; sse[k] = sse[k] + r * r; sae[k] = sae[k] + ar; syt[k] = syt[k] + t; sq[k] = sq[k] + t * t; sr[k] = sr[k] + r
+            if t != 0.0 { var at = t; if at < 0.0 { at = 0.0 - at }; smp[k] = smp[k] + ar / at }
+        }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        let m = cn[g]
+        if m > 0.0 {
+            if mode == 0 { res[g] = sse[g] / m }
+            else { if mode == 1 { res[g] = ml_sqrt(sse[g] / m, sc) }
+            else { if mode == 2 { res[g] = sae[g] / m }
+            else { if mode == 3 { let sstot = sq[g] - syt[g] * syt[g] / m; if sstot > 0.0 { res[g] = 1.0 - sse[g] / sstot } }
+            else { if mode == 4 { res[g] = smp[g] / m }
+            else { let vr = sse[g] / m - (sr[g] / m) * (sr[g] / m); let vy = sq[g] / m - (syt[g] / m) * (syt[g] / m); if vy > 0.0 { res[g] = 1.0 - vr / vy } } } } } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group MEAN SQUARED ERROR, broadcast. NATIVE + lean_single.
+pub fn bf_mse_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_regmetric(src, key_col, yt_col, yp_col, 0) }
+/// Per-group ROOT MEAN SQUARED ERROR, broadcast. NATIVE + lean_single.
+pub fn bf_rmse_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_regmetric(src, key_col, yt_col, yp_col, 1) }
+/// Per-group MEAN ABSOLUTE ERROR, broadcast. NATIVE + lean_single.
+pub fn bf_mae_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_regmetric(src, key_col, yt_col, yp_col, 2) }
+/// Per-group R² (coefficient of determination), broadcast. NATIVE + lean_single.
+pub fn bf_r2_score_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_regmetric(src, key_col, yt_col, yp_col, 3) }
+/// Per-group MEAN ABSOLUTE PERCENTAGE ERROR, broadcast. NATIVE + lean_single.
+pub fn bf_mape_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_regmetric(src, key_col, yt_col, yp_col, 4) }
+/// Per-group EXPLAINED VARIANCE score, broadcast. NATIVE + lean_single.
+pub fn bf_explained_variance_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_regmetric(src, key_col, yt_col, yp_col, 5) }

--- a/tests/stdlib/data/test_bigframe_ml.sio
+++ b/tests/stdlib/data/test_bigframe_ml.sio
@@ -1,0 +1,50 @@
+//@ run
+//@ expect-stdout: BIGFRAME_ML_GATE_OK
+use data::bigframe::*
+use data::bigframe_ml::*
+
+fn aeq(a: f64, b: f64) -> bool { let d = a - b; if d < 0.0 { (0.0 - d) < 0.0005 } else { d < 0.0005 } }
+
+fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
+    // classification: yt={1,1,1,1,0,0,0,0,0,0} yp={1,1,1,0,0,0,0,1,1,0}  TP3 FN1 FP2 TN4
+    var cf = bf_new(3, 16)
+    var cyt: [f64;11] = [1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]
+    var cyp: [f64;11] = [1.0,1.0,1.0,0.0,0.0,0.0,0.0,1.0,1.0,0.0,0.0]
+    var i: i64 = 0
+    while i < 10 { var row:[f64;64]=[0.0;64]; row[0]=0.0; row[1]=cyt[i]; row[2]=cyp[i]; bf_push_row(&!cf,&row,3); i=i+1 }
+    let acc = bf_accuracy_by(&cf,0,1,2)
+    if !aeq(bf_get(&acc,0,0), 0.7) { print("FAIL accuracy\n"); return 1 }
+    let prec = bf_precision_by(&cf,0,1,2)
+    if !aeq(bf_get(&prec,0,0), 0.6) { print("FAIL precision\n"); return 2 }
+    let rec = bf_recall_by(&cf,0,1,2)
+    if !aeq(bf_get(&rec,0,0), 0.75) { print("FAIL recall\n"); return 3 }
+    let spec = bf_specificity_by(&cf,0,1,2)
+    if !aeq(bf_get(&spec,0,0), 0.666667) { print("FAIL specificity\n"); return 4 }
+    let f1 = bf_f1_score_by(&cf,0,1,2)
+    if !aeq(bf_get(&f1,0,0), 0.666667) { print("FAIL f1\n"); return 5 }
+    let mcc = bf_mcc_by(&cf,0,1,2)
+    if !aeq(bf_get(&mcc,0,0), 0.408248) { print("FAIL mcc\n"); return 6 }
+    let bacc = bf_balanced_accuracy_by(&cf,0,1,2)
+    if !aeq(bf_get(&bacc,0,0), 0.708333) { print("FAIL balanced_accuracy\n"); return 7 }
+    // regression: yt={1,2,3,4,5} yp={1.2,1.9,3.1,3.8,5.5}
+    var rf = bf_new(3, 8)
+    var ryt: [f64;6] = [1.0,2.0,3.0,4.0,5.0,0.0]
+    var ryp: [f64;6] = [1.2,1.9,3.1,3.8,5.5,0.0]
+    i = 0
+    while i < 5 { var row2:[f64;64]=[0.0;64]; row2[0]=0.0; row2[1]=ryt[i]; row2[2]=ryp[i]; bf_push_row(&!rf,&row2,3); i=i+1 }
+    let mse = bf_mse_by(&rf,0,1,2)
+    if !aeq(bf_get(&mse,0,0), 0.07) { print("FAIL mse\n"); return 8 }
+    let rmse = bf_rmse_by(&rf,0,1,2)
+    if !aeq(bf_get(&rmse,0,0), 0.264575) { print("FAIL rmse\n"); return 9 }
+    let mae = bf_mae_by(&rf,0,1,2)
+    if !aeq(bf_get(&mae,0,0), 0.22) { print("FAIL mae\n"); return 10 }
+    let r2 = bf_r2_score_by(&rf,0,1,2)
+    if !aeq(bf_get(&r2,0,0), 0.965) { print("FAIL r2\n"); return 11 }
+    let mape = bf_mape_by(&rf,0,1,2)
+    if !aeq(bf_get(&mape,0,0), 0.086667) { print("FAIL mape\n"); return 12 }
+    let ev = bf_explained_variance_by(&rf,0,1,2)
+    if !aeq(bf_get(&ev,0,0), 0.97) { print("FAIL explained_variance\n"); return 13 }
+
+    print("BIGFRAME_ML_GATE_OK\n")
+    return 0
+}


### PR DESCRIPTION
New module **data::bigframe_ml** — per-group classification + regression metrics over 1M rows in one pass, the scale analog of `sklearn.metrics` (which scores one array; this scores **per group** and broadcasts).

**Classification** (bf_group_clfmetric): `bf_accuracy_by` / `bf_precision_by` / `bf_recall_by` / `bf_specificity_by` / `bf_f1_score_by` / `bf_mcc_by` / `bf_balanced_accuracy_by`
**Regression** (bf_group_regmetric): `bf_mse_by` / `bf_rmse_by` / `bf_mae_by` / `bf_r2_score_by` / `bf_mape_by` / `bf_explained_variance_by`

| verb | Sounio | pandas groupby.apply | ratio |
|---|---|---|---|
| f1_score | 16 ms | 104 ms | **0.15x (6.7x)** |

**Verified:** gate 1–13 vs numpy — confusion TP3/FN1/FP2/TN4 → accuracy 0.7, precision 0.6, recall 0.75, F1 0.6667, MCC 0.4082, balanced 0.7083; regression → MSE 0.07, RMSE 0.2646, MAE 0.22, R² 0.965, MAPE 0.0867, explained-var 0.97. Benchmarks reproduced. New module, no collision.

Generated with Claude Code