### PR TITLE
feat(particle): EXP10 approximation effect algebra

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1103
-- Repo-backed topics: 953
+- Total governed topics: 1104
+- Repo-backed topics: 954
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 253
+- Authority count `historical`: 254
 - Authority count `repo_only`: 662
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 287 topics
+- A6: 288 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -801,6 +801,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.octonion-pbpk | historical | docs/research/octonion_pbpk.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.octonion-validation-report | historical | docs/research/OCTONION_VALIDATION_REPORT.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.onn-benchmark-analysis | historical | docs/research/ONN_BENCHMARK_ANALYSIS.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.particle-exp10-approx-algebra-2026-07-26 | historical | docs/research/particle_exp10_approx_algebra_2026-07-26.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-exp123-vertical-2026-07-25 | historical | docs/research/particle_exp123_vertical_2026-07-25.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-exp6-universal-xi-2026-07-26 | historical | docs/research/particle_exp6_universal_xi_2026-07-26.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-exp7-gum-transfer-2026-07-26 | historical | docs/research/particle_exp7_gum_transfer_2026-07-26.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -17764,6 +17764,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.particle-exp10-approx-algebra-2026-07-26",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/particle_exp10_approx_algebra_2026-07-26.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.particle-exp123-vertical-2026-07-25",
       "collection": "repo",
       "repo_doc_path": "docs/research/particle_exp123_vertical_2026-07-25.md",

--- a/docs/research/particle_exp10_approx_algebra_2026-07-26.md
+++ b/docs/research/particle_exp10_approx_algebra_2026-07-26.md
@@ -1,0 +1,78 @@
+<!-- docs:meta
+topic_id: repo.docs.research.particle-exp10-approx-algebra-2026-07-26
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.particle-exp10-approx-algebra-2026-07-26
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# Particle EXP10 — Approximation effect algebra
+
+**Date:** 2026-07-26  
+**Source:** `examples/particle_physics/exp10_approx_effect_algebra.sio`  
+**Gate:** `scripts/ci/particle_exp10_approx_algebra_gate.sh`  
+**Status:** lean 30/30 full; Madaros algebra+core (physics import residual)
+
+---
+
+## Claim
+
+Compiler effects `NonUnitary`, `Perturbative`, `NarrowWidthApproximation` already
+propagate. EXP10 adds a **runtime algebra** of layers, residuals, and tension:
+
+| Law | Stack | Note |
+|---|---|---|
+| L1 | singletons | always legal |
+| L2 | {NWA, Pert} | e.g. H→bb NWA + LO α_s |
+| L3 | {NU, Pert} | LO + unstable line |
+| L4 | {NU, NWA} | typed-legal, **physically in tension** |
+| L5 | triple | L4 + LO residual |
+
+Combined residual: √(Σ r_i²) over active layers.
+
+## Measured residuals
+
+| Species | Γ/M (NWA residual) |
+|---|---:|
+| Z | ~0.027 |
+| top | ~0.008 |
+| H | ~3.3e-5 |
+
+Triple stack combined residual ~1.04 (dominated by unitarity deficit=1 at pole).
+
+## Live effect stack (compiler-enforced)
+
+`main` and `run_effect_stack` declare all three effects and call:
+
+- `alpha_s_lo_ep` (Perturbative)
+- `z_partial_width_nwa_ep` (NWA)
+- `nu_approx` / peak (NonUnitary)
+- `h_bb_width_nwa_ep` (NWA+Pert)
+
+## Types
+
+```
+ApproxStack { layers, residual_nu, residual_nwa, residual_pert, legal }
+```
+
+## Engine note
+
+Madaros full run: algebra laws + effect-core (acks + NonUnitary) green.
+Domain C (`alpha_s_lo` / NWA width Epistemic methods) may fail under Madaros
+imported-module residual — gate accepts `PARTICLE_EXP10_PARTIAL_OK`.
+
+## Non-claims
+
+- Runtime layer tags are not a second effect system; compiler bits remain authority.
+- `approx_pert_residual_lo_default = 0.30` is a construction scale, not a fit.
+- L4 tension is physical honesty, not a type error.
+
+## AI disclosure
+
+Human direction 2026-07-26. GAIDeT-ICMJE 2025.

--- a/docs/research/particle_exp8_collapse_failure_2026-07-26.md
+++ b/docs/research/particle_exp8_collapse_failure_2026-07-26.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.particle-exp8-collapse-failure-2026-07-26
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/examples/particle_physics/exp10_approx_effect_algebra.sio
+++ b/examples/particle_physics/exp10_approx_effect_algebra.sio
@@ -1,0 +1,325 @@
+// examples/particle_physics/exp10_approx_effect_algebra.sio
+//
+// EXP10 — Approximation effect algebra (depth)
+//
+// Compiler already enforces NonUnitary / Perturbative / NarrowWidthApproximation
+// propagation. This vertical makes the *composition laws* and *residuals*
+// first-class executable objects:
+//
+//   L1  Singletons legal
+//   L2  {NWA, Pert} legal (H→bb path)
+//   L3  {NU, Pert} legal
+//   L4  {NU, NWA} typed-legal but physically in tension
+//   L5  Triple stack inherits L4 tension + LO residual
+//
+// Combined residual = √(Σ r_i²) over active layers.
+//
+// Run:
+//   ./bin/souc run examples/particle_physics/exp10_approx_effect_algebra.sio
+// Gate:
+//   bash scripts/ci/particle_exp10_approx_algebra_gate.sh
+
+use particle_physics::sm_params::{mass_z, mass_h, mass_top}
+use epistemic::knowledge::{ep_val}
+use particle_physics::nonunitary::{
+    nu_z_propagator, nu_deficit, nu_approx, eemm_z_peak_xsec_nu,
+}
+use particle_physics::approx_effects::{
+    alpha_s_lo_ep, z_partial_width_nwa_ep, h_bb_width_nwa_ep,
+    ApproxStack,
+    APPROX_LAYER_NONUNITARY, APPROX_LAYER_PERTURBATIVE, APPROX_LAYER_NWA,
+    approx_stack_empty, approx_stack_push_nu, approx_stack_push_nwa, approx_stack_push_pert,
+    approx_nwa_residual, approx_pert_residual_lo_default,
+    approx_stack_in_tension, approx_stack_combined_residual, approx_stack_layer_count,
+    approx_ack_perturbative, approx_ack_nwa,
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn within(a: f64, b: f64, tol: f64) -> bool {
+    abs_f(a - b) < tol
+}
+
+fn print_pass(tag: i64) with IO {
+    print("PASS ")
+    print_int(tag)
+    print("\n")
+}
+
+fn print_fail(tag: i64) with IO {
+    print("FAIL ")
+    print_int(tag)
+    print("\n")
+}
+
+fn pass_if(cond: bool, tag: i64) -> i64 with IO {
+    if cond {
+        print_pass(tag)
+        1
+    } else {
+        print_fail(tag)
+        0
+    }
+}
+
+fn print_stack(label: i64, s: ApproxStack) with IO, Mut, Div, Panic {
+    print("EXP10_STACK ")
+    print_int(label)
+    print(" layers=")
+    print_int(s.layers)
+    print(" n=")
+    print_int(approx_stack_layer_count(s))
+    print(" r_nu=")
+    print_f64(s.residual_nu)
+    print(" r_nwa=")
+    print_f64(s.residual_nwa)
+    print(" r_pert=")
+    print_f64(s.residual_pert)
+    print(" combined=")
+    print_f64(approx_stack_combined_residual(s))
+    print(" tension=")
+    print_int(if approx_stack_in_tension(s) { 1 } else { 0 })
+    print(" legal=")
+    print_int(s.legal)
+    print("\n")
+}
+
+// Domain A — pure stack algebra (no effect calls required beyond Mut/Div)
+fn run_algebra_laws(mz: f64, gz: f64, mh: f64, gh: f64) -> i64 with IO, Mut, Div, Panic {
+    var n: i64 = 0
+    print("=== EXP10 domain algebra_laws ===\n")
+
+    let empty = approx_stack_empty()
+    n = n + pass_if(approx_stack_layer_count(empty) == 0, 1601)
+    n = n + pass_if(approx_stack_combined_residual(empty) == 0.0, 1602)
+    n = n + pass_if(approx_stack_in_tension(empty) == false, 1603)
+
+    // L1 singletons
+    let s_nu = approx_stack_push_nu(empty, 1.0)
+    let s_nw = approx_stack_push_nwa(empty, mz, gz)
+    let s_pe = approx_stack_push_pert(empty, approx_pert_residual_lo_default())
+    print_stack(1, s_nu)
+    print_stack(2, s_nw)
+    print_stack(3, s_pe)
+    n = n + pass_if(s_nu.layers == APPROX_LAYER_NONUNITARY() && s_nu.residual_nu == 1.0, 1604)
+    n = n + pass_if(s_nw.layers == APPROX_LAYER_NWA(), 1605)
+    n = n + pass_if(within(s_nw.residual_nwa, gz / mz, 1.0e-12), 1606)
+    n = n + pass_if(s_pe.layers == APPROX_LAYER_PERTURBATIVE() && within(s_pe.residual_pert, 0.30, 1.0e-12), 1607)
+    n = n + pass_if(approx_stack_in_tension(s_nu) == false, 1608)
+
+    // L2 {NWA, Pert}
+    let s_np = approx_stack_push_pert(approx_stack_push_nwa(empty, mh, gh), 0.30)
+    print_stack(4, s_np)
+    n = n + pass_if(approx_stack_layer_count(s_np) == 2, 1609)
+    n = n + pass_if(approx_stack_in_tension(s_np) == false, 1610)
+    n = n + pass_if(s_np.legal == 1, 1611)
+
+    // L4 {NU, NWA} — tension
+    let s_nn = approx_stack_push_nwa(approx_stack_push_nu(empty, 1.0), mz, gz)
+    print_stack(5, s_nn)
+    n = n + pass_if(approx_stack_in_tension(s_nn) == true, 1612)
+    n = n + pass_if(approx_stack_layer_count(s_nn) == 2, 1613)
+
+    // L5 triple
+    let s_tri = approx_stack_push_pert(s_nn, approx_pert_residual_lo_default())
+    print_stack(6, s_tri)
+    n = n + pass_if(approx_stack_layer_count(s_tri) == 3, 1614)
+    n = n + pass_if(approx_stack_in_tension(s_tri) == true, 1615)
+    let comb = approx_stack_combined_residual(s_tri)
+    // √(1² + (Γ/M)² + 0.3²) ≈ √(1 + 0.00075 + 0.09) ≈ √1.09 ≈ 1.044
+    n = n + pass_if(comb > 1.0 && comb < 1.2, 1616)
+
+    // Idempotent push
+    let s_dup = approx_stack_push_nu(s_nu, 0.5)
+    n = n + pass_if(approx_stack_layer_count(s_dup) == 1, 1617)
+    n = n + pass_if(within(s_dup.residual_nu, 0.5, 1.0e-12), 1618)
+
+    // Higgs NWA much better than Z
+    let r_z = approx_nwa_residual(mz, gz)
+    let r_h = approx_nwa_residual(mh, gh)
+    print("EXP10_NWA_RES_Z ")
+    print_f64(r_z)
+    print("\n")
+    print("EXP10_NWA_RES_H ")
+    print_f64(r_h)
+    print("\n")
+    n = n + pass_if(r_h < r_z && r_h < 1.0e-4, 1619)
+
+    print("EXP10_ALGEBRA_JSON {")
+    print("\"schema\":\"particle.exp10.approx_algebra.v1\",")
+    print("\"laws\":[\"L1_singleton\",\"L2_nwa_pert\",\"L3_nu_pert\",\"L4_nu_nwa_tension\",\"L5_triple\"],")
+    print("\"triple_layers\":")
+    print_int(s_tri.layers)
+    print(",\"triple_combined\":")
+    print_f64(comb)
+    print(",\"triple_tension\":1")
+    print(",\"nwa_z\":")
+    print_f64(r_z)
+    print(",\"nwa_h\":")
+    print_f64(r_h)
+    print("}\n")
+    n
+}
+
+// Domain B — Madaros-safe effect core: acks + NonUnitary + stack
+fn run_effect_core(
+    mz: f64,
+    gz: f64
+) -> i64 with IO, NonUnitary, NarrowWidthApproximation, Perturbative, Mut, Div, Panic {
+    var n: i64 = 0
+    print("=== EXP10 domain effect_core ===\n")
+
+    let a_p = approx_ack_perturbative()
+    let a_n = approx_ack_nwa()
+    n = n + pass_if(a_p == 1 && a_n == 1, 1701)
+
+    let prop = nu_z_propagator(mz * mz, gz)
+    let d = nu_deficit(prop)
+    let amp = nu_approx(prop)
+    print("EXP10_NU_DEFICIT_POLE ")
+    print_f64(d)
+    print("\n")
+    print("EXP10_NU_AMP ")
+    print_f64(amp.val())
+    print("\n")
+    n = n + pass_if(within(d, 1.0, 1.0e-6), 1702)
+    n = n + pass_if(amp.val() > 0.0, 1703)
+
+    // Peak: effect-forced; value may be 0 under Madaros full IR
+    let peak = eemm_z_peak_xsec_nu(0.08399, 0.08399, gz)
+    print("EXP10_PEAK ")
+    print_f64(peak.val())
+    print("\n")
+    n = n + pass_if(peak.val() >= 0.0, 1704)
+
+    let stack = approx_stack_push_pert(
+        approx_stack_push_nwa(
+            approx_stack_push_nu(approx_stack_empty(), d),
+            mz,
+            gz
+        ),
+        approx_pert_residual_lo_default()
+    )
+    print_stack(10, stack)
+    n = n + pass_if(approx_stack_layer_count(stack) == 3, 1705)
+    n = n + pass_if(approx_stack_in_tension(stack) == true, 1706)
+    n = n + pass_if(stack.legal == 1, 1707)
+    n = n + pass_if(approx_stack_combined_residual(stack) > 1.0, 1708)
+
+    print("EXP10_CORE_JSON {")
+    print("\"schema\":\"particle.exp10.effect_core.v1\",")
+    print("\"effects\":[\"NonUnitary\",\"NarrowWidthApproximation\",\"Perturbative\"],")
+    print("\"deficit_pole\":")
+    print_f64(d)
+    print(",\"stack_layers\":")
+    print_int(stack.layers)
+    print(",\"stack_tension\":1")
+    print(",\"combined_residual\":")
+    print_f64(approx_stack_combined_residual(stack))
+    print("}\n")
+    n
+}
+
+// Domain C — full physics stack (lean_single trusted; Madaros may soft-fail values)
+fn run_effect_physics(
+    mz: f64
+) -> i64 with IO, NarrowWidthApproximation, Perturbative, Mut, Div, Panic {
+    var n: i64 = 0
+    print("=== EXP10 domain effect_physics ===\n")
+
+    let as_lo = alpha_s_lo_ep(mz)
+    print("EXP10_ALPHA_S_LO ")
+    print_f64(as_lo.val())
+    print("\n")
+    let as_ok = as_lo.val() > 0.10 && as_lo.val() < 0.14 && as_lo.variance() > 0.0
+    n = n + pass_if(as_ok, 1801)
+
+    let g_nu = 0.5 * 0.5 + 0.5 * 0.5
+    let w_nu = z_partial_width_nwa_ep(g_nu, 1.0)
+    print("EXP10_Z_WIDTH_NWA ")
+    print_f64(w_nu.val())
+    print("\n")
+    n = n + pass_if(w_nu.val() > 0.10 && w_nu.val() < 0.25, 1802)
+
+    let w_bb = h_bb_width_nwa_ep()
+    print("EXP10_HBB_NWA_PERT ")
+    print_f64(w_bb.val())
+    print("\n")
+    n = n + pass_if(w_bb.val() > 0.001 && w_bb.val() < 0.01, 1803)
+
+    print("EXP10_PHYSICS_JSON {")
+    print("\"schema\":\"particle.exp10.effect_physics.v1\",")
+    print("\"alpha_s_lo\":")
+    print_f64(as_lo.val())
+    print(",\"z_width_nwa\":")
+    print_f64(w_nu.val())
+    print(",\"hbb_width\":")
+    print_f64(w_bb.val())
+    print("}\n")
+    n
+}
+
+fn main() -> i32 with IO, NonUnitary, NarrowWidthApproximation, Perturbative, Mut, Div, Panic {
+    print("PARTICLE_EXP10_BEGIN\n")
+    print("EXP10_CLAIM approximation_effect_algebra_with_residuals\n")
+
+    let mz = mass_z().val()
+    let mh = mass_h().val()
+    let mt = mass_top().val()
+    let gz = 2.4952
+    let gh = 0.00407
+    let gt = 1.42
+
+    let n_a = run_algebra_laws(mz, gz, mh, gh)
+    let n_b = run_effect_core(mz, gz)
+    let n_c = run_effect_physics(mz)
+    let npass = n_a + n_b + n_c
+    // A19 + B8 + C3 = 30
+    let expected: i64 = 30
+    let nfail = expected - npass
+
+    print("PARTICLE_EXP10_PASS ")
+    print_int(npass)
+    print("\n")
+    print("PARTICLE_EXP10_FAIL ")
+    print_int(nfail)
+    print("\n")
+    print("PARTICLE_EXP10_NA ")
+    print_int(n_a)
+    print("\n")
+    print("PARTICLE_EXP10_NB ")
+    print_int(n_b)
+    print("\n")
+    print("PARTICLE_EXP10_NC ")
+    print_int(n_c)
+    print("\n")
+
+    print("EXP10_NWA_RES_T ")
+    print_f64(approx_nwa_residual(mt, gt))
+    print("\n")
+
+    if n_a == 19 {
+        print("PARTICLE_EXP10_ALGEBRA_OK\n")
+    }
+    if n_b == 8 {
+        print("PARTICLE_EXP10_EFFECT_CORE_OK\n")
+    }
+    if n_c == 3 {
+        print("PARTICLE_EXP10_EFFECT_PHYSICS_OK\n")
+    }
+    if npass == expected {
+        print("PARTICLE_EXP10_OK\n")
+        0
+    } else {
+        print("PARTICLE_EXP10_FAILED\n")
+        // Still 0 exit if algebra+core green (Madaros residual on physics imports)
+        if n_a == 19 && n_b == 8 {
+            print("PARTICLE_EXP10_PARTIAL_OK\n")
+            0
+        } else {
+            1
+        }
+    }
+}

--- a/examples/particle_physics/results/exp10_approx_algebra.json
+++ b/examples/particle_physics/results/exp10_approx_algebra.json
@@ -1,0 +1,15 @@
+{
+  "laws": [
+    "L1_singleton",
+    "L2_nwa_pert",
+    "L3_nu_pert",
+    "L4_nu_nwa_tension",
+    "L5_triple"
+  ],
+  "nwa_h": 3.3e-05,
+  "nwa_z": 0.027363,
+  "schema": "particle.exp10.approx_algebra.v1",
+  "triple_combined": 1.044389,
+  "triple_layers": 7,
+  "triple_tension": 1
+}

--- a/scripts/ci/particle_exp10_approx_algebra_gate.sh
+++ b/scripts/ci/particle_exp10_approx_algebra_gate.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Gate for examples/particle_physics/exp10_approx_effect_algebra.sio
+#
+# lean_single: full algebra + effect core + physics (30/30)
+# Madaros: algebra + effect core (27/30); physics imports residual (PARTIAL_OK)
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
+
+SRC=examples/particle_physics/exp10_approx_effect_algebra.sio
+JSON_OUT="${PARTICLE_EXP10_JSON:-$ROOT/examples/particle_physics/results/exp10_approx_algebra.json}"
+
+echo "== particle exp10 lean_single full =="
+LEAN_OUT=/tmp/particle_exp10_lean_out.txt
+LEAN_ERR=/tmp/particle_exp10_lean_err.txt
+SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run "$SRC" >"$LEAN_OUT" 2>"$LEAN_ERR" || {
+  echo "lean run failed" >&2
+  tail -40 "$LEAN_ERR" >&2
+  exit 1
+}
+grep -q 'PARTICLE_EXP10_OK' "$LEAN_OUT"
+grep -q 'PARTICLE_EXP10_PASS 30' "$LEAN_OUT"
+grep -q 'PARTICLE_EXP10_ALGEBRA_OK' "$LEAN_OUT"
+grep -q 'PARTICLE_EXP10_EFFECT_CORE_OK' "$LEAN_OUT"
+grep -q 'PARTICLE_EXP10_EFFECT_PHYSICS_OK' "$LEAN_OUT"
+grep -q 'L4_nu_nwa_tension' "$LEAN_OUT"
+if grep -q '^FAIL ' "$LEAN_OUT"; then
+  echo "unexpected FAIL under lean" >&2
+  grep '^FAIL ' "$LEAN_OUT" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$JSON_OUT")"
+python3 - "$LEAN_OUT" "$JSON_OUT" <<'PY'
+import json, re, sys
+text = open(sys.argv[1], encoding="utf-8", errors="replace").read()
+m = re.search(r"EXP10_ALGEBRA_JSON\s+(\{.*?\})", text, re.S)
+if not m:
+    raise SystemExit("EXP10_ALGEBRA_JSON missing")
+raw = re.sub(r"\s+", " ", m.group(1)).strip()
+payload = json.loads(raw)
+assert payload.get("schema") == "particle.exp10.approx_algebra.v1"
+assert int(payload.get("triple_tension", 0)) == 1
+assert float(payload["nwa_h"]) < float(payload["nwa_z"])
+assert float(payload["triple_combined"]) > 1.0
+open(sys.argv[2], "w", encoding="utf-8").write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+print(f"EXP10_ALGEBRA_JSON_WRITTEN {sys.argv[2]}")
+PY
+
+echo "== particle exp10 Madaros algebra+core =="
+MAD_OUT=/tmp/particle_exp10_madaros_out.txt
+MAD_ERR=/tmp/particle_exp10_madaros_err.txt
+set +e
+SOUNIO_SOUC_ENGINE=madaros ./bin/souc run "$SRC" >"$MAD_OUT" 2>"$MAD_ERR"
+MAD_RC=$?
+set -e
+if ! grep -q 'PARTICLE_EXP10_ALGEBRA_OK' "$MAD_OUT"; then
+  echo "Madaros algebra failed rc=$MAD_RC" >&2
+  tail -40 "$MAD_ERR" >&2
+  tail -30 "$MAD_OUT" >&2
+  exit 1
+fi
+if ! grep -q 'PARTICLE_EXP10_EFFECT_CORE_OK' "$MAD_OUT"; then
+  echo "Madaros effect core failed" >&2
+  tail -30 "$MAD_OUT" >&2
+  exit 1
+fi
+# Full OK or PARTIAL_OK (physics import residual)
+if ! grep -qE 'PARTICLE_EXP10_OK|PARTICLE_EXP10_PARTIAL_OK' "$MAD_OUT"; then
+  echo "Madaros missing OK/PARTIAL_OK" >&2
+  exit 1
+fi
+echo "PARTICLE_EXP10_MADAROS_CORE_OK"
+echo "PARTICLE_EXP10_GATE_OK"

--- a/stdlib/particle_physics/approx_effects.sio
+++ b/stdlib/particle_physics/approx_effects.sio
@@ -128,6 +128,188 @@ pub fn h_bb_width_nwa_ep() -> Epistemic with NarrowWidthApproximation, Perturbat
     mh.scale(factor_lo).mul(&corr)
 }
 
+
+// ============================================================================
+// Approximation effect algebra (EXP10)
+// ============================================================================
+//
+// Runtime layer tags (not the compiler effect bits — those are separate).
+// A stack records which physical approximations are *active* in a computation
+// and the residual each layer contributes.
+//
+// Composition laws (executable, not paper):
+//   L1  Singleton stacks are always legal.
+//   L2  {NWA, Perturbative} is legal (e.g. H→bb NWA with LO α_s).
+//   L3  {NonUnitary, Perturbative} is legal (LO amplitude with unstable line).
+//   L4  {NonUnitary, NWA} is *typed-legal* if both effects are declared, but
+//       *physically in tension*: NWA takes Γ→0 while NonUnitary keeps Γ.
+//       `approx_stack_in_tension` flags this.
+//   L5  Triple stack {NU, NWA, Pert} inherits L4 tension + LO residual.
+//
+// Combined residual (construction): √(Σ r_i²) over active layers.
+
+pub fn APPROX_LAYER_NONUNITARY() -> i64 { 1 }
+pub fn APPROX_LAYER_PERTURBATIVE() -> i64 { 2 }
+pub fn APPROX_LAYER_NWA() -> i64 { 4 }
+
+pub struct ApproxStack {
+    layers: i64,
+    residual_nu: f64,
+    residual_nwa: f64,
+    residual_pert: f64,
+    legal: i64,
+}
+
+pub fn approx_stack_empty() -> ApproxStack {
+    ApproxStack {
+        layers: 0,
+        residual_nu: 0.0,
+        residual_nwa: 0.0,
+        residual_pert: 0.0,
+        legal: 1,
+    }
+}
+
+// NWA quality residual: Γ/M (small ⇒ excellent NWA).
+pub fn approx_nwa_residual(mass: f64, gamma: f64) -> f64 with Div, Panic {
+    if mass == 0.0 { return 1.0 }
+    let r = gamma / mass
+    if r < 0.0 { 0.0 - r } else { r }
+}
+
+// NonUnitary residual proxy: unitarity deficit in [0,1] (pole → 1).
+pub fn approx_nu_residual(deficit: f64) -> f64 {
+    if deficit < 0.0 { 0.0 } else { if deficit > 1.0 { 1.0 } else { deficit } }
+}
+
+// LO perturbative residual (construction scale): typical K-factor band.
+// Not a fit — a declared truncation scale for the stack algebra.
+pub fn approx_pert_residual_lo_default() -> f64 {
+    0.30
+}
+
+fn approx_has_layer(layers: i64, bit: i64) -> bool {
+    (layers / bit) % 2 == 1
+}
+
+// Recompute legality + tension after mutation.
+fn approx_finalize(s: ApproxStack) -> ApproxStack {
+    let nu = approx_has_layer(s.layers, APPROX_LAYER_NONUNITARY())
+    let pe = approx_has_layer(s.layers, APPROX_LAYER_PERTURBATIVE())
+    let nw = approx_has_layer(s.layers, APPROX_LAYER_NWA())
+    // All listed compositions are typed-legal; physical tension is separate.
+    let legal: i64 = 1
+    ApproxStack {
+        layers: s.layers,
+        residual_nu: s.residual_nu,
+        residual_nwa: s.residual_nwa,
+        residual_pert: s.residual_pert,
+        legal: legal,
+    }
+}
+
+pub fn approx_stack_push_nu(s: ApproxStack, deficit: f64) -> ApproxStack {
+    var layers = s.layers
+    if approx_has_layer(layers, APPROX_LAYER_NONUNITARY()) {
+        // already present
+    } else {
+        layers = layers + APPROX_LAYER_NONUNITARY()
+    }
+    let base = ApproxStack {
+        layers: layers,
+        residual_nu: approx_nu_residual(deficit),
+        residual_nwa: s.residual_nwa,
+        residual_pert: s.residual_pert,
+        legal: s.legal,
+    }
+    approx_finalize(base)
+}
+
+pub fn approx_stack_push_nwa(s: ApproxStack, mass: f64, gamma: f64) -> ApproxStack with Div, Panic {
+    var layers = s.layers
+    if approx_has_layer(layers, APPROX_LAYER_NWA()) {
+    } else {
+        layers = layers + APPROX_LAYER_NWA()
+    }
+    let base = ApproxStack {
+        layers: layers,
+        residual_nu: s.residual_nu,
+        residual_nwa: approx_nwa_residual(mass, gamma),
+        residual_pert: s.residual_pert,
+        legal: s.legal,
+    }
+    approx_finalize(base)
+}
+
+pub fn approx_stack_push_pert(s: ApproxStack, relative_unc: f64) -> ApproxStack {
+    var layers = s.layers
+    if approx_has_layer(layers, APPROX_LAYER_PERTURBATIVE()) {
+    } else {
+        layers = layers + APPROX_LAYER_PERTURBATIVE()
+    }
+    var r = relative_unc
+    if r < 0.0 { r = 0.0 - r }
+    let base = ApproxStack {
+        layers: layers,
+        residual_nu: s.residual_nu,
+        residual_nwa: s.residual_nwa,
+        residual_pert: r,
+        legal: s.legal,
+    }
+    approx_finalize(base)
+}
+
+// True when NonUnitary and NWA are both active (physical tension).
+pub fn approx_stack_in_tension(s: ApproxStack) -> bool {
+    approx_has_layer(s.layers, APPROX_LAYER_NONUNITARY()) && approx_has_layer(s.layers, APPROX_LAYER_NWA())
+}
+
+// Combined residual √(Σ r²) over active layers only.
+pub fn approx_stack_combined_residual(s: ApproxStack) -> f64 with Mut, Div, Panic {
+    var acc = 0.0
+    if approx_has_layer(s.layers, APPROX_LAYER_NONUNITARY()) {
+        acc = acc + s.residual_nu * s.residual_nu
+    }
+    if approx_has_layer(s.layers, APPROX_LAYER_NWA()) {
+        acc = acc + s.residual_nwa * s.residual_nwa
+    }
+    if approx_has_layer(s.layers, APPROX_LAYER_PERTURBATIVE()) {
+        acc = acc + s.residual_pert * s.residual_pert
+    }
+    // Newton sqrt
+    if acc <= 0.0 { return 0.0 }
+    var g = acc
+    if g > 1.0 { g = acc / 2.0 }
+    var i: i64 = 0
+    while i < 40 {
+        g = 0.5 * (g + acc / g)
+        i = i + 1
+    }
+    g
+}
+
+// Layer count (0–3).
+pub fn approx_stack_layer_count(s: ApproxStack) -> i64 {
+    var n: i64 = 0
+    if approx_has_layer(s.layers, APPROX_LAYER_NONUNITARY()) { n = n + 1 }
+    if approx_has_layer(s.layers, APPROX_LAYER_PERTURBATIVE()) { n = n + 1 }
+    if approx_has_layer(s.layers, APPROX_LAYER_NWA()) { n = n + 1 }
+    n
+}
+
+
+// Effect acknowledgements — force compiler effect without heavy Epistemic graphs.
+// Used by EXP10 Madaros-safe effect-stack core.
+pub fn approx_ack_perturbative() -> i64 with Perturbative {
+    let _flag = perturbative_sentinel()
+    1
+}
+
+pub fn approx_ack_nwa() -> i64 with NarrowWidthApproximation {
+    let _flag = nwa_sentinel()
+    1
+}
+
 // ============================================================================
 // Tests
 // ============================================================================

--- a/stdlib/particle_physics/mod.sio
+++ b/stdlib/particle_physics/mod.sio
@@ -388,4 +388,10 @@ pub use particle_physics::epistemic_chain_z::{
 pub use particle_physics::approx_effects::{
     alpha_s_lo_ep, ggh_lo_xsec_ep,
     z_partial_width_nwa_ep, h_bb_width_nwa_ep,
+    ApproxStack,
+    APPROX_LAYER_NONUNITARY, APPROX_LAYER_PERTURBATIVE, APPROX_LAYER_NWA,
+    approx_stack_empty, approx_stack_push_nu, approx_stack_push_nwa, approx_stack_push_pert,
+    approx_nwa_residual, approx_nu_residual, approx_pert_residual_lo_default,
+    approx_stack_in_tension, approx_stack_combined_residual, approx_stack_layer_count,
+    approx_ack_perturbative, approx_ack_nwa,
 }


### PR DESCRIPTION
## Summary

**EXP10** — approximation effect algebra (depth vertical after EXP6–8).

Compiler already enforces `NonUnitary` / `Perturbative` / `NarrowWidthApproximation`.
This adds a **runtime algebra**:

| Law | Stack | Note |
|-----|--------|------|
| L1 | singletons | legal |
| L2 | {NWA, Pert} | H→bb path |
| L3 | {NU, Pert} | LO + unstable |
| L4 | {NU, NWA} | **physical tension** |
| L5 | triple | L4 + LO residual |

- `ApproxStack` + push/residual/combined/`in_tension`
- Live effect-core (acks + NonUnitary deficit) on lean + Madaros
- Full physics (`alpha_s_lo`, NWA widths) on lean_single; Madaros may `PARTIAL_OK`

## Measured
- NWA residual Z ~0.027, H ~3e-5, top ~0.008
- Triple combined residual ~1.044

## Test plan
- [x] `bash scripts/ci/particle_exp10_approx_algebra_gate.sh` → `PARTICLE_EXP10_GATE_OK`

## Related
- EXP9 (joint GUM + EngineDisagreement): #1465