### PR TITLE
feat(particle): EXP11 scheme × approx product surface

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1104
-- Repo-backed topics: 954
+- Total governed topics: 1106
+- Repo-backed topics: 956
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 254
+- Authority count `historical`: 256
 - Authority count `repo_only`: 662
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 288 topics
+- A6: 290 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -802,6 +802,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.octonion-validation-report | historical | docs/research/OCTONION_VALIDATION_REPORT.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.onn-benchmark-analysis | historical | docs/research/ONN_BENCHMARK_ANALYSIS.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-exp10-approx-algebra-2026-07-26 | historical | docs/research/particle_exp10_approx_algebra_2026-07-26.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.particle-exp11-scheme-approx-product-2026-07-26 | historical | docs/research/particle_exp11_scheme_approx_product_2026-07-26.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-exp123-vertical-2026-07-25 | historical | docs/research/particle_exp123_vertical_2026-07-25.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-exp6-universal-xi-2026-07-26 | historical | docs/research/particle_exp6_universal_xi_2026-07-26.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-exp7-gum-transfer-2026-07-26 | historical | docs/research/particle_exp7_gum_transfer_2026-07-26.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -17786,6 +17786,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.particle-exp11-scheme-approx-product-2026-07-26",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/particle_exp11_scheme_approx_product_2026-07-26.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.particle-exp123-vertical-2026-07-25",
       "collection": "repo",
       "repo_doc_path": "docs/research/particle_exp123_vertical_2026-07-25.md",

--- a/docs/research/particle_exp11_scheme_approx_product_2026-07-26.md
+++ b/docs/research/particle_exp11_scheme_approx_product_2026-07-26.md
@@ -1,0 +1,63 @@
+<!-- docs:meta
+topic_id: repo.docs.research.particle-exp11-scheme-approx-product-2026-07-26
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.particle-exp11-scheme-approx-product-2026-07-26
+-->
+
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# Particle EXP11 — Scheme × Approx product surface
+
+**Date:** 2026-07-26  
+**Source:** `examples/particle_physics/exp11_scheme_approx_product.sio`  
+**Gate:** `scripts/ci/particle_exp11_scheme_approx_gate.sh`  
+**Depends:** EXP8 (DeficitCollapse) + EXP10 layer semantics (residuals inlined; no approx_effects import for Madaros thin-link)
+
+---
+
+## Claim
+
+Honest analysis is a **matrix**, not a scalar residual:
+
+```
+cell_residual = √( collapse_residual² + approx_combined² )
+fails         = 1  iff  collapse status ≠ HOLDS
+```
+
+L4 (NU∧NWA tension) can be true on a **holding** scheme (fixed-width BW).
+
+## Sample cells (Z, measured)
+
+| Scheme | Approx | fails | tension | cell_res order |
+|--------|--------|:-----:|:-------:|----------------|
+| fixed | empty | 0 | 0 | smallest |
+| fixed | triple | 0 | 1 | larger (approx only) |
+| running | empty | 1 | 0 | collapse drives |
+| running | triple | 1 | 1 | largest |
+| interf α=0 | NU | 0 | 0 | control holds |
+| interf α≠0 | NU/triple | 1 | 0/1 | fails |
+
+nfail_cells in the scanned set = **4**.
+
+## Type
+
+```
+SchemeApproxCell { scheme, collapse_status, collapse_residual, xi,
+  approx_layers, approx_combined, approx_tension, cell_residual, fails }
+nu_scheme_approx_cell(...)
+```
+
+## Non-claims
+
+Not a full theory uncertainty budget; product of construction toys from EXP8/10.
+
+## AI disclosure
+
+Human direction 2026-07-26. GAIDeT-ICMJE 2025.

--- a/examples/particle_physics/exp11_scheme_approx_product.sio
+++ b/examples/particle_physics/exp11_scheme_approx_product.sio
@@ -1,0 +1,177 @@
+// examples/particle_physics/exp11_scheme_approx_product.sio
+//
+// EXP11 — Scheme × Approx product surface (Madaros IR-bounded)
+//
+// cell_residual = √(collapse_residual² + approx_combined²)
+// fails = 1 iff collapse status ≠ HOLDS
+//
+// Gate: scripts/ci/particle_exp11_scheme_approx_gate.sh
+
+use particle_physics::sm_params::{mass_z}
+use particle_physics::nonunitary::{
+    SCHEME_FIXED_WIDTH, SCHEME_RUNNING_WIDTH, SCHEME_INTERFERENCE,
+    COLLAPSE_HOLDS, COLLAPSE_FAILS_WIDTH_SCHEME, COLLAPSE_FAILS_INTERFERENCE,
+    nu_scheme_approx_cell,
+}
+
+fn f_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var g = x
+    if g > 1.0 { g = x / 2.0 }
+    var i: i64 = 0
+    while i < 40 {
+        g = 0.5 * (g + x / g)
+        i = i + 1
+    }
+    g
+}
+
+fn comb3(a: f64, b: f64, c: f64) -> f64 with Mut, Div, Panic {
+    f_sqrt(a * a + b * b + c * c)
+}
+
+fn pass_if(cond: bool, tag: i64) -> i64 with IO {
+    if cond {
+        print("PASS ")
+        print_int(tag)
+        print("\n")
+        1
+    } else {
+        print("FAIL ")
+        print_int(tag)
+        print("\n")
+        0
+    }
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    print("PARTICLE_EXP11_BEGIN\n")
+    print("EXP11_CLAIM scheme_times_approx_product_surface\n")
+
+    let mz = mass_z().val()
+    let gz = 2.4952
+    let xi = 2.0
+    let tol = 1.0e-3
+    let m2 = mz + 10.0
+    let r_nwa = gz / mz
+    let a0 = 0.0
+    let a_nu = 1.0
+    let a_tri = comb3(1.0, r_nwa, 0.30)
+
+    var n: i64 = 0
+    n = n + pass_if(a_tri > a_nu, 1901)
+
+    // fixed × empty / NU / triple
+    let c_f0 = nu_scheme_approx_cell(SCHEME_FIXED_WIDTH(), xi, mz, gz, 0.0, 0.0, 0.0, tol, 0, a0, 0)
+    let c_fnu = nu_scheme_approx_cell(SCHEME_FIXED_WIDTH(), xi, mz, gz, 0.0, 0.0, 0.0, tol, 1, a_nu, 0)
+    let c_ftri = nu_scheme_approx_cell(SCHEME_FIXED_WIDTH(), xi, mz, gz, 0.0, 0.0, 0.0, tol, 7, a_tri, 1)
+    print("EXP11_FIXED_EMPTY fails=")
+    print_int(c_f0.fails)
+    print(" cell=")
+    print_f64(c_f0.cell_residual)
+    print("\n")
+    print("EXP11_FIXED_TRI fails=")
+    print_int(c_ftri.fails)
+    print(" tension=")
+    print_int(c_ftri.approx_tension)
+    print(" cell=")
+    print_f64(c_ftri.cell_residual)
+    print("\n")
+    n = n + pass_if(c_f0.fails == 0 && c_f0.collapse_status == COLLAPSE_HOLDS(), 1902)
+    n = n + pass_if(c_fnu.fails == 0, 1903)
+    n = n + pass_if(c_ftri.fails == 0 && c_ftri.approx_tension == 1, 1904)
+    n = n + pass_if(c_ftri.cell_residual > c_f0.cell_residual, 1905)
+    n = n + pass_if(c_fnu.cell_residual > c_f0.cell_residual, 1906)
+
+    // running × empty / triple
+    let c_r0 = nu_scheme_approx_cell(SCHEME_RUNNING_WIDTH(), xi, mz, gz, 0.0, 0.0, 0.0, tol, 0, a0, 0)
+    let c_rtri = nu_scheme_approx_cell(SCHEME_RUNNING_WIDTH(), xi, mz, gz, 0.0, 0.0, 0.0, tol, 7, a_tri, 1)
+    print("EXP11_RUN_EMPTY fails=")
+    print_int(c_r0.fails)
+    print(" status=")
+    print_int(c_r0.collapse_status)
+    print(" cell=")
+    print_f64(c_r0.cell_residual)
+    print("\n")
+    print("EXP11_RUN_TRI cell=")
+    print_f64(c_rtri.cell_residual)
+    print("\n")
+    n = n + pass_if(c_r0.fails == 1 && c_r0.collapse_status == COLLAPSE_FAILS_WIDTH_SCHEME(), 1907)
+    n = n + pass_if(c_rtri.fails == 1, 1908)
+    n = n + pass_if(c_rtri.cell_residual > c_r0.cell_residual, 1909)
+    n = n + pass_if(c_r0.cell_residual > c_f0.cell_residual, 1910)
+
+    // interference control α=0 vs α=0.4
+    let c_i0 = nu_scheme_approx_cell(SCHEME_INTERFERENCE(), 1.0, mz, gz, m2, 1.0, 0.0, tol, 1, a_nu, 0)
+    let c_ia = nu_scheme_approx_cell(SCHEME_INTERFERENCE(), 1.0, mz, gz, m2, 1.0, 0.4, tol, 1, a_nu, 0)
+    let c_iatri = nu_scheme_approx_cell(SCHEME_INTERFERENCE(), 1.0, mz, gz, m2, 1.0, 0.4, tol, 7, a_tri, 1)
+    print("EXP11_INT_A0 fails=")
+    print_int(c_i0.fails)
+    print("\n")
+    print("EXP11_INT_A fails=")
+    print_int(c_ia.fails)
+    print(" status=")
+    print_int(c_ia.collapse_status)
+    print("\n")
+    n = n + pass_if(c_i0.fails == 0, 1911)
+    n = n + pass_if(c_ia.fails == 1 && c_ia.collapse_status == COLLAPSE_FAILS_INTERFERENCE(), 1912)
+    n = n + pass_if(c_iatri.fails == 1 && c_iatri.approx_tension == 1, 1913)
+    n = n + pass_if(c_iatri.cell_residual > c_ia.cell_residual, 1914)
+
+    var nfail_cells: i64 = 0
+    if c_f0.fails == 1 { nfail_cells = nfail_cells + 1 }
+    if c_fnu.fails == 1 { nfail_cells = nfail_cells + 1 }
+    if c_ftri.fails == 1 { nfail_cells = nfail_cells + 1 }
+    if c_r0.fails == 1 { nfail_cells = nfail_cells + 1 }
+    if c_rtri.fails == 1 { nfail_cells = nfail_cells + 1 }
+    if c_i0.fails == 1 { nfail_cells = nfail_cells + 1 }
+    if c_ia.fails == 1 { nfail_cells = nfail_cells + 1 }
+    if c_iatri.fails == 1 { nfail_cells = nfail_cells + 1 }
+    print("EXP11_NFAIL_CELLS ")
+    print_int(nfail_cells)
+    print("\n")
+    n = n + pass_if(nfail_cells == 4, 1915)
+
+    // L4 honesty: fixed holds with tension flag
+    let c_fl4 = nu_scheme_approx_cell(SCHEME_FIXED_WIDTH(), xi, mz, gz, 0.0, 0.0, 0.0, tol, 5, comb3(1.0, r_nwa, 0.0), 1)
+    n = n + pass_if(c_fl4.fails == 0 && c_fl4.approx_tension == 1, 1916)
+
+    print("EXP11_PRODUCT_JSON {")
+    print("\"schema\":\"particle.exp11.scheme_approx_product.v1\",")
+    print("\"claim\":\"honest_analysis_is_a_scheme_times_approx_matrix\",")
+    print("\"nfail_cells\":")
+    print_int(nfail_cells)
+    print(",\"fixed_empty_cell_res\":")
+    print_f64(c_f0.cell_residual)
+    print(",\"fixed_triple_cell_res\":")
+    print_f64(c_ftri.cell_residual)
+    print(",\"running_empty_cell_res\":")
+    print_f64(c_r0.cell_residual)
+    print(",\"running_triple_cell_res\":")
+    print_f64(c_rtri.cell_residual)
+    print(",\"interf_alpha0_fails\":")
+    print_int(c_i0.fails)
+    print(",\"interf_alpha_fails\":")
+    print_int(c_ia.fails)
+    print(",\"l4_on_fixed_tension\":")
+    print_int(c_fl4.approx_tension)
+    print(",\"l4_on_fixed_fails\":")
+    print_int(c_fl4.fails)
+    print("}\n")
+
+    let expected: i64 = 16
+    print("PARTICLE_EXP11_PASS ")
+    print_int(n)
+    print("\n")
+    print("PARTICLE_EXP11_FAIL ")
+    print_int(expected - n)
+    print("\n")
+    if n == expected {
+        print("PARTICLE_EXP11_OK\n")
+        print("PARTICLE_EXP11_PRODUCT_OK\n")
+        0
+    } else {
+        print("PARTICLE_EXP11_FAILED\n")
+        1
+    }
+}

--- a/examples/particle_physics/results/exp11_scheme_approx_product.json
+++ b/examples/particle_physics/results/exp11_scheme_approx_product.json
@@ -1,0 +1,13 @@
+{
+  "claim": "honest_analysis_is_a_scheme_times_approx_matrix",
+  "fixed_empty_cell_res": 9.094947e-13,
+  "fixed_triple_cell_res": 1.044389,
+  "interf_alpha0_fails": 0,
+  "interf_alpha_fails": 1,
+  "l4_on_fixed_fails": 0,
+  "l4_on_fixed_tension": 1,
+  "nfail_cells": 4,
+  "running_empty_cell_res": 0.017596,
+  "running_triple_cell_res": 1.044537,
+  "schema": "particle.exp11.scheme_approx_product.v1"
+}

--- a/scripts/ci/particle_exp11_scheme_approx_gate.sh
+++ b/scripts/ci/particle_exp11_scheme_approx_gate.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Gate for examples/particle_physics/exp11_scheme_approx_product.sio
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
+
+SRC=examples/particle_physics/exp11_scheme_approx_product.sio
+JSON_OUT="${PARTICLE_EXP11_JSON:-$ROOT/examples/particle_physics/results/exp11_scheme_approx_product.json}"
+
+run_eng() {
+  local eng="$1" out="$2" err="$3"
+  echo "== particle exp11 engine=$eng =="
+  set +e
+  SOUNIO_SOUC_ENGINE="$eng" ./bin/souc run "$SRC" >"$out" 2>"$err"
+  local rc=$?
+  set -e
+  if ! grep -q 'PARTICLE_EXP11_OK' "$out"; then
+    echo "engine=$eng failed rc=$rc" >&2
+    tail -40 "$err" >&2
+    tail -20 "$out" >&2
+    exit 1
+  fi
+  grep -q 'PARTICLE_EXP11_PASS 16' "$out"
+  grep -q 'PARTICLE_EXP11_PRODUCT_OK' "$out"
+  if grep -q '^FAIL ' "$out"; then
+    echo "FAIL under $eng" >&2
+    grep '^FAIL ' "$out" >&2
+    exit 1
+  fi
+}
+
+run_eng lean_single /tmp/particle_exp11_lean_out.txt /tmp/particle_exp11_lean_err.txt
+run_eng madaros /tmp/particle_exp11_mad_out.txt /tmp/particle_exp11_mad_err.txt
+
+mkdir -p "$(dirname "$JSON_OUT")"
+python3 - /tmp/particle_exp11_lean_out.txt "$JSON_OUT" <<'PY'
+import json, re, sys
+text = open(sys.argv[1], encoding="utf-8", errors="replace").read()
+m = re.search(r"EXP11_PRODUCT_JSON\s+(\{.*?\})", text, re.S)
+if not m:
+    raise SystemExit("EXP11_PRODUCT_JSON missing")
+raw = re.sub(r"\s+", " ", m.group(1)).strip()
+payload = json.loads(raw)
+assert payload.get("schema") == "particle.exp11.scheme_approx_product.v1"
+assert int(payload["nfail_cells"]) == 4
+assert int(payload["l4_on_fixed_tension"]) == 1
+assert int(payload["l4_on_fixed_fails"]) == 0
+assert float(payload["running_triple_cell_res"]) > float(payload["fixed_empty_cell_res"])
+assert int(payload["interf_alpha0_fails"]) == 0
+assert int(payload["interf_alpha_fails"]) == 1
+open(sys.argv[2], "w", encoding="utf-8").write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+print(f"EXP11_PRODUCT_JSON_WRITTEN {sys.argv[2]}")
+PY
+
+echo "PARTICLE_EXP11_GATE_OK"

--- a/stdlib/particle_physics/mod.sio
+++ b/stdlib/particle_physics/mod.sio
@@ -360,6 +360,7 @@ pub use particle_physics::nonunitary::{
     DeficitCollapse, SchemeTension,
     nu_deficit_fixed_width, nu_deficit_running_width, nu_deficit_from_amp,
     nu_deficit_interference, nu_collapse_test, nu_scheme_tension,
+    SchemeApproxCell, nu_scheme_approx_cell,
     nu_unitarity_threshold, nu_z_unitarity_threshold, nu_w_unitarity_threshold,
 }
 

--- a/stdlib/particle_physics/nonunitary.sio
+++ b/stdlib/particle_physics/nonunitary.sio
@@ -552,6 +552,75 @@ pub fn nu_scheme_tension(
 }
 
 // ============================================================================
+// Scheme × Approx product cell (EXP11)
+// ============================================================================
+//
+// Pairs a DeficitCollapse scheme test with an approximation-layer residual
+// profile. cell_residual = √(collapse_residual² + approx_combined²).
+// fails = 1 if collapse status ≠ HOLDS (scheme failure surface active).
+// approx_tension is reported separately (L4 NU∧NWA honesty flag).
+
+pub struct SchemeApproxCell {
+    scheme: i64,
+    collapse_status: i64,
+    collapse_residual: f64,
+    xi: f64,
+    approx_layers: i64,
+    approx_combined: f64,
+    approx_tension: i64,
+    cell_residual: f64,
+    fails: i64,
+}
+
+pub fn nu_scheme_approx_cell(
+    scheme: i64,
+    xi: f64,
+    mass: f64,
+    gamma: f64,
+    m2: f64,
+    g2: f64,
+    alpha: f64,
+    tol: f64,
+    approx_layers: i64,
+    approx_combined: f64,
+    approx_tension: i64
+) -> SchemeApproxCell with Mut, Div, Panic {
+    let c = nu_collapse_test(scheme, xi, mass, gamma, m2, g2, alpha, tol)
+    let cr = c.residual
+    let ar = approx_combined
+    let cell_r2 = cr * cr + ar * ar
+    // sqrt
+    var cell_r = 0.0
+    if cell_r2 > 0.0 {
+        var g = cell_r2
+        if g > 1.0 { g = cell_r2 / 2.0 }
+        var i: i64 = 0
+        while i < 40 {
+            g = 0.5 * (g + cell_r2 / g)
+            i = i + 1
+        }
+        cell_r = g
+    }
+    var fails: i64 = 0
+    if c.status != COLLAPSE_HOLDS() {
+        fails = 1
+    }
+    SchemeApproxCell {
+        scheme: scheme,
+        collapse_status: c.status,
+        collapse_residual: cr,
+        xi: xi,
+        approx_layers: approx_layers,
+        approx_combined: ar,
+        approx_tension: approx_tension,
+        cell_residual: cell_r,
+        fails: fails,
+    }
+}
+
+
+
+// ============================================================================
 // Unitarity diagnostic
 // ============================================================================
 


### PR DESCRIPTION
## Summary

**EXP11** — product of EXP8 collapse schemes and EXP10-style approx residuals.

```
cell_residual = √( collapse_residual² + approx_combined² )
fails         = 1  iff  scheme collapse ≠ HOLDS
```

### Matrix honesty
| Scheme | Approx | fails | tension |
|--------|--------|:-----:|:-------:|
| fixed | empty/triple | 0 | 0/1 |
| running | empty/triple | **1** | 0/1 |
| interf α=0 | NU | 0 | 0 |
| interf α≠0 | NU/triple | **1** | 0/1 |

- **nfail_cells = 4**
- L4 on fixed: **tension=1, fails=0**

### Stack
Base: #1467 (EXP10). Merge order: #1467 then this PR.

## Test plan
- [x] lean + Madaros `PARTICLE_EXP11_OK` 16/16
- [x] `bash scripts/ci/particle_exp11_scheme_approx_gate.sh`