### PR TITLE
fix(lean_single): indexed-element store family — five silent miscompiles

### DIFF
--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -5063,9 +5063,9 @@ fn stmt_is_deref_indexed_elem_field_store(p0: i64) -> bool with Panic, Mut {
 // instruction reachable), native/codegen_plan.sio:1325 (scheduling priorities stay zero),
 // with the shape appearing ~131 times under self-hosted/ (compiler/main.sio alone ~95) plus
 // the bootstrap chain.
-// The DISPATCH gates this on token_chain_root_is_pointer, following the established pattern
-// of stmt_is_field_field_store_shape at :23245 — a VALUE struct root has a different address
-// story and is left to the generic path, which is why this predicate is shape-only.
+// This predicate is SHAPE-ONLY; root resolvability is decided at the dispatch by
+// ident_chain_root_supported, following the established gating pattern of
+// stmt_is_field_field_store_shape at :23245.
 fn stmt_is_ident_indexed_elem_field_store(p0: i64) -> bool with Panic, Mut {
     if TK[p0 as usize] != 3 { return false }        // bare-ident root
     if TK[(p0 + 1) as usize] != 50 { return false } // must start with `. field`, not `[`
@@ -5135,6 +5135,31 @@ fn stmt_is_field_field_array_store_shape(p0: i64) -> bool with Panic, Mut {
 
 // True when the var named by the token at p0 is a pointer/ref binding (so a
 // `name.f1.f2 = …` write must deref rather than write into a local struct slot).
+// Root-resolvability gate for the indexed-element field store on a BARE-IDENT root.
+// True only when the root is a LOCAL whose base address the store emitter can reproduce
+// exactly as the read path does (emit_load_var):
+//   - pointer-like root  → the slot holds the pointee address (ref/param roots);
+//   - plain struct root  → the slot ALSO holds a pointer to the struct's inline slots,
+//     because a struct value is represented as `lea rax,[rbp-(base+nslots-1)*8]` (see the
+//     struct-literal emission) and that pointer is what gets stored into the local. This is
+//     why reads like `c.heap.objects[i].mark_color` already work through a value root.
+// Anything else — globals (var_find has no slot), non-aggregate roots — returns false so the
+// statement falls through to the generic assignment path EXACTLY as before, rather than being
+// intercepted and hard-rejected. Without that, `G.arr[i].f = v` on a global struct would turn
+// from working code into a false reject.
+fn ident_chain_root_supported(p0: i64) -> bool with Panic, Mut, Div {
+    let lvi = var_find_idx(TS[p0 as usize], TE[p0 as usize])
+    if lvi < 0 { return false }
+    if var_find(TS[p0 as usize], TE[p0 as usize]) < 0 { return false }
+    let vt = VAR_TY[lvi as usize]
+    let vh = VAR_TY_HASH[lvi as usize]
+    if type_is_pointer_like(vt, vh) {
+        let it = ptr_hash_inner_ty(vh)
+        return it == 6 || it == 8
+    }
+    return vt == 6
+}
+
 fn token_chain_root_is_pointer(p0: i64) -> bool with Panic, Mut, Div {
     let lvi = var_find_idx(TS[p0 as usize], TE[p0 as usize])
     if lvi < 0 { return false }
@@ -22461,16 +22486,36 @@ fn compile_deref_indexed_elem_field_store_x86() with IO, Mut, Panic, Div {
     var failed: i64 = 0
     let lslot = var_find(ns, ne)
     let lvi = var_find_idx(ns, ne)
-    if lslot < 0 || lvi < 0 || type_is_pointer_like(VAR_TY[lvi as usize], VAR_TY_HASH[lvi as usize]) == false {
+    // The root must be a resolvable LOCAL; whether it is pointer-like or a plain struct is
+    // decided just below (a value root is legal only for the auto-deref spelling). Requiring
+    // pointer-like HERE would false-reject every value-rooted chain the dispatch admits.
+    if lslot < 0 || lvi < 0 {
         tc_error_hard(name_tok, "field access through deref requires ref or pointer binding")
         EP = eq_pos + 1
         compile_or()
         return
     }
-    var cur_ty = ptr_hash_inner_ty(VAR_TY_HASH[lvi as usize])
-    var cur_hash = ptr_hash_inner_hash(VAR_TY_HASH[lvi as usize])
-    // A struct pointee starts the chain at `.field`; an ARRAY pointee (&![T; N]) starts it
-    // at `[idx]` — `(*arrptr)[i].f = v`. Both are accepted here and discriminated by the
+    // Base address: emit_load_var(lslot) below, identical to the read path for BOTH a
+    // pointer-like root (slot holds the pointee address) and a plain struct root (slot holds
+    // the pointer to the struct's inline slots). Only the TYPE derivation differs.
+    var cur_ty = VAR_TY[lvi as usize]
+    var cur_hash = VAR_TY_HASH[lvi as usize]
+    if type_is_pointer_like(cur_ty, cur_hash) {
+        cur_ty = ptr_hash_inner_ty(VAR_TY_HASH[lvi as usize])
+        cur_hash = ptr_hash_inner_hash(VAR_TY_HASH[lvi as usize])
+    } else {
+        // The `(*name)` spelling asserts a pointer. A value root reaching it is the
+        // pre-existing type error and must stay a hard reject; only the auto-deref spelling
+        // may be value-rooted (gated by ident_chain_root_supported at the dispatch).
+        if TK[EP as usize] == 6 {
+            tc_error_hard(name_tok, "field access through deref requires ref or pointer binding")
+            EP = eq_pos + 1
+            compile_or()
+            return
+        }
+    }
+    // A struct root/pointee starts the chain at `.field`; an ARRAY pointee (&![T; N]) starts
+    // it at `[idx]` — `(*arrptr)[i].f = v`. Both are accepted here and discriminated by the
     // chain walk itself (the `.field` step demands a struct, the `[idx]` step an array), so
     // the array-rooted form is lowered correctly instead of being rejected for not being a
     // struct: it is another shape that previously reached the generic path and was lost.
@@ -23772,14 +23817,14 @@ fn compile_stmt() with IO, Mut, Panic, Div {
         return
     }
 
-    // name.arr[i].field = expr — the auto-deref twin of the shape above, for a POINTER-LIKE
-    // root only. Gated exactly like stmt_is_field_field_store_shape below: a value struct
-    // root has a different address story and the generic path already handles the simple
-    // cases, so it falls through rather than being intercepted here. Dispatched at this
-    // point (not earlier) so every narrow ident-root handler above keeps its shapes — those
-    // cover one field hop before the index; this catches the deeper chains they miss.
+    // name.arr[i].field = expr — the auto-deref twin of the shape above, for a ref/param root
+    // OR a plain struct root (both keep their base address in the slot; see
+    // ident_chain_root_supported, which also makes globals and non-aggregate roots fall
+    // through untouched instead of being hard-rejected). Dispatched at this point (not
+    // earlier) so every narrow ident-root handler above keeps its shapes — those cover one
+    // field hop before the index; this catches the deeper chains they miss.
     if stmt_is_ident_indexed_elem_field_store(EP) {
-        if token_chain_root_is_pointer(EP) {
+        if ident_chain_root_supported(EP) {
             compile_deref_indexed_elem_field_store_x86()
             return
         }

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -4999,6 +4999,59 @@ fn stmt_is_deref_field_field_array_store(p0: i64) -> bool with Panic, Mut {
     return TK[p as usize] == 16
 }
 
+// (*name).f1[i].f2 = expr  and  (*name).f1[i].f2[j].f3 = expr — store into a FIELD OF
+// AN ARRAY ELEMENT reached through an explicit deref. The lvalue chain crosses at least
+// one index and ends in `.field`.
+// Tokens: ( * name ) then a chain of `. ident` / `[ … ]`, ending `. ident =`.
+// lean_single had detectors for (*p).f=, (*p).f[i]=, (*p).f1.f2= and (*p).f1.f2[i]= but
+// NOT for a field of an INDEXED element, so `(*p).arr[i].f = v` fell through to the
+// generic assignment path and silently wrote into a discarded value-copy of the element
+// (reads back as 0) — the same disease as the two-hop forms, and additionally it leaked
+// the assigned field's type into LAST_STMT_HAS_VALUE, so a unit fn whose tail-if arms end
+// in such stores to differently-typed fields was falsely rejected with "if arm type does
+// not match else arm". This is the shape the IR passes use throughout
+// (self-hosted/ir/opt_cleanup.sio ocp_mfi_instr_move_fields:
+// (*module).functions[fi].instrs[dst_i].op = op).
+// Array elements of aggregate type are stored pointer-per-slot, so the element address is
+// LOADED from [array_base + idx*8]; trailing inline fields add their offsets.
+// Discriminated from the already-handled shapes by requiring BOTH an index in the chain
+// and a trailing `. ident` immediately before the `=` (the handled forms end in `]` or
+// contain no index at all), so this predicate is disjoint from all of them.
+fn stmt_is_deref_indexed_elem_field_store(p0: i64) -> bool with Panic, Mut {
+    if TK[p0 as usize] != 6 { return false }        // (
+    if TK[(p0 + 1) as usize] != 19 { return false } // *
+    if TK[(p0 + 2) as usize] != 3 { return false }  // simple-name root
+    if TK[(p0 + 3) as usize] != 7 { return false }  // )
+    var p = p0 + 4
+    var saw_index: i64 = 0
+    while p < TC {
+        if TK[p as usize] == 50 {                   // . field
+            if TK[(p + 1) as usize] != 3 { return false }
+            p = p + 2
+            continue
+        }
+        if TK[p as usize] == 41 {                   // [ … ]
+            var depth: i64 = 1
+            p = p + 1
+            while p < TC && depth > 0 {
+                if TK[p as usize] == 41 { depth = depth + 1 }
+                if TK[p as usize] == 42 { depth = depth - 1 }
+                p = p + 1
+            }
+            saw_index = 1
+            continue
+        }
+        if TK[p as usize] == 16 {                   // =
+            if saw_index == 0 { return false }
+            if p < p0 + 6 { return false }
+            if TK[(p - 1) as usize] != 3 { return false }
+            return TK[(p - 2) as usize] == 50       // must END in `. field`
+        }
+        return false
+    }
+    return false
+}
+
 // name.f1.f2 = expr  — AUTO-DEREF two-level store (ident root, no explicit `(* )`).
 // Shape only: (3|79) 50 3 50 3 16. For a VALUE struct root the generic assignment
 // path already handles this correctly, so the dispatch gates this on the root var
@@ -22312,6 +22365,183 @@ fn compile_deref_field_field_array_store_x86() with IO, Mut, Panic, Div {
     }
 }
 
+// (*name)<chain>.field = expr where <chain> crosses at least one index — see
+// stmt_is_deref_indexed_elem_field_store. Walks the lvalue chain, materialising a real
+// element ADDRESS instead of a value-copy:
+//   `. field`  → inline: accumulate the field's byte offset
+//   `[ idx ]`  → aggregate elements are pointer-per-slot, so LOAD [base + idx*8]
+// and stores the RHS at the final address + accumulated offset. Because it returns before
+// the expression-statement fall-through, the statement is also correctly typed as a unit
+// (LAST_STMT_HAS_VALUE stays 0), which is what makes it legal as a tail-if arm.
+fn compile_deref_indexed_elem_field_store_x86() with IO, Mut, Panic, Div {
+    let name_tok = EP + 2
+    let ns = TS[name_tok as usize]
+    let ne = TE[name_tok as usize]
+    // Locate the terminating `=` up front (same scan the predicate ran) so every
+    // diagnostic path can consume the whole statement instead of leaving a token tail
+    // for the statement loop to re-parse as an expression (which produced a spurious
+    // second "unknown identifier" cascade).
+    var eq_pos = EP + 4
+    while eq_pos < TC && TK[eq_pos as usize] != 16 {
+        if TK[eq_pos as usize] == 41 {
+            var sdepth: i64 = 1
+            eq_pos = eq_pos + 1
+            while eq_pos < TC && sdepth > 0 {
+                if TK[eq_pos as usize] == 41 { sdepth = sdepth + 1 }
+                if TK[eq_pos as usize] == 42 { sdepth = sdepth - 1 }
+                eq_pos = eq_pos + 1
+            }
+        } else {
+            eq_pos = eq_pos + 1
+        }
+    }
+    if current_fn_allows_mutation() == false {
+        tc_effect_violation(name_tok, 2, FN_EFFECTS[CURRENT_FN as usize])
+    }
+    // Structural failures below are HARD: before this handler existed these shapes
+    // reached the generic path, which rejected them outright ("value is not indexable",
+    // "unknown field access"). Reporting them as soft warnings would have turned those
+    // rejections into silent acceptances — a strictly worse trade than the false-reject
+    // this handler removes.
+    var failed: i64 = 0
+    let lslot = var_find(ns, ne)
+    let lvi = var_find_idx(ns, ne)
+    if lslot < 0 || lvi < 0 || type_is_pointer_like(VAR_TY[lvi as usize], VAR_TY_HASH[lvi as usize]) == false {
+        tc_error_hard(name_tok, "field access through deref requires ref or pointer binding")
+        EP = eq_pos + 1
+        compile_or()
+        return
+    }
+    var cur_ty = ptr_hash_inner_ty(VAR_TY_HASH[lvi as usize])
+    var cur_hash = ptr_hash_inner_hash(VAR_TY_HASH[lvi as usize])
+    // A struct pointee starts the chain at `.field`; an ARRAY pointee (&![T; N]) starts it
+    // at `[idx]` — `(*arrptr)[i].f = v`. Both are accepted here and discriminated by the
+    // chain walk itself (the `.field` step demands a struct, the `[idx]` step an array), so
+    // the array-rooted form is lowered correctly instead of being rejected for not being a
+    // struct: it is another shape that previously reached the generic path and was lost.
+    if cur_ty != 6 && cur_ty != 8 {
+        tc_error_hard(name_tok, "field access through pointer/ref requires struct or array pointee")
+        EP = eq_pos + 1
+        compile_or()
+        return
+    }
+    EP = EP + 4  // skip ( * name )
+    emit_load_var(lslot)  // rax = base pointer
+    var pending_off: i64 = 0
+    var target_ty: i64 = 0
+    var target_hash: i64 = 0
+    var done: i64 = 0
+    while done == 0 {
+        if TK[EP as usize] == 50 {
+            let ftok = EP + 1
+            let fh = gl_name_hash(TS[ftok as usize], TE[ftok as usize])
+            if cur_ty != 6 {
+                tc_error_hard(ftok, "field access requires struct value")
+                failed = 1
+                done = 1
+                continue
+            }
+            let si = st_find(cur_hash)
+            if si < 0 {
+                tc_error_hard(ftok, "unknown field access")
+                failed = 1
+                done = 1
+                continue
+            }
+            if st_private_access_denied(si, ftok) {
+                tc_error_hard(ftok, "private struct field access")
+                failed = 1
+                done = 1
+                continue
+            }
+            ST_QUERY_NS = TS[ftok as usize]
+            ST_QUERY_NE = TE[ftok as usize]
+            let foff = st_field_offset(si, fh)
+            let fty = st_field_ty(si, fh)
+            let fhash = st_field_hash(si, fh)
+            ST_QUERY_NS = -1
+            ST_QUERY_NE = -1
+            if foff < 0 {
+                tc_error_hard(ftok, "unknown field access")
+                failed = 1
+                done = 1
+                continue
+            }
+            pending_off = pending_off + foff
+            cur_ty = fty
+            cur_hash = fhash
+            EP = EP + 2
+            if TK[EP as usize] == 16 {
+                target_ty = fty
+                target_hash = fhash
+                done = 1
+            }
+            continue
+        }
+        if TK[EP as usize] == 41 {
+            if cur_ty != 8 {
+                tc_error_hard(EP, "indexed store requires array field")
+                failed = 1
+                done = 1
+                continue
+            }
+            if arr_hash_esiz(cur_hash) != 8 {
+                tc_error_hard(EP, "indexed element field store requires 8-byte array elements")
+                failed = 1
+                done = 1
+                continue
+            }
+            let elem_ty = arr_hash_elem_ty(cur_hash)
+            let elem_hash = arr_hash_elem_hash(cur_hash)
+            if elem_ty != 6 && elem_ty != 8 {
+                tc_error_hard(EP, "indexed element field store requires aggregate elements")
+                failed = 1
+                done = 1
+                continue
+            }
+            if pending_off != 0 { em(0x48); em(0x8d); em(0x80); em32(pending_off) }  // lea rax,[rax+off]
+            pending_off = 0
+            em(0x50)      // push array base
+            EP = EP + 1   // skip [
+            compile_or()  // index in rax
+            if TK[EP as usize] == 37 { EP = EP + 1; EP = EP + 1 }  // 'as usize'
+            if TK[EP as usize] == 42 { EP = EP + 1 }  // ]
+            em(0x48); em(0x89); em(0xc2)            // mov rdx, rax (index)
+            em(0x59)                                // pop rcx (array base)
+            em(0x48); em(0x8b); em(0x04); em(0xd1)  // mov rax, [rcx + rdx*8] (element ptr)
+            cur_ty = elem_ty
+            cur_hash = elem_hash
+            continue
+        }
+        tc_error_hard(EP, "unsupported assignment target")
+        failed = 1
+        done = 1
+    }
+    if failed == 1 {
+        EP = eq_pos + 1
+        compile_or()
+        return
+    }
+    // rax = pointer to the object that owns the final field.
+    let addr_slot = NEXT_SLOT
+    NEXT_SLOT = NEXT_SLOT + 1
+    emit_store_var(addr_slot)
+    if TK[EP as usize] == 16 { EP = EP + 1 }  // skip =
+    compile_or()  // rhs in rax
+    let rhs_ty = EXPR_TY
+    let rhs_ty_hash = EXPR_TY_HASH
+    // Severity note: soft, matching every other deref-store handler in this file
+    // (compile_deref_field_field_store_x86 etc. all use tc_error here). Assignment-type
+    // mismatch being a warning is a PRE-EXISTING file-wide hole, not one this handler
+    // introduces — `(*p).f1.f2 = <wrong type>` warns identically. Tightening it belongs
+    // to a separate, measured change: this seed compiles the whole compiler bundle, so a
+    // new hard reject here risks false-rejecting valid code across all of main.sio.
+    if ty_eq(target_ty, target_hash, rhs_ty, rhs_ty_hash) == false {
+        tc_error(EP - 1, "assignment type mismatch")
+    }
+    emit_store_to_pointer_offset_x86(addr_slot, pending_off, target_ty, target_hash)
+}
+
 fn compile_stmt() with IO, Mut, Panic, Div {
     let k = TK[EP as usize]
     LAST_STMT_HAS_VALUE = 0
@@ -23474,6 +23704,16 @@ fn compile_stmt() with IO, Mut, Panic, Div {
     }
     if stmt_is_deref_field_field_store(EP) {
         compile_deref_field_field_store_x86()
+        return
+    }
+
+    // (*name).arr[i].field = expr (and deeper: (*name).arr[i].arr2[j].field = expr) —
+    // a field of an INDEXED element. Must be dispatched AFTER the shapes above (all of
+    // which end in `]` or carry no index, so the predicate is disjoint) and BEFORE the
+    // expression-statement fall-through, which silently wrote into a discarded value-copy
+    // of the element AND typed the assignment as a value.
+    if stmt_is_deref_indexed_elem_field_store(EP) {
+        compile_deref_indexed_elem_field_store_x86()
         return
     }
 

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -5107,6 +5107,57 @@ fn stmt_is_ident_indexed_elem_field_store(p0: i64) -> bool with Panic, Mut {
     return false
 }
 
+// (*name.field)<chain> = expr — the lvalue ROOT is a deref of a pointer held in a STRUCT
+// FIELD, e.g. `(*lo.module).string_count = 0`, `(*lo.module).string_table[i] = n`,
+// `(*lo.module).functions[i] = new_fn`, where Lowerer.module is a Box<IrModule>.
+// 37 such sites in self-hosted/ir/lower.sio — the LIVE Madaros IR lowerer.
+// No existing store predicate accepts this root: every deref-rooted one requires `)`
+// immediately after the simple name (checks at :4845 :4867 :4882 :4896 :4916 :4972 :4986),
+// and the only complex-root predicate (:4935) requires a PARENTHESISED inner base. So every
+// shape with this root reached the generic assignment path and lost its store, which is why
+// this predicate accepts the whole chain grammar rather than a single shape.
+// Base address: load the root, add the inner field offsets (inline), then LOAD the pointer
+// stored in the final inner field — that is the deref the `(* )` spells.
+fn stmt_is_deref_inner_root_store(p0: i64) -> bool with Panic, Mut {
+    if TK[p0 as usize] != 6 { return false }        // (
+    if TK[(p0 + 1) as usize] != 19 { return false } // *
+    if TK[(p0 + 2) as usize] != 3 { return false }  // simple-name root
+    if TK[(p0 + 3) as usize] != 50 { return false } // `.` — NOT the (*name) forms
+    var p = p0 + 3
+    while p < TC && TK[p as usize] == 50 && TK[(p + 1) as usize] == 3 {
+        p = p + 2
+    }
+    if TK[p as usize] != 7 { return false }         // )
+    p = p + 1
+    // A non-empty chain is required: `(*p.field) = v` is whole-pointee assignment, a
+    // different operation with its own handler, and this emitter has no target field for it.
+    if TK[p as usize] != 50 && TK[p as usize] != 41 { return false }
+    while p < TC {
+        if TK[p as usize] == 50 {
+            if TK[(p + 1) as usize] != 3 { return false }
+            p = p + 2
+            continue
+        }
+        if TK[p as usize] == 41 {
+            var depth: i64 = 1
+            p = p + 1
+            while p < TC && depth > 0 {
+                if TK[p as usize] == 41 { depth = depth + 1 }
+                if TK[p as usize] == 42 { depth = depth - 1 }
+                p = p + 1
+            }
+            continue
+        }
+        if TK[p as usize] == 16 {
+            if TK[(p - 1) as usize] == 42 { return true }
+            if TK[(p - 1) as usize] != 3 { return false }
+            return TK[(p - 2) as usize] == 50
+        }
+        return false
+    }
+    return false
+}
+
 // name.f1.f2 = expr  — AUTO-DEREF two-level store (ident root, no explicit `(* )`).
 // Shape only: (3|79) 50 3 50 3 16. For a VALUE struct root the generic assignment
 // path already handles this correctly, so the dispatch gates this on the root var
@@ -22459,9 +22510,18 @@ fn compile_deref_indexed_elem_field_store_x86() with IO, Mut, Panic, Div {
     // pointee is loaded identically for both, so the chain walk below is shared verbatim.
     var name_tok = EP
     var chain_start = EP + 1
+    var root_inner: i64 = 0   // 1 = `(*name.field…)` root: deref of a pointer FIELD
     if TK[EP as usize] == 6 {
         name_tok = EP + 2
         chain_start = EP + 4
+        if TK[(EP + 3) as usize] == 50 {
+            root_inner = 1
+            var rp = EP + 3
+            while rp < TC && TK[rp as usize] == 50 && TK[(rp + 1) as usize] == 3 {
+                rp = rp + 2
+            }
+            chain_start = rp + 1  // past the `)`
+        }
     }
     let ns = TS[name_tok as usize]
     let ne = TE[name_tok as usize]
@@ -22515,7 +22575,9 @@ fn compile_deref_indexed_elem_field_store_x86() with IO, Mut, Panic, Div {
         // The `(*name)` spelling asserts a pointer. A value root reaching it is the
         // pre-existing type error and must stay a hard reject; only the auto-deref spelling
         // may be value-rooted (gated by ident_chain_root_supported at the dispatch).
-        if TK[EP as usize] == 6 {
+        // `(*name.field)` is exempt: there the `*` applies to the FIELD, not to the root, so
+        // a value-struct root is perfectly legal.
+        if TK[EP as usize] == 6 && root_inner == 0 {
             tc_error_hard(name_tok, "field access through deref requires ref or pointer binding")
             EP = eq_pos + 1
             compile_or()
@@ -22533,9 +22595,74 @@ fn compile_deref_indexed_elem_field_store_x86() with IO, Mut, Panic, Div {
         compile_or()
         return
     }
-    EP = chain_start  // past `( * name )` or past the bare `name`
+    EP = chain_start  // past `( * name … )` or past the bare `name`
     emit_load_var(lslot)  // rax = base pointer
     var pending_off: i64 = 0
+    // `(*name.field…)` root: walk the INNER field chain inside the parens, accumulating inline
+    // offsets, then LOAD the pointer stored in the final inner field. That load is the deref
+    // the `(* )` spells, and it is what no existing predicate was willing to emit.
+    if root_inner == 1 {
+        var ip = name_tok + 1
+        var inner_off: i64 = 0
+        var inner_bad: i64 = 0
+        while inner_bad == 0 && TK[ip as usize] == 50 {
+            let itok = ip + 1
+            if cur_ty != 6 {
+                tc_error_hard(itok, "field access requires struct value")
+                inner_bad = 1
+                continue
+            }
+            let isi = st_find(cur_hash)
+            if isi < 0 {
+                tc_error_hard(itok, "unknown field access")
+                inner_bad = 1
+                continue
+            }
+            if st_private_access_denied(isi, itok) {
+                tc_error_hard(itok, "private struct field access")
+                inner_bad = 1
+                continue
+            }
+            let ifh = gl_name_hash(TS[itok as usize], TE[itok as usize])
+            ST_QUERY_NS = TS[itok as usize]
+            ST_QUERY_NE = TE[itok as usize]
+            let ioff = st_field_offset(isi, ifh)
+            let ifty = st_field_ty(isi, ifh)
+            let ifhash = st_field_hash(isi, ifh)
+            ST_QUERY_NS = -1
+            ST_QUERY_NE = -1
+            if ioff < 0 {
+                tc_error_hard(itok, "unknown field access")
+                inner_bad = 1
+                continue
+            }
+            inner_off = inner_off + ioff
+            cur_ty = ifty
+            cur_hash = ifhash
+            ip = ip + 2
+        }
+        if inner_bad == 1 {
+            EP = eq_pos + 1
+            compile_or()
+            return
+        }
+        if type_is_pointer_like(cur_ty, cur_hash) == false {
+            tc_error_hard(name_tok, "deref of a struct field requires a pointer-typed field")
+            EP = eq_pos + 1
+            compile_or()
+            return
+        }
+        if inner_off != 0 { em(0x48); em(0x8d); em(0x80); em32(inner_off) }  // lea rax,[rax+off]
+        em(0x48); em(0x8b); em(0x00)  // mov rax,[rax] — the pointer held in the field
+        cur_ty = ptr_hash_inner_ty(cur_hash)
+        cur_hash = ptr_hash_inner_hash(cur_hash)
+        if cur_ty != 6 && cur_ty != 8 {
+            tc_error_hard(name_tok, "field access through pointer/ref requires struct or array pointee")
+            EP = eq_pos + 1
+            compile_or()
+            return
+        }
+    }
     var target_ty: i64 = 0
     var target_hash: i64 = 0
     var done: i64 = 0
@@ -23880,6 +24007,15 @@ fn compile_stmt() with IO, Mut, Panic, Div {
             compile_deref_indexed_elem_field_store_x86()
             return
         }
+    }
+
+    // (*name.field)<chain> = expr — root is a deref of a pointer held in a struct field.
+    // Disjoint from every predicate above by construction (they all require `)` right after
+    // the simple name, or a parenthesised inner base), so no dispatch ordering hazard: this
+    // accepts the full chain grammar because nothing else ever accepted this root at all.
+    if stmt_is_deref_inner_root_store(EP) {
+        compile_deref_indexed_elem_field_store_x86()
+        return
     }
 
     // return expr

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -5052,6 +5052,53 @@ fn stmt_is_deref_indexed_elem_field_store(p0: i64) -> bool with Panic, Mut {
     return false
 }
 
+// name.f1[i].f2 = expr and deeper — the AUTO-DEREF twin of
+// stmt_is_deref_indexed_elem_field_store: identical chain, bare-ident root, no `(* )`.
+// Same disease, same magnitude: measured on a single file whose two fns differ ONLY in the
+// root spelling, `(*m).blks[1].ins[0].op = 77` stored 77 while `m.blks[1].ins[0].op = 77`
+// stored nothing — rc=0, zero errors, zero warnings, Madaros correct on both. The narrow
+// ident-root handlers cover only ONE field hop before the index (stmt_is_indexed_field_field_store
+// requires TK[p0+3]==41), so every deeper ident chain fell to the generic assignment path.
+// Live casualties found by shape census: ir/dead_code.sio:260 (dce_mark_reachable marks no
+// instruction reachable), native/codegen_plan.sio:1325 (scheduling priorities stay zero),
+// with the shape appearing ~131 times under self-hosted/ (compiler/main.sio alone ~95) plus
+// the bootstrap chain.
+// The DISPATCH gates this on token_chain_root_is_pointer, following the established pattern
+// of stmt_is_field_field_store_shape at :23245 — a VALUE struct root has a different address
+// story and is left to the generic path, which is why this predicate is shape-only.
+fn stmt_is_ident_indexed_elem_field_store(p0: i64) -> bool with Panic, Mut {
+    if TK[p0 as usize] != 3 { return false }        // bare-ident root
+    if TK[(p0 + 1) as usize] != 50 { return false } // must start with `. field`, not `[`
+    var p = p0 + 1
+    var saw_index: i64 = 0
+    while p < TC {
+        if TK[p as usize] == 50 {                   // . field
+            if TK[(p + 1) as usize] != 3 { return false }
+            p = p + 2
+            continue
+        }
+        if TK[p as usize] == 41 {                   // [ … ]
+            var depth: i64 = 1
+            p = p + 1
+            while p < TC && depth > 0 {
+                if TK[p as usize] == 41 { depth = depth + 1 }
+                if TK[p as usize] == 42 { depth = depth - 1 }
+                p = p + 1
+            }
+            saw_index = 1
+            continue
+        }
+        if TK[p as usize] == 16 {                   // =
+            if saw_index == 0 { return false }
+            if p < p0 + 3 { return false }
+            if TK[(p - 1) as usize] != 3 { return false }
+            return TK[(p - 2) as usize] == 50       // must END in `. field`
+        }
+        return false
+    }
+    return false
+}
+
 // name.f1.f2 = expr  — AUTO-DEREF two-level store (ident root, no explicit `(* )`).
 // Shape only: (3|79) 50 3 50 3 16. For a VALUE struct root the generic assignment
 // path already handles this correctly, so the dispatch gates this on the root var
@@ -22374,14 +22421,22 @@ fn compile_deref_field_field_array_store_x86() with IO, Mut, Panic, Div {
 // the expression-statement fall-through, the statement is also correctly typed as a unit
 // (LAST_STMT_HAS_VALUE stays 0), which is what makes it legal as a tail-if arm.
 fn compile_deref_indexed_elem_field_store_x86() with IO, Mut, Panic, Div {
-    let name_tok = EP + 2
+    // Serves BOTH root spellings, which differ only in where the name sits and how many
+    // tokens precede the chain: `(*name)<chain>` and the auto-deref `name<chain>`. The
+    // pointee is loaded identically for both, so the chain walk below is shared verbatim.
+    var name_tok = EP
+    var chain_start = EP + 1
+    if TK[EP as usize] == 6 {
+        name_tok = EP + 2
+        chain_start = EP + 4
+    }
     let ns = TS[name_tok as usize]
     let ne = TE[name_tok as usize]
     // Locate the terminating `=` up front (same scan the predicate ran) so every
     // diagnostic path can consume the whole statement instead of leaving a token tail
     // for the statement loop to re-parse as an expression (which produced a spurious
     // second "unknown identifier" cascade).
-    var eq_pos = EP + 4
+    var eq_pos = chain_start
     while eq_pos < TC && TK[eq_pos as usize] != 16 {
         if TK[eq_pos as usize] == 41 {
             var sdepth: i64 = 1
@@ -22425,7 +22480,7 @@ fn compile_deref_indexed_elem_field_store_x86() with IO, Mut, Panic, Div {
         compile_or()
         return
     }
-    EP = EP + 4  // skip ( * name )
+    EP = chain_start  // past `( * name )` or past the bare `name`
     emit_load_var(lslot)  // rax = base pointer
     var pending_off: i64 = 0
     var target_ty: i64 = 0
@@ -23715,6 +23770,19 @@ fn compile_stmt() with IO, Mut, Panic, Div {
     if stmt_is_deref_indexed_elem_field_store(EP) {
         compile_deref_indexed_elem_field_store_x86()
         return
+    }
+
+    // name.arr[i].field = expr — the auto-deref twin of the shape above, for a POINTER-LIKE
+    // root only. Gated exactly like stmt_is_field_field_store_shape below: a value struct
+    // root has a different address story and the generic path already handles the simple
+    // cases, so it falls through rather than being intercepted here. Dispatched at this
+    // point (not earlier) so every narrow ident-root handler above keeps its shapes — those
+    // cover one field hop before the index; this catches the deeper chains they miss.
+    if stmt_is_ident_indexed_elem_field_store(EP) {
+        if token_chain_root_is_pointer(EP) {
+            compile_deref_indexed_elem_field_store_x86()
+            return
+        }
     }
 
     // return expr

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -5044,8 +5044,13 @@ fn stmt_is_deref_indexed_elem_field_store(p0: i64) -> bool with Panic, Mut {
         if TK[p as usize] == 16 {                   // =
             if saw_index == 0 { return false }
             if p < p0 + 6 { return false }
+            // Two terminal forms: `. field =` stores into a field, `] =` stores into an
+            // array ELEMENT. The element form is the one ir/opt_cleanup.sio uses for its
+            // whole-record instruction rewrites, e.g.
+            // (*module).functions[fi].instrs[i] = ir_copy(dst, found).
+            if TK[(p - 1) as usize] == 42 { return true }
             if TK[(p - 1) as usize] != 3 { return false }
-            return TK[(p - 2) as usize] == 50       // must END in `. field`
+            return TK[(p - 2) as usize] == 50
         }
         return false
     }
@@ -5091,8 +5096,11 @@ fn stmt_is_ident_indexed_elem_field_store(p0: i64) -> bool with Panic, Mut {
         if TK[p as usize] == 16 {                   // =
             if saw_index == 0 { return false }
             if p < p0 + 3 { return false }
+            // Same two terminal forms as the deref twin: `. field =` (field of an element)
+            // and `] =` (the element itself).
+            if TK[(p - 1) as usize] == 42 { return true }
             if TK[(p - 1) as usize] != 3 { return false }
-            return TK[(p - 2) as usize] == 50       // must END in `. field`
+            return TK[(p - 2) as usize] == 50
         }
         return false
     }
@@ -22584,6 +22592,50 @@ fn compile_deref_indexed_elem_field_store_x86() with IO, Mut, Panic, Div {
                 failed = 1
                 done = 1
                 continue
+            }
+            // Is this the TERMINAL step, i.e. `… [ idx ] = expr`? Then the store target is
+            // the array ELEMENT itself rather than a field of it, which needs the aggregate
+            // store form (elements are pointer-per-slot, so an aggregate RHS is copied into
+            // fresh element storage and the POINTER is written into the slot;
+            // materialize_aggregate_array_element_x86 no-ops for scalar elements and leaves
+            // the value in rax, so one path serves both).
+            var term_p = EP + 1
+            var term_depth: i64 = 1
+            while term_p < TC && term_depth > 0 {
+                if TK[term_p as usize] == 41 { term_depth = term_depth + 1 }
+                if TK[term_p as usize] == 42 { term_depth = term_depth - 1 }
+                term_p = term_p + 1
+            }
+            if TK[term_p as usize] == 16 {
+                let esiz_t = arr_hash_esiz(cur_hash)
+                let elem_ty_t = arr_hash_elem_ty(cur_hash)
+                let elem_hash_t = arr_hash_elem_hash(cur_hash)
+                if pending_off != 0 { em(0x48); em(0x8d); em(0x80); em32(pending_off) }
+                let arr_slot = NEXT_SLOT
+                NEXT_SLOT = NEXT_SLOT + 1
+                emit_store_var(arr_slot)  // save the array base address
+                EP = EP + 1               // skip [
+                compile_or()              // index in rax
+                if TK[EP as usize] == 37 { EP = EP + 1; EP = EP + 1 }  // 'as usize'
+                if TK[EP as usize] == 42 { EP = EP + 1 }  // ]
+                if TK[EP as usize] == 16 { EP = EP + 1 }  // =
+                em(0x50)                  // push index
+                compile_or()              // rhs in rax
+                let rhs_ty_t = EXPR_TY
+                let rhs_hash_t = EXPR_TY_HASH
+                if ty_eq(elem_ty_t, elem_hash_t, rhs_ty_t, rhs_hash_t) == false {
+                    tc_error(EP - 1, "assignment type mismatch")
+                }
+                materialize_aggregate_array_element_x86(cur_hash)
+                em(0x48); em(0x89); em(0xc2)  // mov rdx, rax (value or fresh element ptr)
+                em(0x59)                      // pop rcx (index)
+                emit_load_var(arr_slot)       // rax = array base
+                if esiz_t == 8 {
+                    em(0x48); em(0x89); em(0x14); em(0xc8)  // mov [rax + rcx*8], rdx
+                } else {
+                    em(0x88); em(0x14); em(0x08)            // mov [rax + rcx], dl
+                }
+                return
             }
             if arr_hash_esiz(cur_hash) != 8 {
                 tc_error_hard(EP, "indexed element field store requires 8-byte array elements")

--- a/tests/run-pass/deref_indexed_elem_field_store.sio
+++ b/tests/run-pass/deref_indexed_elem_field_store.sio
@@ -49,6 +49,16 @@ fn set_elem(cs: &! [Cell; 4], i: i64, v: i64) with Mut, Panic {
     (*cs)[i as usize].a = v
 }
 
+// AUTO-DEREF root: same chain, bare-ident spelling, pointer-like root. Pre-fix this was the
+// highest-site-count region of the family (~131 sites under self-hosted/, incl. ~95 in
+// compiler/main.sio), and it silently stored NOTHING with zero errors and zero warnings.
+// The live casualty was ir/dead_code.sio:260 — dce_mark_reachable marked no instruction
+// reachable. A VALUE struct root is deliberately NOT covered (different address story, left
+// to the generic path), so this fn takes a ref.
+fn set_via_ident_root(o: &! Outer, i: i64, j: i64, v: i64) with Mut, Panic {
+    o.ws[i as usize].cs[j as usize].a = v
+}
+
 // Deep chain: two indices, the opt_cleanup shape.
 fn set_deep(o: &! Outer, i: i64, j: i64, v: i64) with Mut, Panic {
     (*o).ws[i as usize].cs[j as usize].a = v
@@ -101,6 +111,12 @@ fn main() with IO, Mut, Panic {
     if o.ws[1].cs[3].a != 42 { ok = false }
     if o.ws[0].cs[3].a != 0 { ok = false }
     if o.ws[1].cs[0].a != 0 { ok = false }
+
+    // Auto-deref root: o.ws[i].cs[j].a = v — same chain, no explicit parens.
+    set_via_ident_root(&!o, 0, 1, 64)
+    if o.ws[0].cs[1].a != 64 { ok = false }
+    if o.ws[0].cs[0].a != 0 { ok = false }
+    if o.ws[1].cs[1].a != 0 { ok = false }
 
     // Array-pointee root: (*cs)[i].a = v
     var bare: [Cell; 4] = [Cell { a: 0, b: false }, Cell { a: 0, b: false }, Cell { a: 0, b: false }, Cell { a: 0, b: false }]

--- a/tests/run-pass/deref_indexed_elem_field_store.sio
+++ b/tests/run-pass/deref_indexed_elem_field_store.sio
@@ -1,0 +1,117 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+//
+// Regression guard for the lean_single seed's array-element-subfield store:
+// `(*p).arr[i].field = v` (and the deeper `(*p).arr[i].arr2[j].field = v`).
+//
+// Before the fix this shape had no store handler, so it fell through to the generic
+// assignment path with TWO defects:
+//   1. SILENT MISCOMPILE — the element was materialised as a value-copy, written, and
+//      discarded, so the store read back as its old value (verified: 0 instead of 7,
+//      while Madaros produced 7).
+//   2. FALSE REJECT — the assignment leaked the assigned field's type into
+//      LAST_STMT_HAS_VALUE, so a unit fn whose tail-if arms end in such stores to
+//      differently-typed fields was rejected with "if arm type does not match else arm".
+//      This is the shape self-hosted/ir/opt_cleanup.sio uses throughout
+//      (ocp_mfi_instr_move_fields: (*module).functions[fi].instrs[dst_i].op = op).
+//
+// Both directions are covered: the stores must PERSIST (defect 1) and the tail-if unit
+// fns must TYPECHECK (defect 2 — this file failing to compile at all is the regression).
+
+struct Cell {
+    a: i64,
+    b: bool,
+}
+
+struct Wrap {
+    cs: [Cell; 4],
+    n: i64,
+}
+
+struct Outer {
+    ws: [Wrap; 2],
+}
+
+// Tail-if whose arms end in indexed-element stores to differently-typed fields.
+// The mere presence of this fn is the defect-2 guard.
+fn set_either(w: &! Wrap, i: i64, flag: bool) with Mut, Panic {
+    if flag {
+        (*w).cs[i as usize].a = 7
+    } else {
+        (*w).cs[i as usize].b = true
+    }
+}
+
+// Array-POINTEE root: the chain starts at an index rather than a field, so the pointee is
+// an array, not a struct. Pre-fix this was a second silent miscompile of the same family —
+// it emitted NO diagnostic at all (not even a warning) and stored nothing.
+fn set_elem(cs: &! [Cell; 4], i: i64, v: i64) with Mut, Panic {
+    (*cs)[i as usize].a = v
+}
+
+// Deep chain: two indices, the opt_cleanup shape.
+fn set_deep(o: &! Outer, i: i64, j: i64, v: i64) with Mut, Panic {
+    (*o).ws[i as usize].cs[j as usize].a = v
+}
+
+// Field-wise move between two elements — reads and writes the same array.
+fn move_cell(w: &! Wrap, dst: i64, src: i64) with Mut, Panic {
+    let a = (*w).cs[src as usize].a
+    let b = (*w).cs[src as usize].b
+    (*w).cs[dst as usize].a = a
+    (*w).cs[dst as usize].b = b
+}
+
+fn main() with IO, Mut, Panic {
+    var ok = true
+
+    // Explicit element lists (not `[V; N]` repeat literals) are used deliberately: repeat
+    // literals of aggregate values alias their slots under Madaros while allocating per
+    // slot under the lean_single seed, so only explicit lists give distinct elements on
+    // BOTH engines — which the "other elements untouched" assertions below depend on.
+    var w: Wrap = Wrap { cs: [Cell { a: 0, b: false }, Cell { a: 0, b: false }, Cell { a: 0, b: false }, Cell { a: 0, b: false }], n: 0 }
+
+    // Defect 1: the store must persist.
+    set_either(&!w, 2, true)
+    if w.cs[2].a != 7 { ok = false }
+    // ...and must hit only the indexed element.
+    if w.cs[0].a != 0 { ok = false }
+    if w.cs[1].a != 0 { ok = false }
+    if w.cs[3].a != 0 { ok = false }
+
+    // The other arm stores a differently-typed field at the same shape.
+    set_either(&!w, 1, false)
+    if w.cs[1].b != true { ok = false }
+    if w.cs[1].a != 0 { ok = false }
+
+    // Field-wise move (the ocp_mfi_instr_move_fields pattern).
+    move_cell(&!w, 3, 2)
+    if w.cs[3].a != 7 { ok = false }
+    if w.cs[2].a != 7 { ok = false }
+
+    // Deep chain: (*o).ws[i].cs[j].a = v
+    // Built from bindings rather than inline nested literals: the seed rejects an
+    // array-of-struct literal written directly inside another struct literal's field
+    // initializer ("field initializer type does not match struct field"), a separate
+    // pre-existing seed gap unrelated to this store fix.
+    let wa: Wrap = Wrap { cs: [Cell { a: 0, b: false }, Cell { a: 0, b: false }, Cell { a: 0, b: false }, Cell { a: 0, b: false }], n: 0 }
+    let wb: Wrap = Wrap { cs: [Cell { a: 0, b: false }, Cell { a: 0, b: false }, Cell { a: 0, b: false }, Cell { a: 0, b: false }], n: 0 }
+    var o: Outer = Outer { ws: [wa, wb] }
+    set_deep(&!o, 1, 3, 42)
+    if o.ws[1].cs[3].a != 42 { ok = false }
+    if o.ws[0].cs[3].a != 0 { ok = false }
+    if o.ws[1].cs[0].a != 0 { ok = false }
+
+    // Array-pointee root: (*cs)[i].a = v
+    var bare: [Cell; 4] = [Cell { a: 0, b: false }, Cell { a: 0, b: false }, Cell { a: 0, b: false }, Cell { a: 0, b: false }]
+    set_elem(&!bare, 2, 5)
+    if bare[2].a != 5 { ok = false }
+    if bare[0].a != 0 { ok = false }
+    if bare[3].a != 0 { ok = false }
+
+    if ok {
+        println("ALL PASS")
+    } else {
+        println("FAIL")
+    }
+}

--- a/tests/run-pass/deref_indexed_elem_field_store.sio
+++ b/tests/run-pass/deref_indexed_elem_field_store.sio
@@ -71,6 +71,33 @@ fn value_root_set(o: Outer, i: i64, j: i64, v: i64) -> Outer with Mut, Panic, Di
     c
 }
 
+fn mk_cell(av: i64, bv: bool) -> Cell {
+    Cell { a: av, b: bv }
+}
+
+// TERMINAL-INDEX form: the chain ends in `[j] =`, so the store target is the array ELEMENT
+// itself, not a field of it. This is the shape ir/opt_cleanup.sio uses 30 times for its
+// whole-record rewrites — (*module).functions[fi].instrs[i] = ir_copy(...) and = ir_nop() —
+// so pre-fix the optimizer's record moves AND its nop marking silently wrote nothing.
+// Elements are pointer-per-slot, so an aggregate RHS is copied into fresh element storage and
+// the pointer is written into the slot.
+fn set_whole_elem(o: &! Outer, i: i64, j: i64, av: i64) with Mut, Panic, Div {
+    (*o).ws[i as usize].cs[j as usize] = mk_cell(av, true)
+}
+
+// Same terminal form with a SCALAR element, where the aggregate materialisation must no-op.
+struct Rows {
+    row: [i64; 4],
+}
+
+struct Grid {
+    rows: [Rows; 2],
+}
+
+fn set_scalar_elem(g: &! Grid, i: i64, j: i64, v: i64) with Mut, Panic, Div {
+    (*g).rows[i as usize].row[j as usize] = v
+}
+
 // Deep chain: two indices, the opt_cleanup shape.
 fn set_deep(o: &! Outer, i: i64, j: i64, v: i64) with Mut, Panic {
     (*o).ws[i as usize].cs[j as usize].a = v
@@ -132,10 +159,30 @@ fn main() with IO, Mut, Panic, Div {
     if o.ws[1].cs[1].a != 0 { ok = false }
 
     // Value struct root: c.ws[i].cs[j].a = v on a by-value copy, returned.
+    // NOTE on semantics, verified identical on both engines: `var c = o` copies the TOP-LEVEL
+    // struct but shares the element pointers of its array-of-struct field, so the copy is
+    // SHALLOW and this write is visible through `o` as well. The assertions below therefore
+    // do not treat `o` as untouched — they only require that the store landed.
     let vout = value_root_set(o, 1, 2, 81)
     if vout.ws[1].cs[2].a != 81 { ok = false }
     if vout.ws[1].cs[3].a != 42 { ok = false }
     if vout.ws[0].cs[2].a != 0 { ok = false }
+
+    // Terminal-index, aggregate element: (*o).ws[i].cs[j] = mk_cell(...)
+    set_whole_elem(&!o, 0, 0, 55)
+    if o.ws[0].cs[0].a != 55 { ok = false }
+    if o.ws[0].cs[1].a != 64 { ok = false }
+    // A slot nothing above has written (ws[1].cs[2] carries 81 from the shallow-copy alias).
+    if o.ws[1].cs[0].a != 0 { ok = false }
+
+    // Terminal-index, scalar element: (*g).rows[i].row[j] = v
+    let gr0: Rows = Rows { row: [1, 2, 3, 4] }
+    let gr1: Rows = Rows { row: [5, 6, 7, 8] }
+    var g: Grid = Grid { rows: [gr0, gr1] }
+    set_scalar_elem(&!g, 1, 2, 99)
+    if g.rows[1].row[2] != 99 { ok = false }
+    if g.rows[1].row[3] != 8 { ok = false }
+    if g.rows[0].row[2] != 3 { ok = false }
 
     // Array-pointee root: (*cs)[i].a = v
     var bare: [Cell; 4] = [Cell { a: 0, b: false }, Cell { a: 0, b: false }, Cell { a: 0, b: false }, Cell { a: 0, b: false }]

--- a/tests/run-pass/deref_indexed_elem_field_store.sio
+++ b/tests/run-pass/deref_indexed_elem_field_store.sio
@@ -59,6 +59,18 @@ fn set_via_ident_root(o: &! Outer, i: i64, j: i64, v: i64) with Mut, Panic {
     o.ws[i as usize].cs[j as usize].a = v
 }
 
+// VALUE struct root: a by-value param copied into a local, mutated, and returned — the
+// vm/gc.sio:258 gc_set_color shape. A struct value keeps its data address in the local's slot
+// (a struct literal evaluates to `lea rax,[rbp-(base+nslots-1)*8]`), which is why reads
+// through a value root always worked; only the store was dropped, so the GC never wrote a
+// mark colour. Two field hops precede the index here, which is what put it outside the narrow
+// one-hop ident handler.
+fn value_root_set(o: Outer, i: i64, j: i64, v: i64) -> Outer with Mut, Panic, Div {
+    var c = o
+    c.ws[i as usize].cs[j as usize].a = v
+    c
+}
+
 // Deep chain: two indices, the opt_cleanup shape.
 fn set_deep(o: &! Outer, i: i64, j: i64, v: i64) with Mut, Panic {
     (*o).ws[i as usize].cs[j as usize].a = v
@@ -72,7 +84,8 @@ fn move_cell(w: &! Wrap, dst: i64, src: i64) with Mut, Panic {
     (*w).cs[dst as usize].b = b
 }
 
-fn main() with IO, Mut, Panic {
+// Div is required because value_root_set declares it (the `as usize` index casts).
+fn main() with IO, Mut, Panic, Div {
     var ok = true
 
     // Explicit element lists (not `[V; N]` repeat literals) are used deliberately: repeat
@@ -117,6 +130,12 @@ fn main() with IO, Mut, Panic {
     if o.ws[0].cs[1].a != 64 { ok = false }
     if o.ws[0].cs[0].a != 0 { ok = false }
     if o.ws[1].cs[1].a != 0 { ok = false }
+
+    // Value struct root: c.ws[i].cs[j].a = v on a by-value copy, returned.
+    let vout = value_root_set(o, 1, 2, 81)
+    if vout.ws[1].cs[2].a != 81 { ok = false }
+    if vout.ws[1].cs[3].a != 42 { ok = false }
+    if vout.ws[0].cs[2].a != 0 { ok = false }
 
     // Array-pointee root: (*cs)[i].a = v
     var bare: [Cell; 4] = [Cell { a: 0, b: false }, Cell { a: 0, b: false }, Cell { a: 0, b: false }, Cell { a: 0, b: false }]


### PR DESCRIPTION
Closes a **silent miscompile** class in the `lean_single` seed: stores whose lvalue chain crosses an array index were compiled into a value-copy that was written and then discarded, so the store landed **nowhere** — with `rc=0`, zero `error:` lines and zero `warning:` lines. Reads of these shapes were always correct, which is why the family survived so long. (Read-path correctness is *not* universal — see the depth-≥3 finding under scope boundaries.)

Five commits, **one measured widening per gate cycle**, so a bundle regression stays bisectable. That discipline earned its keep twice: one attempt shipped a false reject that the probes caught before it could be bundled with the fix it was meant to be part of, and the run-pass guard now fails the immediately preceding commit's seed.

## Shapes closed

Each measured against the seed built from the previous commit, with Madaros as the oracle — **except the last row**, where Madaros cannot serve as oracle because it SEGFAULTS merely *reading* through that shape (clean compile, dying binary; filed as `BLK-20260726-MADAROS-BOXFIELD-DEREF-READ-SIGSEGV`). There the seed is the correct engine and verification is seed-internal: write, then read back through the seed's own read path, which is demonstrably correct on the identical file, plus neighbour-slot checks. That same crash is also why the last commit ships without a run-pass guard — any test proving the store landed must read it back, and that read would break the suite on the default compiler.

| commit | shape | before | after |
|---|---|---|---|
| `1898c7fc6` | `(*p).arr[i].f = v`, deep `(*p).arr[i].arr2[j].f = v` | `0` | `7` |
| `1898c7fc6` | `(*arrptr)[i].f = v` (array-pointee root) | `0`, **no diagnostic at all** | `5` |
| `098f7409b` | `name.arr[i].f = v` (auto-deref, pointer root) | `0` | `7` |
| `13af45a7a` | `c.f1.f2[i].f3 = v` (value struct root) | `0` | `7` |
| `b48a1a5c1` | `(*p).f1[i].f2[j] = v` (chain ends in an index, aggregate element) | `22` | `77` |
| `b48a1a5c1` | same, scalar element | `7` | `99` |
| `b3fe48732` | `(*p.field)<chain> = v` (root is a deref of a pointer held in a struct field) | `0` | `42` / `55` / `77` |

The cleanest witness is one file whose two fns differ **only** in root spelling:

```sounio
fn store_deref_root(m: &! Mod) with Mut, Panic { (*m).blks[1].ins[0].op = 77 }
fn store_ident_root(m: &! Mod) with Mut, Panic {    m.blks[1].ins[0].op = 77 }
```

pre-series `20 / 20` → after commit 1 `77 / 20` → after commit 2 `77 / 77`; Madaros `77 / 77`.

In every case the write lands **nowhere** — all neighbour slots, sibling elements and enclosing fields keep their pre-store values — so the failure mode is data loss, not memory corruption.

## Named casualties in live compiler code

Verified at the source sites (source-site plus shape-level runtime proof — an end-to-end failure of a built Madaros was **not** observed, and this PR does not claim one):

- `ir/dead_code.sio:260` — `dce_mark_reachable` marked **no instruction reachable**.
- `vm/gc.sio:258` — `gc_set_color` **never wrote a mark colour**.
- `native/codegen_plan.sio:1325` — instruction-scheduling priorities stayed all-zero.
- `ir/opt_cleanup.sio` — `ocp_mfi_instr_move_fields` moved nothing (the reported `:9629` blocker), **and** the 30 whole-record rewrites, which include `= ir_nop()`, wrote nothing, so nop marking was dead too.

## Implementation

Two shape-only predicates (`stmt_is_deref_indexed_elem_field_store`, `stmt_is_ident_indexed_elem_field_store`) and **one** shared emitter that walks the lvalue chain materialising a real element **address**: aggregate array elements are pointer-per-slot, so the element address is **loaded** from `[base + idx*8]`, and trailing inline fields add their offsets. The emitter derives the name token and chain start from the root spelling, so walk, guards and error paths are shared verbatim. Two terminal forms are handled: `. field =` stores into a field, `] =` stores into the element itself via `materialize_aggregate_array_element_x86` (which copies an aggregate RHS into fresh element storage and leaves the pointer in `rax`, and no-ops for scalars leaving the value in `rax`, so one path serves both).

Base address for a value-struct root needs no new machinery: a struct value is represented as `lea rax,[rbp-(base+nslots-1)*8]` and that pointer is what lives in the local's slot, which is exactly why reads through a value root already worked. Only the type derivation had to stop unconditionally unwrapping the root as a pointer.

Ordering: dispatched after every narrow store predicate, which keep their shapes and their better codegen, and before the generic assignment path.

`ident_chain_root_supported` gates the auto-deref dispatch so **globals** (no `var_find` slot) and non-aggregate roots fall through to the generic path exactly as before, rather than being intercepted and hard-rejected. Without it, `G.arr[i].f = v` on a global struct would turn from working code into a false reject; `main.sio` uses globals heavily, and the bundle build is the real test of that.

## Severity discipline

Structural guards are `tc_error_hard`, deliberately. `tc_error` in this file prints `warning:` and is **non-fatal**, so reporting them softly would have converted the generic path's pre-existing hard rejections (`value is not indexable`, `unknown field access`) into silent acceptances — worse than the false reject being removed. Each negative was re-verified case by case against the pre-series seed. Every diagnostic path also consumes the whole statement, so a rejected store no longer leaves a token tail for the statement loop to re-parse into a spurious second `unknown identifier`.

## Verification

Every commit was gated independently. Final state:

- **lean_single fixed-point gate PASS** — `stage1 == stage2 == stage3`, md5 `89fb636d47f45253af993988db07dee6`, 2 550 750 bytes.
- **From-source bundle build** `rc=0`, 101 364 306-byte ELF. The seed's hard-error set on the compiler bundle drops **4 → 3** (commit 1 eliminated exactly `opt_cleanup.sio:9629`) and stays at 3 for commits 2–5, i.e. no commit introduces a new bundle diagnostic. For commit 5 that check is load-bearing: `ir/lower.sio` holds 37 sites of exactly the shape it handles, so a new hard error there would have meant the inner-root resolution mishandles real code. None appeared.
- The freshly built compiler still compiles and runs code.
- `tests/run-pass/deref_indexed_elem_field_store.sio` — ALL PASS on this seed **and** on Madaros, **FAIL** on the immediately preceding commit's seed, and **rejected outright** by the pre-series seed. It guards both directions: stores must persist, and the tail-if unit fns must typecheck.

Note on the build signal, because it misled an earlier report of mine: a from-source build exiting 0 is **not** a typecheck guarantee. `tc_mark_failed` does not set `TYPECHECK_FAILED` when `MAIN_SRC_END > 0` and the fn carries effect bit 2048 (`from_import`, `:258`), so hard errors in imported modules are downgraded and the ELF is emitted regardless. The deltas above were read from the error lines, not the exit code. Re-checked for `E200` (which prints without an `error:`/`warning:` prefix and evades both greps) and for the capacity classes (never printed, since `print_limit_error` runs only under `TYPECHECK_FAILED != 0`); a separate throwaway build with that call forced unconditional confirms **no capacity overflow** in the current bundle.

## Corrections to my own earlier claims, recorded

- The census filed the whole terminal-index region as broken; the **ident-root** spelling was already correct via an earlier narrow handler. Only the deref-rooted half lost stores. The 30 `opt_cleanup` sites are all deref-rooted.
- A struct value copy is **shallow**: `var c = o` copies the top-level struct but shares the element pointers of an array-of-struct field, so a write through the copy is visible through the original. Verified identical on both engines; my first test version asserted deep-copy behaviour and was wrong about the language, not about either compiler.

## Scope boundaries and what stays open

- **`compile_stmt_a64`** (`:35448`, dispatch siblings `:36112 :36189 :36372`) mirrors none of these handlers. The predicates are target-independent and reusable; only `..._a64` emitters are missing. No arm64 runtime datum was collected.
- **Field chains of depth ≥3 are NOT part of this family** and are deliberately not touched here. Investigating them reclassified the region twice, and both corrections are recorded because the census had them wrong: they are a **READ-path hard false reject**, not a lost store — a probe containing *no stores at all* is rejected identically by the pre-series seed and by the post-series one, while Madaros evaluates it correctly. Site: `compile_postfix_tail` at `:17154`, where the field resolve scans registered structs and hard-errors on `found == 0` at the third hop. The trigger is root-kind-specific: `&!`-ref roots **and value roots** fail, while `*mut` roots work — which is why the compiler's own 26+8 sites compile (two full bundle builds contain zero `unknown field access`). A sixth store widening was written for this region, built, and **proved unreachable** — the expression compiler rejects the chain before store dispatch is ever consulted — so it was reverted rather than shipped as inert predicate surface.
- A separate, narrower defect surfaced by the same probes and filed on its own: the seed rejects a struct literal whose struct-typed field is initialised from a binding, while the sibling line with two such fields does not — the trigger needs isolation before anyone patches it.
- **Assignment-type mismatch on this path is soft**, matching every other deref-store handler in the file, so `bool` into an `i64` field warns instead of rejecting. Pre-existing and file-wide, not introduced here; tightening it is a separate measured change, because this seed compiles the whole `main.sio` bundle and a new hard reject risks false-rejecting valid code compiler-wide.

The structural conclusion is that this is one bug seen repeatedly: the assignment path is a hand-written enumeration of ~16 token-pattern predicates, and everything outside it reaches a generic path that copy-writes-discards **and** leaks `LAST_STMT_HAS_VALUE`. This series replaces four of those gaps with one shared chain walker rather than four more special cases; the remaining two regions want the same treatment.

`lean_single.sio` itself contains zero sites of any of these shapes, so the seed does not miscompile itself and the fixed point is not implicated.

## Not in this PR — handed to their surface owners

The three residual bundle errors are all **genuine source defects in other files**, and the seed is the only engine that reports them:

- `check/check.sio:18162` and `resolve/imports.sio:285` — one omission. Commit `65639f3b8` added a 27th `ItemKind` variant `ItemClaim` (`parser/ast.sio:946`) and updated only `resolve/resolve.sio` (`:464`, `:601`), leaving those two matches at 26 arms with no wildcard.
- `ir/lower.sio:1789` — the `StructFieldEntry` literal omits `elem_type_name` (declared at `ir.sio:2175-2184`). Both compilers reject the source, and the omitted field reads stale stack residue which is then handed to `field_array_elem_type_name_for_struct` for struct-array-element trait dispatch.
