### PR TITLE
fix(ir): Knowledge.confidence is i64 — stop float-polluting FieldGet

### DIFF
--- a/docs/audit/MADAROS_FIELD_IF_I64_2026-07-26.md
+++ b/docs/audit/MADAROS_FIELD_IF_I64_2026-07-26.md
@@ -10,7 +10,7 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-
 # Madaros multimodule: i64 field load OK on return, wrong on if/sub
 
 **Date:** 2026-07-26  
-**Status:** residual open (stdlib workarounds live). **Claude-1 / Claude-2: help package below.**  
+**Status:** **ROOT CAUSE FOUND + FIX IN FLIGHT** (2026-07-26 Grok)  
 **Witness:** `tests/multimodule/madaros_field_if_i64_{leaf,main}.sio`  
 **Gate:** `scripts/ci/madaros_field_if_i64_gate.sh`
 
@@ -40,7 +40,23 @@ re-materialises a clean i64.
 | `pb_is_credible` / `ck_is_credible` | same pattern (#1492) |
 | EXP123 confidence gates 111/113 | closed via ep_gate |
 
-## Smoking gun for Claude-1 / Claude-2
+## ROOT CAUSE (confirmed)
+
+`self-hosted/ir/lower.sio` — `ir_register_knowledge_layout`:
+
+```text
+fields[2] confidence  is_float: 1   // WRONG — confidence is i64
+// should be is_float: 3  (integer marker)
+```
+
+`field_is_float_by_name_simple("confidence")` walks **all** layouts and returns
+true if **any** field named confidence has `is_float==1`. So MiniEp.confidence
+and Epistemic.confidence FieldGets get `IR_FLOAT_REG_MARKER_FLAG` even when the
+real type is i64. Then `OpGe`/`OpSub` take the float path in codegen.
+
+**Fix:** `is_float: 3` for confidence (landed in this lane's lower.sio).
+
+## Smoking gun (evidence)
 
 Measured `sub_conf(&e, 800)` under Madaros:
 

--- a/docs/handoff/madaros_field_if_i64_2026-07-26.md
+++ b/docs/handoff/madaros_field_if_i64_2026-07-26.md
@@ -9,7 +9,8 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.madaro
 
 # Handoff — Madaros i64 field-if residual
 
-**For:** native/codegen owner  
+**Status:** FIXED in lower.sio (Knowledge.confidence is_float 1→3)
+**For:** native/codegen owner (was suspected; actual root was lower layout)  
 **Blocker class:** Madaros imported multimodule ABI / branch condition  
 **Evidence:** `docs/audit/MADAROS_FIELD_IF_I64_2026-07-26.md`  
 **Witness gate:** `scripts/ci/madaros_field_if_i64_gate.sh`  

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -414,10 +414,16 @@ fn lower_monolithic_public_probe_boundary(label: string) with IO {
     }
 }
 
-// Sprint 116: Register Knowledge<f64> struct layout (value, variance, confidence)
-// β-Madaros 2026-07-25: value/variance/confidence are f64 — is_float MUST be 1.
-// With is_float=0, FieldGet marks the register int and a.value * a.value uses
-// integer imul on IEEE bits (observed: aa=0, Var(4a²)=0 under default Madaros).
+// Sprint 116: Register Knowledge/Epistemic struct layout (value, variance, confidence)
+// β-Madaros 2026-07-25: value/variance are f64 — is_float MUST be 1 so FieldGet
+// marks float and a.value * a.value uses real f64 mul (with is_float=0, integer
+// imul on IEEE bits: aa=0, Var(4a²)=0 under default Madaros).
+//
+// confidence is i64 (is_float=3 integer marker). Was wrongly is_float=1 which
+// polluted field_is_float_by_name_simple("confidence") for EVERY struct field
+// named confidence (MiniEp, Epistemic, …). Result: OpGe/OpSub on confidence
+// took the float path → sub printed f64(-800.0) bits; if conf>=800 → 0.
+// See docs/audit/MADAROS_FIELD_IF_I64_2026-07-26.md / #1496.
 fn ir_register_knowledge_layout(table: StructLayoutTable) -> StructLayoutTable with Mut, Panic, Div {
     var t = table
     if t.count >= 256 {
@@ -427,7 +433,7 @@ fn ir_register_knowledge_layout(table: StructLayoutTable) -> StructLayoutTable w
     var fields: [StructFieldEntry; 64] = [empty_struct_field_entry(); 64]
     fields[0] = StructFieldEntry { name: make_name("value"), index: 0, is_float: 1, elem_type_name: ir_empty_name() }
     fields[1] = StructFieldEntry { name: make_name("variance"), index: 1, is_float: 1, elem_type_name: ir_empty_name() }
-    fields[2] = StructFieldEntry { name: make_name("confidence"), index: 2, is_float: 1, elem_type_name: ir_empty_name() }
+    fields[2] = StructFieldEntry { name: make_name("confidence"), index: 2, is_float: 3, elem_type_name: ir_empty_name() }
     t.entries[idx as usize] = StructLayoutEntry {
         type_name: make_name("Knowledge"),
         fields: fields,


### PR DESCRIPTION
## Root cause (closed)

`ir_register_knowledge_layout` marked **`confidence` as `is_float: 1` (f64)**. It is **i64**.

`field_is_float_by_name_simple("confidence")` walks **all** layouts — so any field named `confidence` (MiniEp, Epistemic, …) got `IR_FLOAT_REG_MARKER_FLAG`. Then `OpGe` / `OpSub` took the **float** path in native codegen.

### Smoking gun
```
sub_conf(846, 800) → bits 0xc089000000000000 = f64(-800.0)
```
i.e. float `0.0 - 800.0`, not int `846 - 800`.

### Fix
`is_float: 3` (integer marker) for confidence. `value`/`variance` stay `1`.

## Verified (current-source Madaros with this patch)
| Check | Result |
|---|---|
| `madaros_field_if_i64_gate` | **FIXED** |
| `ep_gate(846, 800)` | 1 |
| FO `a.value * a.value` | aa=16, var=16 |
| EXP123 Madaros full | 58/58 |

## Claude-1/2
No touch of `codegen_x86_linux.sio`. Coord handoff sent. Founder asked Grok to join you — this is the fix, not just the witness.

## Test plan
- [x] Rebuild Madaros via `build_modular_madaros.sh`
- [x] field-if gate → FIXED
- [x] FO value mul regression
- [x] EXP123 Madaros 58