### PR TITLE
fix(ir): run kernel bodies once per lane, not once at tid=0 (closes #1504)

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -408,6 +408,14 @@ var LOWER_MONOLITHIC_PUBLIC_PROBE_TRACE: bool = false
 // unwritten, i.e. reading 0). See lowerer_lower_fn_mut and the ExprCall lowering.
 var LOWER_KERNEL_TID_REG: i64 = 0 - 1
 
+// Label of the lane-increment block while a `kernel fn` body is lowered; -1
+// outside a kernel. `return` inside a kernel ends THAT LANE, not the launch —
+// CUDA semantics — so it lowers to a jump here instead of IrReturn, which would
+// abandon every remaining lane. lean_single gets this wrong in the same
+// direction (measured: a kernel returning at tid==2 of 8 runs 2 lanes under
+// lean_single); matching that bug was rejected in favour of matching CUDA.
+var LOWER_KERNEL_CONT_LABEL: i64 = 0 - 1
+
 pub fn lower_monolithic_public_probe_trace_set(enabled: bool) with Mut {
     LOWER_MONOLITHIC_PUBLIC_PROBE_TRACE = enabled
 }
@@ -3443,6 +3451,7 @@ fn lowerer_lower_fn_item_mut(
     var kernel_tid_reg: i64 = 0 - 1
     var kernel_top_label: i64 = 0 - 1
     var kernel_end_label: i64 = 0 - 1
+    var kernel_cont_label: i64 = 0 - 1
     if fd.is_kernel {
         let kernel_extent_idx = lower_kernel_extent_param_index(&fd.params)
         if kernel_extent_idx >= 0 {
@@ -3455,11 +3464,15 @@ fn lowerer_lower_fn_item_mut(
             let kend_pair = (*lo).fresh_label()
             (*lo) = kend_pair.0
             kernel_end_label = kend_pair.1
+            let kcont_pair = (*lo).fresh_label()
+            (*lo) = kcont_pair.0
+            kernel_cont_label = kcont_pair.1
             (*lo) = (*lo).emit(ir_label(kernel_top_label))
             let kcond_reg = lowerer_fresh_reg_mut(lo)
             (*lo) = (*lo).emit(ir_binop(kcond_reg, kernel_tid_reg, BinaryOp::OpLt, kernel_extent_reg))
             (*lo) = (*lo).emit(ir_branch_false(kcond_reg, kernel_end_label))
             LOWER_KERNEL_TID_REG = kernel_tid_reg
+            LOWER_KERNEL_CONT_LABEL = kernel_cont_label
         }
     }
 
@@ -3469,6 +3482,10 @@ fn lowerer_lower_fn_item_mut(
 
     if kernel_tid_reg >= 0 {
         LOWER_KERNEL_TID_REG = 0 - 1
+        LOWER_KERNEL_CONT_LABEL = 0 - 1
+        // Lane-continue target: `return` inside the body jumps here, so it ends
+        // the lane and the next one still runs.
+        (*lo) = (*lo).emit(ir_label(kernel_cont_label))
         let kone_pair = (*lo).emit_i64_const(1)
         (*lo) = kone_pair.0
         let kone_reg = kone_pair.1
@@ -12336,9 +12353,23 @@ impl Lowerer {
         // leaves `dst` unwritten — which reads as 0 and is why every lane looked
         // like lane 0. Outside a kernel LOWER_KERNEL_TID_REG is -1 and this is
         // skipped, preserving the previous behaviour for the other 11 intrinsics.
-        if LOWER_KERNEL_TID_REG >= 0 && name_eq(callee_name, make_name("gpu_thread_id_x")) {
-            let lo_tid = lo3.emit(ir_copy(dst, LOWER_KERNEL_TID_REG))
-            return (lo_tid, dst)
+        if name_eq(callee_name, make_name("gpu_thread_id_x")) {
+            if LOWER_KERNEL_TID_REG >= 0 {
+                let lo_tid = lo3.emit(ir_copy(dst, LOWER_KERNEL_TID_REG))
+                return (lo_tid, dst)
+            }
+            // Reached outside a kernel lane loop — typically a helper function
+            // that reads gpu_thread_id_x() and is called from a kernel. The lane
+            // counter is a vreg local to the kernel frame, so it cannot be seen
+            // from here and the read still degrades to 0.
+            //
+            // This is the residue of #1504 and it is announced rather than left
+            // silent: a wrong answer nobody is told about is the failure mode
+            // that let the original defect survive for weeks. lean_single does
+            // not get this right either — it skips the lane loop entirely for
+            // such a kernel (measured: 1 lane instead of 4).
+            print("warning: gpu_thread_id_x() outside a kernel lane loop reads 0")
+            print(" — inline it into the `kernel fn` body; a helper cannot see the lane counter (#1504)\n")
         }
         let callee_strat_ext: i64 = if fn_id >= 0 && fn_id < (*lo3.module).fn_count { (*lo3.module).functions[fn_id as usize].compile_strategy } else { 0 }
         if callee_strat_ext == 6 {
@@ -13257,6 +13288,14 @@ impl Lowerer {
         let pair = self.lower_opt_expr_ref(&e.left)
         let lo = pair.0
         let reg = pair.1
+        // Inside a kernel lane loop, `return` ends the lane, not the launch.
+        // Emitting IrReturn here would abandon every remaining lane — the shape
+        // `if (early_out) return` is common enough in kernels that getting this
+        // wrong reintroduces the same class of silent wrong answer #1504 is about.
+        if LOWER_KERNEL_CONT_LABEL >= 0 {
+            let lo_lane = lo.emit(ir_jump(LOWER_KERNEL_CONT_LABEL))
+            return (lo_lane, reg)
+        }
         let lo2 = lo.emit(ir_return(reg))
         (lo2, reg)
     }

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -402,6 +402,12 @@ pub struct IrLowerBoxResult {
 
 var LOWER_MONOLITHIC_PUBLIC_PROBE_TRACE: bool = false
 
+// vreg holding the live lane counter while a `kernel fn` body is lowered inside
+// the CPU lane loop; -1 outside a kernel. `gpu_thread_id_x()` lowers to a copy of
+// this instead of a call to a name that binds to nothing (which left its dst vreg
+// unwritten, i.e. reading 0). See lowerer_lower_fn_mut and the ExprCall lowering.
+var LOWER_KERNEL_TID_REG: i64 = 0 - 1
+
 pub fn lower_monolithic_public_probe_trace_set(enabled: bool) with Mut {
     LOWER_MONOLITHIC_PUBLIC_PROBE_TRACE = enabled
 }
@@ -3405,6 +3411,10 @@ fn lowerer_lower_fn_item_mut(
     }
 
     (*lo).scope_depth = (*lo).scope_depth + 1
+    // Parameters are assigned consecutive vregs by lowerer_lower_fn_params_mut,
+    // which calls lowerer_fresh_reg_mut once per parameter in declaration order.
+    // Capturing the counter here lets parameter i be addressed as base + i.
+    let kernel_param_reg_base = (*(*lo).current_func).reg_count
     if ir_param_list_count_ref(&fd.params) > 0 {
         lowerer_lower_fn_params_mut(lo, &fd.params)
     }
@@ -3416,9 +3426,59 @@ fn lowerer_lower_fn_item_mut(
         print("\n")
     }
 
+    // ---- kernel CPU lane loop (#1504) ----
+    // A `kernel fn` on a CPU host must run its body once per lane, not once with
+    // every GPU intrinsic reading 0 — the latter is a silent wrong answer, correct
+    // at index 0 and zero everywhere else. lean_single has emitted this fallback
+    // in x86 since lean_single.sio:29335; expressing it here in the IR gives the
+    // Madaros path the same semantics without touching a backend.
+    //
+    //   tid = 0
+    // top:
+    //   if !(tid < extent) goto end
+    //   <body>            // gpu_thread_id_x() lowers to a copy of tid
+    //   tid = tid + 1
+    //   goto top
+    // end:
+    var kernel_tid_reg: i64 = 0 - 1
+    var kernel_top_label: i64 = 0 - 1
+    var kernel_end_label: i64 = 0 - 1
+    if fd.is_kernel {
+        let kernel_extent_idx = lower_kernel_extent_param_index(&fd.params)
+        if kernel_extent_idx >= 0 {
+            let kernel_extent_reg = kernel_param_reg_base + kernel_extent_idx
+            kernel_tid_reg = lowerer_fresh_reg_mut(lo)
+            (*lo) = (*lo).emit(ir_load_imm(kernel_tid_reg, 0))
+            let ktop_pair = (*lo).fresh_label()
+            (*lo) = ktop_pair.0
+            kernel_top_label = ktop_pair.1
+            let kend_pair = (*lo).fresh_label()
+            (*lo) = kend_pair.0
+            kernel_end_label = kend_pair.1
+            (*lo) = (*lo).emit(ir_label(kernel_top_label))
+            let kcond_reg = lowerer_fresh_reg_mut(lo)
+            (*lo) = (*lo).emit(ir_binop(kcond_reg, kernel_tid_reg, BinaryOp::OpLt, kernel_extent_reg))
+            (*lo) = (*lo).emit(ir_branch_false(kcond_reg, kernel_end_label))
+            LOWER_KERNEL_TID_REG = kernel_tid_reg
+        }
+    }
+
     let bpair = (*lo).lower_block_ref(&fd.body)
     (*lo) = bpair.0
     let result_reg = bpair.1
+
+    if kernel_tid_reg >= 0 {
+        LOWER_KERNEL_TID_REG = 0 - 1
+        let kone_pair = (*lo).emit_i64_const(1)
+        (*lo) = kone_pair.0
+        let kone_reg = kone_pair.1
+        let knext_reg = lowerer_fresh_reg_mut(lo)
+        (*lo) = (*lo).emit(ir_binop(knext_reg, kernel_tid_reg, BinaryOp::OpAdd, kone_reg))
+        (*lo) = (*lo).emit(ir_copy(kernel_tid_reg, knext_reg))
+        (*lo) = (*lo).emit(ir_jump(kernel_top_label))
+        (*lo) = (*lo).emit(ir_label(kernel_end_label))
+    }
+    // ---- end kernel CPU lane loop ----
     if lower_live_diag_enabled() {
         print("lower_live: fn_after_block name=")
         print(str_from_bytes(name.buf, name.len))
@@ -3954,6 +4014,29 @@ fn lower_param_struct_type_name(ty: &TypeExpr) -> Name with Mut, Panic, Div {
         return lower_opt_type_named_name(&(*ty).inner)
     }
     ir_empty_name()
+}
+
+// Index of a kernel's launch-extent parameter: the first `i64` parameter.
+// Mirrors lean_single's kernel_extent_slot discovery (lean_single.sio:29210) so
+// both engines agree on which argument bounds the lane loop. -1 when the kernel
+// has no i64 parameter, in which case there is no extent and the body is lowered
+// unwrapped exactly as before.
+fn lower_kernel_extent_param_index(params: &Option<Box<ParamList>>) -> i64 with Mut, Panic, Div {
+    var current = params
+    var idx: i64 = 0
+    while true {
+        match *current {
+            Some(list) => {
+                if name_eq(lower_param_struct_type_name(&(*list).head.ty), make_name("i64")) {
+                    return idx
+                }
+                idx = idx + 1
+                current = &(*list).tail
+            }
+            _ => return 0 - 1,
+        }
+    }
+    0 - 1
 }
 
 fn lower_type_expr_is_ref_like(ty: &TypeExpr) -> bool {
@@ -12247,6 +12330,16 @@ impl Lowerer {
         let pair_d = lo2.fresh_reg()
         let lo3 = pair_d.0
         let dst = pair_d.1
+        // gpu_thread_id_x() inside a kernel lane loop is the loop counter, not a
+        // call. resolve.sio:1059 allowlists the 12 GPU intrinsics as implicit
+        // builtins that are never bound, so the emitted call names nothing and
+        // leaves `dst` unwritten — which reads as 0 and is why every lane looked
+        // like lane 0. Outside a kernel LOWER_KERNEL_TID_REG is -1 and this is
+        // skipped, preserving the previous behaviour for the other 11 intrinsics.
+        if LOWER_KERNEL_TID_REG >= 0 && name_eq(callee_name, make_name("gpu_thread_id_x")) {
+            let lo_tid = lo3.emit(ir_copy(dst, LOWER_KERNEL_TID_REG))
+            return (lo_tid, dst)
+        }
         let callee_strat_ext: i64 = if fn_id >= 0 && fn_id < (*lo3.module).fn_count { (*lo3.module).functions[fn_id as usize].compile_strategy } else { 0 }
         if callee_strat_ext == 6 {
             let lo_ext = lo3.emit(ir_call_extern(dst, callee_name, args, argc))

--- a/tests/run-pass/gpu_kernel_lane_loop.sio
+++ b/tests/run-pass/gpu_kernel_lane_loop.sio
@@ -1,0 +1,49 @@
+//@ run-pass
+//@ expect-stdout: PASS: kernel lane loop
+
+// Regression pin for #1504 — Madaros ran a `kernel fn` body exactly once with
+// every GPU intrinsic reading 0, which is a silent wrong answer rather than a
+// missing feature: results at index 0 were correct and everything else sat at
+// its zero-initialised value.
+//
+// This test asserts the two properties the defect violated, directly:
+//
+//   1. the body executes once per lane  (count, not a spot check at an index)
+//   2. gpu_thread_id_x() takes every value in 0..n  (sum, not just the last)
+//
+// The seven pre-existing gpu_vec_* / gpu_epistemic_* tests check sentinel
+// indices, which is why the defect read as "correct at 0, zero elsewhere" for
+// weeks rather than as a failure. Counting is what makes the one-iteration case
+// impossible to pass.
+//
+// Deliberately no `//@ requires: gpu`. There is no GPU on the CI host and none
+// is needed: the CPU lane loop is the point. lean_single has had this fallback
+// since lean_single.sio:29335; the Madaros path grew it in ir/lower.sio.
+
+kernel fn lane_probe(n: i64, acc: &![f64]) with GPU {
+    let tid = gpu_thread_id_x()
+    // acc[0] counts iterations; acc[1] accumulates the thread ids seen.
+    acc[0] = acc[0] + 1.0
+    acc[1] = acc[1] + (tid as f64)
+}
+
+fn main() -> i32 with IO, Mut, Panic, GPU {
+    var acc: [f64; 4] = [0.0; 4]
+
+    lane_probe(8, &!acc)
+
+    // 8 lanes, thread ids 0..7, so the ids sum to 8*7/2 = 28.
+    let ran_every_lane = acc[0] > 7.99 && acc[0] < 8.01
+    let saw_every_tid = acc[1] > 27.99 && acc[1] < 28.01
+
+    if ran_every_lane && saw_every_tid {
+        println("PASS: kernel lane loop")
+    } else {
+        print("FAIL: kernel lane loop executions=")
+        print_f64(acc[0])
+        print(" tid_sum=")
+        print_f64(acc[1])
+        println("")
+    }
+    0
+}

--- a/tests/run-pass/gpu_kernel_lane_loop.sio
+++ b/tests/run-pass/gpu_kernel_lane_loop.sio
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ requires: madaros
 //@ expect-stdout: PASS: kernel lane loop
 
 // Regression pin for #1504 — Madaros ran a `kernel fn` body exactly once with
@@ -27,23 +28,49 @@ kernel fn lane_probe(n: i64, acc: &![f64]) with GPU {
     acc[1] = acc[1] + (tid as f64)
 }
 
+// `return` inside a kernel ends THAT LANE, as it does in CUDA — it must not
+// abandon the rest of the launch. Pinned separately because both engines got
+// this wrong before: emitting a plain return here ran 2 lanes of 8, and
+// lean_single still does (measured 2026-07-26). The `if early_out { return }`
+// shape is common enough in kernels that this silently truncates real work.
+kernel fn lane_return(n: i64, acc: &![f64]) with GPU {
+    let tid = gpu_thread_id_x()
+    if tid == 2 { return }
+    acc[2] = acc[2] + 1.0
+}
+
 fn main() -> i32 with IO, Mut, Panic, GPU {
     var acc: [f64; 4] = [0.0; 4]
 
     lane_probe(8, &!acc)
+    lane_return(8, &!acc)
 
     // 8 lanes, thread ids 0..7, so the ids sum to 8*7/2 = 28.
     let ran_every_lane = acc[0] > 7.99 && acc[0] < 8.01
     let saw_every_tid = acc[1] > 27.99 && acc[1] < 28.01
+    // 8 lanes, one of which returns early: 7 increments.
+    let return_ends_lane_only = acc[2] > 6.99 && acc[2] < 7.01
 
-    if ran_every_lane && saw_every_tid {
+    if ran_every_lane && saw_every_tid && return_ends_lane_only {
         println("PASS: kernel lane loop")
-    } else {
-        print("FAIL: kernel lane loop executions=")
-        print_f64(acc[0])
-        print(" tid_sum=")
-        print_f64(acc[1])
-        println("")
+        return 0
     }
-    0
+
+    print("FAIL: kernel lane loop executions=")
+    print_f64(acc[0])
+    print(" tid_sum=")
+    print_f64(acc[1])
+    print(" after_return=")
+    print_f64(acc[2])
+    println("")
+    // Exit non-zero on failure, deliberately.
+    //
+    // The harness's `expect-stdout` extraction is quoted, so the capture group
+    // comes back empty and every expect-stdout assertion in the corpus matches
+    // vacuously — the suite source says so at scripts/dev/run_sio_test_suite.sh:306
+    // and estimates ~305 latent vacuous passes. A run-pass test that prints FAIL
+    // and returns 0 is therefore green everywhere, which is exactly how the seven
+    // gpu_* tests hid #1504 for weeks. Returning 1 makes this pin bite under the
+    // harness that actually exists rather than the one that is documented.
+    1
 }


### PR DESCRIPTION
Closes #1504.

A `kernel fn` compiled by Madaros ran its body **exactly once, with every GPU intrinsic reading 0**. That is a silent wrong answer, not a missing feature — index 0 came out correct and everything else sat at its zero-initialised value, which is why the seven affected tests read as "correct at 0, zero elsewhere" instead of as a failure.

Measured directly, on a kernel with launch extent 4:

| | executions | last tid |
|---|---:|---:|
| before | 1 | 0 |
| after | **4** | **3** |

## Two causes, both in `ir/lower.sio`

**No lane loop.** `kernel` is first-class the whole way down — `parser/items.sio:988` sets `FnDef.is_kernel` and `ir/lower.sio` carries it to `compile_strategy` — but the tag changed nothing about how the body was emitted for a CPU host. The body is now wrapped in `tid = 0; while tid < extent { … tid = tid + 1 }`, extent taken from the first `i64` parameter. That mirrors lean_single's `kernel_extent_slot` discovery (`lean_single.sio:29210`) so both engines agree on which argument bounds the loop; lean_single has emitted this x86 fallback since `:29335`.

**`gpu_thread_id_x()` bound to nothing.** `resolve.sio:1059` allowlists the twelve GPU intrinsics as implicit builtins that are never bound, so the emitted call named no function and left its destination vreg unwritten — which reads as 0. That is where the zero came from. Inside a kernel it now lowers to a copy of the lane counter; outside a kernel the interception is skipped, so the other eleven intrinsics keep exactly their previous values.

## Bounded on both sides, verified rather than assumed

| guard | result |
|---|---|
| non-kernel fn whose first param is `i64` | still 1 execution — no loop |
| `kernel fn` with no `i64` param | no extent, lowered unwrapped as before |

## The test pins the count, not an index

`tests/run-pass/gpu_kernel_lane_loop.sio` asserts the lane **count** and the **sum** of thread ids seen. The existing `gpu_vec_*` tests check sentinel indices, which is precisely why one iteration survived inspection for weeks. Counting makes that case impossible to pass — it fails on the pre-patch compiler with `executions=1.000000 tid_sum=0.000000`.

## Verification

- **7/7** affected tests match their declared `expect-stdout` markers (**0/7** before): `gpu_vec_add`, `gpu_vec_ops`, `gpu_vec_scalar_ops`, `gpu_vec_scale`, `gpu_vec_unary`, `gpu_epistemic_f64_ossm_parity`, `gpu_epistemic_f64_sedenion_parity`
- `scripts/ci/madaros_corpus_regression_gate.sh` — **PASS, 0 new failures** (305 known / 1688), run against a current-source build
- new regression test passes patched, fails pre-patch

## One thing reviewers should know

**The corpus gate cannot see this fix.** It checks only `timeout 30 "$elf"` exit status, and all seven of these programs exit 0 while printing `FAIL` — which is why none of them appears in `tests/madaros_corpus_baseline.txt` and why the gate reports "0 newly fixed". That is expected here, not evidence the change is inert. #1503 is what makes this class visible; it should land before this defect is used to measure anything.

## Scope note

`#1504` located the root cause in `self-hosted/compiler/native_compile_driver.sio`. That file is **not in `main.sio`'s module graph** and never reaches `bin/souc` — verified by planting an unconditional print and rebuilding (`strings artifacts/self-hosted/madaros | grep -c V2KDBG` → 0). The measurement and the naming collision behind it are recorded in the issue. The fix here is on the live path.

The other eleven GPU intrinsics still read 0 (lean_single gives `block_dim_x = 256`, `block_id_x = tid >> 8`). No current test constrains them, so that divergence is left open rather than guessed at — all seven affected tests use only `gpu_thread_id_x`.
