### PR TITLE
refactor(epistemic): drop ep_i64_ge workarounds after field-if root fix

### DIFF
--- a/docs/audit/MADAROS_FIELD_IF_I64_2026-07-26.md
+++ b/docs/audit/MADAROS_FIELD_IF_I64_2026-07-26.md
@@ -10,9 +10,9 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-
 # Madaros multimodule: i64 field load OK on return, wrong on if/sub
 
 **Date:** 2026-07-26  
-**Status:** **ROOT CAUSE FOUND + FIX IN FLIGHT** (2026-07-26 Grok)  
+**Status:** **CLOSED** (#1511 lower.sio + workaround drop)  
 **Witness:** `tests/multimodule/madaros_field_if_i64_{leaf,main}.sio`  
-**Gate:** `scripts/ci/madaros_field_if_i64_gate.sh`
+**Gate:** `scripts/ci/madaros_field_if_i64_gate.sh` → `MADAROS_FIELD_IF_I64_FIXED`
 
 ## Measured matrix (current-source Madaros, 2026-07-26)
 

--- a/docs/handoff/particle_madaros_exp_residuals_2026-07-26.md
+++ b/docs/handoff/particle_madaros_exp_residuals_2026-07-26.md
@@ -67,3 +67,7 @@ Madaros imported multimodule:
 
 Native fix blocked this session by active claims on `self-hosted/native/**` and
 `self-hosted/ir/lower.sio`. Stdlib workarounds remain until `MADAROS_FIELD_IF_I64_FIXED`.
+
+## Field-if closeout
+
+**CLOSED** #1511 + workaround drop (direct `e.confidence >= k` restored).

--- a/stdlib/epistemic/composed_effects.sio
+++ b/stdlib/epistemic/composed_effects.sio
@@ -147,13 +147,9 @@ pub fn ck_total_uncertainty(c: &ComposedKnowledge) -> f64 with Mut, Div, Panic {
 // PREDICATES (refinement-style)
 // ============================================================================
 
-// Madaros multimodule: direct field-if on i64 mis-branches; compare via call args.
-fn ck_i64_ge(a: i64, b: i64) -> i64 {
-    if a >= b { 1 } else { 0 }
-}
-
 pub fn ck_is_credible(c: &ComposedKnowledge, min_conf: i64) -> bool {
-    ck_i64_ge(c.confidence, min_conf) == 1
+    // Direct field compare restored after #1511 (confidence float-pollution fixed).
+    c.confidence >= min_conf
 }
 
 pub fn ck_is_causally_confirmed(c: &ComposedKnowledge, min_alpha_share: f64) -> bool with Div {

--- a/stdlib/epistemic/knightian.sio
+++ b/stdlib/epistemic/knightian.sio
@@ -355,13 +355,9 @@ pub fn pb_within(p: &PBox, lo: f64, hi: f64) -> bool {
     p.lo_mean >= lo && p.hi_mean <= hi
 }
 
-// Madaros multimodule: direct field-if on i64 mis-branches; compare via call args.
-fn pb_i64_ge(a: i64, b: i64) -> i64 {
-    if a >= b { 1 } else { 0 }
-}
-
 pub fn pb_is_credible(p: &PBox, min_conf: i64) -> bool {
-    pb_i64_ge(p.confidence, min_conf) == 1
+    // Direct field compare restored after #1511 (confidence float-pollution fixed).
+    p.confidence >= min_conf
 }
 
 // ============================================================================

--- a/stdlib/epistemic/knowledge.sio
+++ b/stdlib/epistemic/knowledge.sio
@@ -85,17 +85,9 @@ pub fn ep_std(e: &Epistemic) -> f64 with Mut, Div, Panic {
     ep_sqrt(e.variance)
 }
 
-// Madaros multimodule residual (2026-07-26): a direct `if field_i64 >= k`
-// inside an imported module can mis-branch even when returning the same field
-// as i64 is correct. Passing the loaded i64 through a call argument forces a
-// clean compare. See tests/multimodule/madaros_ep_gate_*.sio.
-fn ep_i64_ge(a: i64, b: i64) -> i64 {
-    if a >= b { 1 } else { 0 }
-}
-
 pub fn ep_is_credible(e: &Epistemic, min_conf: i64) -> bool {
-    // Same Madaros field-if residual as ep_gate — compare via call boundary.
-    ep_i64_ge(e.confidence, min_conf) == 1
+    // Direct field compare is correct after #1511 (Knowledge.confidence is_float=3).
+    e.confidence >= min_conf
 }
 
 // GUM: Var(X+Y) = Var(X) + Var(Y); conf = min scaled
@@ -188,12 +180,12 @@ pub fn ep_rel_uncertainty(a: &Epistemic) -> f64 with Mut, Div, Panic {
 
 /// Soft gate: returns 1 if confidence ≥ min_conf, 0 otherwise.
 pub fn ep_gate(e: &Epistemic, min_conf: i64) -> i64 {
-    ep_i64_ge(e.confidence, min_conf)
+    if e.confidence >= min_conf { 1 } else { 0 }
 }
 
 /// Hard gate: GATE_FAIL sentinel when below threshold (confidence=0).
 pub fn ep_require_conf(e: Epistemic, min_conf: i64) -> Epistemic {
-    if ep_i64_ge(e.confidence, min_conf) == 1 {
+    if e.confidence >= min_conf {
         e
     } else {
         Epistemic { val: e.val, variance: e.variance, confidence: 0 }


### PR DESCRIPTION
## Summary

After #1511 fixed the root cause (`Knowledge.confidence` `is_float` 1→3), the call-arg workarounds are no longer needed.

Restore direct field compares:
- `ep_gate` / `ep_require_conf` / `ep_is_credible`
- `pb_is_credible` / `ck_is_credible`

## Verified (Madaros with #1511 lower + this stdlib)
- `EP_GATE_DIRECT_OK` (direct `e.confidence >= k`)
- field-if gate **FIXED**
- EXP123 Madaros **58/58**
- EXP12 gate **OK**

## Test plan
- [x] local Madaros probes above
- [ ] CI