### PR TITLE
feat(particle): drop local peak; EXP12 residual-closure ledger

### DIFF
--- a/docs/handoff/particle_madaros_exp_residuals_2026-07-26.md
+++ b/docs/handoff/particle_madaros_exp_residuals_2026-07-26.md
@@ -23,16 +23,23 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.partic
   Witness: `tests/multimodule/madaros_ep_gate_*.sio` + `scripts/ci/madaros_ep_gate_imported_gate.sh`.
   Full EXP123 under Madaros: **58/58** after this fix (gates 111/113 were the fail).
 
-## 2 — Peak under full EXP123 IR (narrowed)
+## 2 — Peak under full EXP123 IR (**closed**)
 
-- Minimal imported `eemm_z_peak_xsec_nu` is OK under Madaros (not always zero).
-- Full EXP123 still uses **local peak body** as defence-in-depth (imported peak forced only for NonUnitary effect).
-- Core path exercises imported peak successfully.
+- Full EXP123 now uses **only** imported `eemm_z_peak_xsec_nu` (local peak body dropped 2026-07-26).
+- Madaros full vertical: **58/58** after drop; lean gate green.
+- EXP12 residual-closure ledger jointly asserts peak + gate + collapse + product.
 
-## 3 — Drop workarounds (not yet)
+## 3 — Drop workarounds (partial)
 
-Local peak and thin physics vertical remain. Compiler residual: i64 field-if mis-branch
-in imported native (stdlib workaround only; true fix is native codegen).
+| Workaround | Status |
+|---|---|
+| Local peak body | **dropped** |
+| `ep_gate` field-if | stdlib `ep_i64_ge` (still needs native fix) |
+| `pb_is_credible` / `ck_is_credible` | same call-arg pattern |
+| Thin EXP10 physics vertical | remains (IR size) |
+| Vertex/amplitude on full EXP123 | remains (SEGV residual) |
+
+Compiler residual: i64 field-if mis-branch in imported native codegen.
 
 ## Main regression note
 

--- a/examples/particle_physics/exp123_z_metrology_nonunitary_ew.sio
+++ b/examples/particle_physics/exp123_z_metrology_nonunitary_ew.sio
@@ -21,7 +21,7 @@ use particle_physics::epistemic_chain_z::{
     eemm_qed_xsec_pb_gated, chain_gate_qed_xsec,
 }
 // Free-function Epistemic access — nested prop.amp_sq.val() SEGVs Madaros lower
-use epistemic::knowledge::{ep_val, ep_variance, ep_confidence, ep_new, ep_certain}
+use epistemic::knowledge::{ep_val, ep_variance, ep_confidence}
 use particle_physics::nonunitary::{
     nu_z_propagator, nu_deficit, nu_deficit_pct, nu_approx, nu_exact,
     eemm_z_peak_xsec_nu, nu_z_unitarity_threshold,
@@ -203,32 +203,15 @@ fn exp2_basic_deficits(mz: f64, gamma_z: f64) -> i64 with IO, Mut, Div, Panic {
     n
 }
 
-// Local peak body mirrors stdlib eemm_z_peak_xsec_nu.
-// Madaros residual (BLK-20260725-madaros-exp123-lower-array-segv): under full
-// EXP123 IR the *imported* eemm_z_peak_xsec_nu returns ep_certain(0) (val=var=0)
-// even with correct args; same formula in the main module is correct. Core
-// exp123_madaros_core still exercises the imported path successfully.
-// We still call the stdlib entry so NonUnitary remains effect-enforced.
-fn exp2_peak_xsec_local(gamma_ee: f64, gamma_mumu: f64, gamma_z: f64) -> Epistemic with NonUnitary, Mut, Div, Panic {
-    let mz = mass_z()
-    let mz_val = ep_val(&mz)
-    let mz2 = mz_val * mz_val
-    if gamma_z == 0.0 || mz2 == 0.0 {
-        return ep_certain(0.0)
-    }
-    let pi = 3.141592653589793
-    let sigma_val = 12.0 * pi * gamma_ee * gamma_mumu / (mz2 * gamma_z * gamma_z)
-    let d_sigma_d_mz = 0.0 - 2.0 * sigma_val / mz_val
-    let sigma_var = d_sigma_d_mz * d_sigma_d_mz * ep_variance(&mz)
-    ep_new(sigma_val, sigma_var, 950)
-}
-
+// Peak uses the imported NonUnitary stdlib path (eemm_z_peak_xsec_nu).
+// Historical residual (imported peak zero under full EXP123 IR) closed after
+// the Madaros ep_gate / free-fn Epistemic stack stabilisation (#1478 + chain_z).
+// Local peak body removed 2026-07-26 — re-check if peak_val collapses to 0.
 fn exp2_peak_approx(mz: f64, gamma_z: f64, gamma_ee: f64, gamma_mumu: f64) -> i64 with IO, NonUnitary, Mut, Div, Panic {
     var n: i64 = 0
     let s_pole = mz * mz
     let prop_pole = nu_z_propagator(s_pole, gamma_z)
-    let _force_nu = eemm_z_peak_xsec_nu(gamma_ee, gamma_mumu, gamma_z)
-    let peak = exp2_peak_xsec_local(gamma_ee, gamma_mumu, gamma_z)
+    let peak = eemm_z_peak_xsec_nu(gamma_ee, gamma_mumu, gamma_z)
     let peak_val = ep_val(&peak)
     let peak_var = ep_variance(&peak)
     print("EXP2_PEAK_XSEC ")

--- a/examples/particle_physics/exp12_residual_closure.sio
+++ b/examples/particle_physics/exp12_residual_closure.sio
@@ -1,0 +1,143 @@
+// examples/particle_physics/exp12_residual_closure.sio
+//
+// EXP12 — Residual-closure ledger (construction, not paper)
+//
+// Single vertical that jointly asserts four pillars closed or still honest:
+//   P1 — imported Z peak under Madaros (NonUnitary effect path)
+//   P2 — confidence gate via call-arg compare (ep_gate)
+//   P3 — collapse ladder: fixed holds, running fails at same ξ
+//   P4 — scheme×approx product residual ordering (EXP11 cell)
+//
+// If any pillar regresses, the ledger fails loudly.
+// Gate: scripts/ci/particle_exp12_residual_closure_gate.sh
+
+use particle_physics::sm_params::{mass_z}
+use particle_physics::nonunitary::{
+    eemm_z_peak_xsec_nu, nu_collapse_test, nu_scheme_approx_cell,
+    SCHEME_FIXED_WIDTH, SCHEME_RUNNING_WIDTH,
+    COLLAPSE_HOLDS, COLLAPSE_FAILS_WIDTH_SCHEME,
+}
+use epistemic::knowledge::{ep_val, ep_variance, ep_new, ep_gate}
+
+fn f_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var g = x
+    if g > 1.0 { g = x / 2.0 }
+    var i: i64 = 0
+    while i < 40 {
+        g = 0.5 * (g + x / g)
+        i = i + 1
+    }
+    g
+}
+
+fn pass_if(cond: bool, tag: i64) -> i64 with IO {
+    if cond {
+        print("PASS ")
+        print_int(tag)
+        print("\n")
+        1
+    } else {
+        print("FAIL ")
+        print_int(tag)
+        print("\n")
+        0
+    }
+}
+
+fn main() -> i32 with IO, NonUnitary, Mut, Div, Panic {
+    print("PARTICLE_EXP12_BEGIN\n")
+    print("EXP12_CLAIM residual_closure_ledger_p1_peak_p2_gate_p3_collapse_p4_product\n")
+    var n: i64 = 0
+    var bits: i64 = 0
+
+    // P1 — imported peak
+    let peak = eemm_z_peak_xsec_nu(0.08399, 0.08399, 2.4952)
+    let pval = ep_val(&peak)
+    let pvar = ep_variance(&peak)
+    print("EXP12_PEAK_VAL ")
+    print_f64(pval)
+    print("\n")
+    print("EXP12_PEAK_VAR ")
+    print_f64(pvar)
+    print("\n")
+    let p1 = pval > 1.0e-7 && pval < 1.0e-4 && pvar > 0.0
+    n = n + pass_if(p1, 2001)
+    if p1 { bits = bits + 1 }
+
+    // P2 — ep_gate on synthetic conf=846
+    let e = ep_new(1.0, 0.01, 846)
+    let g800 = ep_gate(&e, 800)
+    let g9999 = ep_gate(&e, 9999)
+    print("EXP12_GATE_800 ")
+    print_int(g800)
+    print("\n")
+    print("EXP12_GATE_9999 ")
+    print_int(g9999)
+    print("\n")
+    let p2 = g800 == 1 && g9999 == 0
+    n = n + pass_if(p2, 2002)
+    if p2 { bits = bits + 2 }
+
+    // P3 — collapse ladder at ξ=2
+    let mz = mass_z().val()
+    let gz = 2.4952
+    let xi = 2.0
+    let tol = 1.0e-3
+    let c_fix = nu_collapse_test(SCHEME_FIXED_WIDTH(), xi, mz, gz, 0.0, 0.0, 0.0, tol)
+    let c_run = nu_collapse_test(SCHEME_RUNNING_WIDTH(), xi, mz, gz, 0.0, 0.0, 0.0, tol)
+    print("EXP12_COLLAPSE_FIXED ")
+    print_int(c_fix.status)
+    print("\n")
+    print("EXP12_COLLAPSE_RUN ")
+    print_int(c_run.status)
+    print("\n")
+    let p3 = c_fix.status == COLLAPSE_HOLDS() && c_run.status == COLLAPSE_FAILS_WIDTH_SCHEME()
+    n = n + pass_if(p3, 2003)
+    if p3 { bits = bits + 4 }
+
+    // P4 — scheme×approx residual ordering
+    let r_nwa = gz / mz
+    let a_tri = f_sqrt(1.0 + r_nwa * r_nwa + 0.09)
+    let cell0 = nu_scheme_approx_cell(SCHEME_FIXED_WIDTH(), xi, mz, gz, 0.0, 0.0, 0.0, tol, 0, 0.0, 0)
+    let cell_t = nu_scheme_approx_cell(SCHEME_FIXED_WIDTH(), xi, mz, gz, 0.0, 0.0, 0.0, tol, 7, a_tri, 1)
+    print("EXP12_CELL_EMPTY ")
+    print_f64(cell0.cell_residual)
+    print("\n")
+    print("EXP12_CELL_TRI ")
+    print_f64(cell_t.cell_residual)
+    print("\n")
+    let p4 = cell0.fails == 0 && cell_t.fails == 0 && cell_t.cell_residual > cell0.cell_residual && cell_t.approx_tension == 1
+    n = n + pass_if(p4, 2004)
+    if p4 { bits = bits + 8 }
+
+    let expected: i64 = 4
+    print("EXP12_LEDGER_JSON {")
+    print("\"schema\":\"particle.exp12.residual_closure.v1\",")
+    print("\"bits\":")
+    print_int(bits)
+    print(",\"peak_val\":")
+    print_f64(pval)
+    print(",\"gate800\":")
+    print_int(g800)
+    print(",\"collapse_fixed\":")
+    print_int(c_fix.status)
+    print(",\"collapse_run\":")
+    print_int(c_run.status)
+    print(",\"cell_empty\":")
+    print_f64(cell0.cell_residual)
+    print(",\"cell_tri\":")
+    print_f64(cell_t.cell_residual)
+    print("}\n")
+
+    print("PARTICLE_EXP12_PASS ")
+    print_int(n)
+    print("\n")
+    if n == expected && bits == 15 {
+        print("PARTICLE_EXP12_OK\n")
+        0
+    } else {
+        print("PARTICLE_EXP12_FAILED\n")
+        1
+    }
+}

--- a/scripts/ci/particle_exp12_residual_closure_gate.sh
+++ b/scripts/ci/particle_exp12_residual_closure_gate.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Gate for examples/particle_physics/exp12_residual_closure.sio
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
+
+SRC=examples/particle_physics/exp12_residual_closure.sio
+
+run_eng() {
+  local eng="$1" out="$2" err="$3"
+  echo "== particle exp12 engine=$eng =="
+  set +e
+  SOUNIO_SOUC_ENGINE="$eng" ./bin/souc run "$SRC" >"$out" 2>"$err"
+  local rc=$?
+  set -e
+  if ! grep -q 'PARTICLE_EXP12_OK' "$out"; then
+    echo "engine=$eng failed rc=$rc" >&2
+    tail -40 "$err" >&2
+    tail -20 "$out" >&2
+    exit 1
+  fi
+  grep -q 'PARTICLE_EXP12_PASS 4' "$out"
+  grep -q 'EXP12_CLAIM residual_closure_ledger' "$out"
+  if grep -q '^FAIL ' "$out"; then
+    echo "FAIL under $eng" >&2
+    grep '^FAIL ' "$out" >&2
+    exit 1
+  fi
+}
+
+run_eng lean_single /tmp/particle_exp12_lean_out.txt /tmp/particle_exp12_lean_err.txt
+run_eng madaros /tmp/particle_exp12_mad_out.txt /tmp/particle_exp12_mad_err.txt
+
+echo "PARTICLE_EXP12_GATE_OK"

--- a/stdlib/epistemic/composed_effects.sio
+++ b/stdlib/epistemic/composed_effects.sio
@@ -147,8 +147,13 @@ pub fn ck_total_uncertainty(c: &ComposedKnowledge) -> f64 with Mut, Div, Panic {
 // PREDICATES (refinement-style)
 // ============================================================================
 
+// Madaros multimodule: direct field-if on i64 mis-branches; compare via call args.
+fn ck_i64_ge(a: i64, b: i64) -> i64 {
+    if a >= b { 1 } else { 0 }
+}
+
 pub fn ck_is_credible(c: &ComposedKnowledge, min_conf: i64) -> bool {
-    c.confidence >= min_conf
+    ck_i64_ge(c.confidence, min_conf) == 1
 }
 
 pub fn ck_is_causally_confirmed(c: &ComposedKnowledge, min_alpha_share: f64) -> bool with Div {

--- a/stdlib/epistemic/knightian.sio
+++ b/stdlib/epistemic/knightian.sio
@@ -355,8 +355,13 @@ pub fn pb_within(p: &PBox, lo: f64, hi: f64) -> bool {
     p.lo_mean >= lo && p.hi_mean <= hi
 }
 
+// Madaros multimodule: direct field-if on i64 mis-branches; compare via call args.
+fn pb_i64_ge(a: i64, b: i64) -> i64 {
+    if a >= b { 1 } else { 0 }
+}
+
 pub fn pb_is_credible(p: &PBox, min_conf: i64) -> bool {
-    p.confidence >= min_conf
+    pb_i64_ge(p.confidence, min_conf) == 1
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Stops parking on “workarounds remain” and actually **closes** the peak residual:

1. **Drop local peak** in full EXP123 — uses only imported `eemm_z_peak_xsec_nu` under Madaros (**58/58**).
2. **EXP12 residual-closure ledger** — one vertical jointly asserts:
   - P1 imported peak (NonUnitary)
   - P2 `ep_gate` (call-arg confidence compare)
   - P3 collapse ladder (fixed holds / running fails at ξ=2)
   - P4 scheme×approx product residual ordering
3. **Field-if spread**: same call-arg pattern on `pb_is_credible` / `ck_is_credible`.

## Evidence

| Surface | Result |
|---|---|
| Madaros EXP123 full after drop | 58/58 |
| `particle_exp123_gate.sh` | OK |
| EXP12 lean + Madaros | `PARTICLE_EXP12_OK` (4/4) |
| `particle_exp12_residual_closure_gate.sh` | OK |

## Still open (honest)

- Native codegen root fix for `if field_i64 >= k` in imported modules
- Thin EXP10 physics vertical (IR size)
- Vertex/amplitude on full EXP123 (SEGV)

## Test plan

- [x] Madaros EXP123 full after peak drop
- [x] `bash scripts/ci/particle_exp123_gate.sh`
- [x] `bash scripts/ci/particle_exp12_residual_closure_gate.sh`