### PR TITLE
feat(bigframe): per-group logistic regression + Cohen's kappa/confusion-rate/multi-class metrics

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -10,6 +10,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 |---|---|---|---|---|---|
 | data::bigframe_ml per-group metrics: accuracy/precision/recall/F1/MCC + MSE/RMSE/R2/MAE (1M rows, 1000 keys) | | ~16 | ~104 | **0.15x — wins 6.7x** | one-pass confusion/residual sums vs groupby.apply(sklearn.metrics) |
 | bigframe_ml ranking/prob metrics: roc_auc / gini / log_loss / brier (1M rows, 1000 keys) | | ~20 | ~81 | **0.24x — wins 4.1x** | label-split score histogram (rank AUC) / one-pass vs groupby.apply(roc_auc_score) |
+| bigframe_ml per-group LOGISTIC REGRESSION fit (IRLS, correctness-verified capability) | | ~610 | ~126 | **~4.8x LOSS (compute-bound)** | 10 IRLS passes; per-row scalar sigmoid loop vs numpy SIMD — honest loss pending C3 vectorization; a NEW capability (per-group trained classifier) |
 | per-group p-values: ttest_pvalue / mannwhitney_pvalue (tie-corrected) / ks_pvalue (1M rows, 1000 keys, 2 groups) | | ~18 | ~460 | **0.04x — wins 25x** | one-pass stat + tested stats:: CDF vs scipy/pandas groupby.apply |
 | per-group K-sample: anova_pvalue / kruskal_pvalue (tie-corrected) (1M rows, 1000 keys, 4 groups) | | ~22 | ~460 | **0.03-0.12x — wins 8-33x** | one-pass SSB/SSW or rank-sums + tested stats:: CDF vs groupby.apply |
 | per-group correlation inference: pearson_pvalue / pearson CI (Fisher z) / spearman_rho+p (1M rows, 1000 keys, 2 cols) | | ~20-41 | ~150-267 | **0.13-0.15x — wins 7-8x** | one-pass co-moments (Pearson) or rank-LUT co-moment (Spearman) + t_two_tail vs groupby.apply |

--- a/stdlib/data/bigframe_ml.sio
+++ b/stdlib/data/bigframe_ml.sio
@@ -284,3 +284,81 @@ pub fn bf_logistic_coef0_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64
 pub fn bf_logistic_coef1_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, niter: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_logistic(src, key_col, x_col, y_col, niter, 1) }
 /// Per-group LOGISTIC REGRESSION predicted probability σ(β₀+β₁x) per row, broadcast. NATIVE + lean_single.
 pub fn bf_logistic_predict_proba_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, niter: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_logistic(src, key_col, x_col, y_col, niter, 2) }
+
+/// Per-group additional CONFUSION-derived classification metrics (columns key, y_true∈{0,1},
+/// y_pred∈{0,1}). One confusion-count pass. modes: 0 Cohen's κ (chance-corrected agreement),
+/// 1 NPV, 2 false-positive rate, 3 false-negative rate, 4 Jaccard/threat score TP/(TP+FP+FN).
+/// Broadcast. O(n). NATIVE + lean_single only.
+fn bf_group_clfmetric2(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var tp: [f64; 1024] = [0.0; 1024]
+    var fp: [f64; 1024] = [0.0; 1024]
+    var fnn: [f64; 1024] = [0.0; 1024]
+    var tn: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || yt_col < 0 || yt_col >= nc || yp_col < 0 || yp_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let ytp = bf_col_ptr(src, yt_col) as *mut f64
+    let ypp = bf_col_ptr(src, yp_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 { let a = read_f64(ytp, i) > 0.5; let b = read_f64(ypp, i) > 0.5; if a { if b { tp[k] = tp[k] + 1.0 } else { fnn[k] = fnn[k] + 1.0 } } else { if b { fp[k] = fp[k] + 1.0 } else { tn[k] = tn[k] + 1.0 } } }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        let T = tp[g]; let P = fp[g]; let F = fnn[g]; let N = tn[g]; let tot = T + P + F + N
+        if tot > 0.0 {
+            if mode == 0 { let po = (T + N) / tot; let pe = ((T + F) * (T + P) + (N + P) * (N + F)) / (tot * tot); if pe < 1.0 { res[g] = (po - pe) / (1.0 - pe) } }
+            else { if mode == 1 { if N + F > 0.0 { res[g] = N / (N + F) } }
+            else { if mode == 2 { if P + N > 0.0 { res[g] = P / (P + N) } }
+            else { if mode == 3 { if F + T > 0.0 { res[g] = F / (F + T) } }
+            else { if T + P + F > 0.0 { res[g] = T / (T + P + F) } } } } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    out
+}
+/// Per-group COHEN'S KAPPA (chance-corrected agreement), broadcast. NATIVE + lean_single.
+pub fn bf_cohen_kappa_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_clfmetric2(src, key_col, yt_col, yp_col, 0) }
+/// Per-group NEGATIVE PREDICTIVE VALUE, broadcast. NATIVE + lean_single.
+pub fn bf_npv_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_clfmetric2(src, key_col, yt_col, yp_col, 1) }
+/// Per-group FALSE-POSITIVE RATE, broadcast. NATIVE + lean_single.
+pub fn bf_fpr_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_clfmetric2(src, key_col, yt_col, yp_col, 2) }
+/// Per-group FALSE-NEGATIVE RATE, broadcast. NATIVE + lean_single.
+pub fn bf_fnr_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_clfmetric2(src, key_col, yt_col, yp_col, 3) }
+/// Per-group JACCARD (threat score) TP/(TP+FP+FN), broadcast. NATIVE + lean_single.
+pub fn bf_jaccard_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_clfmetric2(src, key_col, yt_col, yp_col, 4) }
+
+/// Per-group MULTI-CLASS ACCURACY (fraction of rows with y_true == y_pred, any integer labels),
+/// broadcast. One pass. O(n). NATIVE + lean_single only.
+fn bf_group_mcacc(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cn: [f64; 1024] = [0.0; 1024]
+    var ok: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || yt_col < 0 || yt_col >= nc || yp_col < 0 || yp_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let ytp = bf_col_ptr(src, yt_col) as *mut f64
+    let ypp = bf_col_ptr(src, yp_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { cn[k] = cn[k] + 1.0; if read_f64(ytp, i) == read_f64(ypp, i) { ok[k] = ok[k] + 1.0 } } i = i + 1 }
+    var g: i64 = 0
+    while g < 1024 { if cn[g] > 0.0 { res[g] = ok[g] / cn[g] } g = g + 1 }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    out
+}
+/// Per-group MULTI-CLASS ACCURACY (any integer labels), broadcast. NATIVE + lean_single.
+pub fn bf_multiclass_accuracy_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_mcacc(src, key_col, yt_col, yp_col) }

--- a/stdlib/data/bigframe_ml.sio
+++ b/stdlib/data/bigframe_ml.sio
@@ -216,3 +216,71 @@ pub fn bf_auc_gini_by(src: &BigFrame, key_col: i64, yt_col: i64, score_col: i64,
 pub fn bf_log_loss_by(src: &BigFrame, key_col: i64, yt_col: i64, prob_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_probmetric(src, key_col, yt_col, prob_col, 0, 2) }
 /// Per-group BRIER SCORE (mean squared error of probabilities), broadcast. NATIVE + lean_single.
 pub fn bf_brier_score_by(src: &BigFrame, key_col: i64, yt_col: i64, prob_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_probmetric(src, key_col, yt_col, prob_col, 0, 3) }
+
+/// Per-group univariate LOGISTIC REGRESSION fit (columns key, x, y∈{0,1}), fitted by `niter`
+/// Newton-Raphson (IRLS) iterations -- each iteration is one pass accumulating the gradient and
+/// 2×2 Hessian per key. The scikit-learn analog, but a separate model PER KEY over 1M rows.
+/// modes: 0 = intercept β₀, 1 = slope β₁, 2 = per-row predicted probability σ(β₀+β₁x). Broadcast.
+/// O(niter·n). NATIVE + lean_single only.
+fn bf_group_logistic(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, niter: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var b0: [f64; 1024] = [0.0; 1024]
+    var b1: [f64; 1024] = [0.0; 1024]
+    var g0: [f64; 1024] = [0.0; 1024]
+    var g1: [f64; 1024] = [0.0; 1024]
+    var h00: [f64; 1024] = [0.0; 1024]
+    var h01: [f64; 1024] = [0.0; 1024]
+    var h11: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || x_col < 0 || x_col >= nc || y_col < 0 || y_col >= nc || n <= 0 || niter <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let xp = bf_col_ptr(src, x_col) as *mut f64
+    let yp = bf_col_ptr(src, y_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var it: i64 = 0
+    while it < niter {
+        var c: i64 = 0
+        while c < 1024 { g0[c] = 0.0; g1[c] = 0.0; h00[c] = 0.0; h01[c] = 0.0; h11[c] = 0.0; c = c + 1 }
+        var i: i64 = 0
+        while i < n {
+            let k = read_f64(kp, i) as i64
+            if k >= 0 && k < 1024 {
+                let x = read_f64(xp, i); let y = read_f64(yp, i)
+                let eta = b0[k] + b1[k] * x
+                var p = 0.5
+                if eta > 30.0 { p = 1.0 } else { if eta < 0.0 - 30.0 { p = 0.0 } else { p = 1.0 / (1.0 + exp(0.0 - eta)) } }
+                let w = p * (1.0 - p); let r = y - p
+                g0[k] = g0[k] + r; g1[k] = g1[k] + x * r
+                h00[k] = h00[k] + w; h01[k] = h01[k] + x * w; h11[k] = h11[k] + x * x * w
+            }
+            i = i + 1
+        }
+        var g: i64 = 0
+        while g < 1024 {
+            let det = h00[g] * h11[g] - h01[g] * h01[g]
+            var ad = det; if ad < 0.0 { ad = 0.0 - ad }
+            if ad > 0.000000000001 { b0[g] = b0[g] + (h11[g] * g0[g] - h01[g] * g1[g]) / det; b1[g] = b1[g] + (0.0 - h01[g] * g0[g] + h00[g] * g1[g]) / det }
+            g = g + 1
+        }
+        it = it + 1
+    }
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 {
+            if mode == 0 { write_f64(op, i, b0[k]) }
+            else { if mode == 1 { write_f64(op, i, b1[k]) }
+            else { let eta = b0[k] + b1[k] * read_f64(xp, i); var p = 0.5; if eta > 30.0 { p = 1.0 } else { if eta < 0.0 - 30.0 { p = 0.0 } else { p = 1.0 / (1.0 + exp(0.0 - eta)) } }; write_f64(op, i, p) } }
+        } else { write_f64(op, i, 0.0) }
+        i = i + 1
+    }
+    out
+}
+/// Per-group LOGISTIC REGRESSION intercept β₀ (IRLS fit), broadcast. NATIVE + lean_single.
+pub fn bf_logistic_coef0_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, niter: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_logistic(src, key_col, x_col, y_col, niter, 0) }
+/// Per-group LOGISTIC REGRESSION slope β₁ (IRLS fit), broadcast. NATIVE + lean_single.
+pub fn bf_logistic_coef1_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, niter: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_logistic(src, key_col, x_col, y_col, niter, 1) }
+/// Per-group LOGISTIC REGRESSION predicted probability σ(β₀+β₁x) per row, broadcast. NATIVE + lean_single.
+pub fn bf_logistic_predict_proba_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, niter: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_logistic(src, key_col, x_col, y_col, niter, 2) }

--- a/tests/stdlib/data/test_bigframe_ml.sio
+++ b/tests/stdlib/data/test_bigframe_ml.sio
@@ -67,6 +67,20 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let br = bf_brier_score_by(&lf,0,1,2)
     if !aeq(bf_get(&br,0,0), 0.045) { print("FAIL brier\n"); return 17 }
 
+    // ===== logistic regression fit (IRLS): x={1..5} y={0,1,0,1,1} =====
+    var lgf = bf_new(3, 8)
+    var lg0:[f64;64]=[0.0;64]; lg0[0]=0.0; lg0[1]=1.0; lg0[2]=0.0; bf_push_row(&!lgf,&lg0,3)
+    var lg1:[f64;64]=[0.0;64]; lg1[0]=0.0; lg1[1]=2.0; lg1[2]=1.0; bf_push_row(&!lgf,&lg1,3)
+    var lg2:[f64;64]=[0.0;64]; lg2[0]=0.0; lg2[1]=3.0; lg2[2]=0.0; bf_push_row(&!lgf,&lg2,3)
+    var lg3:[f64;64]=[0.0;64]; lg3[0]=0.0; lg3[1]=4.0; lg3[2]=1.0; bf_push_row(&!lgf,&lg3,3)
+    var lg4:[f64;64]=[0.0;64]; lg4[0]=0.0; lg4[1]=5.0; lg4[2]=1.0; bf_push_row(&!lgf,&lg4,3)
+    let lc0 = bf_logistic_coef0_by(&lgf,0,1,2,25)
+    if !aeq(bf_get(&lc0,0,0), 0.0 - 2.648587) { print("FAIL logistic_coef0\n"); return 18 }
+    let lc1 = bf_logistic_coef1_by(&lgf,0,1,2,25)
+    if !aeq(bf_get(&lc1,0,0), 1.090426) { print("FAIL logistic_coef1\n"); return 19 }
+    let lpp = bf_logistic_predict_proba_by(&lgf,0,1,2,25)
+    if !aeq(bf_get(&lpp,2,0), 0.650830) { print("FAIL logistic_predict_proba\n"); return 20 }
+
     print("BIGFRAME_ML_GATE_OK\n")
     return 0
 }

--- a/tests/stdlib/data/test_bigframe_ml.sio
+++ b/tests/stdlib/data/test_bigframe_ml.sio
@@ -81,6 +81,26 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let lpp = bf_logistic_predict_proba_by(&lgf,0,1,2,25)
     if !aeq(bf_get(&lpp,2,0), 0.650830) { print("FAIL logistic_predict_proba\n"); return 20 }
 
+    // ===== extra classification metrics (reuse cf) + multi-class accuracy =====
+    let kap = bf_cohen_kappa_by(&cf,0,1,2)
+    if !aeq(bf_get(&kap,0,0), 0.4) { print("FAIL cohen_kappa\n"); return 21 }
+    let npv = bf_npv_by(&cf,0,1,2)
+    if !aeq(bf_get(&npv,0,0), 0.8) { print("FAIL npv\n"); return 22 }
+    let fpr = bf_fpr_by(&cf,0,1,2)
+    if !aeq(bf_get(&fpr,0,0), 0.333333) { print("FAIL fpr\n"); return 23 }
+    let fnr = bf_fnr_by(&cf,0,1,2)
+    if !aeq(bf_get(&fnr,0,0), 0.25) { print("FAIL fnr\n"); return 24 }
+    let jac = bf_jaccard_by(&cf,0,1,2)
+    if !aeq(bf_get(&jac,0,0), 0.5) { print("FAIL jaccard\n"); return 25 }
+    var mcf = bf_new(3, 8)
+    var mc0:[f64;64]=[0.0;64]; mc0[0]=0.0; mc0[1]=0.0; mc0[2]=0.0; bf_push_row(&!mcf,&mc0,3)
+    var mc1:[f64;64]=[0.0;64]; mc1[0]=0.0; mc1[1]=1.0; mc1[2]=2.0; bf_push_row(&!mcf,&mc1,3)
+    var mc2:[f64;64]=[0.0;64]; mc2[0]=0.0; mc2[1]=2.0; mc2[2]=2.0; bf_push_row(&!mcf,&mc2,3)
+    var mc3:[f64;64]=[0.0;64]; mc3[0]=0.0; mc3[1]=1.0; mc3[2]=1.0; bf_push_row(&!mcf,&mc3,3)
+    var mc4:[f64;64]=[0.0;64]; mc4[0]=0.0; mc4[1]=0.0; mc4[2]=0.0; bf_push_row(&!mcf,&mc4,3)
+    let mca = bf_multiclass_accuracy_by(&mcf,0,1,2)
+    if !aeq(bf_get(&mca,0,0), 0.8) { print("FAIL multiclass_accuracy\n"); return 26 }
+
     print("BIGFRAME_ML_GATE_OK\n")
     return 0
 }


### PR DESCRIPTION
Adds a real **trained per-group model** to data::bigframe_ml (key, x, y∈{0,1}), fitted by Newton-Raphson (IRLS) — the `sklearn.LogisticRegression` analog but a separate model **per key**:
- `bf_logistic_coef0_by` / `bf_logistic_coef1_by` (fitted intercept/slope)
- `bf_logistic_predict_proba_by` (per-row σ(β₀+β₁x))

**Verified:** gate 18–20 vs numpy IRLS on x={1..5} y={0,1,0,1,1}: β₀=−2.6486, β₁=1.0904, proba(x=3)=0.6508.

**Honest performance:** unlike the one-pass metrics (win 4–7×), logistic is **iterative** (niter full passes, per-row scalar sigmoid) → compute-bound, **loses ~4.8×** to a hand-vectorized numpy IRLS (no SIMD yet — pending the C3 auto-vectorization dispatch). Shipped as a **capability** (per-group trained classifier at 1000-group scale in one call), not a speed win. Against `sklearn.LogisticRegression`'s per-fit overhead ×1000 groups it would win, but sklearn is absent to confirm, so the reported baseline is the faster bare-numpy IRLS.

Generated with Claude Code