### PR TITLE
test(madaros): field-if i64 residual witness + forensic audit

### DIFF
--- a/docs/audit/MADAROS_FIELD_IF_I64_2026-07-26.md
+++ b/docs/audit/MADAROS_FIELD_IF_I64_2026-07-26.md
@@ -1,0 +1,65 @@
+# Madaros multimodule: i64 field load OK on return, wrong on if/sub
+
+**Date:** 2026-07-26  
+**Status:** residual open (stdlib workarounds live; native fix blocked by active claims on `self-hosted/native/**` + `self-hosted/ir/lower.sio`)  
+**Witness:** `tests/multimodule/madaros_field_if_i64_{leaf,main}.sio`  
+**Gate:** `scripts/ci/madaros_field_if_i64_gate.sh`
+
+## Measured matrix (current-source Madaros, 2026-07-26)
+
+| Pattern | Result |
+|---|---|
+| `return e.confidence` | **846** OK |
+| `let c = e.confidence; return c` | **846** OK |
+| `e.confidence + 0` | **846** OK |
+| `e.confidence - m` | **garbage** (pointer-scale i64, e.g. −4.57e18) |
+| `if e.confidence >= m { 1 } else { 0 }` | **0** wrong |
+| `let c = e.confidence; if c >= m` | **0** wrong |
+| `ge(e.confidence, m)` call-arg | **1** OK |
+| `ge(ret_conf(e), m)` | **1** OK |
+
+Interpretation: the **load itself is not always wrong** — return and `+ 0` see 846.
+Using the field value as the **condition of a branch** or as the **LHS of subtraction**
+sees a wrong/pointer-like value. Passing the same field through a **call argument**
+re-materialises a clean i64.
+
+## Product impact (already mitigated)
+
+| Surface | Mitigation |
+|---|---|
+| `ep_gate` / `ep_require_conf` / `ep_is_credible` | `ep_i64_ge(field, k)` (#1478) |
+| `pb_is_credible` / `ck_is_credible` | same pattern (#1492) |
+| EXP123 confidence gates 111/113 | closed via ep_gate |
+
+## Suspected fix surface (for owner of native lane)
+
+Priority order for forensics:
+
+1. **Native branch condition materialisation** for SSA values produced by `IrFieldGet` of i64  
+   (`self-hosted/native/codegen_x86_linux.sio` — active claim elsewhere)
+2. **Imported multimodule finalize / restore** of field-get results used as cmp operands  
+   (`self-hosted/compiler/module_frontend.sio` finalize path)
+3. **IR lower of `if` with field-loaded condition**  
+   (`self-hosted/ir/lower.sio` — active FO claim elsewhere)
+
+Acceptance for close:
+
+```text
+MADAROS_FIELD_IF_I64_FIXED
+# requires: gate_field=1 gate_let=1 sub=46 via_arg=1 ret=846
+```
+
+## Reproduction
+
+```bash
+export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+export MADAROS_RAW_BIN=artifacts/self-hosted/madaros   # or bin/madaros-linux-x86_64
+bash scripts/ci/madaros_field_if_i64_gate.sh
+# expect: PASS: RESIDUAL documented  until native fix
+```
+
+## Coordination note
+
+2026-07-26: `self-hosted/native/codegen_x86_linux.sio` held by claude co-own lane;
+`self-hosted/ir/lower.sio` held by fo-transcendental. This audit + witness ship
+without touching those files. Handoff ready for the native owner.

--- a/docs/audit/MADAROS_FIELD_IF_I64_2026-07-26.md
+++ b/docs/audit/MADAROS_FIELD_IF_I64_2026-07-26.md
@@ -1,7 +1,16 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-field-if-i64-2026-07-26
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-field-if-i64-2026-07-26
+-->
+
 # Madaros multimodule: i64 field load OK on return, wrong on if/sub
 
 **Date:** 2026-07-26  
-**Status:** residual open (stdlib workarounds live; native fix blocked by active claims on `self-hosted/native/**` + `self-hosted/ir/lower.sio`)  
+**Status:** residual open (stdlib workarounds live). **Claude-1 / Claude-2: help package below.**  
 **Witness:** `tests/multimodule/madaros_field_if_i64_{leaf,main}.sio`  
 **Gate:** `scripts/ci/madaros_field_if_i64_gate.sh`
 
@@ -31,35 +40,64 @@ re-materialises a clean i64.
 | `pb_is_credible` / `ck_is_credible` | same pattern (#1492) |
 | EXP123 confidence gates 111/113 | closed via ep_gate |
 
-## Suspected fix surface (for owner of native lane)
+## Smoking gun for Claude-1 / Claude-2
 
-Priority order for forensics:
+Measured `sub_conf(&e, 800)` under Madaros:
 
-1. **Native branch condition materialisation** for SSA values produced by `IrFieldGet` of i64  
-   (`self-hosted/native/codegen_x86_linux.sio` — active claim elsewhere)
-2. **Imported multimodule finalize / restore** of field-get results used as cmp operands  
-   (`self-hosted/compiler/module_frontend.sio` finalize path)
-3. **IR lower of `if` with field-loaded condition**  
-   (`self-hosted/ir/lower.sio` — active FO claim elsewhere)
+```
+printed i64 = -4573123946618028032
+bit pattern = 0xc089000000000000
+as f64      = -800.0   exactly
+```
 
-Acceptance for close:
+So the binop path is doing **float** `0.0 - 800.0` (or equivalent), not integer
+`846 - 800`. That fits:
+
+1. field value of `confidence` is seen as **0.0** on the binop path, and  
+2. `OpSub` / `OpGe` take the **float** arm of `nc_emit_core_binop`.
+
+Integer `return e.confidence` still prints **846** — so not every use of the
+field is broken; return vs binop diverge.
+
+### Where to look first
+
+| Site | File (approx) | Why |
+|---|---|---|
+| `IrFieldGet` emit + float mark | `codegen_x86_linux.sio` ~7272–7286 | marks dst float via `nc_core_field_is_float` / imm_flags |
+| float vs int binop | same file ~6788–6868 | `OpGe`/`OpSub` float override when reg typed float |
+| `IrBranchTrue` | same file ~7577–7582 | `test rax,rax` — needs clean 0/1 from int cmp |
+| ref vs handle FieldGet | `label_id == 1` branch at FieldGet | `&MiniEp` must use ref-field load |
+
+### Hypotheses
+
+**H1 (preferred):** `confidence` (i64 after two f64 fields) is wrongly
+float-marked after FieldGet; binops reinterpret / zero; return path still
+prints a prior integer materialisation of 846.
+
+**H2:** multimodule FieldGet on `&T` misses `label_id=1`, handle-resolve yields 0
+for some consumers; return uses another path.
+
+### Acceptance
 
 ```text
 MADAROS_FIELD_IF_I64_FIXED
 # requires: gate_field=1 gate_let=1 sub=46 via_arg=1 ret=846
+bash scripts/ci/madaros_field_if_i64_gate.sh
 ```
 
 ## Reproduction
 
 ```bash
 export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
-export MADAROS_RAW_BIN=artifacts/self-hosted/madaros   # or bin/madaros-linux-x86_64
+export MADAROS_RAW_BIN=artifacts/self-hosted/madaros
 bash scripts/ci/madaros_field_if_i64_gate.sh
-# expect: PASS: RESIDUAL documented  until native fix
+# residual: PASS: RESIDUAL documented
+# fixed:    PASS: FIXED
 ```
 
-## Coordination note
+## Coordination
 
-2026-07-26: `self-hosted/native/codegen_x86_linux.sio` held by claude co-own lane;
-`self-hosted/ir/lower.sio` held by fo-transcendental. This audit + witness ship
-without touching those files. Handoff ready for the native owner.
+Product workarounds already on main (`ep_i64_ge`, `pb_i64_ge`, `ck_i64_ge`).
+Do **not** drop them until FIXED is green. Founder asked Grok to help
+Claude-1/2 — this audit is the intake package; native patch is theirs (or
+shared if they free the claim).

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1183
-- Repo-backed topics: 1033
+- Total governed topics: 1185
+- Repo-backed topics: 1035
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 308
-- Authority count `repo_only`: 687
+- Authority count `repo_only`: 689
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 705 topics
+- A2: 707 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -155,6 +155,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-closures-step2-capture-2026-06-24 | repo_only | docs/audit/MADAROS_CLOSURES_STEP2_CAPTURE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-dual-gum-knowledge-import-2026-07-19 | repo_only | docs/audit/MADAROS_DUAL_GUM_KNOWLEDGE_IMPORT_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-enum-variant-sigsegv-2026-06-20 | repo_only | docs/audit/MADAROS_ENUM_VARIANT_SIGSEGV_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-field-if-i64-2026-07-26 | repo_only | docs/audit/MADAROS_FIELD_IF_I64_2026-07-26.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-for-loop-lowering-2026-06-20 | repo_only | docs/audit/MADAROS_FOR_LOOP_LOWERING_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-impl-method-two-roots-2026-06-23 | repo_only | docs/audit/MADAROS_IMPL_METHOD_TWO_ROOTS_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-impl-methods-three-layer-fix-2026-06-23 | repo_only | docs/audit/MADAROS_IMPL_METHODS_THREE_LAYER_FIX_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -434,6 +435,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.handoff.deep-four-lanes-2026-07-25 | repo_only | docs/handoff/deep_four_lanes_2026-07-25.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.exact-engine-prereqs | repo_only | docs/handoff/exact_engine_prereqs.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.gpu-knowledge-vecmat-swarm-plan | repo_only | docs/handoff/gpu_knowledge_vecmat_swarm_plan.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.madaros-field-if-i64-2026-07-26 | repo_only | docs/handoff/madaros_field_if_i64_2026-07-26.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.madaros-fixed-array-call-boundary-alias-2026-07-14 | repo_only | docs/handoff/madaros_fixed_array_call_boundary_alias_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.mem-copy-builtin-codex-dispatch-2026-07-19 | repo_only | docs/handoff/mem_copy_builtin_codex_dispatch_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.monolithic-public-lower-call-blocker-2026-07-13 | repo_only | docs/handoff/monolithic_public_lower_call_blocker_2026-07-13.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -3029,6 +3029,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-field-if-i64-2026-07-26",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_FIELD_IF_I64_2026-07-26.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-for-loop-lowering-2026-06-20",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_FOR_LOOP_LOWERING_2026-06-20.md",
@@ -9463,6 +9486,29 @@
       "topic_id": "repo.docs.handoff.gpu-knowledge-vecmat-swarm-plan",
       "collection": "repo",
       "repo_doc_path": "docs/handoff/gpu_knowledge_vecmat_swarm_plan.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.handoff.madaros-field-if-i64-2026-07-26",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/madaros_field_if_i64_2026-07-26.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",

--- a/docs/handoff/madaros_field_if_i64_2026-07-26.md
+++ b/docs/handoff/madaros_field_if_i64_2026-07-26.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.madaros-field-if-i64-2026-07-26
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.madaros-field-if-i64-2026-07-26
+-->
+
 # Handoff — Madaros i64 field-if residual
 
 **For:** native/codegen owner  

--- a/docs/handoff/madaros_field_if_i64_2026-07-26.md
+++ b/docs/handoff/madaros_field_if_i64_2026-07-26.md
@@ -1,0 +1,23 @@
+# Handoff — Madaros i64 field-if residual
+
+**For:** native/codegen owner  
+**Blocker class:** Madaros imported multimodule ABI / branch condition  
+**Evidence:** `docs/audit/MADAROS_FIELD_IF_I64_2026-07-26.md`  
+**Witness gate:** `scripts/ci/madaros_field_if_i64_gate.sh`  
+
+## Ask
+
+Implement native fix so `if e.confidence >= m` returns 1 for conf=846, m=800
+in `tests/multimodule/madaros_field_if_i64_main.sio`, then gate prints
+`MADAROS_FIELD_IF_I64_FIXED`.
+
+## Already shipped workarounds (do not regress)
+
+- `stdlib/epistemic/knowledge.sio` → `ep_i64_ge`
+- `stdlib/epistemic/knightian.sio` → `pb_i64_ge`
+- `stdlib/epistemic/composed_effects.sio` → `ck_i64_ge`
+
+## Do not
+
+- Delete workarounds until FIXED marker is green on CI with current-source Madaros.
+- Conflate with peak ABI (peak residual closed #1492).

--- a/docs/handoff/particle_madaros_exp_residuals_2026-07-26.md
+++ b/docs/handoff/particle_madaros_exp_residuals_2026-07-26.md
@@ -51,3 +51,19 @@ Merge of `research/particle-exp123-20260725` into main reintroduced vertex impor
 131072 → 524288 KiB. FO GUM multi-channel growth made 128 MiB insufficient on
 GitHub runners (SEGV / call-arg scratch overflow). Measured: 262144 passes;
 131072 fails. Contracts LoRA sync for `variance_covariance_blindness.sio` (β10).
+
+## 4 — Native field-if residual (forensic, 2026-07-26)
+
+Witness: `tests/multimodule/madaros_field_if_i64_{leaf,main}.sio`  
+Gate: `scripts/ci/madaros_field_if_i64_gate.sh`  
+Audit: `docs/audit/MADAROS_FIELD_IF_I64_2026-07-26.md`
+
+Madaros imported multimodule:
+
+- `return e.confidence` / `+ 0` → **846 OK**
+- `if e.confidence >= m` / `let c; if c >= m` → **0 wrong**
+- `e.confidence - m` → **pointer-scale garbage**
+- `ge(e.confidence, m)` call-arg → **1 OK**
+
+Native fix blocked this session by active claims on `self-hosted/native/**` and
+`self-hosted/ir/lower.sio`. Stdlib workarounds remain until `MADAROS_FIELD_IF_I64_FIXED`.

--- a/scripts/ci/madaros_field_if_i64_gate.sh
+++ b/scripts/ci/madaros_field_if_i64_gate.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Madaros multimodule residual: i64 struct-field used in if/sub vs return/call-arg.
+#
+# Current expected Madaros behaviour (residual open):
+#   ret/add0 correct; gate_field/gate_let == 0; sub garbage; via_arg/via_ret == 1
+# When native field-if is fixed, the gate upgrades to require FIXED marker.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
+
+RAW_MADAROS="${MADAROS_RAW_BIN:-}"
+if [[ -z "$RAW_MADAROS" ]]; then
+  if [[ -x "$ROOT/artifacts/self-hosted/madaros" ]]; then
+    RAW_MADAROS="$ROOT/artifacts/self-hosted/madaros"
+  elif [[ -x "$ROOT/bin/madaros-linux-x86_64" ]]; then
+    RAW_MADAROS="$ROOT/bin/madaros-linux-x86_64"
+  else
+    echo "[madaros-field-if-i64] FAIL: set MADAROS_RAW_BIN" >&2
+    exit 1
+  fi
+fi
+
+stack_kb="${SOUNIO_MADAROS_FIELD_IF_STACK_KB:-524288}"
+stack_before="$(ulimit -S -s 2>/dev/null || echo unlimited)"
+if [[ "$stack_before" != "unlimited" ]] && [[ "$stack_before" =~ ^[0-9]+$ ]] && ((stack_before < stack_kb)); then
+  ulimit -S -s "$stack_kb" 2>/dev/null || true
+fi
+
+WORK=$(mktemp -d /tmp/sounio-madaros-field-if.XXXXXX)
+trap 'rm -rf "$WORK"' EXIT
+ELF="$WORK/field-if.elf"
+SRC="$ROOT/tests/multimodule/madaros_field_if_i64_main.sio"
+
+"$RAW_MADAROS" --native-compile "$SRC" -o "$ELF" >"$WORK/compile.log" 2>&1 || {
+  cat "$WORK/compile.log" >&2
+  echo "[madaros-field-if-i64] FAIL: compile" >&2
+  exit 1
+}
+chmod +x "$ELF"
+"$ELF" >"$WORK/run.log" 2>&1 || {
+  cat "$WORK/run.log" >&2
+  echo "[madaros-field-if-i64] FAIL: run" >&2
+  exit 1
+}
+
+if grep -q 'MADAROS_FIELD_IF_I64_FIXED' "$WORK/run.log"; then
+  echo "[madaros-field-if-i64] PASS: FIXED (native field-if closed)"
+  exit 0
+fi
+if grep -q 'MADAROS_FIELD_IF_I64_RESIDUAL' "$WORK/run.log"; then
+  # Residual is documented-open: gate still PASSes while workarounds hold.
+  # Fail hard only if via_arg baseline regresses.
+  grep -q 'via_arg=1' "$WORK/run.log" || {
+    cat "$WORK/run.log" >&2
+    echo "[madaros-field-if-i64] FAIL: via_arg baseline broken" >&2
+    exit 1
+  }
+  grep -q 'via_ret=1' "$WORK/run.log" || {
+    cat "$WORK/run.log" >&2
+    echo "[madaros-field-if-i64] FAIL: via_ret baseline broken" >&2
+    exit 1
+  }
+  echo "[madaros-field-if-i64] PASS: RESIDUAL documented (gate_field broken; via_arg holds)"
+  cat "$WORK/run.log"
+  exit 0
+fi
+
+cat "$WORK/run.log" >&2
+echo "[madaros-field-if-i64] FAIL: unexpected marker" >&2
+exit 1

--- a/tests/multimodule/madaros_field_if_i64_leaf.sio
+++ b/tests/multimodule/madaros_field_if_i64_leaf.sio
@@ -1,0 +1,47 @@
+struct MiniEp {
+    val: f64,
+    variance: f64,
+    confidence: i64,
+}
+
+pub fn mini_new(v: f64, var: f64, conf: i64) -> MiniEp {
+    MiniEp { val: v, variance: var, confidence: conf }
+}
+
+pub fn ret_conf(e: &MiniEp) -> i64 {
+    e.confidence
+}
+
+pub fn ret_conf_let(e: &MiniEp) -> i64 {
+    let c = e.confidence
+    c
+}
+
+pub fn add_conf_zero(e: &MiniEp) -> i64 {
+    e.confidence + 0
+}
+
+pub fn sub_conf(e: &MiniEp, m: i64) -> i64 {
+    e.confidence - m
+}
+
+pub fn gate_field(e: &MiniEp, m: i64) -> i64 {
+    if e.confidence >= m { 1 } else { 0 }
+}
+
+pub fn gate_let(e: &MiniEp, m: i64) -> i64 {
+    let c = e.confidence
+    if c >= m { 1 } else { 0 }
+}
+
+fn ge(a: i64, b: i64) -> i64 {
+    if a >= b { 1 } else { 0 }
+}
+
+pub fn via_arg(e: &MiniEp, m: i64) -> i64 {
+    ge(e.confidence, m)
+}
+
+pub fn via_ret(e: &MiniEp, m: i64) -> i64 {
+    ge(ret_conf(e), m)
+}

--- a/tests/multimodule/madaros_field_if_i64_main.sio
+++ b/tests/multimodule/madaros_field_if_i64_main.sio
@@ -1,0 +1,35 @@
+use madaros_field_if_i64_leaf::{
+    mini_new, ret_conf, ret_conf_let, add_conf_zero, sub_conf,
+    gate_field, gate_let, via_arg, via_ret,
+}
+
+fn main() with IO {
+    let e = mini_new(1.0, 0.01, 846)
+    print("ret=")
+    print_int(ret_conf(&e))
+    print(" ret_let=")
+    print_int(ret_conf_let(&e))
+    print(" add0=")
+    print_int(add_conf_zero(&e))
+    print(" sub=")
+    print_int(sub_conf(&e, 800))
+    print(" gate_field=")
+    print_int(gate_field(&e, 800))
+    print(" gate_let=")
+    print_int(gate_let(&e, 800))
+    print(" via_arg=")
+    print_int(via_arg(&e, 800))
+    print(" via_ret=")
+    print_int(via_ret(&e, 800))
+    println("")
+    // Closure criterion for true fix: gate_field == 1
+    if via_arg(&e, 800) == 1 && via_ret(&e, 800) == 1 && ret_conf(&e) == 846 {
+        if gate_field(&e, 800) == 1 && gate_let(&e, 800) == 1 && sub_conf(&e, 800) == 46 {
+            println("MADAROS_FIELD_IF_I64_FIXED")
+        } else {
+            println("MADAROS_FIELD_IF_I64_RESIDUAL")
+        }
+    } else {
+        println("MADAROS_FIELD_IF_I64_BROKEN_BASELINE")
+    }
+}


### PR DESCRIPTION
## Summary

Does **not** stop at “workarounds remain”. Ships a permanent residual ladder + forensic audit for the Madaros multimodule i64 field-if bug that broke `ep_gate` (mitigated #1478/#1492).

### Measured matrix (current-source Madaros)

| Pattern | Result |
|---|---|
| `return e.confidence` / `+ 0` | 846 OK |
| `e.confidence - m` | pointer-scale garbage |
| `if e.confidence >= m` | **0** wrong |
| `ge(e.confidence, m)` call-arg | **1** OK |

### Deliverables

- `tests/multimodule/madaros_field_if_i64_{leaf,main}.sio`
- `scripts/ci/madaros_field_if_i64_gate.sh` — green on **RESIDUAL** (via_arg holds); flips to **FIXED** when native closes `gate_field`/`sub`
- `docs/audit/MADAROS_FIELD_IF_I64_2026-07-26.md` + handoff for native owner

### Why no native patch in this PR

Active claims on `self-hosted/native/**` (claude co-own) and `self-hosted/ir/lower.sio` (FO lane). This PR is the acceptance witness + forensics so the native owner can close without rediscovering.

### Test plan

- [x] `MADAROS_RAW_BIN=... bash scripts/ci/madaros_field_if_i64_gate.sh` → `PASS: RESIDUAL documented`