### PR TITLE
feat(bigframe): multivariate per-group ridge/OLS — the p-dimensional frontier (exact, wins)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -8,6 +8,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 
 | operation | 1M rows | Sounio ms | pandas ms | Sounio/pandas | before |
 |---|---|---|---|---|---|
+| bigframe_ml MULTIVARIATE ridge/OLS (p=4 features, Gram+Gaussian-elim) (1M rows, 1000 keys) | | ~125 | 161 (numpy normal-eq, FAIR) | **0.78x — wins 1.3x** | one-pass symmetric Gram XᵀX + per-group d×d solve vs groupby.apply(np.linalg.solve); modest because numpy's per-group work is a real BLAS matmul |
 | bigframe_ml BINNED-IRLS LOGISTIC (boundary-breaker: iterative made to WIN) (1M rows, 1000 keys, vmax 20) | | ~27 | 234 (numpy binned, FAIR) / 270 (numpy naive) | **0.12x — wins 8.7x fair / 10x vs naive** | exact bit-match to per-row IRLS; per-bin sufficient stats built once, IRLS re-sums bins not rows |
 | bigframe_ml LDA fit+predict (closed-form, pooled variance) (1M rows, 1000 keys) | | ~18 | ~77 | **0.23x — wins 4.3x** | one-pass per-class mean + pooled var + discriminant vs groupby.apply(LDA) |
 | bigframe_ml DECISION STUMP fit+predict (depth-1 CART, histogram) (1M rows, 1000 keys) | | ~22 | ~300 | **0.07x — wins 14x** | one-pass histogram + threshold scan vs groupby.apply threshold search |

--- a/stdlib/data/bigframe_ml.sio
+++ b/stdlib/data/bigframe_ml.sio
@@ -891,3 +891,131 @@ pub fn bf_binlogit_coef0_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64
 pub fn bf_binlogit_coef1_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, niter: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_binlogit(src, key_col, x_col, y_col, niter, vmax, 1) }
 /// Per-group binned-IRLS logistic P(y=1|x). NATIVE + lean_single.
 pub fn bf_binlogit_proba_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64, niter: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_binlogit(src, key_col, x_col, y_col, niter, vmax, 2) }
+
+/// Per-group MULTIVARIATE ridge / linear regression — the p-dimensional frontier (columns key,
+/// then p CONTIGUOUS feature columns starting at f0_col, then y_col). This is the bold multivariate
+/// move: sklearn's whole value is p features, and binning cannot help here. One pass accumulates
+/// the per-group Gram matrix G = XᵀX (with an intercept column of 1s) and Xᵀy over the augmented
+/// design [1, f0..f_{p-1}] (dimension d = p+1); then each group solves (G + lambda·I) beta = Xᵀy by
+/// Gaussian elimination with partial pivoting. Closed-form -> wins (the solve is a tiny d×d system
+/// per group, not an iteration over rows). lambda=0 gives OLS. modes: 0 = prediction per row;
+/// 1..d = coefficient (1 = intercept, 2 = coef of f0, ...). p in 1..7. O(n·d² + keys·d³).
+/// NATIVE + lean_single only.
+fn bf_group_mvridge(src: &BigFrame, key_col: i64, f0_col: i64, p: i64, y_col: i64, lambda: f64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var seen: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || y_col < 0 || y_col >= nc || n <= 0 || p < 1 || p > 7 || f0_col < 0 || f0_col + p > nc { return out }
+    let d = p + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let yp = bf_col_ptr(src, y_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let gG = heap_alloc(1024 * d * d * 8) as *mut f64
+    let gB = heap_alloc(1024 * d * 8) as *mut f64
+    let beta = heap_alloc(1024 * d * 8) as *mut f64
+    var vecp = heap_alloc(d * 8) as *mut f64
+    // hoist feature-column base pointers out of the row loop
+    let fptr = heap_alloc(p * 8) as *mut i64
+    var fc: i64 = 0
+    while fc < p { write_i64(fptr, fc, bf_col_ptr(src, f0_col + fc)); fc = fc + 1 }
+    // one pass: accumulate Gram (upper triangle) + rhs per group
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 {
+            seen[k] = 1.0
+            write_f64(vecp, 0, 1.0)
+            var c: i64 = 0
+            while c < p { write_f64(vecp, c + 1, read_f64(read_i64(fptr, c) as *mut f64, i)); c = c + 1 }
+            let yv = read_f64(yp, i)
+            let gbase = k * d * d; let bbase = k * d
+            var a: i64 = 0
+            while a < d {
+                let va = read_f64(vecp, a)
+                write_f64(gB, bbase + a, read_f64(gB, bbase + a) + va * yv)
+                var b: i64 = a
+                while b < d { let idx = gbase + a * d + b; write_f64(gG, idx, read_f64(gG, idx) + va * read_f64(vecp, b)); b = b + 1 }
+                a = a + 1
+            }
+        }
+        i = i + 1
+    }
+    // mirror upper triangle to lower (Gram is symmetric)
+    var mg: i64 = 0
+    while mg < 1024 {
+        if seen[mg] > 0.5 { let gb = mg * d * d; var a: i64 = 0; while a < d { var b: i64 = a + 1; while b < d { write_f64(gG, gb + b * d + a, read_f64(gG, gb + a * d + b)); b = b + 1 }; a = a + 1 } }
+        mg = mg + 1
+    }
+    // per group: solve (G + lambda I) beta = b via Gaussian elimination w/ partial pivoting
+    var A = heap_alloc(64 * 8) as *mut f64
+    var rhs = heap_alloc(8 * 8) as *mut f64
+    var g: i64 = 0
+    while g < 1024 {
+        if seen[g] > 0.5 {
+            let gbase = g * d * d; let bbase = g * d
+            var r: i64 = 0
+            while r < d {
+                var cc: i64 = 0
+                while cc < d { var val = read_f64(gG, gbase + r * d + cc); if r == cc { val = val + lambda }; write_f64(A, r * d + cc, val); cc = cc + 1 }
+                write_f64(rhs, r, read_f64(gB, bbase + r)); r = r + 1
+            }
+            // forward elimination with partial pivot
+            var col: i64 = 0
+            var ok = 1
+            while col < d {
+                var piv = col; var pmax = read_f64(A, col * d + col); if pmax < 0.0 { pmax = 0.0 - pmax }
+                var rr = col + 1
+                while rr < d { var av = read_f64(A, rr * d + col); if av < 0.0 { av = 0.0 - av }; if av > pmax { pmax = av; piv = rr }; rr = rr + 1 }
+                if pmax < 0.000000000001 { ok = 0; col = d } else {
+                    if piv != col { var t: i64 = 0; while t < d { let tmp = read_f64(A, col * d + t); write_f64(A, col * d + t, read_f64(A, piv * d + t)); write_f64(A, piv * d + t, tmp); t = t + 1 }; let tb = read_f64(rhs, col); write_f64(rhs, col, read_f64(rhs, piv)); write_f64(rhs, piv, tb) }
+                    let pivval = read_f64(A, col * d + col)
+                    var row2 = col + 1
+                    while row2 < d {
+                        let factor = read_f64(A, row2 * d + col) / pivval
+                        var t2: i64 = 0
+                        while t2 < d { write_f64(A, row2 * d + t2, read_f64(A, row2 * d + t2) - factor * read_f64(A, col * d + t2)); t2 = t2 + 1 }
+                        write_f64(rhs, row2, read_f64(rhs, row2) - factor * read_f64(rhs, col))
+                        row2 = row2 + 1
+                    }
+                    col = col + 1
+                }
+            }
+            if ok == 1 {
+                var rb = d - 1
+                while rb >= 0 {
+                    var s = read_f64(rhs, rb)
+                    var jj = rb + 1
+                    while jj < d { s = s - read_f64(A, rb * d + jj) * read_f64(beta, g * d + jj); jj = jj + 1 }
+                    write_f64(beta, g * d + rb, s / read_f64(A, rb * d + rb))
+                    rb = rb - 1
+                }
+            }
+        }
+        g = g + 1
+    }
+    // broadcast
+    i = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 && seen[k] > 0.5 {
+            if mode == 0 {
+                var yhat = read_f64(beta, k * d + 0)
+                var c: i64 = 0
+                while c < p { yhat = yhat + read_f64(beta, k * d + c + 1) * read_f64(bf_col_ptr(src, f0_col + c) as *mut f64, i); c = c + 1 }
+                write_f64(op, i, yhat)
+            } else { if mode >= 1 && mode <= d { write_f64(op, i, read_f64(beta, k * d + mode - 1)) } else { write_f64(op, i, 0.0) } }
+        } else { write_f64(op, i, 0.0) }
+        i = i + 1
+    }
+    heap_free(gG as *mut i8); heap_free(gB as *mut i8); heap_free(beta as *mut i8)
+    heap_free(vecp as *mut i8); heap_free(A as *mut i8); heap_free(rhs as *mut i8); heap_free(fptr as *mut i8)
+    out
+}
+/// Per-group MULTIVARIATE ridge/OLS PREDICTION (p contiguous features from f0_col). lambda=0 = OLS.
+/// NATIVE + lean_single.
+pub fn bf_mvridge_predict_by(src: &BigFrame, key_col: i64, f0_col: i64, p: i64, y_col: i64, lambda: f64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_mvridge(src, key_col, f0_col, p, y_col, lambda, 0) }
+/// Per-group MULTIVARIATE coefficient j (0 = intercept, 1..p = feature coefs). lambda=0 = OLS.
+/// NATIVE + lean_single.
+pub fn bf_mvridge_coef_by(src: &BigFrame, key_col: i64, f0_col: i64, p: i64, y_col: i64, lambda: f64, j: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_mvridge(src, key_col, f0_col, p, y_col, lambda, j + 1) }

--- a/tests/stdlib/data/test_bigframe_ml.sio
+++ b/tests/stdlib/data/test_bigframe_ml.sio
@@ -245,6 +245,25 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let refc1 = bf_logistic_coef1_by(&blf,0,1,2,10)
     if !aeq(bf_get(&blc1,0,0), bf_get(&refc1,0,0)) { print("FAIL binlogit_ne_perrow_b1\n"); return 58 }
 
+    // ===== MULTIVARIATE ridge/OLS regression — the p-dimensional frontier =====
+    var mvf = bf_new(4, 8)
+    var mvr0:[f64;64]=[0.0;64]; mvr0[0]=0.0; mvr0[1]=1.0; mvr0[2]=2.0; mvr0[3]=3.1; bf_push_row(&!mvf,&mvr0,4)
+    var mvr1:[f64;64]=[0.0;64]; mvr1[0]=0.0; mvr1[1]=2.0; mvr1[2]=1.0; mvr1[3]=6.9; bf_push_row(&!mvf,&mvr1,4)
+    var mvr2:[f64;64]=[0.0;64]; mvr2[0]=0.0; mvr2[1]=3.0; mvr2[2]=4.0; mvr2[3]=7.05; bf_push_row(&!mvf,&mvr2,4)
+    var mvr3:[f64;64]=[0.0;64]; mvr3[0]=0.0; mvr3[1]=4.0; mvr3[2]=3.0; mvr3[3]=10.95; bf_push_row(&!mvf,&mvr3,4)
+    var mvr4:[f64;64]=[0.0;64]; mvr4[0]=0.0; mvr4[1]=5.0; mvr4[2]=6.0; mvr4[3]=11.1; bf_push_row(&!mvf,&mvr4,4)
+    var mvr5:[f64;64]=[0.0;64]; mvr5[0]=0.0; mvr5[1]=6.0; mvr5[2]=5.0; mvr5[3]=14.9; bf_push_row(&!mvf,&mvr5,4)
+    let mvc0 = bf_mvridge_coef_by(&mvf,0,1,2,3,0.0,0)
+    if !aeq(bf_get(&mvc0,0,0), 2.0) { print("FAIL mvridge_intercept\n"); return 59 }
+    let mvc1 = bf_mvridge_coef_by(&mvf,0,1,2,3,0.0,1)
+    if !aeq(bf_get(&mvc1,0,0), 2.916667) { print("FAIL mvridge_c1\n"); return 60 }
+    let mvc2 = bf_mvridge_coef_by(&mvf,0,1,2,3,0.0,2)
+    if !aeq(bf_get(&mvc2,0,0), -0.916667) { print("FAIL mvridge_c2\n"); return 61 }
+    let mvp = bf_mvridge_predict_by(&mvf,0,1,2,3,0.0)
+    if !aeq(bf_get(&mvp,0,0), 3.083333) { print("FAIL mvridge_predict\n"); return 62 }
+    let mvr1 = bf_mvridge_coef_by(&mvf,0,1,2,3,1.0,1)
+    if !aeq(bf_get(&mvr1,0,0), 2.530093) { print("FAIL mvridge_ridge_c1\n"); return 63 }
+
     print("BIGFRAME_ML_GATE_OK\n")
     return 0
 }


### PR DESCRIPTION
**The bold multivariate move.** Every model so far was univariate (one x); PCA was the only 2-feature verb. This fits a **p-feature** linear/ridge model **per group** — sklearn's core territory, exactly where binning can't help.
- `bf_mvridge_predict_by` / `bf_mvridge_coef_by` (p∈1..7, λ=0 ⇒ OLS)

One pass accumulates the per-group Gram matrix G = XᵀX (with intercept) and Xᵀy over [1, f0..f_{p-1}] (upper triangle, mirrored); each group solves (G + λI)β = Xᵀy by **Gaussian elimination with partial pivoting**. Closed-form, exact.

**Verified** (gate 59–63) vs numpy on a 2-feature system: OLS coeffs [2, 2.916667, −0.916667], prediction 3.083333, ridge(λ=1) slope 2.530093 — all exact.

**Benchmarked fairly** (p=4, 1M rows, 1000 keys) — numpy gets the *same* normal-equations solve inside `groupby.apply`:
| | Sounio | numpy (fair) | ratio |
|---|---|---|---|
| mvridge(p=4) | 125 ms | 161 ms | **1.3× win** |

The margin is smaller than the univariate verbs (4–14×) precisely because numpy's per-group work here is a real BLAS XᵀX matmul, not a scalar reduction — an honest reflection of where the per-group-overhead advantage narrows. Still a win, and now the models are genuinely p-dimensional.

Generated with Claude Code