### PR TITLE
fix(compiler): soft-keyword renames wave2

### DIFF
--- a/self-hosted/effects/types.sio
+++ b/self-hosted/effects/types.sio
@@ -126,17 +126,18 @@ impl EffectSet {
     }
 
     // Add an effect to the set (if not already present)
-    fn add(self, effect: Effect) -> EffectSet with Mut, Panic, Div {
+    // Soft-keyword: Madaros parser rejects param name `effect`.
+    fn add(self, eff: Effect) -> EffectSet with Mut, Panic, Div {
         var set = self
 
         // Check if already present
         var i: i64 = 0
         while i < set.count {
-            if set.effects[i as usize].kind == effect.kind {
+            if set.effects[i as usize].kind == eff.kind {
                 // Already present, check if names match for effect vars
-                if effect.kind == EffectKind::EffVar {
+                if eff.kind == EffectKind::EffVar {
                     // For effect variables, names must match
-                    if name_eq(set.effects[i as usize].name, effect.name) {
+                    if name_eq(set.effects[i as usize].name, eff.name) {
                         return set  // Already present
                     }
                 } else {
@@ -148,7 +149,7 @@ impl EffectSet {
 
         // Not present, add it
         if set.count < 16 {
-            set.effects[set.count as usize] = effect
+            set.effects[set.count as usize] = eff
             set.count = set.count + 1
         } else {
             // Effect set overflow: 16 effects is the fixed capacity.

--- a/self-hosted/ir/closure.sio
+++ b/self-hosted/ir/closure.sio
@@ -988,9 +988,9 @@ fn test_closure_convert_no_free() -> i64 with Mut, Panic, Div {
     func.instrs[1] = ir_return(1)
     func.instr_count = 2
 
-    let scope = free_var_set_new()
+    let parent_scope = free_var_set_new()
     let table = closure_table_new()
-    let pair = closure_convert_function(func, scope, table)
+    let pair = closure_convert_function(func, parent_scope, table)
     let converted = pair.0
     let new_table = pair.1
 
@@ -1009,9 +1009,9 @@ fn test_closure_convert_with_free() -> i64 with Mut, Panic, Div {
     free_regs[1] = 20
     let func = make_closure_func(free_regs, 2)
 
-    let scope = free_var_set_new()
+    let parent_scope = free_var_set_new()
     let table = closure_table_new()
-    let pair = closure_convert_function(func, scope, table)
+    let pair = closure_convert_function(func, parent_scope, table)
     let converted = pair.0
     let new_table = pair.1
 
@@ -1312,13 +1312,13 @@ fn test_build_parent_scope() -> i64 with Mut, Panic, Div {
     parent.instrs[1] = ir_load_imm(3, 20)
     parent.instr_count = 2
 
-    let scope = build_parent_scope(parent)
+    let parent_scope = build_parent_scope(parent)
     // Should contain param regs 0, 1 and dst regs 2, 3
-    if !free_var_contains(scope, 0) { return 1 }
-    if !free_var_contains(scope, 1) { return 2 }
-    if !free_var_contains(scope, 2) { return 3 }
-    if !free_var_contains(scope, 3) { return 4 }
-    if free_var_contains(scope, 4) { return 5 }
+    if !free_var_contains(parent_scope, 0) { return 1 }
+    if !free_var_contains(parent_scope, 1) { return 2 }
+    if !free_var_contains(parent_scope, 2) { return 3 }
+    if !free_var_contains(parent_scope, 3) { return 4 }
+    if free_var_contains(parent_scope, 4) { return 5 }
     0
 }
 

--- a/self-hosted/native/codegen.sio
+++ b/self-hosted/native/codegen.sio
@@ -212,35 +212,35 @@ fn native_v2_runtime_context_group_name(idx: i64) -> string {
 }
 
 fn native_v2_target_contract_supported(spec: NativeTargetSpec) -> bool {
-    let policy = native_target_policy_for(spec.arch_id, spec.os_id)
-    policy.arch_id != native_policy_arch_unknown()
+    let tgt_policy = native_target_policy_for(spec.arch_id, spec.os_id)
+    tgt_policy.arch_id != native_policy_arch_unknown()
 }
 
 fn native_v2_target_policy_summary(spec: NativeTargetSpec) -> NativeV2TargetPolicySummary {
-    let policy = native_target_policy_for(spec.arch_id, spec.os_id)
+    let tgt_policy = native_target_policy_for(spec.arch_id, spec.os_id)
     NativeV2TargetPolicySummary {
-        reserved_count: policy.reserved_count,
-        allocatable_count: policy.allocatable_count,
-        allocation_order_count: policy.allocation_order_count,
-        scratch_count: policy.scratch_count,
-        arg_count: policy.arg_count,
-        ret_count: policy.ret_count,
-        frame_has_gc_area: policy.frame_has_gc_area,
-        frame_has_deopt_area: policy.frame_has_deopt_area,
-        frame_has_unwind: policy.frame_has_unwind,
-        frame_has_vector_align: policy.frame_has_vector_align,
-        emitter_ready: policy.emitter_ready,
+        reserved_count: tgt_policy.reserved_count,
+        allocatable_count: tgt_policy.allocatable_count,
+        allocation_order_count: tgt_policy.allocation_order_count,
+        scratch_count: tgt_policy.scratch_count,
+        arg_count: tgt_policy.arg_count,
+        ret_count: tgt_policy.ret_count,
+        frame_has_gc_area: tgt_policy.frame_has_gc_area,
+        frame_has_deopt_area: tgt_policy.frame_has_deopt_area,
+        frame_has_unwind: tgt_policy.frame_has_unwind,
+        frame_has_vector_align: tgt_policy.frame_has_vector_align,
+        emitter_ready: tgt_policy.emitter_ready,
     }
 }
 
 fn native_v2_target_policy_group_count(spec: NativeTargetSpec, group: i64) -> i64 {
-    let policy = native_target_policy_for(spec.arch_id, spec.os_id)
-    native_target_policy_group_count(policy, group)
+    let tgt_policy = native_target_policy_for(spec.arch_id, spec.os_id)
+    native_target_policy_group_count(tgt_policy, group)
 }
 
 fn native_v2_target_policy_group_name(spec: NativeTargetSpec, group: i64, idx: i64) -> string {
-    let policy = native_target_policy_for(spec.arch_id, spec.os_id)
-    native_target_policy_group_name(policy, group, idx)
+    let tgt_policy = native_target_policy_for(spec.arch_id, spec.os_id)
+    native_target_policy_group_name(tgt_policy, group, idx)
 }
 
 fn native_v2_target_has_attested_runtime_data(spec: NativeTargetSpec) -> bool {
@@ -251,8 +251,8 @@ fn native_v2_target_has_attested_runtime_data(spec: NativeTargetSpec) -> bool {
 }
 
 fn native_v2_target_runtime_metadata_active(spec: NativeTargetSpec, compile_ok: bool) -> bool {
-    let policy = native_target_policy_for(spec.arch_id, spec.os_id)
-    compile_ok && policy.emitter_ready && native_v2_target_has_attested_runtime_data(spec)
+    let tgt_policy = native_target_policy_for(spec.arch_id, spec.os_id)
+    compile_ok && tgt_policy.emitter_ready && native_v2_target_has_attested_runtime_data(spec)
 }
 
 fn native_v2_target_emitter_mode(spec: NativeTargetSpec) -> string {
@@ -447,7 +447,7 @@ fn native_v2_write_contract(path: string, module: &IrModule, target_spec: Native
     var p: i64 = 0
     let runtime = native_v2_runtime_context_layout()
     let machine = native_v2_shadow_machine_module(module, target_spec)
-    let policy = native_v2_target_policy_summary(target_spec)
+    let tgt_policy = native_v2_target_policy_summary(target_spec)
     let runtime_metadata_active = native_v2_target_runtime_metadata_active(target_spec, compile_ok)
 
     let p0 = io_trace_append_byte(buf, p, 123)
@@ -618,15 +618,15 @@ fn native_v2_write_contract(path: string, module: &IrModule, target_spec: Native
     buf = p46.0; p = p46.1
     let p47 = io_trace_append_byte(buf, p, 44)
     buf = p47.0; p = p47.1
-    let p48 = native_v2_append_named_json_bool(buf, p, "frame_has_gc_area", policy.frame_has_gc_area, true)
+    let p48 = native_v2_append_named_json_bool(buf, p, "frame_has_gc_area", tgt_policy.frame_has_gc_area, true)
     buf = p48.0; p = p48.1
-    let p49 = native_v2_append_named_json_bool(buf, p, "frame_has_deopt_area", policy.frame_has_deopt_area, true)
+    let p49 = native_v2_append_named_json_bool(buf, p, "frame_has_deopt_area", tgt_policy.frame_has_deopt_area, true)
     buf = p49.0; p = p49.1
-    let p50 = native_v2_append_named_json_bool(buf, p, "frame_has_unwind", policy.frame_has_unwind, true)
+    let p50 = native_v2_append_named_json_bool(buf, p, "frame_has_unwind", tgt_policy.frame_has_unwind, true)
     buf = p50.0; p = p50.1
-    let p51 = native_v2_append_named_json_bool(buf, p, "frame_has_vector_align", policy.frame_has_vector_align, true)
+    let p51 = native_v2_append_named_json_bool(buf, p, "frame_has_vector_align", tgt_policy.frame_has_vector_align, true)
     buf = p51.0; p = p51.1
-    let p52 = native_v2_append_named_json_bool(buf, p, "emitter_ready", policy.emitter_ready, false)
+    let p52 = native_v2_append_named_json_bool(buf, p, "emitter_ready", tgt_policy.emitter_ready, false)
     buf = p52.0; p = p52.1
     let p53 = io_trace_append_byte(buf, p, 125)
     buf = p53.0; p = p53.1

--- a/self-hosted/native/debug_info.sio
+++ b/self-hosted/native/debug_info.sio
@@ -506,12 +506,13 @@ fn dbg_find_scope_for_line(
 
     var i: i64 = 0
     while i < builder.scope_count {
-        let scope = builder.scopes[i as usize]
-        if line >= scope.start_line && line <= scope.end_line {
-            let range = scope.end_line - scope.start_line
+        // Soft-keyword: Madaros parser rejects `let scope`.
+        let scope_frame = builder.scopes[i as usize]
+        if line >= scope_frame.start_line && line <= scope_frame.end_line {
+            let range = scope_frame.end_line - scope_frame.start_line
             if range < best_range {
                 best_range = range
-                best_id = scope.id
+                best_id = scope_frame.id
             }
         }
         i = i + 1


### PR DESCRIPTION
## Summary
Second wave of soft-keyword identifier renames on free self-host modules (follow-up to #1520).

| File | Rename |
|---|---|
| `native/codegen.sio` | `let policy` → `tgt_policy` |
| `native/debug_info.sio` | `let scope` → `scope_frame` |
| `ir/closure.sio` | `let scope` → `parent_scope` |
| `effects/types.sio` | param `effect` → `eff` |

Still blocked (Claude claim): `check.sio` (`let study`), `codegen_x86_linux.sio` (`let policy`).

## Test plan
- [x] local renames only
- [ ] merge after green triage