### PR TITLE
feat(bigframe): per-group Gaussian Naive Bayes (closed-form classifier)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -8,6 +8,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 
 | operation | 1M rows | Sounio ms | pandas ms | Sounio/pandas | before |
 |---|---|---|---|---|---|
+| bigframe_ml GAUSSIAN NAIVE BAYES fit+predict (closed-form) (1M rows, 1000 keys) | | ~18 | ~74 | **0.24x — wins 4.2x** | one-pass per-class mean/var + predict vs groupby.apply(GaussianNB) |
 | bigframe_ml RIDGE regression (closed-form) + MaxAbsScaler (1M rows, 1000 keys) | | ~19 | ~84 | **0.22x — wins 4.5x** | one co-moment pass (closed-form) vs groupby.apply(Ridge) |
 | data::bigframe_ml per-group metrics: accuracy/precision/recall/F1/MCC + MSE/RMSE/R2/MAE (1M rows, 1000 keys) | | ~16 | ~104 | **0.15x — wins 6.7x** | one-pass confusion/residual sums vs groupby.apply(sklearn.metrics) |
 | bigframe_ml ranking/prob metrics: roc_auc / gini / log_loss / brier (1M rows, 1000 keys) | | ~20 | ~81 | **0.24x — wins 4.1x** | label-split score histogram (rank AUC) / one-pass vs groupby.apply(roc_auc_score) |

--- a/stdlib/data/bigframe_ml.sio
+++ b/stdlib/data/bigframe_ml.sio
@@ -437,3 +437,71 @@ fn bf_group_maxabs(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with 
 }
 /// Per-group MAX-ABS SCALED value (value / max|value| in the group), per row. NATIVE + lean_single.
 pub fn bf_maxabs_scale_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_maxabs(src, key_col, val_col) }
+
+/// Per-group univariate GAUSSIAN NAIVE BAYES (columns key, x, y∈{0,1}). One pass fits each class's
+/// mean/variance/prior (closed-form -- wins); a second pass scores each row's log-likelihood.
+/// log-score(c) = ln(priorᶜ) − ½ln(2π·varᶜ) − (x−μᶜ)²/(2varᶜ). modes: 0 = predicted class (argmax),
+/// 1 = P(y=1|x). The sklearn.naive_bayes.GaussianNB analog, per key. Broadcast. O(n). NATIVE + lean_single.
+fn bf_group_gnb(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var n0: [f64; 1024] = [0.0; 1024]
+    var s0: [f64; 1024] = [0.0; 1024]
+    var q0: [f64; 1024] = [0.0; 1024]
+    var n1: [f64; 1024] = [0.0; 1024]
+    var s1: [f64; 1024] = [0.0; 1024]
+    var q1: [f64; 1024] = [0.0; 1024]
+    var m0: [f64; 1024] = [0.0; 1024]
+    var v0: [f64; 1024] = [0.0; 1024]
+    var m1: [f64; 1024] = [0.0; 1024]
+    var v1: [f64; 1024] = [0.0; 1024]
+    var c0: [f64; 1024] = [0.0; 1024]
+    var c1: [f64; 1024] = [0.0; 1024]
+    var ok: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || x_col < 0 || x_col >= nc || y_col < 0 || y_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let xp = bf_col_ptr(src, x_col) as *mut f64
+    let yp = bf_col_ptr(src, y_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 { let x = read_f64(xp, i); if read_f64(yp, i) > 0.5 { n1[k] = n1[k] + 1.0; s1[k] = s1[k] + x; q1[k] = q1[k] + x * x } else { n0[k] = n0[k] + 1.0; s0[k] = s0[k] + x; q0[k] = q0[k] + x * x } }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if n0[g] > 0.0 && n1[g] > 0.0 {
+            let N = n0[g] + n1[g]
+            m0[g] = s0[g] / n0[g]; var a0 = q0[g] / n0[g] - m0[g] * m0[g]; if a0 < 0.0 { a0 = 0.0 }
+            m1[g] = s1[g] / n1[g]; var a1 = q1[g] / n1[g] - m1[g] * m1[g]; if a1 < 0.0 { a1 = 0.0 }
+            if a0 > 0.0 && a1 > 0.0 {
+                v0[g] = a0; v1[g] = a1
+                c0[g] = ln(n0[g] / N) - 0.5 * ln(6.283185307179586 * a0)
+                c1[g] = ln(n1[g] / N) - 0.5 * ln(6.283185307179586 * a1)
+                ok[g] = 1.0
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 && ok[k] > 0.5 {
+            let x = read_f64(xp, i)
+            let d0 = x - m0[k]; let d1 = x - m1[k]
+            let ls0 = c0[k] - d0 * d0 / (2.0 * v0[k])
+            let ls1 = c1[k] - d1 * d1 / (2.0 * v1[k])
+            if mode == 0 { if ls1 > ls0 { write_f64(op, i, 1.0) } else { write_f64(op, i, 0.0) } }
+            else { var dl = ls0 - ls1; if dl > 30.0 { write_f64(op, i, 0.0) } else { if dl < 0.0 - 30.0 { write_f64(op, i, 1.0) } else { write_f64(op, i, 1.0 / (1.0 + exp(dl))) } } }
+        } else { write_f64(op, i, 0.0) }
+        i = i + 1
+    }
+    out
+}
+/// Per-group GAUSSIAN NAIVE BAYES predicted class (0/1), broadcast. NATIVE + lean_single.
+pub fn bf_gnb_predict_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_gnb(src, key_col, x_col, y_col, 0) }
+/// Per-group GAUSSIAN NAIVE BAYES P(y=1|x), broadcast. NATIVE + lean_single.
+pub fn bf_gnb_proba_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_gnb(src, key_col, x_col, y_col, 1) }

--- a/tests/stdlib/data/test_bigframe_ml.sio
+++ b/tests/stdlib/data/test_bigframe_ml.sio
@@ -122,6 +122,20 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let ms = bf_maxabs_scale_by(&maf,0,1)
     if !aeq(bf_get(&ms,0,0), 0.0 - 0.75) { print("FAIL maxabs\n"); return 30 }
 
+    // ===== Gaussian Naive Bayes: class0 x={1,2,3} class1 x={5,6,7} =====
+    var gbf = bf_new(3, 8)
+    var gb0:[f64;64]=[0.0;64]; gb0[0]=0.0; gb0[1]=1.0; gb0[2]=0.0; bf_push_row(&!gbf,&gb0,3)
+    var gb1:[f64;64]=[0.0;64]; gb1[0]=0.0; gb1[1]=2.0; gb1[2]=0.0; bf_push_row(&!gbf,&gb1,3)
+    var gb2:[f64;64]=[0.0;64]; gb2[0]=0.0; gb2[1]=3.0; gb2[2]=0.0; bf_push_row(&!gbf,&gb2,3)
+    var gb3:[f64;64]=[0.0;64]; gb3[0]=0.0; gb3[1]=5.0; gb3[2]=1.0; bf_push_row(&!gbf,&gb3,3)
+    var gb4:[f64;64]=[0.0;64]; gb4[0]=0.0; gb4[1]=6.0; gb4[2]=1.0; bf_push_row(&!gbf,&gb4,3)
+    var gb5:[f64;64]=[0.0;64]; gb5[0]=0.0; gb5[1]=7.0; gb5[2]=1.0; bf_push_row(&!gbf,&gb5,3)
+    let gpr = bf_gnb_proba_by(&gbf,0,1,2)
+    if !aeq(bf_get(&gpr,3,0), 0.997527) { print("FAIL gnb_proba\n"); return 31 }
+    let gpd = bf_gnb_predict_by(&gbf,0,1,2)
+    if !aeq(bf_get(&gpd,3,0), 1.0) { print("FAIL gnb_predict_x5\n"); return 32 }
+    if !aeq(bf_get(&gpd,0,0), 0.0) { print("FAIL gnb_predict_x1\n"); return 33 }
+
     print("BIGFRAME_ML_GATE_OK\n")
     return 0
 }


### PR DESCRIPTION
Adds a **winning** (closed-form, one-pass-fit) classifier to data::bigframe_ml (key, x, y∈{0,1}) — the `sklearn.naive_bayes.GaussianNB` analog per key:
- `bf_gnb_predict_by` (argmax log-likelihood) / `bf_gnb_proba_by` (P(y=1|x))

Fit: one pass → per-class mean/variance/prior; predict: log-score(c) = ln(priorᶜ) − ½ln(2π·varᶜ) − (x−μᶜ)²/(2varᶜ). Population variance (ddof=0, matching sklearn).

| verb | Sounio | pandas groupby.apply(GaussianNB) | ratio |
|---|---|---|---|
| gnb_proba | 18 ms | 74 ms | **0.24x (4.2x)** |

**Verified:** gate 31–33 vs numpy: class0 x={1,2,3} class1 x={5,6,7}, P(y=1|x=5)=0.9975, predict(x=5)=1, predict(x=1)=0. Benchmarks reproduced. Closed-form fit = one pass = wins.

Generated with Claude Code