### PR TITLE
fix(particle): scalar NC couplings + tuple-f64 lower recipe

### DIFF
--- a/docs/audit/MADAROS_IMPORTED_F64_MUL_2026-07-26.md
+++ b/docs/audit/MADAROS_IMPORTED_F64_MUL_2026-07-26.md
@@ -37,7 +37,14 @@ Candidates:
 ## Product mitigation
 
 - #1514: first amp workaround via `ep_square`
-- Follow-up: `nonunitary_amp` avoids tuple couplings; uses `neutral_current_gv_ep` + exact `g_A²=0.25`
+- #1516: `nonunitary_amp` avoids tuple couplings; uses `neutral_current_gv_ep` + exact `g_A²=0.25`
+- Follow-up: `vertex` exports scalar `neutral_current_gv` / `neutral_current_ga` and
+  `nc_gv_*` / `nc_ga_*`; `amplitude` uses them (no imported tuple unpack)
+
+## True lower fix (Claude)
+
+Recipe: `docs/audit/MADAROS_TUPLE_F64_FLOAT_FIX_RECIPE_2026-07-26.md`  
+3-site patch in `self-hosted/ir/lower.sio` (returns_float=2 for all-f64 tuples + FieldGet float mark).
 
 ## Acceptance
 

--- a/docs/audit/MADAROS_TUPLE_F64_FLOAT_FIX_RECIPE_2026-07-26.md
+++ b/docs/audit/MADAROS_TUPLE_F64_FLOAT_FIX_RECIPE_2026-07-26.md
@@ -1,0 +1,88 @@
+# Recipe: float-type `(f64, f64)` import unpack (for Claude native/lower)
+
+**Status:** residual open — product mitigates; this is the true lower fix  
+**Witness gate:** `scripts/ci/madaros_imported_f64_mul_gate.sh` → want `MADAROS_IMPORTED_F64_MUL_FIXED`  
+**Owner:** Claude-1 (`lower.sio` claim) — Grok cannot write that file while claimed
+
+## Mechanism
+
+Parser desugars:
+
+```sounio
+let (a, b) = f()
+```
+
+to:
+
+```sounio
+let __tupN = f()
+let a = __tupN.0
+let b = __tupN.1
+```
+
+(`self-hosted/parser/stmts.sio` tplet_*).
+
+Tuples lower as **array-like alloc** (`lower_tuple_literal_expr_ref`).  
+`.0` / `.1` are **field gets** by numeric name.
+
+If `__tupN` is not marked **float-element local**, FieldGet of `.0`/`.1` omits
+`IR_FLOAT_REG_MARKER_FLAG` → integer mul path → `ga*ga` → 0.
+
+Scalar imported `f64` already works (`returns_float == 1` on call sites).
+
+## Surgical fix (3 sites in `self-hosted/ir/lower.sio`)
+
+### 1) Classify `(f64, f64)` return as float-element aggregate (`returns_float = 2`)
+
+Near `lower_opt_return_float_code` (~3915):
+
+```sounio
+// After array-of-f64 check, add:
+// if return type is TypeTuple and every element is f64 → return 2
+```
+
+Need a helper `lower_opt_type_is_tuple_of_all_f64(opt) -> bool` walking TypeTuple.
+
+### 2) Already present: `let r = mk()` binds float-element local when returns_float==2
+
+`expr_result_is_f64_array_ref` (~10050) + bind at ~10240 already do this for
+returns_float==2. Once (1) returns 2 for f64 tuples, `let __tup = ret_pair()`
+marks `__tup` as float-element.
+
+### 3) Field access: float-element base ⇒ FieldGet is float
+
+In `lower_field_access_expr_ref` (~12376), extend:
+
+```sounio
+var field_is_float = lo1.field_is_float_for_base_ref(...) || lo1.field_is_float_by_name_simple(...)
+// ADD:
+match e.left {
+  Some(be) => {
+    if (*be).kind == ExprKind::ExprIdent {
+      if lo1.lookup_local_array_elem_float((*be).name) {
+        field_is_float = true
+      }
+    }
+  }
+  _ => {}
+}
+```
+
+## Acceptance
+
+```bash
+export MADAROS_RAW_BIN=... # current-source Madaros with the patch
+bash scripts/ci/madaros_imported_f64_mul_gate.sh
+# expect: MADAROS_IMPORTED_F64_MUL_FIXED
+# (scalar a*a and tuple ga*ga both 0.25)
+```
+
+## Product mitigations already on main
+
+- #1516: avoid vertex tuple unpack in `nonunitary_amp`  
+- Witness residual marker documents open compiler fix
+
+## Coordination
+
+Grok claims only free files (module_frontend/vertex/amplitude).  
+When you free `lower.sio` for 30 min, apply (1)+(3) above; (2) is already wired.

--- a/examples/particle_physics/exp13_amplitude_honesty.sio
+++ b/examples/particle_physics/exp13_amplitude_honesty.sio
@@ -14,7 +14,8 @@
 // Gate: scripts/ci/particle_exp13_amplitude_honesty_gate.sh
 
 use particle_physics::sm_params::{mass_z}
-use particle_physics::vertex::{nc_coupling_electron, nc_coupling_muon}
+// Scalar NC helpers: imported (f64,f64) unpack not float-typed under Madaros.
+use particle_physics::vertex::{nc_gv_electron, nc_ga_electron, nc_gv_muon, nc_ga_muon}
 use particle_physics::nonunitary::{nu_z_propagator}
 use particle_physics::nonunitary_amp::{eemm_z_amplitude_nu}
 use epistemic::knowledge::{ep_val}
@@ -42,8 +43,10 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     print("EXP13_CLAIM amplitude_honesty_vertex_path_madaros_safe\n")
     var n: i64 = 0
 
-    let (gv_e, ga_e) = nc_coupling_electron()
-    let (gv_m, ga_m) = nc_coupling_muon()
+    let gv_e = nc_gv_electron()
+    let ga_e = nc_ga_electron()
+    let gv_m = nc_gv_muon()
+    let ga_m = nc_ga_muon()
     print("EXP13_GV_E ")
     print_f64(gv_e)
     print("\n")

--- a/stdlib/particle_physics/amplitude.sio
+++ b/stdlib/particle_physics/amplitude.sio
@@ -29,8 +29,13 @@ use particle_physics::sm_params::{alpha_em, mass_z, mass_w, mass_h,
                                    mass_charm, mass_strange, mass_tau,
                                    coupling_e, coupling_g, sin2_theta_w}
 use particle_physics::propagator::{scalar_propagator_sq, vector_propagator_sq}
-use particle_physics::vertex::{neutral_current_couplings, nc_coupling_electron,
-                                nc_coupling_muon, nc_coupling_up, nc_coupling_down}
+// Madaros multimodule: avoid imported (f64,f64) unpack — use scalar nc_gv_*/nc_ga_*.
+// Residual: docs/audit/MADAROS_IMPORTED_F64_MUL_2026-07-26.md
+use particle_physics::vertex::{
+    nc_gv_electron, nc_ga_electron, nc_gv_muon, nc_ga_muon,
+    nc_gv_up, nc_ga_up, nc_gv_down, nc_ga_down,
+    nc_gv_neutrino, nc_ga_neutrino,
+}
 use particle_physics::kinematics::{cm_energy_sq, cm_momentum_final,
                                     diff_cross_section, total_cross_section_isotropic,
                                     decay_width_2_body, cross_section_pb, kallen_lambda}
@@ -120,8 +125,10 @@ pub fn eemm_z_amplitude_sq(s: f64, gamma_z: f64) -> Epistemic with Mut, Div, Pan
     let cw_sq = 1.0 - s2w.val()
     let cw4 = cw_sq * cw_sq
 
-    let (gv_e, ga_e) = nc_coupling_electron()
-    let (gv_m, ga_m) = nc_coupling_muon()
+    let gv_e = nc_gv_electron()
+    let ga_e = nc_ga_electron()
+    let gv_m = nc_gv_muon()
+    let ga_m = nc_ga_muon()
 
     let c_e = gv_e * gv_e + ga_e * ga_e
     let c_m = gv_m * gv_m + ga_m * ga_m
@@ -152,8 +159,10 @@ pub fn eemm_z_total_cross_section(s: f64, gamma_z: f64) -> f64 with Mut, Div, Pa
     let cw = sqrt(1.0 - s2w)
     let cw2 = cw * cw
 
-    let (gv_e, ga_e) = nc_coupling_electron()
-    let (gv_m, ga_m) = nc_coupling_muon()
+    let gv_e = nc_gv_electron()
+    let ga_e = nc_ga_electron()
+    let gv_m = nc_gv_muon()
+    let ga_m = nc_ga_muon()
 
     let c_e = gv_e * gv_e + ga_e * ga_e
     let c_m = gv_m * gv_m + ga_m * ga_m
@@ -298,7 +307,8 @@ pub fn z_decay_width(m_z: f64, m_f: f64, g_v: f64, g_a: f64, n_c: f64) -> f64 wi
 pub fn z_decay_width_ee() -> f64 with Mut, Div, Panic {
     let mz = mass_z().val()
     let me = mass_electron().val()
-    let (gv, ga) = nc_coupling_electron()
+    let gv = nc_gv_electron()
+    let ga = nc_ga_electron()
     z_decay_width(mz, me, gv, ga, 1.0)
 }
 
@@ -306,7 +316,8 @@ pub fn z_decay_width_ee() -> f64 with Mut, Div, Panic {
 pub fn z_decay_width_mumu() -> f64 with Mut, Div, Panic {
     let mz = mass_z().val()
     let mm = mass_muon().val()
-    let (gv, ga) = nc_coupling_muon()
+    let gv = nc_gv_muon()
+    let ga = nc_ga_muon()
     z_decay_width(mz, mm, gv, ga, 1.0)
 }
 
@@ -315,12 +326,14 @@ pub fn z_decay_width_hadrons() -> f64 with Mut, Div, Panic {
     let mz = mass_z().val()
     var sum: f64 = 0.0
     // d, s, b
-    let (gv_d, ga_d) = nc_coupling_down()
+    let gv_d = nc_gv_down()
+    let ga_d = nc_ga_down()
     sum = sum + z_decay_width(mz, mass_down().val(), gv_d, ga_d, 3.0)
     sum = sum + z_decay_width(mz, mass_strange().val(), gv_d, ga_d, 3.0)
     sum = sum + z_decay_width(mz, mass_bottom().val(), gv_d, ga_d, 3.0)
     // u, c
-    let (gv_u, ga_u) = nc_coupling_up()
+    let gv_u = nc_gv_up()
+    let ga_u = nc_ga_up()
     sum = sum + z_decay_width(mz, mass_up().val(), gv_u, ga_u, 3.0)
     sum = sum + z_decay_width(mz, mass_charm().val(), gv_u, ga_u, 3.0)
     sum
@@ -332,10 +345,13 @@ pub fn z_total_width() -> f64 with Mut, Div, Panic {
     var total = z_decay_width_ee() + z_decay_width_mumu()
     let mz = mass_z().val()
     let mt = mass_tau().val()
-    let (gv_t, ga_t) = nc_coupling_muon()  // same couplings for tau
+    // Tau: same couplings as muon (scalar imports — Madaros-safe).
+    let gv_t = nc_gv_muon()
+    let ga_t = nc_ga_muon()
     total = total + z_decay_width(mz, mt, gv_t, ga_t, 1.0)
     // Neutrinos (invisible)
-    let (gv_nu, ga_nu) = nc_coupling_neutrino()
+    let gv_nu = nc_gv_neutrino()
+    let ga_nu = nc_ga_neutrino()
     total = total + 3.0 * z_decay_width(mz, 0.0, gv_nu, ga_nu, 1.0)
     // Hadrons
     total = total + z_decay_width_hadrons()

--- a/stdlib/particle_physics/mod.sio
+++ b/stdlib/particle_physics/mod.sio
@@ -66,8 +66,10 @@ pub use particle_physics::vertex::{
     qed_vertex, qed_vertex_factor_sq,
     qcd_quark_gluon_vertex, qcd_vertex_factor_sq, qcd_triple_gluon_factor,
     weak_charged_current_vertex, weak_neutral_current_vertex,
-    neutral_current_couplings,
+    neutral_current_couplings, neutral_current_gv, neutral_current_ga,
     nc_coupling_electron, nc_coupling_muon, nc_coupling_up, nc_coupling_down, nc_coupling_neutrino,
+    nc_gv_electron, nc_ga_electron, nc_gv_muon, nc_ga_muon,
+    nc_gv_up, nc_ga_up, nc_gv_down, nc_ga_down, nc_gv_neutrino, nc_ga_neutrino,
     yukawa_vertex, higgs_vev,
 }
 

--- a/stdlib/particle_physics/vertex.sio
+++ b/stdlib/particle_physics/vertex.sio
@@ -201,11 +201,24 @@ pub fn weak_neutral_current_vertex(mu: i64, g_v: f64, g_a: f64) -> DiracMatrix w
 ///
 /// # Returns
 /// (g_V, g_A) as a tuple — returned as two separate values.
+///
+/// Prefer `neutral_current_gv` + `neutral_current_ga` under Madaros multimodule:
+/// imported `(f64, f64)` unpack leaves elements not float-typed (ga*ga → 0).
+/// Scalar imported f64 multiplies correctly. See
+/// `docs/audit/MADAROS_IMPORTED_F64_MUL_2026-07-26.md`.
 pub fn neutral_current_couplings(t3: f64, charge: f64) -> (f64, f64) with Mut, Div, Panic {
+    (neutral_current_gv(t3, charge), neutral_current_ga(t3))
+}
+
+/// Scalar g_V = t3 − 2Q sin²θ_W (Madaros-safe: single f64 return).
+pub fn neutral_current_gv(t3: f64, charge: f64) -> f64 with Mut, Div, Panic {
     let s2w = sin2_theta_w().val()
-    let gv = t3 - 2.0 * charge * s2w
-    let ga = t3
-    (gv, ga)
+    t3 - 2.0 * charge * s2w
+}
+
+/// Scalar g_A = t3 (exact integer quantum number; Madaros-safe).
+pub fn neutral_current_ga(t3: f64) -> f64 with Mut, Div, Panic {
+    t3
 }
 
 /// GUM-exact neutral-current vector coupling g_V with sin²θ_W uncertainty.
@@ -224,15 +237,16 @@ pub fn neutral_current_couplings_ep(t3: f64, charge: f64) -> (Epistemic, f64) wi
 }
 
 // Pre-computed neutral current couplings for common fermions
+// Tuple forms kept for API compatibility; prefer scalar gv/ga under Madaros.
 
 /// Electron neutral current couplings: T_3 = −1/2, Q = −1.
 pub fn nc_coupling_electron() -> (f64, f64) with Mut, Div, Panic {
-    neutral_current_couplings(-0.5, -1.0)
+    neutral_current_couplings(0.0 - 0.5, 0.0 - 1.0)
 }
 
 /// Muon neutral current couplings: same as electron.
 pub fn nc_coupling_muon() -> (f64, f64) with Mut, Div, Panic {
-    neutral_current_couplings(-0.5, -1.0)
+    neutral_current_couplings(0.0 - 0.5, 0.0 - 1.0)
 }
 
 /// Up-quark neutral current couplings: T_3 = +1/2, Q = +2/3.
@@ -242,12 +256,62 @@ pub fn nc_coupling_up() -> (f64, f64) with Mut, Div, Panic {
 
 /// Down-quark neutral current couplings: T_3 = −1/2, Q = −1/3.
 pub fn nc_coupling_down() -> (f64, f64) with Mut, Div, Panic {
-    neutral_current_couplings(-0.5, -0.3333333333333333)
+    neutral_current_couplings(0.0 - 0.5, 0.0 - 0.3333333333333333)
 }
 
 /// Neutrino neutral current couplings: T_3 = +1/2, Q = 0.
 pub fn nc_coupling_neutrino() -> (f64, f64) with Mut, Div, Panic {
     neutral_current_couplings(0.5, 0.0)
+}
+
+/// Electron g_V (scalar import; Madaros-safe mul).
+pub fn nc_gv_electron() -> f64 with Mut, Div, Panic {
+    neutral_current_gv(0.0 - 0.5, 0.0 - 1.0)
+}
+
+/// Electron g_A = −1/2 (scalar).
+pub fn nc_ga_electron() -> f64 with Mut, Div, Panic {
+    neutral_current_ga(0.0 - 0.5)
+}
+
+/// Muon g_V (same as electron).
+pub fn nc_gv_muon() -> f64 with Mut, Div, Panic {
+    neutral_current_gv(0.0 - 0.5, 0.0 - 1.0)
+}
+
+/// Muon g_A = −1/2.
+pub fn nc_ga_muon() -> f64 with Mut, Div, Panic {
+    neutral_current_ga(0.0 - 0.5)
+}
+
+/// Up-quark g_V.
+pub fn nc_gv_up() -> f64 with Mut, Div, Panic {
+    neutral_current_gv(0.5, 0.6666666666666666)
+}
+
+/// Up-quark g_A = +1/2.
+pub fn nc_ga_up() -> f64 with Mut, Div, Panic {
+    neutral_current_ga(0.5)
+}
+
+/// Down-quark g_V.
+pub fn nc_gv_down() -> f64 with Mut, Div, Panic {
+    neutral_current_gv(0.0 - 0.5, 0.0 - 0.3333333333333333)
+}
+
+/// Down-quark g_A = −1/2.
+pub fn nc_ga_down() -> f64 with Mut, Div, Panic {
+    neutral_current_ga(0.0 - 0.5)
+}
+
+/// Neutrino g_V.
+pub fn nc_gv_neutrino() -> f64 with Mut, Div, Panic {
+    neutral_current_gv(0.5, 0.0)
+}
+
+/// Neutrino g_A = +1/2.
+pub fn nc_ga_neutrino() -> f64 with Mut, Div, Panic {
+    neutral_current_ga(0.5)
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Madaros multimodule residual: imported `(f64, f64)` unpack elements are not float-typed (`ga*ga → 0`), while scalar imported `f64` multiplies correctly.

**Product (this PR):**
- `vertex.sio`: `neutral_current_gv` / `neutral_current_ga` + `nc_gv_*` / `nc_ga_*` scalar helpers
- `amplitude.sio`: all NC coupling sites use scalar imports (no tuple unpack)
- Tuple `nc_coupling_*` kept for API compatibility

**Compiler handoff (Claude-1 holds `lower.sio`):**
- Recipe: `docs/audit/MADAROS_TUPLE_F64_FLOAT_FIX_RECIPE_2026-07-26.md`
- Gate: `scripts/ci/madaros_imported_f64_mul_gate.sh` → want `MADAROS_IMPORTED_F64_MUL_FIXED`
- 3 sites in `self-hosted/ir/lower.sio`: `returns_float=2` for all-f64 TypeTuple; FieldGet float when base is `array_elem_float` local

## Evidence

```
lean_single z_decay_width_ee=0.083410 → AMP_SCALAR_NC_OK
bash scripts/ci/particle_exp13_amplitude_honesty_gate.sh → PARTICLE_EXP13_GATE_OK
bash scripts/ci/madaros_imported_f64_mul_gate.sh → RESIDUAL (tuple path still open until lower fix)
```

## Test plan

- [x] `./bin/souc check` vertex + amplitude
- [x] EXP13 gate
- [x] scalar amplitude smoke
- [ ] Claude applies lower recipe → FIXED marker