### PR TITLE
fix(epistemic): Madaros-safe ep_gate via call-arg i64 compare

### DIFF
--- a/docs/handoff/particle_madaros_exp_residuals_2026-07-26.md
+++ b/docs/handoff/particle_madaros_exp_residuals_2026-07-26.md
@@ -2,7 +2,7 @@
 topic_id: repo.docs.handoff.particle-madaros-exp-residuals-2026-07-26
 authority: repo_only
 audience: users
-last_validated: 2026-03-07
+last_validated: 2026-07-26
 validated_by: A2
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.particle-madaros-exp-residuals-2026-07-26
 -->
@@ -17,16 +17,22 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.partic
 - Thin vertical `exp10_approx_physics.sio` Madaros **8/8**.
 - Gate requires `PARTICLE_EXP10_MADAROS_PHYSICS_OK`.
 - Original `approx_effects` untouched (lean full EXP10 30/30).
+- **2026-07-26 closeout:** `ep_gate` / `ep_require_conf` / `ep_is_credible` now compare
+  confidence via `ep_i64_ge(field, k)` call-arg boundary. Madaros multimodule mis-branches
+  on direct `if e.confidence >= k` even when returning the same field is correct.
+  Witness: `tests/multimodule/madaros_ep_gate_*.sio` + `scripts/ci/madaros_ep_gate_imported_gate.sh`.
+  Full EXP123 under Madaros: **58/58** after this fix (gates 111/113 were the fail).
 
-## 2 — Peak under full EXP123 IR (still open)
+## 2 — Peak under full EXP123 IR (narrowed)
 
-- Imported Epistemic **and** f64 returns from `nonunitary` can zero under large main IR.
-- Main-module **fully inlined** peak works; EXP123 restored Madaros-safe (chain_z, free-fn, local peak).
-- Expected checks **58** (lean-compatible EXP3 without EpistemicTension API).
+- Minimal imported `eemm_z_peak_xsec_nu` is OK under Madaros (not always zero).
+- Full EXP123 still uses **local peak body** as defence-in-depth (imported peak forced only for NonUnitary effect).
+- Core path exercises imported peak successfully.
 
 ## 3 — Drop workarounds (not yet)
 
-Local peak and thin physics vertical remain. Compiler: imported return ABI under large multimodule IR.
+Local peak and thin physics vertical remain. Compiler residual: i64 field-if mis-branch
+in imported native (stdlib workaround only; true fix is native codegen).
 
 ## Main regression note
 

--- a/docs/handoff/particle_madaros_exp_residuals_2026-07-26.md
+++ b/docs/handoff/particle_madaros_exp_residuals_2026-07-26.md
@@ -2,7 +2,7 @@
 topic_id: repo.docs.handoff.particle-madaros-exp-residuals-2026-07-26
 authority: repo_only
 audience: users
-last_validated: 2026-07-26
+last_validated: 2026-03-07
 validated_by: A2
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.particle-madaros-exp-residuals-2026-07-26
 -->

--- a/scripts/ci/madaros_ep_gate_imported_gate.sh
+++ b/scripts/ci/madaros_ep_gate_imported_gate.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Madaros multimodule: i64 field-compare via call-arg boundary (ep_gate residual).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RAW_MADAROS="${MADAROS_RAW_BIN:-}"
+WORK="${SOUNIO_MADAROS_EP_GATE_DIR:-$(mktemp -d /tmp/sounio-madaros-ep-gate.XXXXXX)}"
+SOURCE="$ROOT_DIR/tests/multimodule/madaros_ep_gate_main.sio"
+ELF="$WORK/ep-gate.elf"
+
+fail() {
+  echo "[madaros-ep-gate] FAIL: $*" >&2
+  exit 1
+}
+
+[[ -n "$RAW_MADAROS" ]] || fail "MADAROS_RAW_BIN must name a Madaros ELF"
+[[ -x "$RAW_MADAROS" ]] || fail "Madaros ELF missing or not executable: $RAW_MADAROS"
+
+stack_kb="${SOUNIO_MADAROS_EP_GATE_STACK_KB:-524288}"
+stack_before="$(ulimit -S -s 2>/dev/null || echo unlimited)"
+if [[ "$stack_before" != "unlimited" ]] && [[ "$stack_before" =~ ^[0-9]+$ ]] && ((stack_before < stack_kb)); then
+  ulimit -S -s "$stack_kb" 2>/dev/null || fail "could not raise soft stack to ${stack_kb} KiB"
+fi
+
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+
+"$RAW_MADAROS" --native-compile "$SOURCE" -o "$ELF" >"$WORK/compile.log" 2>&1 || {
+  cat "$WORK/compile.log" >&2
+  fail "ep_gate multimodule probe did not compile"
+}
+[[ -s "$ELF" ]] || fail "compiler did not emit ELF"
+chmod +x "$ELF"
+
+"$ELF" >"$WORK/run.log" 2>&1 || {
+  cat "$WORK/run.log" >&2
+  fail "ep_gate multimodule probe did not execute"
+}
+grep -Fxq 'MADAROS_EP_GATE_VIA_ARG_OK' "$WORK/run.log" || {
+  cat "$WORK/run.log" >&2
+  fail "via_arg gate marker missing"
+}
+
+echo "[madaros-ep-gate] PASS: imported i64 field compare via call-arg boundary"

--- a/stdlib/epistemic/knowledge.sio
+++ b/stdlib/epistemic/knowledge.sio
@@ -85,8 +85,17 @@ pub fn ep_std(e: &Epistemic) -> f64 with Mut, Div, Panic {
     ep_sqrt(e.variance)
 }
 
+// Madaros multimodule residual (2026-07-26): a direct `if field_i64 >= k`
+// inside an imported module can mis-branch even when returning the same field
+// as i64 is correct. Passing the loaded i64 through a call argument forces a
+// clean compare. See tests/multimodule/madaros_ep_gate_*.sio.
+fn ep_i64_ge(a: i64, b: i64) -> i64 {
+    if a >= b { 1 } else { 0 }
+}
+
 pub fn ep_is_credible(e: &Epistemic, min_conf: i64) -> bool {
-    e.confidence >= min_conf
+    // Same Madaros field-if residual as ep_gate — compare via call boundary.
+    ep_i64_ge(e.confidence, min_conf) == 1
 }
 
 // GUM: Var(X+Y) = Var(X) + Var(Y); conf = min scaled
@@ -179,12 +188,12 @@ pub fn ep_rel_uncertainty(a: &Epistemic) -> f64 with Mut, Div, Panic {
 
 /// Soft gate: returns 1 if confidence ≥ min_conf, 0 otherwise.
 pub fn ep_gate(e: &Epistemic, min_conf: i64) -> i64 {
-    if e.confidence >= min_conf { 1 } else { 0 }
+    ep_i64_ge(e.confidence, min_conf)
 }
 
 /// Hard gate: GATE_FAIL sentinel when below threshold (confidence=0).
 pub fn ep_require_conf(e: Epistemic, min_conf: i64) -> Epistemic {
-    if e.confidence >= min_conf {
+    if ep_i64_ge(e.confidence, min_conf) == 1 {
         e
     } else {
         Epistemic { val: e.val, variance: e.variance, confidence: 0 }

--- a/tests/multimodule/madaros_ep_gate_leaf.sio
+++ b/tests/multimodule/madaros_ep_gate_leaf.sio
@@ -1,0 +1,31 @@
+// Madaros multimodule witness: i64 field compare residual.
+// Direct `if e.confidence >= k` mis-branches under Madaros imported native;
+// passing the field through a call argument compares correctly.
+
+struct MiniEp {
+    val: f64,
+    variance: f64,
+    confidence: i64,
+}
+
+pub fn mini_new(v: f64, var: f64, conf: i64) -> MiniEp {
+    MiniEp { val: v, variance: var, confidence: conf }
+}
+
+pub fn mini_conf(e: &MiniEp) -> i64 {
+    e.confidence
+}
+
+/// Broken pattern under Madaros multimodule native (field-if).
+pub fn mini_gate_direct(e: &MiniEp, min_conf: i64) -> i64 {
+    if e.confidence >= min_conf { 1 } else { 0 }
+}
+
+fn mini_i64_ge(a: i64, b: i64) -> i64 {
+    if a >= b { 1 } else { 0 }
+}
+
+/// Working pattern: field loaded as call argument before compare.
+pub fn mini_gate_via_arg(e: &MiniEp, min_conf: i64) -> i64 {
+    mini_i64_ge(e.confidence, min_conf)
+}

--- a/tests/multimodule/madaros_ep_gate_main.sio
+++ b/tests/multimodule/madaros_ep_gate_main.sio
@@ -1,0 +1,26 @@
+// Madaros multimodule ep_gate residual probe.
+//
+// Run:
+//   MADAROS_RAW_BIN=... bash scripts/ci/madaros_ep_gate_imported_gate.sh
+
+use madaros_ep_gate_leaf::{mini_new, mini_conf, mini_gate_direct, mini_gate_via_arg}
+
+fn main() with IO {
+    let e = mini_new(1.0, 0.01, 846)
+    let conf = mini_conf(&e)
+    let direct = mini_gate_direct(&e, 800)
+    let via = mini_gate_via_arg(&e, 800)
+    print("conf=")
+    print_int(conf)
+    print(" direct=")
+    print_int(direct)
+    print(" via_arg=")
+    print_int(via)
+    println("")
+    // Document residual: direct may be 0 under Madaros; via_arg must be 1.
+    if conf == 846 && via == 1 {
+        println("MADAROS_EP_GATE_VIA_ARG_OK")
+    } else {
+        println("MADAROS_EP_GATE_VIA_ARG_FAIL")
+    }
+}


### PR DESCRIPTION
## Summary

Madaros multimodule native mis-branches on `if field_i64 >= k` even when returning the same struct field as `i64` is correct. Confidence gates (`ep_gate`, `ep_require_conf`, `ep_is_credible`) now compare via `ep_i64_ge(a, b)` so the compare runs on plain call arguments.

This restores full EXP123 under Madaros (**58/58**; checks 111/113 were the residual fails after #1469).

## Evidence

| Probe | Before | After |
|---|---|---|
| `ep_gate(ep_new(..., 846), 800)` Madaros | 0 | 1 |
| `chain_gate_z_width(800)` Madaros | 0 | 1 |
| EXP123 Madaros full | 56/58 | **58/58** |
| lean_single `particle_exp123_gate` | OK | OK |

Multimodule witness: `tests/multimodule/madaros_ep_gate_{leaf,main}.sio` + `scripts/ci/madaros_ep_gate_imported_gate.sh`.

## Note

This is a **stdlib workaround**, not the native codegen root fix. Peak local-body defence-in-depth remains; compiler lane still owns true field-if ABI.

## Test plan

- [x] Madaros ep_gate ladder
- [x] Madaros chain_gate / QED gate
- [x] Madaros EXP123 core 11/11 + full 58/58
- [x] `bash scripts/ci/particle_exp123_gate.sh`
- [x] `MADAROS_RAW_BIN=... bash scripts/ci/madaros_ep_gate_imported_gate.sh`