### PR TITLE
feat(bigframe): data::bigframe_np — the numpy-on-columns package (101 verbs, one batch)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -8,6 +8,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 
 | operation | 1M rows | Sounio ms | pandas ms | Sounio/pandas | before |
 |---|---|---|---|---|---|
+| bigframe_np NUMPY-ON-COLUMNS package: 101 verbs (reductions/elementwise/cumulative/pairwise) | 100 gate-verified vs numpy | ~13 (std) | ~2 (numpy std) | **capability, not speed** | single-array ops are SIMD/BLAS-bound (lose ~6x); value = native numpy API coverage w/o the dependency; the per-group versions (bigframe_ops/ml) are the speed wins |
 | bigframe_ml MULTIVARIATE diagonal GaussianNB (p=4, binary) (1M rows, 1000 keys) | | ~43 | 293 (numpy, FAIR) | **0.15x — wins 6.9x** | one-pass per-class/feature mean+var, diagonal log-likelihood vs groupby.apply |
 | bigframe_ml MULTIVARIATE LDA shared-covariance (p=4, binary) (1M rows, 1000 keys) | | ~95 | 289 (numpy, FAIR) | **0.33x — wins 3.0x** | one-pass pooled covariance + Gaussian-elim solve Σ[w0|w1]=[μ0|μ1] vs groupby.apply(LDA) |
 | bigframe_ml MULTIVARIATE ridge/OLS (p=4 features, Gram+Gaussian-elim) (1M rows, 1000 keys) | | ~125 | 161 (numpy normal-eq, FAIR) | **0.78x — wins 1.3x** | one-pass symmetric Gram XᵀX + per-group d×d solve vs groupby.apply(np.linalg.solve); modest because numpy's per-group work is a real BLAS matmul |

--- a/stdlib/data/bigframe_np.sio
+++ b/stdlib/data/bigframe_np.sio
@@ -1,0 +1,248 @@
+// data::bigframe_np — the numpy-on-columns package at BigFrame scale. ~100 per-column verbs:
+// reductions, elementwise transforms, cumulative scans, pairwise ops. Six mode-dispatched engines;
+// every public verb is a thin wrapper. Arithmetic + accurate builtins (ln/exp) + Newton sqrt only.
+use data::bigframe::*
+
+fn np_sqrt(x: f64, sc: *mut i64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    let b = f64_to_bits(x)
+    write_i64(sc, 0, (b + 4607182418800017408) >> 1)
+    var y = read_f64(sc as *mut f64, 0)
+    if y < 0.0 { y = 0.0 - y }
+    y = 0.5 * (y + x / y); y = 0.5 * (y + x / y); y = 0.5 * (y + x / y); y = 0.5 * (y + x / y); y = 0.5 * (y + x / y); y = 0.5 * (y + x / y)
+    y
+}
+
+/// Column REDUCTION engine (col -> scalar). One pass.
+fn np_reduce(src: &BigFrame, col: i64, mode: i64) -> f64 with Alloc, Mut, Div, Panic {
+    let n = bf_nrows(src)
+    if col < 0 || col >= bf_ncols(src) || n <= 0 { return 0.0 }
+    let cp = bf_col_ptr(src, col) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    var sum = 0.0; var ssq = 0.0; var l1 = 0.0; var prod = 1.0
+    var mn = read_f64(cp, 0); var mx = read_f64(cp, 0); var mni = 0.0; var mxi = 0.0
+    var i: i64 = 0
+    while i < n {
+        let x = read_f64(cp, i)
+        sum = sum + x; ssq = ssq + x * x; prod = prod * x
+        var ax = x; if ax < 0.0 { ax = 0.0 - ax }; l1 = l1 + ax
+        if x < mn { mn = x; mni = i as f64 }
+        if x > mx { mx = x; mxi = i as f64 }
+        i = i + 1
+    }
+    let nf = n as f64; let mean = sum / nf; let varp = ssq / nf - mean * mean
+    var vs = 0.0; if nf > 1.0 { vs = (ssq - sum * mean) / (nf - 1.0) }
+    var r = 0.0
+    if mode == 0 { r = sum } else { if mode == 1 { r = mean } else { if mode == 2 { r = mn } else { if mode == 3 { r = mx } else { if mode == 4 { r = prod } else { if mode == 5 { r = varp } else { if mode == 6 { r = np_sqrt(varp, sc) } else { if mode == 7 { r = mx - mn } else { if mode == 8 { r = nf } else { if mode == 9 { r = mni } else { if mode == 10 { r = mxi } else { if mode == 11 { r = read_f64(cp, 0) } else { if mode == 12 { r = read_f64(cp, n - 1) } else { if mode == 13 { r = ssq } else { if mode == 14 { r = np_sqrt(ssq, sc) } else { if mode == 15 { r = l1 } else { if mode == 16 { r = l1 / nf } else { if mode == 17 { r = np_sqrt(ssq / nf, sc) } else { if mode == 18 { r = vs } else { r = np_sqrt(vs, sc) } } } } } } } } } } } } } } } } } } }
+    heap_free(sc as *mut i8)
+    r
+}
+
+/// Column ELEMENTWISE engine (col -> col), with an optional scalar operand. O(n).
+fn np_map(src: &BigFrame, col: i64, s: f64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let n = bf_nrows(src)
+    var out = bf_new(1, n); out.n_rows = n
+    if col < 0 || col >= bf_ncols(src) || n <= 0 { return out }
+    let cp = bf_col_ptr(src, col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let x = read_f64(cp, i)
+        var ax = x; if ax < 0.0 { ax = 0.0 - ax }
+        var v = 0.0
+        if mode == 0 { v = ax } else { if mode == 1 { v = 0.0 - x } else { if mode == 2 { v = x * x } else { if mode == 3 { v = x * x * x } else { if mode == 4 { if x > 0.0 { v = 1.0 } else { if x < 0.0 { v = 0.0 - 1.0 } } } else { if mode == 5 { if x != 0.0 { v = 1.0 / x } } else { if mode == 6 { v = x + s } else { if mode == 7 { v = x - s } else { if mode == 8 { v = x * s } else { if mode == 9 { if s != 0.0 { v = x / s } } else { if mode == 10 { v = s - x } else { if mode == 11 { if x != 0.0 { v = s / x } } else { if mode == 12 { if x < s { v = s } else { v = x } } else { if mode == 13 { if x > s { v = s } else { v = x } } else { if mode == 14 { if x > 0.0 { v = x } } else { if mode == 15 { if x >= 0.0 { v = 1.0 } } else { if mode == 16 { v = (x as i64) as f64 } else { if mode == 17 { if x > 0.0 { v = exp(s * ln(x)) } } else { if mode == 18 { v = exp(x) } else { if mode == 19 { if x > 0.0 { v = ln(x) } } else { if mode == 20 { if x > 0.0 { v = ln(x) / 0.6931471805599453 } } else { if mode == 21 { if x > 0.0 { v = ln(x) / 2.302585092994046 } } else { if mode == 22 { v = exp(x * 0.6931471805599453) } else { if mode == 23 { v = exp(x) - 1.0 } else { if mode == 24 { if x > -1.0 { v = ln(1.0 + x) } } else { if mode == 25 { v = np_sqrt(x, sc) } else { if mode == 26 { if x > 0.0 { v = exp(ln(x) / 3.0) } } else { if mode == 27 { v = 1.0 / (1.0 + exp(0.0 - x)) } else { if mode == 28 { if x > 0.0 && x < 1.0 { v = ln(x / (1.0 - x)) } } else { if mode == 29 { v = ln(1.0 + exp(x)) } else { if mode == 30 { let e = exp(2.0 * x); v = (e - 1.0) / (e + 1.0) } else { if mode == 31 { if x > s { v = 1.0 } } else { if mode == 32 { if x < s { v = 1.0 } } else { if mode == 33 { if x >= s { v = 1.0 } } else { if mode == 34 { if x <= s { v = 1.0 } } else { if mode == 35 { if x == s { v = 1.0 } } else { if mode == 36 { if x != s { v = 1.0 } } else { if mode == 37 { v = x * 0.017453292519943295 } else { if mode == 38 { v = x * 57.29577951308232 } else { if mode == 39 { v = 1.0 - x } else { v = x * s + s } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } }
+        write_f64(op, i, v)
+        i = i + 1
+    }
+    heap_free(sc as *mut i8)
+    out
+}
+
+/// Column CUMULATIVE engine (col -> col). O(n).
+fn np_cum(src: &BigFrame, col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let n = bf_nrows(src)
+    var out = bf_new(1, n); out.n_rows = n
+    if col < 0 || col >= bf_ncols(src) || n <= 0 { return out }
+    let cp = bf_col_ptr(src, col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var acc = 0.0; var prod = 1.0; var cmx = read_f64(cp, 0); var cmn = read_f64(cp, 0); var cnt = 0.0; var ssq = 0.0
+    var i: i64 = 0
+    while i < n {
+        let x = read_f64(cp, i)
+        acc = acc + x; prod = prod * x; cnt = cnt + 1.0; ssq = ssq + x * x
+        if x > cmx { cmx = x }; if x < cmn { cmn = x }
+        var v = 0.0
+        if mode == 0 { v = acc } else { if mode == 1 { v = prod } else { if mode == 2 { v = cmx } else { if mode == 3 { v = cmn } else { if mode == 4 { v = cnt } else { if mode == 5 { v = acc / cnt } else { if mode == 6 { v = ssq } else { v = cmx - cmn } } } } } } }
+        write_f64(op, i, v)
+        i = i + 1
+    }
+    out
+}
+
+/// Pairwise ELEMENTWISE engine (col1,col2 -> col). O(n).
+fn np_binmap(src: &BigFrame, c1: i64, c2: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let n = bf_nrows(src)
+    var out = bf_new(1, n); out.n_rows = n
+    let nc = bf_ncols(src)
+    if c1 < 0 || c1 >= nc || c2 < 0 || c2 >= nc || n <= 0 { return out }
+    let p1 = bf_col_ptr(src, c1) as *mut f64
+    let p2 = bf_col_ptr(src, c2) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let a = read_f64(p1, i); let b = read_f64(p2, i)
+        var v = 0.0
+        if mode == 0 { v = a + b } else { if mode == 1 { v = a - b } else { if mode == 2 { v = a * b } else { if mode == 3 { if b != 0.0 { v = a / b } } else { if mode == 4 { if a > 0.0 { v = exp(b * ln(a)) } } else { if mode == 5 { v = np_sqrt(a * a + b * b, sc) } else { if mode == 6 { if a > b { v = a } else { v = b } } else { if mode == 7 { if a < b { v = a } else { v = b } } else { if mode == 8 { var d = a - b; if d < 0.0 { d = 0.0 - d }; v = d } else { if mode == 9 { v = (a + b) / 2.0 } else { if mode == 10 { if a > b { v = 1.0 } } else { if mode == 11 { v = a * a + b * b } else { v = a - 2.0 * b } } } } } } } } } } } }
+        write_f64(op, i, v)
+        i = i + 1
+    }
+    heap_free(sc as *mut i8)
+    out
+}
+
+/// Pairwise REDUCTION engine (col1,col2 -> scalar). One pass.
+fn np_binreduce(src: &BigFrame, c1: i64, c2: i64, mode: i64) -> f64 with Alloc, Mut, Div, Panic {
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    if c1 < 0 || c1 >= nc || c2 < 0 || c2 >= nc || n <= 0 { return 0.0 }
+    let p1 = bf_col_ptr(src, c1) as *mut f64
+    let p2 = bf_col_ptr(src, c2) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    var dot = 0.0; var sa = 0.0; var sb = 0.0; var saa = 0.0; var sbb = 0.0
+    var sse = 0.0; var sae = 0.0
+    var i: i64 = 0
+    while i < n {
+        let a = read_f64(p1, i); let b = read_f64(p2, i); let d = a - b
+        dot = dot + a * b; sa = sa + a; sb = sb + b; saa = saa + a * a; sbb = sbb + b * b
+        sse = sse + d * d; var ad = d; if ad < 0.0 { ad = 0.0 - ad }; sae = sae + ad
+        i = i + 1
+    }
+    let nf = n as f64
+    let cov = dot / nf - (sa / nf) * (sb / nf)
+    let va = saa / nf - (sa / nf) * (sa / nf); let vb = sbb / nf - (sb / nf) * (sb / nf)
+    var r = 0.0
+    if mode == 0 { r = dot } else { if mode == 1 { r = cov } else { if mode == 2 { let de = np_sqrt(va, sc) * np_sqrt(vb, sc); if de > 0.0 { r = cov / de } } else { if mode == 3 { r = dot } else { if mode == 4 { r = sse / nf } else { if mode == 5 { r = sae / nf } else { if mode == 6 { r = np_sqrt(sse / nf, sc) } else { if mode == 7 { r = sse } else { r = sae } } } } } } } }
+    heap_free(sc as *mut i8)
+    r
+}
+
+/// Column COUNT-PREDICATE engine (col,threshold -> count). One pass.
+fn np_countpred(src: &BigFrame, col: i64, t: f64, mode: i64) -> f64 with Alloc, Mut, Div, Panic {
+    let n = bf_nrows(src)
+    if col < 0 || col >= bf_ncols(src) || n <= 0 { return 0.0 }
+    let cp = bf_col_ptr(src, col) as *mut f64
+    var r = 0.0
+    var i: i64 = 0
+    while i < n {
+        let x = read_f64(cp, i)
+        var hit = 0
+        if mode == 0 { if x > t { hit = 1 } } else { if mode == 1 { if x >= t { hit = 1 } } else { if mode == 2 { if x < t { hit = 1 } } else { if mode == 3 { if x <= t { hit = 1 } } else { if mode == 4 { if x == t { hit = 1 } } else { if mode == 5 { if x != t { hit = 1 } } else { if mode == 6 { if x == 0.0 { hit = 1 } } else { if mode == 7 { if x != 0.0 { hit = 1 } } else { if mode == 8 { if x > 0.0 { hit = 1 } } else { if x < 0.0 { hit = 1 } } } } } } } } } }
+        if hit == 1 { r = r + 1.0 }
+        i = i + 1
+    }
+    r
+}
+
+pub fn bf_np_sum(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 0) }
+pub fn bf_np_mean(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 1) }
+pub fn bf_np_min(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 2) }
+pub fn bf_np_max(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 3) }
+pub fn bf_np_prod(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 4) }
+pub fn bf_np_var(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 5) }
+pub fn bf_np_std(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 6) }
+pub fn bf_np_ptp(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 7) }
+pub fn bf_np_count(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 8) }
+pub fn bf_np_argmin(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 9) }
+pub fn bf_np_argmax(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 10) }
+pub fn bf_np_first(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 11) }
+pub fn bf_np_last(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 12) }
+pub fn bf_np_sumsq(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 13) }
+pub fn bf_np_l2norm(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 14) }
+pub fn bf_np_l1norm(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 15) }
+pub fn bf_np_meanabs(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 16) }
+pub fn bf_np_rms(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 17) }
+pub fn bf_np_var_sample(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 18) }
+pub fn bf_np_std_sample(src: &BigFrame, col: i64) -> f64 with Alloc, Mut, Div, Panic { np_reduce(src, col, 19) }
+pub fn bf_np_abs(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 0) }
+pub fn bf_np_neg(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 1) }
+pub fn bf_np_square(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 2) }
+pub fn bf_np_cube(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 3) }
+pub fn bf_np_sign(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 4) }
+pub fn bf_np_recip(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 5) }
+pub fn bf_np_add_scalar(src: &BigFrame, col: i64, s: f64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, s, 6) }
+pub fn bf_np_sub_scalar(src: &BigFrame, col: i64, s: f64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, s, 7) }
+pub fn bf_np_mul_scalar(src: &BigFrame, col: i64, s: f64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, s, 8) }
+pub fn bf_np_div_scalar(src: &BigFrame, col: i64, s: f64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, s, 9) }
+pub fn bf_np_rsub_scalar(src: &BigFrame, col: i64, s: f64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, s, 10) }
+pub fn bf_np_rdiv_scalar(src: &BigFrame, col: i64, s: f64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, s, 11) }
+pub fn bf_np_clip_min(src: &BigFrame, col: i64, s: f64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, s, 12) }
+pub fn bf_np_clip_max(src: &BigFrame, col: i64, s: f64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, s, 13) }
+pub fn bf_np_relu(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 14) }
+pub fn bf_np_step(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 15) }
+pub fn bf_np_trunc(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 16) }
+pub fn bf_np_pow_scalar(src: &BigFrame, col: i64, s: f64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, s, 17) }
+pub fn bf_np_exp(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 18) }
+pub fn bf_np_ln(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 19) }
+pub fn bf_np_log2(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 20) }
+pub fn bf_np_log10(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 21) }
+pub fn bf_np_exp2(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 22) }
+pub fn bf_np_expm1(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 23) }
+pub fn bf_np_log1p(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 24) }
+pub fn bf_np_sqrt(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 25) }
+pub fn bf_np_cbrt(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 26) }
+pub fn bf_np_sigmoid(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 27) }
+pub fn bf_np_logit(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 28) }
+pub fn bf_np_softplus(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 29) }
+pub fn bf_np_tanh(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 30) }
+pub fn bf_np_gt_scalar(src: &BigFrame, col: i64, s: f64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, s, 31) }
+pub fn bf_np_lt_scalar(src: &BigFrame, col: i64, s: f64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, s, 32) }
+pub fn bf_np_ge_scalar(src: &BigFrame, col: i64, s: f64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, s, 33) }
+pub fn bf_np_le_scalar(src: &BigFrame, col: i64, s: f64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, s, 34) }
+pub fn bf_np_eq_scalar(src: &BigFrame, col: i64, s: f64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, s, 35) }
+pub fn bf_np_ne_scalar(src: &BigFrame, col: i64, s: f64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, s, 36) }
+pub fn bf_np_deg2rad(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 37) }
+pub fn bf_np_rad2deg(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 38) }
+pub fn bf_np_logistic_not(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, 0.0, 39) }
+pub fn bf_np_scaleshift(src: &BigFrame, col: i64, s: f64) -> BigFrame with Alloc, Mut, Div, Panic { np_map(src, col, s, 40) }
+pub fn bf_np_cumsum(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_cum(src, col, 0) }
+pub fn bf_np_cumprod(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_cum(src, col, 1) }
+pub fn bf_np_cummax(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_cum(src, col, 2) }
+pub fn bf_np_cummin(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_cum(src, col, 3) }
+pub fn bf_np_cumcount(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_cum(src, col, 4) }
+pub fn bf_np_cummean(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_cum(src, col, 5) }
+pub fn bf_np_cumsumsq(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_cum(src, col, 6) }
+pub fn bf_np_cumrange(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_cum(src, col, 7) }
+pub fn bf_np_add(src: &BigFrame, c1: i64, c2: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_binmap(src, c1, c2, 0) }
+pub fn bf_np_sub(src: &BigFrame, c1: i64, c2: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_binmap(src, c1, c2, 1) }
+pub fn bf_np_mul(src: &BigFrame, c1: i64, c2: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_binmap(src, c1, c2, 2) }
+pub fn bf_np_div(src: &BigFrame, c1: i64, c2: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_binmap(src, c1, c2, 3) }
+pub fn bf_np_pow(src: &BigFrame, c1: i64, c2: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_binmap(src, c1, c2, 4) }
+pub fn bf_np_hypot(src: &BigFrame, c1: i64, c2: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_binmap(src, c1, c2, 5) }
+pub fn bf_np_maximum(src: &BigFrame, c1: i64, c2: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_binmap(src, c1, c2, 6) }
+pub fn bf_np_minimum(src: &BigFrame, c1: i64, c2: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_binmap(src, c1, c2, 7) }
+pub fn bf_np_absdiff(src: &BigFrame, c1: i64, c2: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_binmap(src, c1, c2, 8) }
+pub fn bf_np_mean2(src: &BigFrame, c1: i64, c2: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_binmap(src, c1, c2, 9) }
+pub fn bf_np_gt(src: &BigFrame, c1: i64, c2: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_binmap(src, c1, c2, 10) }
+pub fn bf_np_sumsq2(src: &BigFrame, c1: i64, c2: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_binmap(src, c1, c2, 11) }
+pub fn bf_np_wdiff(src: &BigFrame, c1: i64, c2: i64) -> BigFrame with Alloc, Mut, Div, Panic { np_binmap(src, c1, c2, 12) }
+pub fn bf_np_dot(src: &BigFrame, c1: i64, c2: i64) -> f64 with Alloc, Mut, Div, Panic { np_binreduce(src, c1, c2, 0) }
+pub fn bf_np_cov(src: &BigFrame, c1: i64, c2: i64) -> f64 with Alloc, Mut, Div, Panic { np_binreduce(src, c1, c2, 1) }
+pub fn bf_np_corr(src: &BigFrame, c1: i64, c2: i64) -> f64 with Alloc, Mut, Div, Panic { np_binreduce(src, c1, c2, 2) }
+pub fn bf_np_sumprod(src: &BigFrame, c1: i64, c2: i64) -> f64 with Alloc, Mut, Div, Panic { np_binreduce(src, c1, c2, 3) }
+pub fn bf_np_mse(src: &BigFrame, c1: i64, c2: i64) -> f64 with Alloc, Mut, Div, Panic { np_binreduce(src, c1, c2, 4) }
+pub fn bf_np_mae(src: &BigFrame, c1: i64, c2: i64) -> f64 with Alloc, Mut, Div, Panic { np_binreduce(src, c1, c2, 5) }
+pub fn bf_np_rmse(src: &BigFrame, c1: i64, c2: i64) -> f64 with Alloc, Mut, Div, Panic { np_binreduce(src, c1, c2, 6) }
+pub fn bf_np_sse(src: &BigFrame, c1: i64, c2: i64) -> f64 with Alloc, Mut, Div, Panic { np_binreduce(src, c1, c2, 7) }
+pub fn bf_np_sae(src: &BigFrame, c1: i64, c2: i64) -> f64 with Alloc, Mut, Div, Panic { np_binreduce(src, c1, c2, 8) }
+pub fn bf_np_count_gt(src: &BigFrame, col: i64, t: f64) -> f64 with Alloc, Mut, Div, Panic { np_countpred(src, col, t, 0) }
+pub fn bf_np_count_ge(src: &BigFrame, col: i64, t: f64) -> f64 with Alloc, Mut, Div, Panic { np_countpred(src, col, t, 1) }
+pub fn bf_np_count_lt(src: &BigFrame, col: i64, t: f64) -> f64 with Alloc, Mut, Div, Panic { np_countpred(src, col, t, 2) }
+pub fn bf_np_count_le(src: &BigFrame, col: i64, t: f64) -> f64 with Alloc, Mut, Div, Panic { np_countpred(src, col, t, 3) }
+pub fn bf_np_count_eq(src: &BigFrame, col: i64, t: f64) -> f64 with Alloc, Mut, Div, Panic { np_countpred(src, col, t, 4) }
+pub fn bf_np_count_ne(src: &BigFrame, col: i64, t: f64) -> f64 with Alloc, Mut, Div, Panic { np_countpred(src, col, t, 5) }
+pub fn bf_np_count_zero(src: &BigFrame, col: i64, t: f64) -> f64 with Alloc, Mut, Div, Panic { np_countpred(src, col, t, 6) }
+pub fn bf_np_count_nonzero(src: &BigFrame, col: i64, t: f64) -> f64 with Alloc, Mut, Div, Panic { np_countpred(src, col, t, 7) }
+pub fn bf_np_count_positive(src: &BigFrame, col: i64, t: f64) -> f64 with Alloc, Mut, Div, Panic { np_countpred(src, col, t, 8) }
+pub fn bf_np_count_negative(src: &BigFrame, col: i64, t: f64) -> f64 with Alloc, Mut, Div, Panic { np_countpred(src, col, t, 9) }

--- a/tests/stdlib/data/test_bigframe_np.sio
+++ b/tests/stdlib/data/test_bigframe_np.sio
@@ -1,0 +1,175 @@
+use data::bigframe::*
+use data::bigframe_np::*
+
+fn aeq(a: f64, b: f64) -> bool { let d = a - b; if d < 0.0 { (0.0 - d) < 0.0005 } else { d < 0.0005 } }
+
+fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
+    var f = bf_new(2, 8)
+    var row0:[f64;64]=[0.0;64]; row0[0]=1.0; row0[1]=2.0; bf_push_row(&!f,&row0,2)
+    var row1:[f64;64]=[0.0;64]; row1[0]=2.0; row1[1]=4.0; bf_push_row(&!f,&row1,2)
+    var row2:[f64;64]=[0.0;64]; row2[0]=3.0; row2[1]=1.0; bf_push_row(&!f,&row2,2)
+    var row3:[f64;64]=[0.0;64]; row3[0]=4.0; row3[1]=3.0; bf_push_row(&!f,&row3,2)
+    if !aeq(bf_np_sum(&f,0), 10.0) { print("FAIL @1\n"); return 1 }
+    if !aeq(bf_np_mean(&f,0), 2.5) { print("FAIL @2\n"); return 2 }
+    if !aeq(bf_np_min(&f,0), 1.0) { print("FAIL @3\n"); return 3 }
+    if !aeq(bf_np_max(&f,0), 4.0) { print("FAIL @4\n"); return 4 }
+    if !aeq(bf_np_prod(&f,0), 24.0) { print("FAIL @5\n"); return 5 }
+    if !aeq(bf_np_var(&f,0), 1.25) { print("FAIL @6\n"); return 6 }
+    if !aeq(bf_np_std(&f,0), 1.118034) { print("FAIL @7\n"); return 7 }
+    if !aeq(bf_np_ptp(&f,0), 3.0) { print("FAIL @8\n"); return 8 }
+    if !aeq(bf_np_count(&f,0), 4.0) { print("FAIL @9\n"); return 9 }
+    if !aeq(bf_np_argmin(&f,0), 0.0) { print("FAIL @10\n"); return 10 }
+    if !aeq(bf_np_argmax(&f,0), 3.0) { print("FAIL @11\n"); return 11 }
+    if !aeq(bf_np_first(&f,0), 1.0) { print("FAIL @12\n"); return 12 }
+    if !aeq(bf_np_last(&f,0), 4.0) { print("FAIL @13\n"); return 13 }
+    if !aeq(bf_np_sumsq(&f,0), 30.0) { print("FAIL @14\n"); return 14 }
+    if !aeq(bf_np_l2norm(&f,0), 5.477226) { print("FAIL @15\n"); return 15 }
+    if !aeq(bf_np_l1norm(&f,0), 10.0) { print("FAIL @16\n"); return 16 }
+    if !aeq(bf_np_meanabs(&f,0), 2.5) { print("FAIL @17\n"); return 17 }
+    if !aeq(bf_np_rms(&f,0), 2.738613) { print("FAIL @18\n"); return 18 }
+    if !aeq(bf_np_var_sample(&f,0), 1.666667) { print("FAIL @19\n"); return 19 }
+    if !aeq(bf_np_std_sample(&f,0), 1.290994) { print("FAIL @20\n"); return 20 }
+    let t21 = bf_np_abs(&f,0)
+    if !aeq(bf_get(&t21, 2, 0), 3.0) { print("FAIL @21\n"); return 21 }
+    let t22 = bf_np_neg(&f,0)
+    if !aeq(bf_get(&t22, 2, 0), -3.0) { print("FAIL @22\n"); return 22 }
+    let t23 = bf_np_square(&f,0)
+    if !aeq(bf_get(&t23, 2, 0), 9.0) { print("FAIL @23\n"); return 23 }
+    let t24 = bf_np_cube(&f,0)
+    if !aeq(bf_get(&t24, 2, 0), 27.0) { print("FAIL @24\n"); return 24 }
+    let t25 = bf_np_sign(&f,0)
+    if !aeq(bf_get(&t25, 2, 0), 1.0) { print("FAIL @25\n"); return 25 }
+    let t26 = bf_np_recip(&f,0)
+    if !aeq(bf_get(&t26, 2, 0), 0.333333) { print("FAIL @26\n"); return 26 }
+    let t27 = bf_np_add_scalar(&f,0,2.0)
+    if !aeq(bf_get(&t27, 2, 0), 5.0) { print("FAIL @27\n"); return 27 }
+    let t28 = bf_np_sub_scalar(&f,0,2.0)
+    if !aeq(bf_get(&t28, 2, 0), 1.0) { print("FAIL @28\n"); return 28 }
+    let t29 = bf_np_mul_scalar(&f,0,2.0)
+    if !aeq(bf_get(&t29, 2, 0), 6.0) { print("FAIL @29\n"); return 29 }
+    let t30 = bf_np_div_scalar(&f,0,2.0)
+    if !aeq(bf_get(&t30, 2, 0), 1.5) { print("FAIL @30\n"); return 30 }
+    let t31 = bf_np_rsub_scalar(&f,0,2.0)
+    if !aeq(bf_get(&t31, 2, 0), -1.0) { print("FAIL @31\n"); return 31 }
+    let t32 = bf_np_rdiv_scalar(&f,0,2.0)
+    if !aeq(bf_get(&t32, 2, 0), 0.666667) { print("FAIL @32\n"); return 32 }
+    let t33 = bf_np_clip_min(&f,0,2.0)
+    if !aeq(bf_get(&t33, 2, 0), 3.0) { print("FAIL @33\n"); return 33 }
+    let t34 = bf_np_clip_max(&f,0,2.0)
+    if !aeq(bf_get(&t34, 2, 0), 2.0) { print("FAIL @34\n"); return 34 }
+    let t35 = bf_np_relu(&f,0)
+    if !aeq(bf_get(&t35, 2, 0), 3.0) { print("FAIL @35\n"); return 35 }
+    let t36 = bf_np_step(&f,0)
+    if !aeq(bf_get(&t36, 2, 0), 1.0) { print("FAIL @36\n"); return 36 }
+    let t37 = bf_np_trunc(&f,0)
+    if !aeq(bf_get(&t37, 2, 0), 3.0) { print("FAIL @37\n"); return 37 }
+    let t38 = bf_np_pow_scalar(&f,0,2.0)
+    if !aeq(bf_get(&t38, 2, 0), 9.0) { print("FAIL @38\n"); return 38 }
+    let t39 = bf_np_exp(&f,0)
+    if !aeq(bf_get(&t39, 2, 0), 20.085537) { print("FAIL @39\n"); return 39 }
+    let t40 = bf_np_ln(&f,0)
+    if !aeq(bf_get(&t40, 2, 0), 1.098612) { print("FAIL @40\n"); return 40 }
+    let t41 = bf_np_log2(&f,0)
+    if !aeq(bf_get(&t41, 2, 0), 1.584963) { print("FAIL @41\n"); return 41 }
+    let t42 = bf_np_log10(&f,0)
+    if !aeq(bf_get(&t42, 2, 0), 0.477121) { print("FAIL @42\n"); return 42 }
+    let t43 = bf_np_exp2(&f,0)
+    if !aeq(bf_get(&t43, 2, 0), 8.0) { print("FAIL @43\n"); return 43 }
+    let t44 = bf_np_expm1(&f,0)
+    if !aeq(bf_get(&t44, 2, 0), 19.085537) { print("FAIL @44\n"); return 44 }
+    let t45 = bf_np_log1p(&f,0)
+    if !aeq(bf_get(&t45, 2, 0), 1.386294) { print("FAIL @45\n"); return 45 }
+    let t46 = bf_np_sqrt(&f,0)
+    if !aeq(bf_get(&t46, 2, 0), 1.732051) { print("FAIL @46\n"); return 46 }
+    let t47 = bf_np_cbrt(&f,0)
+    if !aeq(bf_get(&t47, 2, 0), 1.44225) { print("FAIL @47\n"); return 47 }
+    let t48 = bf_np_sigmoid(&f,0)
+    if !aeq(bf_get(&t48, 2, 0), 0.952574) { print("FAIL @48\n"); return 48 }
+    let t49 = bf_np_softplus(&f,0)
+    if !aeq(bf_get(&t49, 2, 0), 3.048587) { print("FAIL @49\n"); return 49 }
+    let t50 = bf_np_tanh(&f,0)
+    if !aeq(bf_get(&t50, 2, 0), 0.995055) { print("FAIL @50\n"); return 50 }
+    let t51 = bf_np_gt_scalar(&f,0,2.0)
+    if !aeq(bf_get(&t51, 2, 0), 1.0) { print("FAIL @51\n"); return 51 }
+    let t52 = bf_np_lt_scalar(&f,0,2.0)
+    if !aeq(bf_get(&t52, 2, 0), 0.0) { print("FAIL @52\n"); return 52 }
+    let t53 = bf_np_ge_scalar(&f,0,2.0)
+    if !aeq(bf_get(&t53, 2, 0), 1.0) { print("FAIL @53\n"); return 53 }
+    let t54 = bf_np_le_scalar(&f,0,2.0)
+    if !aeq(bf_get(&t54, 2, 0), 0.0) { print("FAIL @54\n"); return 54 }
+    let t55 = bf_np_eq_scalar(&f,0,2.0)
+    if !aeq(bf_get(&t55, 2, 0), 0.0) { print("FAIL @55\n"); return 55 }
+    let t56 = bf_np_ne_scalar(&f,0,2.0)
+    if !aeq(bf_get(&t56, 2, 0), 1.0) { print("FAIL @56\n"); return 56 }
+    let t57 = bf_np_deg2rad(&f,0)
+    if !aeq(bf_get(&t57, 2, 0), 0.05236) { print("FAIL @57\n"); return 57 }
+    let t58 = bf_np_rad2deg(&f,0)
+    if !aeq(bf_get(&t58, 2, 0), 171.887339) { print("FAIL @58\n"); return 58 }
+    let t59 = bf_np_logistic_not(&f,0)
+    if !aeq(bf_get(&t59, 2, 0), -2.0) { print("FAIL @59\n"); return 59 }
+    let t60 = bf_np_scaleshift(&f,0,2.0)
+    if !aeq(bf_get(&t60, 2, 0), 8.0) { print("FAIL @60\n"); return 60 }
+    let t61 = bf_np_cumsum(&f,0)
+    if !aeq(bf_get(&t61, 3, 0), 10.0) { print("FAIL @61\n"); return 61 }
+    let t62 = bf_np_cumprod(&f,0)
+    if !aeq(bf_get(&t62, 3, 0), 24.0) { print("FAIL @62\n"); return 62 }
+    let t63 = bf_np_cummax(&f,0)
+    if !aeq(bf_get(&t63, 3, 0), 4.0) { print("FAIL @63\n"); return 63 }
+    let t64 = bf_np_cummin(&f,0)
+    if !aeq(bf_get(&t64, 3, 0), 1.0) { print("FAIL @64\n"); return 64 }
+    let t65 = bf_np_cumcount(&f,0)
+    if !aeq(bf_get(&t65, 3, 0), 4.0) { print("FAIL @65\n"); return 65 }
+    let t66 = bf_np_cummean(&f,0)
+    if !aeq(bf_get(&t66, 3, 0), 2.5) { print("FAIL @66\n"); return 66 }
+    let t67 = bf_np_cumsumsq(&f,0)
+    if !aeq(bf_get(&t67, 3, 0), 30.0) { print("FAIL @67\n"); return 67 }
+    let t68 = bf_np_cumrange(&f,0)
+    if !aeq(bf_get(&t68, 3, 0), 3.0) { print("FAIL @68\n"); return 68 }
+    let t69 = bf_np_add(&f,0,1)
+    if !aeq(bf_get(&t69, 0, 0), 3.0) { print("FAIL @69\n"); return 69 }
+    let t70 = bf_np_sub(&f,0,1)
+    if !aeq(bf_get(&t70, 0, 0), -1.0) { print("FAIL @70\n"); return 70 }
+    let t71 = bf_np_mul(&f,0,1)
+    if !aeq(bf_get(&t71, 0, 0), 2.0) { print("FAIL @71\n"); return 71 }
+    let t72 = bf_np_div(&f,0,1)
+    if !aeq(bf_get(&t72, 0, 0), 0.5) { print("FAIL @72\n"); return 72 }
+    let t73 = bf_np_pow(&f,0,1)
+    if !aeq(bf_get(&t73, 0, 0), 1.0) { print("FAIL @73\n"); return 73 }
+    let t74 = bf_np_hypot(&f,0,1)
+    if !aeq(bf_get(&t74, 0, 0), 2.236068) { print("FAIL @74\n"); return 74 }
+    let t75 = bf_np_maximum(&f,0,1)
+    if !aeq(bf_get(&t75, 0, 0), 2.0) { print("FAIL @75\n"); return 75 }
+    let t76 = bf_np_minimum(&f,0,1)
+    if !aeq(bf_get(&t76, 0, 0), 1.0) { print("FAIL @76\n"); return 76 }
+    let t77 = bf_np_absdiff(&f,0,1)
+    if !aeq(bf_get(&t77, 0, 0), 1.0) { print("FAIL @77\n"); return 77 }
+    let t78 = bf_np_mean2(&f,0,1)
+    if !aeq(bf_get(&t78, 0, 0), 1.5) { print("FAIL @78\n"); return 78 }
+    let t79 = bf_np_gt(&f,0,1)
+    if !aeq(bf_get(&t79, 0, 0), 0.0) { print("FAIL @79\n"); return 79 }
+    let t80 = bf_np_sumsq2(&f,0,1)
+    if !aeq(bf_get(&t80, 0, 0), 5.0) { print("FAIL @80\n"); return 80 }
+    let t81 = bf_np_wdiff(&f,0,1)
+    if !aeq(bf_get(&t81, 0, 0), -3.0) { print("FAIL @81\n"); return 81 }
+    if !aeq(bf_np_dot(&f,0,1), 25.0) { print("FAIL @82\n"); return 82 }
+    if !aeq(bf_np_cov(&f,0,1), 0.0) { print("FAIL @83\n"); return 83 }
+    if !aeq(bf_np_corr(&f,0,1), 0.0) { print("FAIL @84\n"); return 84 }
+    if !aeq(bf_np_sumprod(&f,0,1), 25.0) { print("FAIL @85\n"); return 85 }
+    if !aeq(bf_np_mse(&f,0,1), 2.5) { print("FAIL @86\n"); return 86 }
+    if !aeq(bf_np_mae(&f,0,1), 1.5) { print("FAIL @87\n"); return 87 }
+    if !aeq(bf_np_rmse(&f,0,1), 1.581139) { print("FAIL @88\n"); return 88 }
+    if !aeq(bf_np_sse(&f,0,1), 10.0) { print("FAIL @89\n"); return 89 }
+    if !aeq(bf_np_sae(&f,0,1), 6.0) { print("FAIL @90\n"); return 90 }
+    if !aeq(bf_np_count_gt(&f,0,2.0), 2.0) { print("FAIL @91\n"); return 91 }
+    if !aeq(bf_np_count_ge(&f,0,2.0), 3.0) { print("FAIL @92\n"); return 92 }
+    if !aeq(bf_np_count_lt(&f,0,2.0), 1.0) { print("FAIL @93\n"); return 93 }
+    if !aeq(bf_np_count_le(&f,0,2.0), 2.0) { print("FAIL @94\n"); return 94 }
+    if !aeq(bf_np_count_eq(&f,0,2.0), 1.0) { print("FAIL @95\n"); return 95 }
+    if !aeq(bf_np_count_ne(&f,0,2.0), 3.0) { print("FAIL @96\n"); return 96 }
+    if !aeq(bf_np_count_zero(&f,0,2.0), 0.0) { print("FAIL @97\n"); return 97 }
+    if !aeq(bf_np_count_nonzero(&f,0,2.0), 4.0) { print("FAIL @98\n"); return 98 }
+    if !aeq(bf_np_count_positive(&f,0,2.0), 4.0) { print("FAIL @99\n"); return 99 }
+    if !aeq(bf_np_count_negative(&f,0,2.0), 0.0) { print("FAIL @100\n"); return 100 }
+    print("BIGFRAME_NP_GATE_OK\n")
+    return 0
+}


### PR DESCRIPTION
**One batch, one package eliminated: 101 numpy-on-columns verbs**, over six mode-dispatched engines (every verb a thin wrapper).

- **reductions (20):** sum mean min max prod var std ptp count argmin argmax first last sumsq l2norm l1norm meanabs rms var_sample std_sample
- **elementwise (41):** abs neg square cube sign recip {add,sub,mul,div,rsub,rdiv}_scalar clip_min clip_max relu step trunc pow_scalar exp ln log2 log10 exp2 expm1 log1p sqrt cbrt sigmoid logit softplus tanh {gt,lt,ge,le,eq,ne}_scalar deg2rad rad2deg …
- **cumulative (8):** cumsum cumprod cummax cummin cumcount cummean cumsumsq cumrange
- **pairwise→col (13):** add sub mul div pow hypot maximum minimum absdiff mean2 gt sumsq2 wdiff
- **pairwise→scalar (9):** dot cov corr sumprod mse mae rmse sse sae
- **count-predicate (10):** count_{gt,ge,lt,le,eq,ne,zero,nonzero,positive,negative}

Arithmetic + accurate builtins (ln/exp) + a Newton sqrt — no exotic intrinsics. **100 of 101 verbs asserted value-for-value against numpy** in the compiled run gate (codes 1–100, all pass; logit is the one guarded-domain verb without an in-range gate value).

**Honest framing:** on a *single* column these are SIMD/BLAS-bound and lose to numpy (~6× on std at 1M rows) — the value is native numpy-API coverage **without the dependency**, not a speed win. The speed wins live in the per-**group** versions (bigframe_ops / bigframe_ml).

Generated with Claude Code