### PR TITLE
feat(bigframe): per-group ROC-AUC + log-loss + Brier (ranking/probabilistic ML metrics)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -9,6 +9,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | operation | 1M rows | Sounio ms | pandas ms | Sounio/pandas | before |
 |---|---|---|---|---|---|
 | data::bigframe_ml per-group metrics: accuracy/precision/recall/F1/MCC + MSE/RMSE/R2/MAE (1M rows, 1000 keys) | | ~16 | ~104 | **0.15x — wins 6.7x** | one-pass confusion/residual sums vs groupby.apply(sklearn.metrics) |
+| bigframe_ml ranking/prob metrics: roc_auc / gini / log_loss / brier (1M rows, 1000 keys) | | ~20 | ~81 | **0.24x — wins 4.1x** | label-split score histogram (rank AUC) / one-pass vs groupby.apply(roc_auc_score) |
 | per-group p-values: ttest_pvalue / mannwhitney_pvalue (tie-corrected) / ks_pvalue (1M rows, 1000 keys, 2 groups) | | ~18 | ~460 | **0.04x — wins 25x** | one-pass stat + tested stats:: CDF vs scipy/pandas groupby.apply |
 | per-group K-sample: anova_pvalue / kruskal_pvalue (tie-corrected) (1M rows, 1000 keys, 4 groups) | | ~22 | ~460 | **0.03-0.12x — wins 8-33x** | one-pass SSB/SSW or rank-sums + tested stats:: CDF vs groupby.apply |
 | per-group correlation inference: pearson_pvalue / pearson CI (Fisher z) / spearman_rho+p (1M rows, 1000 keys, 2 cols) | | ~20-41 | ~150-267 | **0.13-0.15x — wins 7-8x** | one-pass co-moments (Pearson) or rank-LUT co-moment (Spearman) + t_two_tail vs groupby.apply |

--- a/stdlib/data/bigframe_ml.sio
+++ b/stdlib/data/bigframe_ml.sio
@@ -143,3 +143,76 @@ pub fn bf_r2_score_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) ->
 pub fn bf_mape_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_regmetric(src, key_col, yt_col, yp_col, 4) }
 /// Per-group EXPLAINED VARIANCE score, broadcast. NATIVE + lean_single.
 pub fn bf_explained_variance_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_regmetric(src, key_col, yt_col, yp_col, 5) }
+
+/// Per-group ROC-AUC and probabilistic scoring. For ROC-AUC (mode 0) the input is (key, y_true∈{0,1},
+/// y_score integer 0..smax): a per-key score histogram split by label gives AUC = P(score₊>score₋)
+/// = (wins + ½·ties)/(n₊·n₋) -- the rank identity, no sort. mode 1 = Gini (2·AUC−1). For log-loss
+/// (mode 2) and Brier (mode 3) the third column is a predicted PROBABILITY in [0,1] (one moment
+/// pass; probabilities clipped to [1e-15, 1−1e-15] for the log). Broadcast. NATIVE + lean_single.
+fn bf_group_probmetric(src: &BigFrame, key_col: i64, yt_col: i64, s_col: i64, smax: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cn:  [f64; 1024] = [0.0; 1024]
+    var acc: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || yt_col < 0 || yt_col >= nc || s_col < 0 || s_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let ytp = bf_col_ptr(src, yt_col) as *mut f64
+    let sp = bf_col_ptr(src, s_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    if mode == 0 || mode == 1 {
+        // ROC-AUC via label-split score histogram
+        let vm1 = smax + 1
+        var np1: [f64; 1024] = [0.0; 1024]
+        var nn1: [f64; 1024] = [0.0; 1024]
+        let hp = heap_alloc(1024 * vm1 * 8) as *mut i64
+        let hn = heap_alloc(1024 * vm1 * 8) as *mut i64
+        var i: i64 = 0
+        while i < n {
+            let k = read_f64(kp, i) as i64
+            let sv = read_f64(sp, i) as i64
+            if k >= 0 && k < 1024 && sv >= 0 && sv < vm1 { if read_f64(ytp, i) > 0.5 { let ix = k * vm1 + sv; write_i64(hp, ix, read_i64(hp, ix) + 1); np1[k] = np1[k] + 1.0 } else { let ix = k * vm1 + sv; write_i64(hn, ix, read_i64(hn, ix) + 1); nn1[k] = nn1[k] + 1.0 } }
+            i = i + 1
+        }
+        var g: i64 = 0
+        while g < 1024 {
+            if np1[g] > 0.0 && nn1[g] > 0.0 {
+                let base = g * vm1
+                var cumn = 0.0; var wins = 0.0; var ties = 0.0; var v: i64 = 0
+                while v < vm1 { let p = read_i64(hp, base + v) as f64; let ng = read_i64(hn, base + v) as f64; if p > 0.0 { wins = wins + p * cumn; ties = ties + p * ng }; cumn = cumn + ng; v = v + 1 }
+                let auc = (wins + 0.5 * ties) / (np1[g] * nn1[g])
+                if mode == 0 { res[g] = auc } else { res[g] = 2.0 * auc - 1.0 }
+            }
+            g = g + 1
+        }
+        heap_free(hp as *mut i8); heap_free(hn as *mut i8)
+    } else {
+        // log-loss / brier (probability column)
+        var i: i64 = 0
+        while i < n {
+            let k = read_f64(kp, i) as i64
+            if k >= 0 && k < 1024 {
+                let y = read_f64(ytp, i); var p = read_f64(sp, i)
+                cn[k] = cn[k] + 1.0
+                if mode == 2 { if p < 0.000000000000001 { p = 0.000000000000001 }; if p > 0.999999999999999 { p = 0.999999999999999 }; if y > 0.5 { acc[k] = acc[k] - ln(p) } else { acc[k] = acc[k] - ln(1.0 - p) } }
+                else { let d = y - p; acc[k] = acc[k] + d * d }
+            }
+            i = i + 1
+        }
+        var g: i64 = 0
+        while g < 1024 { if cn[g] > 0.0 { res[g] = acc[g] / cn[g] } g = g + 1 }
+    }
+    var i2: i64 = 0
+    while i2 < n { let k = read_f64(kp, i2) as i64; if k >= 0 && k < 1024 { write_f64(op, i2, read_f64(res as *mut f64, k)) } else { write_f64(op, i2, 0.0) } i2 = i2 + 1 }
+    out
+}
+/// Per-group ROC-AUC (rank-based, integer-scored y_score 0..smax), broadcast. NATIVE + lean_single.
+pub fn bf_roc_auc_by(src: &BigFrame, key_col: i64, yt_col: i64, score_col: i64, smax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_probmetric(src, key_col, yt_col, score_col, smax, 0) }
+/// Per-group GINI COEFFICIENT of ranking (2·AUC−1), broadcast. NATIVE + lean_single.
+pub fn bf_auc_gini_by(src: &BigFrame, key_col: i64, yt_col: i64, score_col: i64, smax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_probmetric(src, key_col, yt_col, score_col, smax, 1) }
+/// Per-group LOG LOSS (binary cross-entropy; third col is predicted probability), broadcast. NATIVE + lean_single.
+pub fn bf_log_loss_by(src: &BigFrame, key_col: i64, yt_col: i64, prob_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_probmetric(src, key_col, yt_col, prob_col, 0, 2) }
+/// Per-group BRIER SCORE (mean squared error of probabilities), broadcast. NATIVE + lean_single.
+pub fn bf_brier_score_by(src: &BigFrame, key_col: i64, yt_col: i64, prob_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_probmetric(src, key_col, yt_col, prob_col, 0, 3) }

--- a/tests/stdlib/data/test_bigframe_ml.sio
+++ b/tests/stdlib/data/test_bigframe_ml.sio
@@ -45,6 +45,28 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let ev = bf_explained_variance_by(&rf,0,1,2)
     if !aeq(bf_get(&ev,0,0), 0.97) { print("FAIL explained_variance\n"); return 13 }
 
+    // ===== ROC-AUC + log-loss + Brier =====
+    var af = bf_new(3, 8)
+    var ar0:[f64;64]=[0.0;64]; ar0[0]=0.0; ar0[1]=0.0; ar0[2]=1.0; bf_push_row(&!af,&ar0,3)
+    var ar1:[f64;64]=[0.0;64]; ar1[0]=0.0; ar1[1]=0.0; ar1[2]=2.0; bf_push_row(&!af,&ar1,3)
+    var ar2:[f64;64]=[0.0;64]; ar2[0]=0.0; ar2[1]=1.0; ar2[2]=2.0; bf_push_row(&!af,&ar2,3)
+    var ar3:[f64;64]=[0.0;64]; ar3[0]=0.0; ar3[1]=0.0; ar3[2]=3.0; bf_push_row(&!af,&ar3,3)
+    var ar4:[f64;64]=[0.0;64]; ar4[0]=0.0; ar4[1]=1.0; ar4[2]=4.0; bf_push_row(&!af,&ar4,3)
+    var ar5:[f64;64]=[0.0;64]; ar5[0]=0.0; ar5[1]=1.0; ar5[2]=5.0; bf_push_row(&!af,&ar5,3)
+    let auc = bf_roc_auc_by(&af,0,1,2,5)
+    if !aeq(bf_get(&auc,0,0), 0.833333) { print("FAIL roc_auc\n"); return 14 }
+    let gn = bf_auc_gini_by(&af,0,1,2,5)
+    if !aeq(bf_get(&gn,0,0), 0.666667) { print("FAIL auc_gini\n"); return 15 }
+    var lf = bf_new(3, 8)
+    var lr0:[f64;64]=[0.0;64]; lr0[0]=0.0; lr0[1]=1.0; lr0[2]=0.9; bf_push_row(&!lf,&lr0,3)
+    var lr1:[f64;64]=[0.0;64]; lr1[0]=0.0; lr1[1]=0.0; lr1[2]=0.2; bf_push_row(&!lf,&lr1,3)
+    var lr2:[f64;64]=[0.0;64]; lr2[0]=0.0; lr2[1]=1.0; lr2[2]=0.8; bf_push_row(&!lf,&lr2,3)
+    var lr3:[f64;64]=[0.0;64]; lr3[0]=0.0; lr3[1]=0.0; lr3[2]=0.3; bf_push_row(&!lf,&lr3,3)
+    let ll = bf_log_loss_by(&lf,0,1,2)
+    if !aeq(bf_get(&ll,0,0), 0.227081) { print("FAIL log_loss\n"); return 16 }
+    let br = bf_brier_score_by(&lf,0,1,2)
+    if !aeq(bf_get(&br,0,0), 0.045) { print("FAIL brier\n"); return 17 }
+
     print("BIGFRAME_ML_GATE_OK\n")
     return 0
 }


### PR DESCRIPTION
Extends **data::bigframe_ml** with ranking/probabilistic scoring:
- `bf_roc_auc_by` / `bf_auc_gini_by` — ROC-AUC via a per-key label-split score histogram (AUC = (wins+½ties)/(n₊n₋), the rank identity, no sort); Gini = 2·AUC−1
- `bf_log_loss_by` — binary cross-entropy (probability col, clipped) / `bf_brier_score_by`

| verb | Sounio | pandas groupby.apply(roc_auc_score) | ratio |
|---|---|---|---|
| roc_auc | 20 ms | 81 ms | **0.24x (4.1x)** |

**Verified:** gate 14–17 vs numpy — ROC-AUC 0.8333 (Gini 0.6667), log-loss 0.2271, Brier 0.045. Benchmarks reproduced.

Generated with Claude Code