### PR TITLE
fix(coord): scope agent lanes to (session, worktree) so they stop colliding

### DIFF
--- a/scripts/ci/sounio_coord_agent_hook_selftest.sh
+++ b/scripts/ci/sounio_coord_agent_hook_selftest.sh
@@ -47,8 +47,14 @@ run_coord() {
 
 output="$(run_hook codex "$REPO" \
   "{\"session_id\":\"codex-a\",\"cwd\":\"$REPO\",\"hook_event_name\":\"SessionStart\"}")"
+# Lanes are scoped to (session, worktree) -- see sounio_coord_agent_hook.py and
+# issue #1477. The suffix is a hash of the worktree path, so the selftest must
+# READ the lane the hook actually registered instead of hardcoding it; two
+# worktrees of the same session deliberately get different lanes.
 grep -q 'agent=codex lane=session-codex-a' <<< "$output" || \
   fail 'Codex session identity was not injected'
+CODEX_LANE="$(sed -n 's/.*agent=codex lane=\(session-codex-a[A-Za-z0-9_-]*\).*/\1/p' <<< "$output" | head -1)"
+[[ -n "$CODEX_LANE" ]] || fail 'could not read the codex lane from hook output'
 output="$(run_coord "$REPO" brief --max-rows 4)"
 grep -q 'ACTIVE claim_id=codex--session-codex-a' <<< "$output" || \
   fail 'Codex session presence was not registered'
@@ -65,8 +71,12 @@ output="$(run_hook claude "$SECOND" \
   "{\"session_id\":\"claude-b\",\"cwd\":\"$SECOND\",\"hook_event_name\":\"SessionStart\"}")"
 grep -q 'agent=claude lane=session-claude-b' <<< "$output" || \
   fail 'Claude session identity was not injected'
-send_output="$(run_coord "$REPO" send --agent codex --lane session-codex-a \
-  --to-agent claude --to-lane session-claude-b --kind request \
+CLAUDE_LANE="$(sed -n 's/.*agent=claude lane=\(session-claude-b[A-Za-z0-9_-]*\).*/\1/p' <<< "$output" | head -1)"
+[[ -n "$CLAUDE_LANE" ]] || fail 'could not read the claude lane from hook output'
+# The two lanes must differ: SECOND is a different worktree than REPO.
+[[ "$CLAUDE_LANE" != "$CODEX_LANE" ]] || fail 'lanes in different worktrees collided'
+send_output="$(run_coord "$REPO" send --agent codex --lane "$CODEX_LANE" \
+  --to-agent claude --to-lane "$CLAUDE_LANE" --kind request \
   --message 'Please review the parser ownership boundary')"
 message_id="$(sed -n 's/^SENT message_id=\([^ ]*\).*/\1/p' <<< "$send_output")"
 [[ -n "$message_id" ]] || fail 'message id was not returned'
@@ -74,8 +84,8 @@ message_id="$(sed -n 's/^SENT message_id=\([^ ]*\).*/\1/p' <<< "$send_output")"
 output="$(run_hook claude "$SECOND" \
   "{\"session_id\":\"claude-b\",\"cwd\":\"$SECOND\",\"hook_event_name\":\"PostToolUse\",\"tool_name\":\"Read\",\"tool_input\":{}}")"
 grep -q "MESSAGE id=$message_id" <<< "$output" || fail 'message was not delivered to Claude'
-run_coord "$SECOND" ack --agent claude --lane session-claude-b --message "$message_id" >/dev/null
-output="$(run_coord "$SECOND" inbox --agent claude --lane session-claude-b)"
+run_coord "$SECOND" ack --agent claude --lane "$CLAUDE_LANE" --message "$message_id" >/dev/null
+output="$(run_coord "$SECOND" inbox --agent claude --lane "$CLAUDE_LANE")"
 grep -q '^inbox_messages=0$' <<< "$output" || fail 'acknowledged message remained unread'
 
 set +e
@@ -86,8 +96,8 @@ set -e
 [[ "$conflict_rc" -eq 2 ]] || fail "conflicting write returned $conflict_rc instead of 2"
 grep -q 'requested file set overlaps an active claim' <<< "$conflict_output" || \
   fail 'conflicting write did not explain the ownership collision'
-output="$(run_coord "$REPO" inbox --agent codex --lane session-codex-a)"
-grep -q 'kind=request text=Write conflict requested by claude/session-claude-b' <<< "$output" || \
+output="$(run_coord "$REPO" inbox --agent codex --lane "$CODEX_LANE")"
+grep -q "kind=request text=Write conflict requested by claude/$CLAUDE_LANE" <<< "$output" || \
   fail 'conflict owner did not receive an automatic message'
 
 run_hook claude "$SECOND" \
@@ -96,7 +106,7 @@ output="$(run_coord "$SECOND" brief --max-rows 4)"
 grep -q 'ACTIVE claim_id=claude--session-claude-b' <<< "$output" && \
   fail 'Claude session claim survived SessionEnd'
 
-run_coord "$REPO" send --agent codex --lane session-codex-a --kind info \
+run_coord "$REPO" send --agent codex --lane "$CODEX_LANE" --kind info \
   --ttl-seconds 1 --message 'ephemeral selftest message' >/dev/null
 sleep 2
 output="$(run_coord "$REPO" prune)"

--- a/scripts/dev/sounio_coord_agent_hook.py
+++ b/scripts/dev/sounio_coord_agent_hook.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -46,6 +47,27 @@ def repo_root(cwd: str) -> Path | None:
 def safe_token(value: str, limit: int = 24) -> str:
     token = re.sub(r"[^A-Za-z0-9._-]", "_", value)[:limit]
     return token or "unknown"
+
+
+def worktree_token(root: Path) -> str:
+    """A short, stable token identifying THIS worktree.
+
+    Two things depend on this, both learned from issue #1477:
+
+    1. `session_id` is sometimes absent from the hook event. Falling back to the
+       literal string "unknown" put every agent in that state on the same lane
+       `session-unknown`, where they collided with each other and blocked
+       Edit/Write for entire sessions.
+    2. A lane that does not name the worktree collides with ITSELF when one
+       session works in more than one worktree: the claim is bound to the first
+       worktree and every later tool call is refused with
+       "claim belongs to worktree ...". Agents legitimately run in
+       .claude/worktrees/<name> while a claim was registered against the repo
+       root, so the paths never actually conflicted.
+
+    Including the worktree in the lane makes both impossible.
+    """
+    return safe_token(hashlib.sha1(str(root.resolve()).encode()).hexdigest()[:10])
 
 
 def run_coord(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -132,9 +154,16 @@ def main() -> int:
         return 0
 
     event_name = str(event.get("hook_event_name", ""))
-    session_id = safe_token(str(event.get("session_id", "unknown")))
+    raw_session = str(event.get("session_id") or "").strip()
     agent = safe_token(args.agent)
-    lane = f"session-{session_id}"
+    wt = worktree_token(root)
+    # Lane is scoped to (session, worktree). See worktree_token for why both are
+    # required. When session_id is absent the worktree token alone still keeps
+    # concurrent agents apart, instead of funnelling them into "session-unknown".
+    if raw_session:
+        lane = f"session-{safe_token(raw_session)}-{wt}"
+    else:
+        lane = f"session-wt-{wt}"
     intent = f"active {agent} session"
     common = scope_args(agent, lane, intent)
 


### PR DESCRIPTION
Closes #1477.

The coordination hook blocked `Edit`/`Write` for **entire agent sessions** today — three separate agents lost their write access and had to apply patches through scripts under manually-taken claims. The paths never actually conflicted.

## Two collision modes

**1. Absent `session_id` funnels everyone into one lane.** The fallback was the literal string `"unknown"`, so every agent in that state landed on lane `session-unknown` and collided with each other.

**2. The lane did not name the worktree, so a session collided with itself.** The claim binds to the first worktree it saw, and every later tool call is refused with `claim belongs to worktree ...`. Agents legitimately run in `.claude/worktrees/<name>` while the claim was registered against the repo root — the refusal was a pure false positive on non-overlapping paths.

## Fix

Put the worktree in the lane: a short stable hash of the resolved worktree path. With a session id the lane is `session-<id>-<worktree>`; without one it is `session-wt-<worktree>`, which still keeps concurrent agents apart instead of funnelling them together.

## Verified

Exercising the derivation directly:

```
absent session, repo root : session-wt-d33b8f3156
absent session, worktree  : session-wt-cc84e55f36
same session, repo root   : session-abc123-d33b8f3156
same session, worktree    : session-abc123-cc84e55f36
```

Two worktrees no longer collide when the session id is absent; one session no longer collides with itself across worktrees; nothing falls back to `unknown`.

## Not addressed here

A claim was observed still held **~4 hours** after its agent died, which suggests the lease expiry is either very long or not enforced on crash. Worth its own look — an abandoned claim on a hot file (`ir/lower.sio`) cost an agent ~12 minutes of waiting today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)