### PR TITLE
feat(bigframe): per-group decision stump (depth-1 CART) — tree-family atom

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -8,6 +8,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 
 | operation | 1M rows | Sounio ms | pandas ms | Sounio/pandas | before |
 |---|---|---|---|---|---|
+| bigframe_ml DECISION STUMP fit+predict (depth-1 CART, histogram) (1M rows, 1000 keys) | | ~22 | ~300 | **0.07x — wins 14x** | one-pass histogram + threshold scan vs groupby.apply threshold search |
 | bigframe_ml PCA explained-variance-ratio (closed-form 2x2 eigen) (1M rows, 1000 keys) | | ~20 | ~142 | **0.14x — wins 7x** | one-pass covariance + 2x2 eigendecomposition vs groupby.apply(eigvalsh) |
 | bigframe_ml CONFUSION-MATRIX cells (TP/FP/FN/TN) (1M rows, 1000 keys) | | ~10 | ~55 | **wins** | one-pass confusion counts vs groupby.apply |
 | bigframe_ml NEAREST-CENTROID fit+predict (closed-form) (1M rows, 1000 keys) | | ~16 | ~75 | **0.22x — wins 4.6x** | one-pass per-class centroid + nearest-centroid predict vs groupby.apply |

--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -8,6 +8,8 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 
 | operation | 1M rows | Sounio ms | pandas ms | Sounio/pandas | before |
 |---|---|---|---|---|---|
+| bigframe_ml PCA explained-variance-ratio (closed-form 2x2 eigen) (1M rows, 1000 keys) | | ~20 | ~142 | **0.14x — wins 7x** | one-pass covariance + 2x2 eigendecomposition vs groupby.apply(eigvalsh) |
+| bigframe_ml CONFUSION-MATRIX cells (TP/FP/FN/TN) (1M rows, 1000 keys) | | ~10 | ~55 | **wins** | one-pass confusion counts vs groupby.apply |
 | bigframe_ml NEAREST-CENTROID fit+predict (closed-form) (1M rows, 1000 keys) | | ~16 | ~75 | **0.22x — wins 4.6x** | one-pass per-class centroid + nearest-centroid predict vs groupby.apply |
 | bigframe_ml CALIBRATION metrics (mean_pred/observed_rate/calib_err) (1M rows, 1000 keys) | | ~9 | ~40 | **wins** | one-pass reliability check vs groupby.apply |
 | bigframe_ml GAUSSIAN NAIVE BAYES fit+predict (closed-form) (1M rows, 1000 keys) | | ~18 | ~74 | **0.24x — wins 4.2x** | one-pass per-class mean/var + predict vs groupby.apply(GaussianNB) |

--- a/stdlib/data/bigframe_ml.sio
+++ b/stdlib/data/bigframe_ml.sio
@@ -579,3 +579,87 @@ pub fn bf_mean_predicted_prob_by(src: &BigFrame, key_col: i64, yt_col: i64, p_co
 pub fn bf_observed_rate_by(src: &BigFrame, key_col: i64, yt_col: i64, p_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_calib(src, key_col, yt_col, p_col, 1) }
 /// Per-group CALIBRATION ERROR |mean_prob − observed_rate|, broadcast. NATIVE + lean_single.
 pub fn bf_calibration_error_by(src: &BigFrame, key_col: i64, yt_col: i64, p_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_calib(src, key_col, yt_col, p_col, 2) }
+
+/// Per-group 2-feature PCA (columns key, x1, x2) via closed-form 2x2 covariance
+/// eigendecomposition. One pass accumulates per-key sums -> population covariance
+/// [[a,b],[b,c]]; eigenvalues lam = (a+c)/2 +/- sqrt(((a-c)/2)^2 + b^2). The
+/// sklearn.decomposition.PCA(n_components analog per key, closed-form (wins). modes:
+/// 0 = explained variance ratio of PC1 (lam_max/(a+c)), 1 = lam_max (PC1 variance),
+/// 2 = lam_min (PC2 variance). Broadcast. O(n). NATIVE + lean_single only.
+fn bf_group_pca2(src: &BigFrame, key_col: i64, x1_col: i64, x2_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cn: [f64; 1024] = [0.0; 1024]
+    var s1: [f64; 1024] = [0.0; 1024]
+    var s2: [f64; 1024] = [0.0; 1024]
+    var q1: [f64; 1024] = [0.0; 1024]
+    var q2: [f64; 1024] = [0.0; 1024]
+    var q12: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || x1_col < 0 || x1_col >= nc || x2_col < 0 || x2_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let x1p = bf_col_ptr(src, x1_col) as *mut f64
+    let x2p = bf_col_ptr(src, x2_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    var i: i64 = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { let a = read_f64(x1p, i); let b = read_f64(x2p, i); cn[k] = cn[k] + 1.0; s1[k] = s1[k] + a; s2[k] = s2[k] + b; q1[k] = q1[k] + a * a; q2[k] = q2[k] + b * b; q12[k] = q12[k] + a * b } i = i + 1 }
+    var g: i64 = 0
+    while g < 1024 {
+        if cn[g] > 1.0 {
+            let m1 = s1[g] / cn[g]; let m2 = s2[g] / cn[g]
+            let ca = q1[g] / cn[g] - m1 * m1
+            let cc = q2[g] / cn[g] - m2 * m2
+            let cb = q12[g] / cn[g] - m1 * m2
+            let half = (ca - cc) / 2.0
+            let disc = ml_sqrt(half * half + cb * cb, sc)
+            let lmax = (ca + cc) / 2.0 + disc
+            let lmin = (ca + cc) / 2.0 - disc
+            let tr = ca + cc
+            if mode == 0 { if tr > 0.0 { res[g] = lmax / tr } else { res[g] = 0.0 } } else { if mode == 1 { res[g] = lmax } else { res[g] = lmin } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res as *mut f64, k)) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group PCA1 EXPLAINED VARIANCE RATIO, broadcast. NATIVE + lean_single.
+pub fn bf_pca_evr_by(src: &BigFrame, key_col: i64, x1_col: i64, x2_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_pca2(src, key_col, x1_col, x2_col, 0) }
+/// Per-group PCA1 VARIANCE (largest eigenvalue), broadcast. NATIVE + lean_single.
+pub fn bf_pca_pc1_var_by(src: &BigFrame, key_col: i64, x1_col: i64, x2_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_pca2(src, key_col, x1_col, x2_col, 1) }
+
+/// Per-group CONFUSION-MATRIX cell counts (columns key, y_true∈{0,1}, y_pred∈{0,1}),
+/// one pass. The sklearn.metrics.confusion_matrix analog per key. modes: 0 = TP, 1 = FP,
+/// 2 = FN, 3 = TN. Broadcast. O(n). NATIVE + lean_single only.
+fn bf_group_confusion(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var tp: [f64; 1024] = [0.0; 1024]
+    var fp: [f64; 1024] = [0.0; 1024]
+    var fn_: [f64; 1024] = [0.0; 1024]
+    var tn: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || yt_col < 0 || yt_col >= nc || yp_col < 0 || yp_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let ytp = bf_col_ptr(src, yt_col) as *mut f64
+    let ypp = bf_col_ptr(src, yp_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { let t = read_f64(ytp, i) > 0.5; let p = read_f64(ypp, i) > 0.5; if t { if p { tp[k] = tp[k] + 1.0 } else { fn_[k] = fn_[k] + 1.0 } } else { if p { fp[k] = fp[k] + 1.0 } else { tn[k] = tn[k] + 1.0 } } } i = i + 1 }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { var v = 0.0; if mode == 0 { v = tp[k] } else { if mode == 1 { v = fp[k] } else { if mode == 2 { v = fn_[k] } else { v = tn[k] } } }; write_f64(op, i, v) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    out
+}
+/// Per-group confusion TRUE POSITIVES, broadcast. NATIVE + lean_single.
+pub fn bf_confusion_tp_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_confusion(src, key_col, yt_col, yp_col, 0) }
+/// Per-group confusion FALSE POSITIVES, broadcast. NATIVE + lean_single.
+pub fn bf_confusion_fp_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_confusion(src, key_col, yt_col, yp_col, 1) }
+/// Per-group confusion FALSE NEGATIVES, broadcast. NATIVE + lean_single.
+pub fn bf_confusion_fn_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_confusion(src, key_col, yt_col, yp_col, 2) }
+/// Per-group confusion TRUE NEGATIVES, broadcast. NATIVE + lean_single.
+pub fn bf_confusion_tn_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_confusion(src, key_col, yt_col, yp_col, 3) }

--- a/stdlib/data/bigframe_ml.sio
+++ b/stdlib/data/bigframe_ml.sio
@@ -663,3 +663,81 @@ pub fn bf_confusion_fp_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64
 pub fn bf_confusion_fn_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_confusion(src, key_col, yt_col, yp_col, 2) }
 /// Per-group confusion TRUE NEGATIVES, broadcast. NATIVE + lean_single.
 pub fn bf_confusion_tn_by(src: &BigFrame, key_col: i64, yt_col: i64, yp_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_confusion(src, key_col, yt_col, yp_col, 3) }
+
+/// Per-group DECISION STUMP — the depth-1 CART tree, the atom of the tree/ensemble family
+/// (columns key, x∈[0,vmax] integer-valued, y∈{0,1}). For each key it histograms (pos,neg) by
+/// x-value in one pass, then finds the threshold t and direction that MAXIMIZE training accuracy
+/// (predict 1 if x>=t, or the flipped rule). Closed scan over the value range -> wins. modes:
+/// 0 = best training accuracy, 1 = best threshold t, 2 = predicted class per row under the best
+/// stump. Broadcast. O(n + keys*vmax). NATIVE + lean_single only.
+fn bf_group_stump(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, vmax: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var totp: [f64; 1024] = [0.0; 1024]
+    var totn: [f64; 1024] = [0.0; 1024]
+    var bacc: [f64; 1024] = [0.0; 1024]
+    var bthr: [f64; 1024] = [0.0; 1024]
+    var bdir: [f64; 1024] = [0.0; 1024]
+    var seen: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || x_col < 0 || x_col >= nc || y_col < 0 || y_col >= nc || n <= 0 || vmax < 1 || vmax > 4095 { return out }
+    let v = vmax + 1
+    let hp = heap_alloc(1024 * v * 8) as *mut i64
+    let hn = heap_alloc(1024 * v * 8) as *mut i64
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let xp = bf_col_ptr(src, x_col) as *mut f64
+    let yp = bf_col_ptr(src, y_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        var xb = read_f64(xp, i) as i64
+        if xb < 0 { xb = 0 }; if xb > vmax { xb = vmax }
+        if k >= 0 && k < 1024 {
+            seen[k] = 1.0
+            let idx = k * v + xb
+            if read_f64(yp, i) > 0.5 { write_i64(hp, idx, read_i64(hp, idx) + 1); totp[k] = totp[k] + 1.0 } else { write_i64(hn, idx, read_i64(hn, idx) + 1); totn[k] = totn[k] + 1.0 } }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if seen[g] > 0.5 {
+            let tp_all = totp[g]; let tn_all = totn[g]; let tot = tp_all + tn_all
+            var best = 0.0; var bt = 0.0; var bd = 1.0
+            // cumulative pos/neg with x < t, scanning t from 0..v
+            var cp = 0.0; var cnn = 0.0
+            var t: i64 = 0
+            while t <= v {
+                // predict 1 if x>=t: TP = tp_all-cp, TN = cnn ; correct = (tp_all-cp)+cnn
+                let acc_ge = (tp_all - cp + cnn) / tot
+                // predict 1 if x<t:  TP = cp, TN = tn_all-cnn ; correct = cp + (tn_all-cnn)
+                let acc_lt = (cp + tn_all - cnn) / tot
+                if acc_ge > best { best = acc_ge; bt = t as f64; bd = 1.0 }
+                if acc_lt > best { best = acc_lt; bt = t as f64; bd = 0.0 }
+                if t < v { let idx = g * v + t; cp = cp + read_i64(hp, idx) as f64; cnn = cnn + read_i64(hn, idx) as f64 }
+                t = t + 1
+            }
+            bacc[g] = best; bthr[g] = bt; bdir[g] = bd
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 && seen[k] > 0.5 {
+            if mode == 0 { write_f64(op, i, bacc[k]) }
+            else { if mode == 1 { write_f64(op, i, bthr[k]) }
+            else { let xb = read_f64(xp, i); let ge = xb >= bthr[k]; if bdir[k] > 0.5 { if ge { write_f64(op, i, 1.0) } else { write_f64(op, i, 0.0) } } else { if ge { write_f64(op, i, 0.0) } else { write_f64(op, i, 1.0) } } } }
+        } else { write_f64(op, i, 0.0) }
+        i = i + 1
+    }
+    heap_free(hp as *mut i8); heap_free(hn as *mut i8)
+    out
+}
+/// Per-group decision-stump TRAINING ACCURACY, broadcast. NATIVE + lean_single.
+pub fn bf_stump_accuracy_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_stump(src, key_col, x_col, y_col, vmax, 0) }
+/// Per-group decision-stump BEST THRESHOLD, broadcast. NATIVE + lean_single.
+pub fn bf_stump_threshold_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_stump(src, key_col, x_col, y_col, vmax, 1) }
+/// Per-group decision-stump PREDICTED CLASS, broadcast. NATIVE + lean_single.
+pub fn bf_stump_predict_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_stump(src, key_col, x_col, y_col, vmax, 2) }

--- a/tests/stdlib/data/test_bigframe_ml.sio
+++ b/tests/stdlib/data/test_bigframe_ml.sio
@@ -188,6 +188,29 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let ctn = bf_confusion_tn_by(&conf,0,1,2)
     if !aeq(bf_get(&ctn,0,0), 2.0) { print("FAIL conf_tn\n"); return 45 }
 
+    // ===== decision stump (tree-family atom) =====
+    var stf = bf_new(3, 16)
+    var sr0:[f64;64]=[0.0;64]; sr0[0]=0.0; sr0[1]=1.0; sr0[2]=0.0; bf_push_row(&!stf,&sr0,3)
+    var sr1:[f64;64]=[0.0;64]; sr1[0]=0.0; sr1[1]=2.0; sr1[2]=0.0; bf_push_row(&!stf,&sr1,3)
+    var sr2:[f64;64]=[0.0;64]; sr2[0]=0.0; sr2[1]=3.0; sr2[2]=0.0; bf_push_row(&!stf,&sr2,3)
+    var sr3:[f64;64]=[0.0;64]; sr3[0]=0.0; sr3[1]=4.0; sr3[2]=1.0; bf_push_row(&!stf,&sr3,3)
+    var sr4:[f64;64]=[0.0;64]; sr4[0]=0.0; sr4[1]=5.0; sr4[2]=1.0; bf_push_row(&!stf,&sr4,3)
+    var sr5:[f64;64]=[0.0;64]; sr5[0]=0.0; sr5[1]=6.0; sr5[2]=1.0; bf_push_row(&!stf,&sr5,3)
+    var sr6:[f64;64]=[0.0;64]; sr6[0]=1.0; sr6[1]=1.0; sr6[2]=0.0; bf_push_row(&!stf,&sr6,3)
+    var sr7:[f64;64]=[0.0;64]; sr7[0]=1.0; sr7[1]=2.0; sr7[2]=1.0; bf_push_row(&!stf,&sr7,3)
+    var sr8:[f64;64]=[0.0;64]; sr8[0]=1.0; sr8[1]=3.0; sr8[2]=0.0; bf_push_row(&!stf,&sr8,3)
+    var sr9:[f64;64]=[0.0;64]; sr9[0]=1.0; sr9[1]=4.0; sr9[2]=1.0; bf_push_row(&!stf,&sr9,3)
+    var sr10:[f64;64]=[0.0;64]; sr10[0]=1.0; sr10[1]=5.0; sr10[2]=1.0; bf_push_row(&!stf,&sr10,3)
+    var sr11:[f64;64]=[0.0;64]; sr11[0]=1.0; sr11[1]=6.0; sr11[2]=1.0; bf_push_row(&!stf,&sr11,3)
+    let sac = bf_stump_accuracy_by(&stf,0,1,2,7)
+    if !aeq(bf_get(&sac,0,0), 1.0) { print("FAIL stump_acc_clean\n"); return 46 }
+    if !aeq(bf_get(&sac,6,0), 0.833333) { print("FAIL stump_acc_noisy\n"); return 47 }
+    let sth = bf_stump_threshold_by(&stf,0,1,2,7)
+    if !aeq(bf_get(&sth,0,0), 4.0) { print("FAIL stump_thr\n"); return 48 }
+    let spr = bf_stump_predict_by(&stf,0,1,2,7)
+    if !aeq(bf_get(&spr,0,0), 0.0) { print("FAIL stump_pred_x1\n"); return 49 }
+    if !aeq(bf_get(&spr,3,0), 1.0) { print("FAIL stump_pred_x4\n"); return 50 }
+
     print("BIGFRAME_ML_GATE_OK\n")
     return 0
 }

--- a/tests/stdlib/data/test_bigframe_ml.sio
+++ b/tests/stdlib/data/test_bigframe_ml.sio
@@ -159,6 +159,35 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let cce = bf_calibration_error_by(&calf,0,1,2)
     if !aeq(bf_get(&cce,0,0), 0.05) { print("FAIL calib_err\n"); return 38 }
 
+    // ===== PCA (closed-form 2x2 eigen) + confusion-matrix cells =====
+    var pcaf = bf_new(3, 8)
+    var pr0:[f64;64]=[0.0;64]; pr0[0]=0.0; pr0[1]=1.0; pr0[2]=2.0; bf_push_row(&!pcaf,&pr0,3)
+    var pr1:[f64;64]=[0.0;64]; pr1[0]=0.0; pr1[1]=2.0; pr1[2]=4.0; bf_push_row(&!pcaf,&pr1,3)
+    var pr2:[f64;64]=[0.0;64]; pr2[0]=0.0; pr2[1]=3.0; pr2[2]=6.0; bf_push_row(&!pcaf,&pr2,3)
+    var pr3:[f64;64]=[0.0;64]; pr3[0]=0.0; pr3[1]=4.0; pr3[2]=8.0; bf_push_row(&!pcaf,&pr3,3)
+    var pr4:[f64;64]=[0.0;64]; pr4[0]=1.0; pr4[1]=1.0; pr4[2]=1.0; bf_push_row(&!pcaf,&pr4,3)
+    var pr5:[f64;64]=[0.0;64]; pr5[0]=1.0; pr5[1]=2.0; pr5[2]=3.0; bf_push_row(&!pcaf,&pr5,3)
+    var pr6:[f64;64]=[0.0;64]; pr6[0]=1.0; pr6[1]=3.0; pr6[2]=2.0; bf_push_row(&!pcaf,&pr6,3)
+    var pr7:[f64;64]=[0.0;64]; pr7[0]=1.0; pr7[1]=4.0; pr7[2]=5.0; bf_push_row(&!pcaf,&pr7,3)
+    let pev = bf_pca_evr_by(&pcaf,0,1,2)
+    if !aeq(bf_get(&pev,0,0), 1.0) { print("FAIL pca_evr_A\n"); return 39 }
+    if !aeq(bf_get(&pev,4,0), 0.922605) { print("FAIL pca_evr_B\n"); return 40 }
+    let plv = bf_pca_pc1_var_by(&pcaf,0,1,2)
+    if !aeq(bf_get(&plv,0,0), 6.25) { print("FAIL pca_pc1var_A\n"); return 41 }
+    var conf = bf_new(3, 8)
+    var cf0:[f64;64]=[0.0;64]; cf0[0]=0.0; cf0[1]=1.0; cf0[2]=1.0; bf_push_row(&!conf,&cf0,3)
+    var cf1:[f64;64]=[0.0;64]; cf1[0]=0.0; cf1[1]=1.0; cf1[2]=0.0; bf_push_row(&!conf,&cf1,3)
+    var cf2:[f64;64]=[0.0;64]; cf2[0]=0.0; cf2[1]=0.0; cf2[2]=0.0; bf_push_row(&!conf,&cf2,3)
+    var cf3:[f64;64]=[0.0;64]; cf3[0]=0.0; cf3[1]=0.0; cf3[2]=0.0; bf_push_row(&!conf,&cf3,3)
+    let ctp = bf_confusion_tp_by(&conf,0,1,2)
+    if !aeq(bf_get(&ctp,0,0), 1.0) { print("FAIL conf_tp\n"); return 42 }
+    let cfp = bf_confusion_fp_by(&conf,0,1,2)
+    if !aeq(bf_get(&cfp,0,0), 0.0) { print("FAIL conf_fp\n"); return 43 }
+    let cfnn = bf_confusion_fn_by(&conf,0,1,2)
+    if !aeq(bf_get(&cfnn,0,0), 1.0) { print("FAIL conf_fn\n"); return 44 }
+    let ctn = bf_confusion_tn_by(&conf,0,1,2)
+    if !aeq(bf_get(&ctn,0,0), 2.0) { print("FAIL conf_tn\n"); return 45 }
+
     print("BIGFRAME_ML_GATE_OK\n")
     return 0
 }


### PR DESCRIPTION
Adds the **tree/ensemble family's atom** to data::bigframe_ml — a per-group depth-1 decision tree (key, x∈[0,vmax], y∈{0,1}), the winning histogram-based building block:
- `bf_stump_accuracy_by` / `bf_stump_threshold_by` / `bf_stump_predict_by`

One pass histograms (pos,neg) by x-value per key, then a closed scan over the value range finds the threshold+direction maximizing training accuracy.

| verb | Sounio | pandas groupby.apply | ratio |
|---|---|---|---|
| stump | 22 ms | 300 ms | **0.07x (14x)** |

**Verified:** gate 46–50 vs numpy (clean key → acc=1.0/thr=4, predict(x=1)=0/predict(x=4)=1; noisy key → acc=0.8333). Benchmark reproduced. The per-value histogram replaces pandas' per-threshold rescan.

_Note: this PR stacks the earlier PCA + confusion work (#1442); if #1442 merges first this is the delta._

Generated with Claude Code