### PR TITLE
fix(compiler-help): imported (f64,f64) mul residual + amp tuple-avoid

### DIFF
--- a/docs/audit/MADAROS_IMPORTED_F64_MUL_2026-07-26.md
+++ b/docs/audit/MADAROS_IMPORTED_F64_MUL_2026-07-26.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-imported-f64-mul-2026-07-26
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-imported-f64-mul-2026-07-26
+-->
+
 # Madaros multimodule: imported f64 prints OK, raw f64*f64 wrong
 
 **Date:** 2026-07-26  

--- a/docs/audit/MADAROS_IMPORTED_F64_MUL_2026-07-26.md
+++ b/docs/audit/MADAROS_IMPORTED_F64_MUL_2026-07-26.md
@@ -1,0 +1,38 @@
+# Madaros multimodule: imported f64 prints OK, raw f64*f64 wrong
+
+**Date:** 2026-07-26  
+**Status:** residual open (stdlib workarounds in nonunitary_amp via ep_square)  
+**Witness:** `tests/multimodule/madaros_imported_f64_mul_{leaf,main}.sio`  
+**Gate:** `scripts/ci/madaros_imported_f64_mul_gate.sh`
+
+## Measured (refined)
+
+| Expression | lean | Madaros multimodule |
+|---|---|---|
+| Scalar import `ret_neg_half()` then `a*a` | 0.25 | **0.25 OK** |
+| Tuple import `let (gv, ga) = ret_pair()` then `ga*ga` | 0.25 | **0 WRONG** |
+| Tuple `gv*gv` | ~0.0014 | **~0.69 WRONG** |
+| `0.0 -` scalar import | 0.5 | 0.5 OK |
+
+So the residual is **not** every imported f64 — it is **tuple-unpack of `(f64, f64)`** from an imported callee. Vertex `nc_coupling_*` returns tuples → amplitude broke.
+
+## Likely fix surface (Claude-1 / native)
+
+Tuple / multi-value return from imported modules: each element used as f64 must be float-typed at the call site (destructure / field-of-tuple).
+
+Candidates:
+- `self-hosted/ir/lower.sio` — lower of `let (a,b) = f()` for f64 elements
+- `self-hosted/native/codegen_x86_linux.sio` — multi-return / pair ABI float marks
+- `module_frontend` finalize of imported multi-return calls
+
+## Product mitigation
+
+- #1514: first amp workaround via `ep_square`
+- Follow-up: `nonunitary_amp` avoids tuple couplings; uses `neutral_current_gv_ep` + exact `g_A²=0.25`
+
+## Acceptance
+
+```text
+MADAROS_IMPORTED_F64_MUL_FIXED
+# a*a=0.25, b*b=0.25, a*b=-0.25, ga*ga=0.25
+```

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1185
-- Repo-backed topics: 1035
+- Total governed topics: 1186
+- Repo-backed topics: 1036
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 308
-- Authority count `repo_only`: 689
+- Authority count `repo_only`: 690
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 707 topics
+- A2: 708 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -161,6 +161,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-impl-methods-three-layer-fix-2026-06-23 | repo_only | docs/audit/MADAROS_IMPL_METHODS_THREE_LAYER_FIX_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-imported-array-byvalue-913-2026-07-21 | repo_only | docs/audit/MADAROS_IMPORTED_ARRAY_BYVALUE_913_2026-07-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-imported-f64-bss-arith-2026-07-22 | repo_only | docs/audit/MADAROS_IMPORTED_F64_BSS_ARITH_2026-07-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-imported-f64-mul-2026-07-26 | repo_only | docs/audit/MADAROS_IMPORTED_F64_MUL_2026-07-26.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-imported-module-f64-cast-bitcast-2026-07-14 | repo_only | docs/audit/MADAROS_IMPORTED_MODULE_F64_CAST_BITCAST_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-imported-module-native-path-escalation-2026-07-14 | repo_only | docs/audit/MADAROS_IMPORTED_MODULE_NATIVE_PATH_ESCALATION_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-match-guards-2026-06-24 | repo_only | docs/audit/MADAROS_MATCH_GUARDS_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -3167,6 +3167,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-imported-f64-mul-2026-07-26",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_IMPORTED_F64_MUL_2026-07-26.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-imported-module-f64-cast-bitcast-2026-07-14",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_IMPORTED_MODULE_F64_CAST_BITCAST_2026-07-14.md",

--- a/scripts/ci/madaros_imported_f64_mul_gate.sh
+++ b/scripts/ci/madaros_imported_f64_mul_gate.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Madaros multimodule: imported f64 return * f64 residual.
+#
+# RESIDUAL: prints correct f64, raw mul wrong (e.g. (-0.5)*(-0.5)→0).
+# FIXED: mul matches 0.25.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
+
+RAW_MADAROS="${MADAROS_RAW_BIN:-}"
+if [[ -z "$RAW_MADAROS" ]]; then
+  if [[ -x "$ROOT/artifacts/self-hosted/madaros" ]]; then
+    RAW_MADAROS="$ROOT/artifacts/self-hosted/madaros"
+  elif [[ -x "$ROOT/bin/madaros-linux-x86_64" ]]; then
+    RAW_MADAROS="$ROOT/bin/madaros-linux-x86_64"
+  else
+    echo "[madaros-imported-f64-mul] FAIL: set MADAROS_RAW_BIN" >&2
+    exit 1
+  fi
+fi
+
+stack_kb="${SOUNIO_MADAROS_F64_MUL_STACK_KB:-524288}"
+stack_before="$(ulimit -S -s 2>/dev/null || echo unlimited)"
+if [[ "$stack_before" != "unlimited" ]] && [[ "$stack_before" =~ ^[0-9]+$ ]] && ((stack_before < stack_kb)); then
+  ulimit -S -s "$stack_kb" 2>/dev/null || true
+fi
+
+WORK=$(mktemp -d /tmp/sounio-madaros-f64-mul.XXXXXX)
+trap 'rm -rf "$WORK"' EXIT
+ELF="$WORK/f64-mul.elf"
+SRC="$ROOT/tests/multimodule/madaros_imported_f64_mul_main.sio"
+
+"$RAW_MADAROS" --native-compile "$SRC" -o "$ELF" >"$WORK/compile.log" 2>&1 || {
+  cat "$WORK/compile.log" >&2
+  echo "[madaros-imported-f64-mul] FAIL: compile" >&2
+  exit 1
+}
+chmod +x "$ELF"
+"$ELF" >"$WORK/run.log" 2>&1 || {
+  cat "$WORK/run.log" >&2
+  echo "[madaros-imported-f64-mul] FAIL: run" >&2
+  exit 1
+}
+
+if grep -q 'MADAROS_IMPORTED_F64_MUL_FIXED' "$WORK/run.log"; then
+  echo "[madaros-imported-f64-mul] PASS: FIXED"
+  cat "$WORK/run.log"
+  exit 0
+fi
+if grep -q 'MADAROS_IMPORTED_F64_MUL_RESIDUAL' "$WORK/run.log"; then
+  # Documented open residual — gate green while baseline print works.
+  grep -q 'a=-0.500000' "$WORK/run.log" || grep -q 'a=-0.5' "$WORK/run.log" || true
+  echo "[madaros-imported-f64-mul] PASS: RESIDUAL documented (imported f64*f64 wrong)"
+  cat "$WORK/run.log"
+  exit 0
+fi
+
+cat "$WORK/run.log" >&2
+echo "[madaros-imported-f64-mul] FAIL: unexpected marker" >&2
+exit 1

--- a/stdlib/particle_physics/nonunitary_amp.sio
+++ b/stdlib/particle_physics/nonunitary_amp.sio
@@ -12,24 +12,19 @@
 module particle_physics::nonunitary_amp
 
 use epistemic::knowledge::{
-    Epistemic, ep_scale, ep_mul, ep_square, ep_val, ep_certain,
+    Epistemic, ep_scale, ep_mul, ep_square, ep_val,
 }
 use particle_physics::sm_params::{coupling_g, sin2_theta_w}
-use particle_physics::vertex::{nc_coupling_electron, nc_coupling_muon}
+use particle_physics::vertex::{neutral_current_gv_ep}
 use particle_physics::nonunitary::{
     NonUnitary, NU_Z, nu_z_propagator,
 }
 
-// Madaros multimodule: raw f64 returns from vertex (and f64*f64 of those values)
-// are not float-typed in native codegen — ga_e*ga_e → 0, 0.0-ga_e → garbage.
-// Route squares through Epistemic ep_square so the float path is forced.
-fn coupling_sq_sum(gv: f64, ga: f64) -> f64 with Mut, Div, Panic {
-    let gv_ep = ep_certain(gv)
-    let ga_ep = ep_certain(ga)
-    let gv2 = ep_square(&gv_ep)
-    let ga2 = ep_square(&ga_ep)
-    ep_val(&gv2) + ep_val(&ga2)
-}
+// Madaros multimodule residual (2026-07-26): unpacking (f64, f64) from an
+// imported call leaves the elements not float-typed — ga*ga → 0 while a scalar
+// imported f64 return multiplies correctly. Avoid nc_coupling_* tuples; use
+// Epistemic g_V and exact g_A = T3 (local constant squares are fine).
+// Witness: tests/multimodule/madaros_imported_f64_mul_*.sio
 
 /// e⁺e⁻ → Z → μ⁺μ⁻ amplitude squared, wrapped in NonUnitary.
 ///
@@ -40,15 +35,18 @@ pub fn eemm_z_amplitude_nu(s: f64, gamma_z: f64) -> NonUnitary with Mut, Div, Pa
     let s2w = sin2_theta_w()
     let cw_sq = 1.0 - ep_val(&s2w)
     let cw4 = cw_sq * cw_sq
-    let (gv_e, ga_e) = nc_coupling_electron()
-    let (gv_m, ga_m) = nc_coupling_muon()
-    let c_e = coupling_sq_sum(gv_e, ga_e)
-    let c_m = coupling_sq_sum(gv_m, ga_m)
+    // Electron / muon: T3 = −1/2, Q = −1 → g_A = −1/2 exact, g_A² = 1/4.
+    let gv_e = neutral_current_gv_ep(0.0 - 0.5, 0.0 - 1.0)
+    let gv_m = neutral_current_gv_ep(0.0 - 0.5, 0.0 - 1.0)
+    let ga2 = 0.25
+    let gve2 = ep_square(&gv_e)
+    let gvm2 = ep_square(&gv_m)
+    let c_e = ep_val(&gve2) + ga2
+    let c_m = ep_val(&gvm2) + ga2
     let g2 = ep_square(&g)
     let g4 = ep_square(&g2)
     let num = ep_scale(&g4, c_e * c_m / cw4)
     let prop = nu_z_propagator(s, gamma_z)
-    // Local bind of prop fields — avoid nested &prop.amp_sq into ep_mul.
     let amp_sq = prop.amp_sq
     let denom_re = prop.denom_re
     let denom_im = prop.denom_im

--- a/tests/multimodule/madaros_imported_f64_mul_leaf.sio
+++ b/tests/multimodule/madaros_imported_f64_mul_leaf.sio
@@ -1,0 +1,15 @@
+pub fn ret_neg_half() -> f64 {
+    0.0 - 0.5
+}
+
+pub fn ret_half() -> f64 {
+    0.5
+}
+
+pub fn ret_pair() -> (f64, f64) {
+    (0.0 - 0.037579, 0.0 - 0.5)
+}
+
+pub fn ret_ga_only() -> f64 {
+    0.0 - 0.5
+}

--- a/tests/multimodule/madaros_imported_f64_mul_main.sio
+++ b/tests/multimodule/madaros_imported_f64_mul_main.sio
@@ -1,0 +1,57 @@
+use madaros_imported_f64_mul_leaf::{ret_neg_half, ret_half, ret_pair, ret_ga_only}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() with IO {
+    let a = ret_neg_half()
+    let b = ret_half()
+    let aa = a * a
+    let bb = b * b
+    let ab = a * b
+    print("scalar a*a=")
+    print_f64(aa)
+    print(" b*b=")
+    print_f64(bb)
+    print(" a*b=")
+    print_f64(ab)
+    println("")
+
+    let ga1 = ret_ga_only()
+    print("ga_only*ga_only=")
+    print_f64(ga1 * ga1)
+    println("")
+
+    let (gv, ga) = ret_pair()
+    print("tuple ga=")
+    print_f64(ga)
+    print(" tuple ga*ga=")
+    print_f64(ga * ga)
+    print(" tuple gv*gv=")
+    print_f64(gv * gv)
+    println("")
+
+    // Also: 0.0 - imported f64
+    print("0-a=")
+    print_f64(0.0 - a)
+    println("")
+
+    let ok_scalar = abs_f(aa - 0.25) < 1.0e-9 && abs_f(bb - 0.25) < 1.0e-9 && abs_f(ab + 0.25) < 1.0e-9
+    let ok_ga_only = abs_f(ga1 * ga1 - 0.25) < 1.0e-9
+    let ok_tuple = abs_f(ga * ga - 0.25) < 1.0e-9 && abs_f(gv * gv - 0.001412) < 1.0e-6
+    let ok_neg = abs_f((0.0 - a) - 0.5) < 1.0e-9
+
+    if ok_scalar && ok_ga_only && ok_tuple && ok_neg {
+        println("MADAROS_IMPORTED_F64_MUL_FIXED")
+    } else {
+        if ok_scalar {
+            println("MADAROS_IMPORTED_F64_MUL_RESIDUAL")
+            if !ok_tuple { println("  residual: tuple unpack f64*f64") }
+            if !ok_ga_only { println("  residual: scalar return f64*f64") }
+            if !ok_neg { println("  residual: 0.0 - imported_f64") }
+        } else {
+            println("MADAROS_IMPORTED_F64_MUL_BROKEN_BASELINE")
+        }
+    }
+}


### PR DESCRIPTION
## Still helping the compiler

Yes. After field-if (#1511/#1513) and EXP13 (#1514), the next Madaros residual is sharper:

### Residual (for Claude-1/2 native)
| Pattern | Madaros |
|---|---|
| Scalar import `f64` then `x*x` | OK |
| `let (a,b) = imported_pair()` then `b*b` | **WRONG** (0 / garbage) |

Witness: `tests/multimodule/madaros_imported_f64_mul_*.sio`  
Gate: `scripts/ci/madaros_imported_f64_mul_gate.sh` → RESIDUAL until FIXED  
Audit: `docs/audit/MADAROS_IMPORTED_F64_MUL_2026-07-26.md`

### Product mitigation (this PR)
`eemm_z_amplitude_nu` no longer unpacks `nc_coupling_*` tuples; uses `neutral_current_gv_ep` + exact `g_A²=0.25`.

## Test plan
- [x] f64 mul gate RESIDUAL documented
- [x] EXP13 gate still OK
- [ ] CI