### PR TITLE
fix(compiler): soft-keyword renames on free self-host modules

### DIFF
--- a/self-hosted/check/lint.sio
+++ b/self-hosted/check/lint.sio
@@ -1095,10 +1095,11 @@ fn lint_exit_scope(ctx: &! LintContext) with Mut, Div, Panic {
     if ctx.scope_depth <= 0 { return }
 
     let scope_idx = ctx.scope_depth - 1
-    let scope = ctx.scopes[scope_idx as usize]
+    // Soft-keyword: Madaros parser rejects `let scope` as binding name.
+    let scope_frame = ctx.scopes[scope_idx as usize]
 
     // Check for unused variables in this scope
-    lint_check_scope_unused(ctx, scope.var_start)
+    lint_check_scope_unused(ctx, scope_frame.var_start)
 
     // Pop scope
     ctx.scope_depth = ctx.scope_depth - 1

--- a/self-hosted/check/ownership.sio
+++ b/self-hosted/check/ownership.sio
@@ -1006,17 +1006,18 @@ fn own_exit_scope(ctx: &! OwnContext) with Mut, Div, Panic {
         return
     }
     let scope_idx = ctx.scope_depth - 1
-    let scope = ctx.scopes[scope_idx as usize]
+    // Soft-keyword: Madaros parser rejects `let scope` as binding name.
+    let scope_frame = ctx.scopes[scope_idx as usize]
 
     // Release borrows created in this scope
     var bi = ctx.borrow_count - 1
-    while bi >= scope.borrow_start {
+    while bi >= scope_frame.borrow_start {
         own_release_borrow(ctx, bi)
         bi = bi - 1
     }
 
     // Insert drops for variables declared in this scope that are still owned
-    var vi = scope.var_start
+    var vi = scope_frame.var_start
     while vi < ctx.var_count {
         let st = ctx.vars[vi as usize].state
         if own_state_is_owned(st) || own_state_is_borrowed(st) || own_state_is_borrowed_mut(st) {

--- a/self-hosted/gpu/metal.sio
+++ b/self-hosted/gpu/metal.sio
@@ -187,24 +187,25 @@ fn metal_default_f64_policy() -> MetalF64Policy {
     MetalF64Policy::MetalF64F32Checked
 }
 
-fn metal_f64_policy_to_string(policy: MetalF64Policy) -> string {
-    match policy {
+// Soft-keyword: Madaros parser rejects param name `policy`.
+fn metal_f64_policy_to_string(f64_policy: MetalF64Policy) -> string {
+    match f64_policy {
         MetalF64Policy::MetalF64Reject => "reject"
         MetalF64Policy::MetalF64F32Checked => "f32_checked"
         MetalF64Policy::MetalF64Float2Compensated => "float2_compensated"
     }
 }
 
-fn metal_f64_value_type(policy: MetalF64Policy) -> string {
-    match policy {
+fn metal_f64_value_type(f64_policy: MetalF64Policy) -> string {
+    match f64_policy {
         MetalF64Policy::MetalF64Reject => "unsupported_f64"
         MetalF64Policy::MetalF64F32Checked => "float"
         MetalF64Policy::MetalF64Float2Compensated => "float2"
     }
 }
 
-fn metal_f64_param_type(policy: MetalF64Policy) -> string {
-    match policy {
+fn metal_f64_param_type(f64_policy: MetalF64Policy) -> string {
+    match f64_policy {
         MetalF64Policy::MetalF64Reject => "device unsupported_f64*"
         MetalF64Policy::MetalF64F32Checked => "device float*"
         MetalF64Policy::MetalF64Float2Compensated => "device float2*"

--- a/self-hosted/hlir/ir.sio
+++ b/self-hosted/hlir/ir.sio
@@ -1610,10 +1610,11 @@ pub fn hlir_function_lookup_local_type(f: HlirFunction, value_id: i64) -> HlirTy
     hlir_type_void()
 }
 
-pub fn hlir_function_add_effect(f: HlirFunction, effect: HlirName) -> HlirFunction with Mut, Panic {
+// Soft-keyword: Madaros parser rejects param name `effect`.
+pub fn hlir_function_add_effect(f: HlirFunction, effect_name: HlirName) -> HlirFunction with Mut, Panic {
     var func = f
     if func.effect_count < HLIR_MAX_EFFECTS {
-        func.effects[func.effect_count as usize] = effect
+        func.effects[func.effect_count as usize] = effect_name
         func.effect_count = func.effect_count + 1
     }
     func

--- a/self-hosted/ir/dce.sio
+++ b/self-hosted/ir/dce.sio
@@ -1768,11 +1768,12 @@ fn test_dce_terminator_classification() -> bool with Mut, Panic, Div {
 // T42: Store classification.
 fn test_dce_store_classification() -> bool with Mut, Panic, Div {
     let fs = dce_is_store(DCE_OP_FIELD_SET)
-    let is = dce_is_store(DCE_OP_INDEX_SET)
+    // Soft-keyword: Madaros parser rejects `let is` as binding name.
+    let is_index_set = dce_is_store(DCE_OP_INDEX_SET)
     let li = !dce_is_store(DCE_OP_LOAD_IMM)
     let ca = !dce_is_store(DCE_OP_CALL)
 
-    fs && is && li && ca
+    fs && is_index_set && li && ca
 }
 
 // T43 inner: populate, set use_count, eliminate trivial phis, check zero-input phi.

--- a/self-hosted/native/target_policy.sio
+++ b/self-hosted/native/target_policy.sio
@@ -189,19 +189,20 @@ pub fn native_target_policy_for(arch_id: i64, os_id: i64) -> NativeTargetPolicy 
     native_target_policy_empty()
 }
 
-pub fn native_target_policy_group_count(policy: NativeTargetPolicy, group: i64) -> i64 {
-    if group == native_policy_group_reserved() { return policy.reserved_count }
-    if group == native_policy_group_allocatable() { return policy.allocatable_count }
-    if group == native_policy_group_allocation_order() { return policy.allocation_order_count }
-    if group == native_policy_group_scratch() { return policy.scratch_count }
-    if group == native_policy_group_args() { return policy.arg_count }
-    if group == native_policy_group_returns() { return policy.ret_count }
+// Soft-keyword: Madaros parser rejects param name `policy`.
+pub fn native_target_policy_group_count(tgt_policy: NativeTargetPolicy, group: i64) -> i64 {
+    if group == native_policy_group_reserved() { return tgt_policy.reserved_count }
+    if group == native_policy_group_allocatable() { return tgt_policy.allocatable_count }
+    if group == native_policy_group_allocation_order() { return tgt_policy.allocation_order_count }
+    if group == native_policy_group_scratch() { return tgt_policy.scratch_count }
+    if group == native_policy_group_args() { return tgt_policy.arg_count }
+    if group == native_policy_group_returns() { return tgt_policy.ret_count }
     0
 }
 
-pub fn native_target_policy_group_name(policy: NativeTargetPolicy, group: i64, idx: i64) -> string {
-    if policy.arch_id == native_policy_arch_x86_64() &&
-       (policy.os_id == native_policy_os_linux() || policy.os_id == native_policy_os_macos() || policy.os_id == native_policy_os_windows()) {
+pub fn native_target_policy_group_name(tgt_policy: NativeTargetPolicy, group: i64, idx: i64) -> string {
+    if tgt_policy.arch_id == native_policy_arch_x86_64() &&
+       (tgt_policy.os_id == native_policy_os_linux() || tgt_policy.os_id == native_policy_os_macos() || tgt_policy.os_id == native_policy_os_windows()) {
         if group == native_policy_group_reserved() {
             if idx == 0 { return "rsp" }
             if idx == 1 { return "rbp" }
@@ -238,8 +239,8 @@ pub fn native_target_policy_group_name(policy: NativeTargetPolicy, group: i64, i
             if idx == 0 { return "rax" }
         }
     }
-    if policy.arch_id == native_policy_arch_aarch64() &&
-       (policy.os_id == native_policy_os_macos() || policy.os_id == native_policy_os_linux() || policy.os_id == native_policy_os_windows()) {
+    if tgt_policy.arch_id == native_policy_arch_aarch64() &&
+       (tgt_policy.os_id == native_policy_os_macos() || tgt_policy.os_id == native_policy_os_linux() || tgt_policy.os_id == native_policy_os_windows()) {
         if group == native_policy_group_reserved() {
             if idx == 0 { return "sp" }
             if idx == 1 { return "fp" }


### PR DESCRIPTION
## Summary

Help Madaros self-host parse: rename soft-keyword identifiers on **free** modules (Claude-1 still owns `check.sio` / `codegen_x86_linux.sio` / `lower.sio`).

| File | Change |
|---|---|
| `check/lint.sio` | `let scope` → `scope_frame` |
| `check/ownership.sio` | `let scope` → `scope_frame` |
| `ir/dce.sio` | `let is` → `is_index_set` |
| `gpu/metal.sio` | param `policy` → `f64_policy` |
| `native/target_policy.sio` | param `policy` → `tgt_policy` |
| `hlir/ir.sio` | param `effect` → `effect_name` |

## Test plan
- [x] surgical renames only (semantics-preserving)
- [ ] Claude applies remaining sites on claimed files
- [ ] Madaros parse of self-host closure re-measure