### PR TITLE
perf(madaros): raise the native-v2 handle-table ceiling 2^20 -> 2^22

### DIFF
--- a/self-hosted/native/gc.sio
+++ b/self-hosted/native/gc.sio
@@ -33,7 +33,35 @@ pub fn native_v2_handle_entry_field_pin_count() -> i64 { 24 }
 pub fn native_v2_handle_entry_field_flags() -> i64 { 32 }
 pub fn native_v2_handle_entry_field_epoch() -> i64 { 40 }
 pub fn native_v2_handle_entry_size() -> i64 { 48 }
-pub fn native_v2_handle_table_capacity_default() -> i64 { 1048576 }
+// Managed-handle ceiling for one native-v2 process. Handles are allocated by a
+// MONOTONIC bump of RuntimeContext.handle_count and are NEVER reclaimed: the
+// only reset emitter (native_v2_emit_gc_empty_frame_reset) is deliberately
+// unwired on this backend because stack maps carry slot COUNTS, not a root
+// bitmap, so no safe liveness point exists (see the "Fail closed" comment at the
+// exit-182 site in native/codegen_x86_linux.sio). This number is therefore a
+// hard per-process allocation budget, not a working-set size.
+//
+// 2^22 (raised from 2^20 on 2026-07-26). This MOVES the wall; it does not
+// remove it. The lifetime problem is unchanged and still open.
+//
+// Cost is zero-sum against the heap, not against the ELF. The table is carved
+// out of the single fixed 2 GiB anonymous mmap taken in the entry trampoline:
+//   handle_table_base = mmap_base + runtime_context_size()
+//   heap_base         = handle_table_base + native_v2_handle_table_bytes()
+//   heap_limit        = heap_base + (2147483648 - ctx - handle_table_bytes)
+// so ELF FileSiz/MemSiz are unchanged, the virtual mapping stays 2 GiB, and RSS
+// grows only for handle-table pages a program actually touches (demand-paged
+// MAP_ANONYMOUS). What it does spend is heap budget: 48 B/slot, so 2^20 -> 2^22
+// hands 144 MiB of the ~2000 MiB heap to the table.
+//
+// Headroom check at this capacity: the smallest MANAGED object is 56 B (32 B
+// header + a 24 B three-field aggregate; <=16 B structs are unboxed and take no
+// slot, see native_v2_is_small_value_struct_tag). Filling the table therefore
+// needs >= 56 * 2^22 = 235 MiB of heap against a 192 MiB table -- ~427 MiB of
+// the 2 GiB arena, so the handle table stays the first wall reached and the
+// heap is not starved. The balance point where both walls coincide is around
+// 2^24; do not raise past that without also growing the mmap.
+pub fn native_v2_handle_table_capacity_default() -> i64 { 4194304 }
 pub fn native_v2_handle_table_bytes() -> i64 { native_v2_handle_entry_size() * native_v2_handle_table_capacity_default() }
 
 // Values stored in struct-base slots may be either a managed handle id


### PR DESCRIPTION
Raises `native_v2_handle_table_capacity_default` from 2^20 to 2^22. It unblocks the verified fix in #1487, and it is **a deferral, not a cure** — stated up front because that distinction is the whole point of the investigation behind it.

## The handle table, mapped

| what | where |
|---|---|
| capacity constant | `self-hosted/native/gc.sio:36` — `1048576` |
| table size | `gc.sio:37` — 48 B/slot × capacity = 48 MiB |
| raw-pointer discrimination threshold | `gc.sio:43` — **equals the capacity** |
| allocation (live backend) | `codegen_x86_linux.sio:6621-6675` (`nc_core_emit_alloc_into`), by-value twin at `:5838-5884` |
| exhaustion → **exit 182** | `codegen_x86_linux.sio:6745`, `:5960` |
| arena | `codegen_x86_linux.sio:9522` — one 2 GiB `MAP_PRIVATE\|MAP_ANONYMOUS`: `[RuntimeContext][handle table][heap]` |

Allocation is a **monotonic bump** of `RuntimeContext.handle_count`. Nothing is decremented anywhere.

## Why reclamation is not the fix in this PR

The machinery already exists and is **deliberately unwired**: `native_v2_emit_gc_empty_frame_reset` (`codegen_x86_linux.sio:2849`) is defined and never called on the live backend. The source says why, at the exit-182 site (`:5951`): *"Fail closed: no empty-frame reset (live roots not precisely mapped)."*

That reason is real. Emitted stack maps carry **counts, not roots**: `root_temp_count = temp_count` (`:2996`), `callee_saved_root_mask = 0` (`:2998`), `root_kind_mask = mixed` (`:2999`), capped at 256 records program-wide (`:2986`). There is no refcount, no scope-end hook, no arena boundary. `NativeV2GcModel` (`gc.sio:464`) is a genuine mark/sweep but compile-time only, over 32 handles.

**Precise root maps are the prerequisite; everything downstream is already built.** Month-scale, not session-scale.

Escape analysis was also evaluated and rejected as out of scope: `ir/memory_analysis.sio` is 2,686 lines, intraprocedural by its own docstring, has a 512-region bit-vector cap, and is **imported by nothing**.

## Cost — measured, and the BSS analogy does not hold

The #1481 tier raise was nearly free because those were BSS reservations. **This table is not in the ELF at all**, so the cost is zero-sum against the heap inside the same 2 GiB mmap:

| | before | after |
|---|---|---|
| emitted program LOAD FileSiz/MemSiz | unchanged | unchanged (253,960 B both; only immediates differ) |
| peak RSS, 30,000-step program | 41,140 KiB | 41,140 KiB |
| heap budget | ~2000 MiB | ~1856 MiB (−144 MiB) |

## Ceiling, bisected rather than estimated

Varying only the `integrate_to` horizon, dt = 0.001:

| compiler | ceiling | margin over the 30,000 the program runs |
|---|---:|---:|
| base, 2^20 | 116,494 pass / 116,660 fail(182) | 3.9× |
| base + #1487, 2^20 | ~26,800 *(inherited from #1487, not re-measured here)* | 0.9× **RED** |
| base, 2^22 | 465,944 pass / 466,132 fail(182) | 15.5× |
| **base + #1487, 2^22** | **107,518 pass / 107,650 fail(182)** | **3.6× GREEN** |

9.00 handles/step before #1487, 39.01 after (4.33×). The new ceiling still terminates in **182, not 181** — the handle table remains the first wall, so the heap is not being starved by the trade.

## The blocked combination now passes

`d45b15f9f` (#1487) cherry-picked onto this raise, built from source:

- `dissertation_pbpk28_parity_ref_rapamycin.sio`: **exit 182 → exit 0**
- stdout **byte-identical** (md5 `7f6ff75824e1e8218bf37dc7845fd100`) across baseline, raise-only, and raise+#1487
- `dissertation_pbpk28_parity_gate.sh`: cases 1–6 PASS, outcome **identical to the same-commit baseline**. Case 7 fails on both — `dissertation_pbpk28_parity_ref_semaglutide.sio` is a pre-existing Madaros compile failure already listed in `tests/madaros_corpus_baseline.txt`.

Stacked verification branch: `compiler/aggregate-deep-copy-on-cap22-20260726`.

## Gates

- `madaros_full_gate.sh` — **exit 0, 11 PASS** (note: needs `MADAROS_RAW_BIN=<elf>`, not `MADAROS_BIN`; the gate asserts wrapper diagnostics)
- `madaros_corpus_regression_gate.sh` — **exit 0, no new failures**, on both the raise-only and the raise+#1487 builds

**Bonus, verified not assumed:** `dissertation_pbpk14_gum.sio` was failing under baseline Madaros with exit 182 and now passes. The corpus baseline was left untouched. That corroborates that exhaustion is *recurrent* — which argues **for** reclamation, not for this raise being sufficient.

## Explicitly deferred

**This moves the wall; it does not remove it.** The lifetime problem is untouched. The next program past 2^22 gets the same exit 182, with no recourse short of 2^24 or growing the mmap — and the two walls coincide near 2^24, so **that is the last free raise**.

Two things left alone because `codegen_x86_linux.sio` is under another lane's active claim, both worth their own change:

1. `codegen_x86_linux.sio:202` reports **`precise_stack_maps: true`**. The emitted records do not support that claim — see the root-map evidence above. The compiler is asserting something false about itself.
2. Stale "512MB" comments at `:9518/9519/9522` and the Win64 analogues `:9671/9672/9675/9683` — 4× wrong against the actual `2147483648`.

## One note for review

The single edit changes **two** semantics, because `native_v2_handle_raw_ptr_threshold` (`gc.sio:43`) is *defined as* the capacity. The discrimination threshold moves 2^20 → 2^22, still ~26 orders of magnitude below any mmap base address. The 1,688-program corpus run is the empirical evidence that it did not break anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
