### PR TITLE
fix(parser): accept policy soft identifiers in expressions

### DIFF
--- a/self-hosted/lexer/token.sio
+++ b/self-hosted/lexer/token.sio
@@ -365,6 +365,20 @@ impl Token {
 // TOKEN KIND CLASSIFICATION
 // ============================================================================
 
+pub fn tk_is_policy_soft_ident(kind: TokenKind) -> bool {
+    match kind {
+        TokenKind::PolicyLower => true,
+        TokenKind::AcquisitionPolicyLower => true,
+        TokenKind::RecoursePolicyLower => true,
+        TokenKind::TransitionPolicyLower => true,
+        TokenKind::MonitoringPolicyLower => true,
+        TokenKind::AlternativePolicyLower => true,
+        TokenKind::DecisionPolicyLower => true,
+        TokenKind::DeferralPolicyLower => true,
+        _ => false,
+    }
+}
+
 pub fn tk_is_keyword(kind: TokenKind) -> bool {
     match kind {
         TokenKind::Module => true,

--- a/self-hosted/parser/exprs.sio
+++ b/self-hosted/parser/exprs.sio
@@ -310,7 +310,7 @@ impl Parser {
         // TokenKind::Var is included so bare `var` works as a binding *use*
         // after `let var = ...` (contextual keyword; see patterns.sio).
         // Statement `var x = ...` is dispatched from parse_stmt, not here.
-        else if k == TokenKind::Ident || k == TokenKind::Knowledge || k == TokenKind::Close || k == TokenKind::Unit || k == TokenKind::Kernel || k == TokenKind::Var {
+        else if k == TokenKind::Ident || tk_is_policy_soft_ident(k) || k == TokenKind::Knowledge || k == TokenKind::Close || k == TokenKind::Unit || k == TokenKind::Kernel || k == TokenKind::Var {
             self.parse_ident_expr()
         }
         // Error recovery: advance past unrecognized token to avoid infinite loops

--- a/tests/run-pass/policy_soft_identifier.sio
+++ b/tests/run-pass/policy_soft_identifier.sio
@@ -1,0 +1,40 @@
+//@ run-pass
+//@ description: Policy keyword tokens remain available as identifiers in expression context.
+
+struct P {
+    x: i64,
+}
+
+fn policy_sum(
+    policy: P,
+    acquisition_policy: P,
+    recourse_policy: P,
+    transition_policy: P,
+    monitoring_policy: P,
+    alternative_policy: P,
+    decision_policy: P,
+    deferral_policy: P,
+) -> i64 {
+    policy.x
+        + acquisition_policy.x
+        + recourse_policy.x
+        + transition_policy.x
+        + monitoring_policy.x
+        + alternative_policy.x
+        + decision_policy.x
+        + deferral_policy.x
+}
+
+fn main() -> i64 {
+    let _sum = policy_sum(
+        P { x: 1 },
+        P { x: 1 },
+        P { x: 1 },
+        P { x: 1 },
+        P { x: 1 },
+        P { x: 1 },
+        P { x: 1 },
+        P { x: 1 },
+    )
+    0
+}


### PR DESCRIPTION
## Description

Treat the reserved `policy` / `*_policy` token family as soft identifiers when parsing expression atoms. This makes raw-AST parsing accept field accesses such as `policy.x` while preserving the existing top-level `policy ...` item dispatch.

A focused run-pass regression covers all eight policy-token names in parameter and expression contexts.

## Type of Change

- [x] Bug fix (non-breaking change that fixes a compiler or runtime bug)
- [ ] New feature (non-breaking change that adds a language or stdlib capability)
- [ ] Breaking change (fix or feature that would cause existing Sounio code to fail compilation)
- [ ] Refactoring (internal compiler or website optimization, no functional changes)
- [ ] Documentation update (translations, expansions, or spec syncs)
- [x] Test improvement (adding compile-fail gates or golden snapshot validations)
- [ ] Performance improvement (reduction of bootstrap build time or codegen optimization)

## Related Issues

Fixes #1454

## Traceability

- Traceability Matrix ID(s): COMP-1454
- Evidence Log(s): `tests/run-pass/policy_soft_identifier.sio`

## Release Scope

- [x] Compiler (self-hosted / codegen)
- [ ] Stdlib (modules, units, epistemic types, ontology)
- [ ] Docs
- [ ] Website
- [ ] CI / Workflow contracts
- [x] Non-release-blocking change

---

## Quality Checklist

- [x] **Semicolon Check**: no Sounio statement terminators were added.
- [x] **Sounio Syntax Standards**: the change uses existing Sounio parser conventions.
- [x] **Algebraic Effects declared**: no effectful function signature was changed.
- [x] **No Rust Macro syntax**: no Rust macro syntax was introduced.
- [x] **Mathematical Operators**: no negative numeric literal was introduced.
- [x] **Bit Shifts**: no bit-shift expression was introduced.
- [ ] **Compile and Type-Check**: the checked-in carrier is x86_64 Linux; the local arm64 macOS attempt exited 126 before parsing. Authoritative source-built CI is required.
- [ ] **Test Suite passes**: the focused runner selected the new test but could not execute the Linux carrier on arm64 macOS.
- [x] **Documentation Registry Sync**: not applicable; no documentation registry entry changed.
- [x] **LLM-Offload Policy Compliance**: not triggered; this patch contains no math derivation, Lean proof, or clinical pathway.
- [x] **Apache-2.0 License**: I understand that my contributions will be licensed under the Apache License, Version 2.0.
