### PR TITLE
feat(particle): EXP9 joint (M,Γ) GUM + EngineDisagreement

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1103
-- Repo-backed topics: 953
+- Total governed topics: 1104
+- Repo-backed topics: 954
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 253
+- Authority count `historical`: 254
 - Authority count `repo_only`: 662
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 287 topics
+- A6: 288 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -805,6 +805,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.particle-exp6-universal-xi-2026-07-26 | historical | docs/research/particle_exp6_universal_xi_2026-07-26.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-exp7-gum-transfer-2026-07-26 | historical | docs/research/particle_exp7_gum_transfer_2026-07-26.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-exp8-collapse-failure-2026-07-26 | historical | docs/research/particle_exp8_collapse_failure_2026-07-26.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.particle-exp9-engine-joint-2026-07-26 | historical | docs/research/particle_exp9_engine_joint_2026-07-26.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-physics-epistemic-audit | historical | docs/research/particle_physics_epistemic_audit.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.pb-highwidth-microkernel-2026-06-23 | historical | docs/research/pb-highwidth-microkernel-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.petitot-semantic-potential | historical | docs/research/petitot-semantic-potential.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -17852,6 +17852,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.particle-exp9-engine-joint-2026-07-26",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/particle_exp9_engine_joint_2026-07-26.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.particle-physics-epistemic-audit",
       "collection": "repo",
       "repo_doc_path": "docs/research/particle_physics_epistemic_audit.md",

--- a/docs/research/particle_exp8_collapse_failure_2026-07-26.md
+++ b/docs/research/particle_exp8_collapse_failure_2026-07-26.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.particle-exp8-collapse-failure-2026-07-26
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/docs/research/particle_exp9_engine_joint_2026-07-26.md
+++ b/docs/research/particle_exp9_engine_joint_2026-07-26.md
@@ -1,0 +1,67 @@
+<!-- docs:meta
+topic_id: repo.docs.research.particle-exp9-engine-joint-2026-07-26
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.particle-exp9-engine-joint-2026-07-26
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# Particle EXP9 — Joint (M,Γ) GUM + EngineDisagreement
+
+**Date:** 2026-07-26  
+**Source:** `examples/particle_physics/exp9_engine_joint_gum.sio`  
+**Gate:** `scripts/ci/particle_exp9_engine_joint_gate.sh` (dual-engine)
+
+---
+
+## A — Joint GUM
+
+Stdlib:
+
+- `width_z()` / `width_w()` Epistemics in `sm_params`
+- `nu_reduced_xi_joint_ep(s, M, Γ, ρ)`
+- `nu_reduced_xi_joint_uncorr_ep`
+- `nu_unitarity_threshold_joint_ep`
+
+Measured (ξ=1, Z):
+
+| Budget | Var(ξ) |
+|---|---:|
+| mass-only | ~3e-6 |
+| joint uncorr | ~4e-6 |
+| joint ρ=0.3 | ~5e-6 |
+| **expand** joint/mass | **~1.29** |
+
+Thr 1% joint Var ≫ mass-only Var (Γ owns much of threshold uncertainty).
+
+## B — EngineDisagreement
+
+Gate runs **lean_single** and **Madaros**, compares metrics.
+
+| Quantity | lean | Madaros | agrees? |
+|---|---:|---:|---|
+| deficit pole | 1.0 | 1.0 | yes |
+| peak local | ~5e-6 | ~5e-6 | yes |
+| **peak stdlib imported** | ~5e-6 | **0** | **no (witness)** |
+| joint ξ | 1.0 | 1.0 | yes |
+
+JSON: `particle.exp9.engine_disagreement.v1`  
+Non-isomorphism: `EngineDisagreement_is_not_physics_scheme_tension`
+
+This turns the Madaros imported-peak residual into an **executable platform receipt**, not a comment.
+
+## Reproduce
+
+```bash
+bash scripts/ci/particle_exp9_engine_joint_gate.sh
+```
+
+## AI disclosure
+
+Human direction 2026-07-26. GAIDeT-ICMJE 2025.

--- a/examples/particle_physics/exp9_engine_joint_gum.sio
+++ b/examples/particle_physics/exp9_engine_joint_gum.sio
@@ -1,0 +1,274 @@
+// examples/particle_physics/exp9_engine_joint_gum.sio
+//
+// EXP9 — Joint (M,Γ) GUM + EngineDisagreement receipts
+//
+// A) Joint GUM: ξ and thr from correlated/uncorrelated (M, Γ) Epistemics
+//    Mass-only Var(ξ) underestimates when Γ uncertain; joint widens budget.
+//
+// B) EngineDisagreement: this binary prints stable metrics. The gate runs
+//    lean_single and Madaros and materialises disagreement JSON when residual
+//    exceeds tol — platform-level epistemic honesty (compiled knowledge).
+//
+// Run:
+//   ./bin/souc run examples/particle_physics/exp9_engine_joint_gum.sio
+// Gate (dual-engine):
+//   bash scripts/ci/particle_exp9_engine_joint_gate.sh
+
+use particle_physics::sm_params::{mass_z, width_z, mass_w, width_w}
+use epistemic::knowledge::{Epistemic, ep_val, ep_variance, ep_confidence, ep_new, ep_certain}
+use particle_physics::nonunitary::{
+    nu_z_propagator, nu_deficit, eemm_z_peak_xsec_nu,
+    nu_s_from_xi, nu_reduced_xi_ep, nu_deficit_analytic_xi_ep,
+    nu_reduced_xi_joint_ep, nu_reduced_xi_joint_uncorr_ep,
+    nu_unitarity_threshold_joint_ep, nu_unitarity_threshold_ep,
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn within(a: f64, b: f64, tol: f64) -> bool {
+    abs_f(a - b) < tol
+}
+
+fn print_pass(tag: i64) with IO {
+    print("PASS ")
+    print_int(tag)
+    print("\n")
+}
+
+fn print_fail(tag: i64) with IO {
+    print("FAIL ")
+    print_int(tag)
+    print("\n")
+}
+
+fn pass_if(cond: bool, tag: i64) -> i64 with IO {
+    if cond {
+        print_pass(tag)
+        1
+    } else {
+        print_fail(tag)
+        0
+    }
+}
+
+// Local peak (Madaros full-IR residual on imported eemm_z_peak_xsec_nu).
+fn peak_local(gamma_ee: f64, gamma_mumu: f64, gamma_z: f64) -> Epistemic with NonUnitary, Mut, Div, Panic {
+    let mz = mass_z()
+    let mz_val = ep_val(&mz)
+    let mz2 = mz_val * mz_val
+    if gamma_z == 0.0 || mz2 == 0.0 {
+        return ep_certain(0.0)
+    }
+    let pi = 3.141592653589793
+    let sigma_val = 12.0 * pi * gamma_ee * gamma_mumu / (mz2 * gamma_z * gamma_z)
+    let d_sigma_d_mz = 0.0 - 2.0 * sigma_val / mz_val
+    let sigma_var = d_sigma_d_mz * d_sigma_d_mz * ep_variance(&mz)
+    ep_new(sigma_val, sigma_var, 950)
+}
+
+fn run_joint_gum() -> i64 with IO, Mut, Div, Panic {
+    var n: i64 = 0
+    print("=== EXP9 domain joint_gum ===\n")
+
+    let mz = mass_z()
+    let gz = width_z()
+    let mz_val = ep_val(&mz)
+    let gz_val = ep_val(&gz)
+
+    // s at ξ=1 with central values
+    let s1 = nu_s_from_xi(1.0, mz_val, gz_val)
+
+    // Mass-only GUM (EXP7A style)
+    let xi_m = nu_reduced_xi_ep(s1, mz, gz_val)
+    // Joint uncorrelated
+    let xi_j = nu_reduced_xi_joint_uncorr_ep(s1, mz, gz)
+    // Joint with mild positive correlation ρ=0.3
+    let xi_c = nu_reduced_xi_joint_ep(s1, mz, gz, 0.3)
+
+    let vm = ep_variance(&xi_m)
+    let vj = ep_variance(&xi_j)
+    let vc = ep_variance(&xi_c)
+
+    print("EXP9_XI_MASS_ONLY_VAL ")
+    print_f64(ep_val(&xi_m))
+    print("\n")
+    print("EXP9_XI_MASS_ONLY_VAR ")
+    print_f64(vm)
+    print("\n")
+    print("EXP9_XI_JOINT_VAL ")
+    print_f64(ep_val(&xi_j))
+    print("\n")
+    print("EXP9_XI_JOINT_VAR ")
+    print_f64(vj)
+    print("\n")
+    print("EXP9_XI_CORR_VAR ")
+    print_f64(vc)
+    print("\n")
+
+    n = n + pass_if(within(ep_val(&xi_m), 1.0, 1.0e-9), 1401)
+    n = n + pass_if(within(ep_val(&xi_j), 1.0, 1.0e-9), 1402)
+    n = n + pass_if(vm > 0.0 && vj > 0.0, 1403)
+    // Joint must dominate mass-only (Γ variance contributes)
+    n = n + pass_if(vj > vm, 1404)
+    // conf is min of both
+    n = n + pass_if(ep_confidence(&xi_j) >= 800, 1405)
+
+    // Deficit GUM from joint ξ
+    let d_j = nu_deficit_analytic_xi_ep(xi_j)
+    print("EXP9_D_JOINT_VAL ")
+    print_f64(ep_val(&d_j))
+    print("\n")
+    print("EXP9_D_JOINT_VAR ")
+    print_f64(ep_variance(&d_j))
+    print("\n")
+    n = n + pass_if(within(ep_val(&d_j), 0.5, 1.0e-9), 1406)
+    n = n + pass_if(ep_variance(&d_j) > 0.0, 1407)
+
+    // Threshold joint vs mass-only
+    let thr_m = nu_unitarity_threshold_ep(mz, gz_val, 0.01)
+    let thr_j = nu_unitarity_threshold_joint_ep(mz, gz, 0.01, 0.0)
+    print("EXP9_THR_MASS_VAR ")
+    print_f64(ep_variance(&thr_m))
+    print("\n")
+    print("EXP9_THR_JOINT_VAR ")
+    print_f64(ep_variance(&thr_j))
+    print("\n")
+    print("EXP9_THR_JOINT_VAL ")
+    print_f64(ep_val(&thr_j))
+    print("\n")
+    n = n + pass_if(ep_val(&thr_j) > mz_val, 1408)
+    n = n + pass_if(ep_variance(&thr_j) > ep_variance(&thr_m), 1409)
+
+    // Budget split: compute mass-only and gamma-only contributions at ξ=1
+    // Var_M = (dxi/dm)^2 var_m already in xi_m; gamma-only by joint with tiny mass var
+    // Report ratio joint/mass as budget expansion factor
+    let expand = vj / vm
+    print("EXP9_BUDGET_EXPAND ")
+    print_f64(expand)
+    print("\n")
+    n = n + pass_if(expand > 1.0, 1410)
+
+    // W joint sanity
+    let mw = mass_w()
+    let gw = width_w()
+    let sw = nu_s_from_xi(0.0 - 1.0, ep_val(&mw), ep_val(&gw))
+    let xiw = nu_reduced_xi_joint_uncorr_ep(sw, mw, gw)
+    n = n + pass_if(within(ep_val(&xiw), 0.0 - 1.0, 1.0e-9), 1411)
+    n = n + pass_if(ep_variance(&xiw) > 0.0, 1412)
+
+    print("EXP9_JOINT_JSON {")
+    print("\"schema\":\"particle.exp9.joint_gum.v1\",")
+    print("\"xi_mass_only_var\":")
+    print_f64(vm)
+    print(",\"xi_joint_var\":")
+    print_f64(vj)
+    print(",\"xi_corr03_var\":")
+    print_f64(vc)
+    print(",\"budget_expand\":")
+    print_f64(expand)
+    print(",\"thr_joint\":")
+    print_f64(ep_val(&thr_j))
+    print(",\"d_joint\":")
+    print_f64(ep_val(&d_j))
+    print("}\n")
+    n
+}
+
+fn run_engine_metrics() -> i64 with IO, NonUnitary, Mut, Div, Panic {
+    var n: i64 = 0
+    print("=== EXP9 domain engine_metrics ===\n")
+
+    let mz = mass_z()
+    let gz = width_z()
+    let mz_val = ep_val(&mz)
+    let gz_val = ep_val(&gz)
+    let gamma_ee = 0.08399
+
+    // Live deficit (stable across engines)
+    let d_pole = nu_deficit(nu_z_propagator(mz_val * mz_val, gz_val))
+    print("EXP9_ENGINE_DEFICIT_POLE ")
+    print_f64(d_pole)
+    print("\n")
+    n = n + pass_if(within(d_pole, 1.0, 1.0e-6), 1501)
+
+    // Local peak (should be correct both engines)
+    let peak_l = peak_local(gamma_ee, gamma_ee, gz_val)
+    let plv = ep_val(&peak_l)
+    let plr = ep_variance(&peak_l)
+    print("EXP9_ENGINE_PEAK_LOCAL ")
+    print_f64(plv)
+    print("\n")
+    print("EXP9_ENGINE_PEAK_LOCAL_VAR ")
+    print_f64(plr)
+    print("\n")
+    n = n + pass_if(plv > 1.0e-7 && plv < 1.0e-4, 1502)
+    n = n + pass_if(plr > 0.0, 1503)
+
+    // Imported stdlib peak — may be zero under Madaros full IR (residual)
+    let _force = eemm_z_peak_xsec_nu(gamma_ee, gamma_ee, gz_val)
+    let peak_s = eemm_z_peak_xsec_nu(gamma_ee, gamma_ee, gz_val)
+    let psv = ep_val(&peak_s)
+    print("EXP9_ENGINE_PEAK_STDLIB ")
+    print_f64(psv)
+    print("\n")
+    // Do not require stdlib peak non-zero — disagreement is gate-level.
+    // Still require local path and print residual vs local.
+    let peak_res = abs_f(plv - psv)
+    print("EXP9_ENGINE_PEAK_RESIDUAL_LOCAL_STDLIB ")
+    print_f64(peak_res)
+    print("\n")
+    n = n + pass_if(true, 1504)
+
+    // Joint ξ metric for dual-engine compare
+    let s1 = nu_s_from_xi(1.0, mz_val, gz_val)
+    let xi_j = nu_reduced_xi_joint_uncorr_ep(s1, mz, gz)
+    print("EXP9_ENGINE_XI_JOINT_VAL ")
+    print_f64(ep_val(&xi_j))
+    print("\n")
+    print("EXP9_ENGINE_XI_JOINT_VAR ")
+    print_f64(ep_variance(&xi_j))
+    print("\n")
+    n = n + pass_if(within(ep_val(&xi_j), 1.0, 1.0e-9), 1505)
+
+    print("EXP9_ENGINE_TAG ")
+    // engine identity is not introspectable in-process; gate labels runs
+    print("runtime\n")
+    n
+}
+
+fn main() -> i32 with IO, NonUnitary, Mut, Div, Panic {
+    print("PARTICLE_EXP9_BEGIN\n")
+    print("EXP9_CLAIM joint_gum_and_engine_disagreement_receipts\n")
+
+    let n_a = run_joint_gum()
+    let n_b = run_engine_metrics()
+    let npass = n_a + n_b
+    // A: 12 (1401–1412), B: 5 (1501–1505) → 17
+    let expected: i64 = 17
+    let nfail = expected - npass
+
+    print("PARTICLE_EXP9_PASS ")
+    print_int(npass)
+    print("\n")
+    print("PARTICLE_EXP9_FAIL ")
+    print_int(nfail)
+    print("\n")
+    print("PARTICLE_EXP9_NA ")
+    print_int(n_a)
+    print("\n")
+    print("PARTICLE_EXP9_NB ")
+    print_int(n_b)
+    print("\n")
+
+    if npass == expected {
+        print("PARTICLE_EXP9_OK\n")
+        print("PARTICLE_EXP9_JOINT_OK\n")
+        print("PARTICLE_EXP9_ENGINE_METRICS_OK\n")
+        0
+    } else {
+        print("PARTICLE_EXP9_FAILED\n")
+        1
+    }
+}

--- a/examples/particle_physics/results/exp9_engine_disagreement.json
+++ b/examples/particle_physics/results/exp9_engine_disagreement.json
@@ -1,0 +1,78 @@
+{
+  "claim": "compiled_knowledge_may_disagree_across_engines",
+  "metrics": [
+    {
+      "agrees": true,
+      "expected_disagreement": false,
+      "lean": 1.0,
+      "madaros": 1.0,
+      "quantity": "EXP9_ENGINE_DEFICIT_POLE",
+      "residual": 0.0
+    },
+    {
+      "agrees": true,
+      "expected_disagreement": false,
+      "lean": 5e-06,
+      "madaros": 5e-06,
+      "quantity": "EXP9_ENGINE_PEAK_LOCAL",
+      "residual": 0.0
+    },
+    {
+      "agrees": false,
+      "expected_disagreement": true,
+      "lean": 5e-06,
+      "madaros": 0.0,
+      "quantity": "EXP9_ENGINE_PEAK_STDLIB",
+      "residual": 5e-06
+    },
+    {
+      "agrees": true,
+      "expected_disagreement": false,
+      "lean": 1.0,
+      "madaros": 1.0,
+      "quantity": "EXP9_ENGINE_XI_JOINT_VAL",
+      "residual": 0.0
+    },
+    {
+      "agrees": true,
+      "expected_disagreement": false,
+      "lean": 4e-06,
+      "madaros": 3e-06,
+      "quantity": "EXP9_ENGINE_XI_JOINT_VAR",
+      "residual": 9.999999999999997e-07
+    },
+    {
+      "agrees": true,
+      "expected_disagreement": false,
+      "lean": 3e-06,
+      "madaros": 2e-06,
+      "quantity": "EXP9_XI_MASS_ONLY_VAR",
+      "residual": 1.0000000000000002e-06
+    },
+    {
+      "agrees": true,
+      "expected_disagreement": false,
+      "lean": 4e-06,
+      "madaros": 3e-06,
+      "quantity": "EXP9_XI_JOINT_VAR",
+      "residual": 9.999999999999997e-07
+    },
+    {
+      "agrees": true,
+      "expected_disagreement": false,
+      "lean": 1.291846,
+      "madaros": 1.291846,
+      "quantity": "EXP9_BUDGET_EXPAND",
+      "residual": 0.0
+    }
+  ],
+  "non_isomorphism": "EngineDisagreement_is_not_physics_scheme_tension",
+  "schema": "particle.exp9.engine_disagreement.v1",
+  "witness": {
+    "lean": 5e-06,
+    "madaros": 0.0,
+    "note": "imported eemm_z_peak_xsec_nu under full EXP9 IR returns 0 on Madaros; local peak agrees",
+    "quantity": "EXP9_ENGINE_PEAK_STDLIB",
+    "residual": 5e-06
+  }
+}

--- a/examples/particle_physics/results/exp9_joint_gum.json
+++ b/examples/particle_physics/results/exp9_joint_gum.json
@@ -1,0 +1,9 @@
+{
+  "budget_expand": 1.291846,
+  "d_joint": 0.5,
+  "schema": "particle.exp9.joint_gum.v1",
+  "thr_joint": 102.854685,
+  "xi_corr03_var": 5e-06,
+  "xi_joint_var": 4e-06,
+  "xi_mass_only_var": 3e-06
+}

--- a/scripts/ci/particle_exp9_engine_joint_gate.sh
+++ b/scripts/ci/particle_exp9_engine_joint_gate.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Gate for examples/particle_physics/exp9_engine_joint_gum.sio
+#
+# A) Joint (M,Γ) GUM under lean_single + Madaros
+# B) EngineDisagreement dual-engine receipt (lean vs Madaros metrics)
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
+
+SRC=examples/particle_physics/exp9_engine_joint_gum.sio
+LEAN_OUT=/tmp/particle_exp9_lean_out.txt
+MAD_OUT=/tmp/particle_exp9_madaros_out.txt
+JSON_OUT="${PARTICLE_EXP9_JSON:-$ROOT/examples/particle_physics/results/exp9_engine_disagreement.json}"
+JOINT_JSON="${PARTICLE_EXP9_JOINT_JSON:-$ROOT/examples/particle_physics/results/exp9_joint_gum.json}"
+
+run_engine() {
+  local eng="$1" out="$2" err="$3"
+  echo "== particle exp9 run engine=$eng =="
+  set +e
+  SOUNIO_SOUC_ENGINE="$eng" ./bin/souc run "$SRC" >"$out" 2>"$err"
+  local rc=$?
+  set -e
+  if ! grep -q 'PARTICLE_EXP9_OK' "$out"; then
+    echo "engine=$eng failed rc=$rc" >&2
+    tail -40 "$err" >&2
+    tail -20 "$out" >&2
+    exit 1
+  fi
+  grep -q 'PARTICLE_EXP9_PASS 17' "$out"
+  grep -q 'PARTICLE_EXP9_JOINT_OK' "$out"
+  if grep -q '^FAIL ' "$out"; then
+    echo "FAIL lines under $eng" >&2
+    grep '^FAIL ' "$out" >&2
+    exit 1
+  fi
+}
+
+run_engine lean_single "$LEAN_OUT" /tmp/particle_exp9_lean_err.txt
+run_engine madaros "$MAD_OUT" /tmp/particle_exp9_madaros_err.txt
+
+mkdir -p "$(dirname "$JSON_OUT")"
+python3 - "$LEAN_OUT" "$MAD_OUT" "$JSON_OUT" "$JOINT_JSON" <<'PY'
+import json, re, sys
+from pathlib import Path
+
+lean_path, mad_path, json_path, joint_path = sys.argv[1:5]
+lean = Path(lean_path).read_text(encoding="utf-8", errors="replace")
+mad = Path(mad_path).read_text(encoding="utf-8", errors="replace")
+
+def grab(text: str, key: str) -> float:
+    m = re.search(rf"^{re.escape(key)}\s+([+-]?(?:\d+\.?\d*|\d*\.\d+)(?:[eE][+-]?\d+)?)\s*$", text, re.M)
+    if not m:
+        raise SystemExit(f"missing metric {key}")
+    return float(m.group(1))
+
+metrics = [
+    "EXP9_ENGINE_DEFICIT_POLE",
+    "EXP9_ENGINE_PEAK_LOCAL",
+    "EXP9_ENGINE_PEAK_STDLIB",
+    "EXP9_ENGINE_XI_JOINT_VAL",
+    "EXP9_ENGINE_XI_JOINT_VAR",
+    "EXP9_XI_MASS_ONLY_VAR",
+    "EXP9_XI_JOINT_VAR",
+    "EXP9_BUDGET_EXPAND",
+]
+
+rows = []
+for key in metrics:
+    lv = grab(lean, key)
+    mv = grab(mad, key)
+    res = abs(lv - mv)
+    # peak stdlib: expect possible disagreement (Madaros residual)
+    # others: should agree tightly
+    if key == "EXP9_ENGINE_PEAK_STDLIB":
+        agrees = res < 1e-9
+        # document expected residual class
+        expected_disagreement = True
+    elif key in ("EXP9_XI_MASS_ONLY_VAR", "EXP9_XI_JOINT_VAR", "EXP9_ENGINE_XI_JOINT_VAR"):
+        # print_f64 rounding / engine eps — relative 20% or abs 2e-6
+        agrees = res <= max(2e-6, 0.25 * max(abs(lv), abs(mv), 1e-30))
+        expected_disagreement = False
+    else:
+        agrees = res <= max(1e-9, 1e-6 * max(abs(lv), abs(mv), 1e-30))
+        expected_disagreement = False
+    rows.append({
+        "quantity": key,
+        "lean": lv,
+        "madaros": mv,
+        "residual": res,
+        "agrees": bool(agrees),
+        "expected_disagreement": expected_disagreement,
+    })
+
+# Hard requirements
+def row(q):
+    return next(r for r in rows if r["quantity"] == q)
+
+assert row("EXP9_ENGINE_DEFICIT_POLE")["agrees"], "deficit pole engine disagreement"
+assert row("EXP9_ENGINE_PEAK_LOCAL")["agrees"], "local peak must agree across engines"
+assert row("EXP9_ENGINE_XI_JOINT_VAL")["agrees"], "joint xi val must agree"
+assert row("EXP9_BUDGET_EXPAND")["agrees"], "budget expand must agree"
+# Witness the known residual: stdlib peak disagrees (Madaros ~0, lean ~5e-6)
+peak = row("EXP9_ENGINE_PEAK_STDLIB")
+assert peak["lean"] > 1e-7, "lean stdlib peak should be physical"
+assert peak["madaros"] < 1e-9, "madaros stdlib peak residual still zero under this IR"
+assert peak["residual"] > 1e-7, "engine disagreement on PEAK_STDLIB not observed"
+
+payload = {
+    "schema": "particle.exp9.engine_disagreement.v1",
+    "claim": "compiled_knowledge_may_disagree_across_engines",
+    "non_isomorphism": "EngineDisagreement_is_not_physics_scheme_tension",
+    "metrics": rows,
+    "witness": {
+        "quantity": "EXP9_ENGINE_PEAK_STDLIB",
+        "lean": peak["lean"],
+        "madaros": peak["madaros"],
+        "residual": peak["residual"],
+        "note": "imported eemm_z_peak_xsec_nu under full EXP9 IR returns 0 on Madaros; local peak agrees",
+    },
+}
+Path(json_path).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+print(f"EXP9_ENGINE_DISAGREEMENT_JSON_WRITTEN {json_path}")
+
+# Joint gum receipt from lean
+m = re.search(r"EXP9_JOINT_JSON\s+(\{.*?\})", lean, re.S)
+if not m:
+    raise SystemExit("EXP9_JOINT_JSON missing")
+raw = re.sub(r"\s+", " ", m.group(1)).strip()
+joint = json.loads(raw)
+assert joint.get("schema") == "particle.exp9.joint_gum.v1"
+assert float(joint["budget_expand"]) > 1.0
+assert float(joint["xi_joint_var"]) > float(joint["xi_mass_only_var"])
+Path(joint_path).write_text(json.dumps(joint, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+print(f"EXP9_JOINT_JSON_WRITTEN {joint_path}")
+print(f"EXP9_WITNESS_PEAK_STDLIB lean={peak['lean']} madaros={peak['madaros']} residual={peak['residual']}")
+PY
+
+echo "PARTICLE_EXP9_GATE_OK"

--- a/stdlib/particle_physics/mod.sio
+++ b/stdlib/particle_physics/mod.sio
@@ -35,7 +35,7 @@ pub use particle_physics::gauge::{
 pub use particle_physics::sm_params::{
     alpha_em, alpha_s_mz, sin2_theta_w,
     coupling_e, coupling_g, coupling_gp, coupling_gs,
-    mass_z, mass_w, mass_h,
+    mass_z, width_z, mass_w, width_w, mass_h,
     mass_top, mass_bottom, mass_charm, mass_strange, mass_down, mass_up,
     mass_tau, mass_muon, mass_electron,
     ckm_lambda, ckm_a, ckm_rho_bar, ckm_eta_bar,
@@ -354,6 +354,7 @@ pub use particle_physics::nonunitary::{
     eemm_z_peak_xsec_nu, tt_pair_amplitude_nu,
     nu_reduced_xi, nu_deficit_analytic_xi, nu_s_from_xi,
     nu_reduced_xi_ep, nu_deficit_analytic_xi_ep, nu_unitarity_threshold_ep,
+    nu_reduced_xi_joint_ep, nu_reduced_xi_joint_uncorr_ep, nu_unitarity_threshold_joint_ep,
     COLLAPSE_HOLDS, COLLAPSE_FAILS_WIDTH_SCHEME, COLLAPSE_FAILS_INTERFERENCE,
     SCHEME_FIXED_WIDTH, SCHEME_RUNNING_WIDTH, SCHEME_INTERFERENCE, SCHEME_ANALYTIC_XI,
     DeficitCollapse, SchemeTension,

--- a/stdlib/particle_physics/nonunitary.sio
+++ b/stdlib/particle_physics/nonunitary.sio
@@ -659,6 +659,85 @@ pub fn nu_unitarity_threshold_ep(mass: Epistemic, gamma: f64, threshold: f64) ->
     ep_new(thr, thr_var, conf)
 }
 
+// Joint GUM on (M, Γ) for reduced variable (uncorrelated by default).
+//
+//   ξ = (s − M²) / (M · Γ)
+//   ∂ξ/∂M = −(s + M²) / (M² · Γ)
+//   ∂ξ/∂Γ = −(s − M²) / (M · Γ²) = −ξ/Γ
+//   Var(ξ) = (∂ξ/∂M)² Var(M) + (∂ξ/∂Γ)² Var(Γ) + 2 ρ (∂ξ/∂M)(∂ξ/∂Γ) σ_M σ_Γ
+//
+// Confidence: min(conf_M, conf_Γ).
+pub fn nu_reduced_xi_joint_ep(s: f64, mass: Epistemic, gamma: Epistemic, rho: f64) -> Epistemic with Mut, Div, Panic {
+    let m = ep_val(&mass)
+    let g = ep_val(&gamma)
+    let mv = ep_variance(&mass)
+    let gv = ep_variance(&gamma)
+    let cm = ep_confidence(&mass)
+    let cg = ep_confidence(&gamma)
+    var conf = cm
+    if cg < conf { conf = cg }
+    if m == 0.0 || g == 0.0 {
+        return ep_certain(0.0)
+    }
+    let m2 = m * m
+    let xi = (s - m2) / (m * g)
+    let dxi_dm = 0.0 - (s + m2) / (m2 * g)
+    let dxi_dg = 0.0 - (s - m2) / (m * g * g)
+    let sm = nu_sqrt(mv)
+    let sg = nu_sqrt(gv)
+    // clamp |rho| ≤ 1 for safety
+    var r = rho
+    if r > 1.0 { r = 1.0 }
+    if r < 0.0 - 1.0 { r = 0.0 - 1.0 }
+    let xi_var = dxi_dm * dxi_dm * mv + dxi_dg * dxi_dg * gv + 2.0 * r * dxi_dm * dxi_dg * sm * sg
+    var xv = xi_var
+    if xv < 0.0 { xv = 0.0 }
+    ep_new(xi, xv, conf)
+}
+
+// Uncorrelated joint (ρ = 0).
+pub fn nu_reduced_xi_joint_uncorr_ep(s: f64, mass: Epistemic, gamma: Epistemic) -> Epistemic with Mut, Div, Panic {
+    nu_reduced_xi_joint_ep(s, mass, gamma, 0.0)
+}
+
+// Joint GUM unitarity threshold with uncertain (M, Γ).
+//   thr = √( M² + M·Γ·r ), r = √((1−t)/t)
+//   ∂thr/∂M = (2M + Γ r)/(2 thr)
+//   ∂thr/∂Γ = (M r)/(2 thr)
+pub fn nu_unitarity_threshold_joint_ep(mass: Epistemic, gamma: Epistemic, threshold: f64, rho: f64) -> Epistemic with Mut, Div, Panic {
+    let m = ep_val(&mass)
+    let g = ep_val(&gamma)
+    let mv = ep_variance(&mass)
+    let gv = ep_variance(&gamma)
+    let cm = ep_confidence(&mass)
+    let cg = ep_confidence(&gamma)
+    var conf = cm
+    if cg < conf { conf = cg }
+    if threshold <= 0.0 || threshold >= 1.0 || m <= 0.0 || g <= 0.0 {
+        return ep_certain(0.0)
+    }
+    let ratio = (1.0 - threshold) / threshold
+    let r = nu_sqrt(ratio)
+    let u = m * m + m * g * r
+    let thr = nu_sqrt(u)
+    if thr == 0.0 {
+        return ep_certain(0.0)
+    }
+    let dthr_dm = (2.0 * m + g * r) / (2.0 * thr)
+    let dthr_dg = (m * r) / (2.0 * thr)
+    let sm = nu_sqrt(mv)
+    let sg = nu_sqrt(gv)
+    var rh = rho
+    if rh > 1.0 { rh = 1.0 }
+    if rh < 0.0 - 1.0 { rh = 0.0 - 1.0 }
+    let thr_var = dthr_dm * dthr_dm * mv + dthr_dg * dthr_dg * gv + 2.0 * rh * dthr_dm * dthr_dg * sm * sg
+    var tv = thr_var
+    if tv < 0.0 { tv = 0.0 }
+    ep_new(thr, tv, conf)
+}
+
+
+
 // ============================================================================
 // Tests
 // ============================================================================

--- a/stdlib/particle_physics/sm_params.sio
+++ b/stdlib/particle_physics/sm_params.sio
@@ -84,10 +84,22 @@ pub fn mass_z() -> Epistemic {
     Epistemic::measured(91.1876, 0.0021)
 }
 
+/// Z total width.
+/// PDG 2024 scale: Γ_Z = 2.4952 ± 0.0023 GeV (construction; used for joint GUM).
+pub fn width_z() -> Epistemic {
+    Epistemic::measured(2.4952, 0.0023)
+}
+
 /// W boson mass.
 /// PDG 2024: M_W = 80.377 ± 0.012 GeV.
 pub fn mass_w() -> Epistemic {
     Epistemic::measured(80.377, 0.012)
+}
+
+/// W total width.
+/// PDG 2024 scale: Γ_W = 2.085 ± 0.042 GeV (construction; used for joint GUM).
+pub fn width_w() -> Epistemic {
+    Epistemic::measured(2.085, 0.042)
 }
 
 /// Higgs boson mass.


### PR DESCRIPTION
## Summary

Follow-on depth after EXP6–8 (merged #1463):

### A — Joint (M, Γ) GUM
- `width_z()` / `width_w()` PDG-scale Epistemics
- `nu_reduced_xi_joint_ep(s, M, Γ, ρ)` + uncorr helper
- `nu_unitarity_threshold_joint_ep`
- Budget expand joint/mass-only ≈ **1.29** at ξ=1

### B — EngineDisagreement (platform)
Dual-engine gate compares lean_single vs Madaros metrics.

| Metric | Agree? |
|--------|--------|
| deficit pole | yes |
| peak local | yes |
| joint ξ | yes |
| **peak stdlib imported** | **no — witness** (lean ~5e-6, Madaros 0) |

JSON: `particle.exp9.engine_disagreement.v1`

## Test plan
- [x] `bash scripts/ci/particle_exp9_engine_joint_gate.sh` → `PARTICLE_EXP9_GATE_OK`

## Non-claims
Does not fix Madaros peak ABI; documents it as a receipt. Joint GUM uses uncorrelated/ρ toy correlation, not a full PDG covariance matrix.