### PR TITLE
feat(bigframe): per-group Linear Discriminant Analysis (closed-form) — sklearn LDA analog

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -8,6 +8,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 
 | operation | 1M rows | Sounio ms | pandas ms | Sounio/pandas | before |
 |---|---|---|---|---|---|
+| bigframe_ml LDA fit+predict (closed-form, pooled variance) (1M rows, 1000 keys) | | ~18 | ~77 | **0.23x — wins 4.3x** | one-pass per-class mean + pooled var + discriminant vs groupby.apply(LDA) |
 | bigframe_ml DECISION STUMP fit+predict (depth-1 CART, histogram) (1M rows, 1000 keys) | | ~22 | ~300 | **0.07x — wins 14x** | one-pass histogram + threshold scan vs groupby.apply threshold search |
 | bigframe_ml PCA explained-variance-ratio (closed-form 2x2 eigen) (1M rows, 1000 keys) | | ~20 | ~142 | **0.14x — wins 7x** | one-pass covariance + 2x2 eigendecomposition vs groupby.apply(eigvalsh) |
 | bigframe_ml CONFUSION-MATRIX cells (TP/FP/FN/TN) (1M rows, 1000 keys) | | ~10 | ~55 | **wins** | one-pass confusion counts vs groupby.apply |

--- a/stdlib/data/bigframe_ml.sio
+++ b/stdlib/data/bigframe_ml.sio
@@ -741,3 +741,67 @@ pub fn bf_stump_accuracy_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64
 pub fn bf_stump_threshold_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_stump(src, key_col, x_col, y_col, vmax, 1) }
 /// Per-group decision-stump PREDICTED CLASS, broadcast. NATIVE + lean_single.
 pub fn bf_stump_predict_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_stump(src, key_col, x_col, y_col, vmax, 2) }
+
+/// Per-group LINEAR DISCRIMINANT ANALYSIS (binary, 1 feature; columns key, x, y∈{0,1}). One pass
+/// fits per-class mean + a POOLED within-class variance and class priors, then classifies by the
+/// linear discriminant delta_c(x) = x*mu_c/var - mu_c^2/(2 var) + ln(prior_c). Unlike
+/// NearestCentroid this weights by variance and priors -- the sklearn LinearDiscriminantAnalysis
+/// analog per key, closed-form (wins). modes: 0 = predicted class (argmax), 1 = P(y=1|x) via the
+/// logistic of the discriminant gap. Broadcast. O(n). NATIVE + lean_single only.
+fn bf_group_lda(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var n0: [f64; 1024] = [0.0; 1024]
+    var s0: [f64; 1024] = [0.0; 1024]
+    var q0: [f64; 1024] = [0.0; 1024]
+    var n1: [f64; 1024] = [0.0; 1024]
+    var s1: [f64; 1024] = [0.0; 1024]
+    var q1: [f64; 1024] = [0.0; 1024]
+    var m0a: [f64; 1024] = [0.0; 1024]
+    var m1a: [f64; 1024] = [0.0; 1024]
+    var iva: [f64; 1024] = [0.0; 1024]
+    var lp0: [f64; 1024] = [0.0; 1024]
+    var lp1: [f64; 1024] = [0.0; 1024]
+    var ok: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || x_col < 0 || x_col >= nc || y_col < 0 || y_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let xp = bf_col_ptr(src, x_col) as *mut f64
+    let yp = bf_col_ptr(src, y_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { let x = read_f64(xp, i); if read_f64(yp, i) > 0.5 { n1[k] = n1[k] + 1.0; s1[k] = s1[k] + x; q1[k] = q1[k] + x * x } else { n0[k] = n0[k] + 1.0; s0[k] = s0[k] + x; q0[k] = q0[k] + x * x } } i = i + 1 }
+    var g: i64 = 0
+    while g < 1024 {
+        if n0[g] > 0.0 && n1[g] > 0.0 {
+            let tot = n0[g] + n1[g]
+            if tot > 2.0 {
+                let m0 = s0[g] / n0[g]; let m1 = s1[g] / n1[g]
+                let sw = (q0[g] - n0[g] * m0 * m0) + (q1[g] - n1[g] * m1 * m1)
+                let var_ = sw / (tot - 2.0)
+                if var_ > 0.0 {
+                    m0a[g] = m0; m1a[g] = m1; iva[g] = 1.0 / var_
+                    lp0[g] = ln(n0[g] / tot); lp1[g] = ln(n1[g] / tot); ok[g] = 1.0
+                }
+            }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 && ok[k] > 0.5 {
+            let x = read_f64(xp, i)
+            let d0 = x * m0a[k] * iva[k] - m0a[k] * m0a[k] * iva[k] * 0.5 + lp0[k]
+            let d1 = x * m1a[k] * iva[k] - m1a[k] * m1a[k] * iva[k] * 0.5 + lp1[k]
+            if mode == 0 { if d1 > d0 { write_f64(op, i, 1.0) } else { write_f64(op, i, 0.0) } } else { write_f64(op, i, 1.0 / (1.0 + exp(d0 - d1))) }
+        } else { write_f64(op, i, 0.0) }
+        i = i + 1
+    }
+    out
+}
+/// Per-group LDA predicted class (0/1), broadcast. NATIVE + lean_single.
+pub fn bf_lda_predict_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_lda(src, key_col, x_col, y_col, 0) }
+/// Per-group LDA P(y=1|x), broadcast. NATIVE + lean_single.
+pub fn bf_lda_proba_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_lda(src, key_col, x_col, y_col, 1) }

--- a/tests/stdlib/data/test_bigframe_ml.sio
+++ b/tests/stdlib/data/test_bigframe_ml.sio
@@ -211,6 +211,20 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     if !aeq(bf_get(&spr,0,0), 0.0) { print("FAIL stump_pred_x1\n"); return 49 }
     if !aeq(bf_get(&spr,3,0), 1.0) { print("FAIL stump_pred_x4\n"); return 50 }
 
+    // ===== linear discriminant analysis (closed-form, variance+prior weighted) =====
+    var ldaf = bf_new(3, 8)
+    var lr0:[f64;64]=[0.0;64]; lr0[0]=0.0; lr0[1]=1.0; lr0[2]=0.0; bf_push_row(&!ldaf,&lr0,3)
+    var lr1:[f64;64]=[0.0;64]; lr1[0]=0.0; lr1[1]=2.0; lr1[2]=0.0; bf_push_row(&!ldaf,&lr1,3)
+    var lr2:[f64;64]=[0.0;64]; lr2[0]=0.0; lr2[1]=3.0; lr2[2]=0.0; bf_push_row(&!ldaf,&lr2,3)
+    var lr3:[f64;64]=[0.0;64]; lr3[0]=0.0; lr3[1]=5.0; lr3[2]=1.0; bf_push_row(&!ldaf,&lr3,3)
+    var lr4:[f64;64]=[0.0;64]; lr4[0]=0.0; lr4[1]=6.0; lr4[2]=1.0; bf_push_row(&!ldaf,&lr4,3)
+    var lr5:[f64;64]=[0.0;64]; lr5[0]=0.0; lr5[1]=7.0; lr5[2]=1.0; bf_push_row(&!ldaf,&lr5,3)
+    let lpb = bf_lda_proba_by(&ldaf,0,1,2)
+    if !aeq(bf_get(&lpb,3,0), 0.982014) { print("FAIL lda_proba_x5\n"); return 51 }
+    let lpr = bf_lda_predict_by(&ldaf,0,1,2)
+    if !aeq(bf_get(&lpr,3,0), 1.0) { print("FAIL lda_pred_x5\n"); return 52 }
+    if !aeq(bf_get(&lpr,0,0), 0.0) { print("FAIL lda_pred_x1\n"); return 53 }
+
     print("BIGFRAME_ML_GATE_OK\n")
     return 0
 }


### PR DESCRIPTION
Adds a **winning** (closed-form, one-pass-fit) discriminant classifier to data::bigframe_ml (key, x, y∈{0,1}) — the `sklearn.discriminant_analysis.LinearDiscriminantAnalysis` analog per key:
- `bf_lda_predict_by` (argmax discriminant) / `bf_lda_proba_by` (P(y=1|x))

Fit: one pass → per-class mean + **pooled within-class variance** + priors; classify by δ_c(x) = x·μ_c/var − μ_c²/(2var) + ln(priorᶜ). Unlike NearestCentroid this weights by variance and priors.

| verb | Sounio | pandas groupby.apply | ratio |
|---|---|---|---|
| lda_proba | 18 ms | 77 ms | **0.23x (4.3x)** |

**Verified:** gate 51–53 vs numpy: class0 x={1,2,3} class1 x={5,6,7} (pooled var=1.0) → P(y=1|x=5)=0.982014, predict(x=5)=1, predict(x=1)=0. Benchmark reproduced.

Generated with Claude Code