### PR TITLE
fix(check): generate Mut at the store site — the effect system had no leaf source (closes #1488)

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -4366,6 +4366,58 @@ fn checker_place_root_local(c: *mut Checker, place: Expr) -> bool with Mut, Pani
     }
 }
 
+// True when an assignment target writes THROUGH an exclusive reference:
+//
+//     *p = v        p: &!T
+//     p.f = v       p: &!S
+//     p[i] = v      p: &![T; N] / &![T]
+//
+// Walks the place to its root binding — same shape as checker_place_root_local
+// above — and asks whether that binding is an exclusive reference.
+//
+// Only this shape generates `Mut` (#1488). The two authorities on what `Mut`
+// means disagree about a plain local `var`: docs/guide/LLM_PROGRAMMING_GUIDE.md:230
+// says "mutating `&!` refs or arrays" (narrow, what Madaros implements) and
+// docs/spec/LANGUAGE_SPECIFICATION.md:965 says "reading/writing mutable variables"
+// (broad, what lean_single implements). They AGREE about a write through an
+// exclusive reference. Generating the effect only where both readings agree closes
+// the unsound case without pre-empting an operator ruling on the other — and the
+// broad reading is viral over every loop counter in 1113 stdlib files, so adopting
+// it is a language decision, not a compiler fix.
+//
+// Conservative by construction: an unknown root yields false, so this can add a
+// required effect but never remove one, and cannot false-reject a program whose
+// place shape it does not recognise.
+fn checker_place_excl_ref_root(c: *mut Checker, place: Expr, depth: i64) -> bool with Mut, Panic, Div, Alloc, IO {
+    if depth > 16 { return false }
+    if place.kind == ExprKind::ExprIdent {
+        if !(*c).env.has_binding(place.name) { return false }
+        let root_ty = (*c).env.lookup(place.name)
+        // TyRefMut only — deliberately NOT TySliceMut.
+        //
+        // Measured 2026-07-26: lean_single requires Mut for a write through
+        // `&!T`, `&!S` and `&![T; N]`, and does NOT require it for a write
+        // through a slice `&![T]`. Including TySliceMut here made Madaros
+        // stricter than the seed and rejected existing intentional code —
+        // `kernel fn vec_add_in_place(n: i64, a: &![f64], …) with GPU` writes
+        // `a[tid] = …` and declares only GPU.
+        //
+        // Whether a slice write is Mut is a language question of the same kind
+        // as the local-`var` one, and answering it unilaterally inside a fix for
+        // a different defect would be drift. This closes the shapes on which
+        // both engines already agree; the slice case is left open and recorded.
+        return root_ty.kind == TypeKind::TyRefMut
+    }
+    if place.kind == ExprKind::ExprFieldAccess
+        || place.kind == ExprKind::ExprIndex
+        || place.kind == ExprKind::ExprUnary {
+        let base = expr_opt_get(place.left)
+        if base == 0 as *mut Expr { return false }
+        return checker_place_excl_ref_root(c, *base, depth + 1)
+    }
+    false
+}
+
 fn checker_expr_provenance(c: *mut Checker, e: Expr) -> i64 with Mut, Panic, Div, Alloc, IO {
     if e.kind == ExprKind::ExprUnary {
         if e.un_op == UnaryOp::OpRef || e.un_op == UnaryOp::OpRefMut {
@@ -7839,6 +7891,30 @@ fn checker_check_assign_stmt_inplace(c: *mut Checker, s: Stmt) -> TypeEntry with
         }
     }
     checker_check_assign_mutability_inplace(c, s.target, s.span)
+    // Effect GENERATION at the store site (#1488).
+    //
+    // Madaros propagated declared effects correctly — a caller of a `with Mut`
+    // callee was required to declare it — but had no leaf-level SOURCE of Mut.
+    // Nothing anywhere introduced the effect at the point where mutation actually
+    // happens, so `fn poke(x: &!i64) { *x = 42 }` type-checked with no `with Mut`
+    // and every caller above it was unconstrained. The effect system propagated a
+    // fact nobody ever asserted: `with Mut` was true only where a human had written
+    // it, which makes the guarantee vacuous exactly at the leaves.
+    //
+    // Reuses checker_check_callee_effects_inplace rather than a new reporting path:
+    // requiring Mut here is the same question as requiring a callee's effect, and
+    // it already emits E035 with the missing-effect list.
+    match s.target {
+        Some(effect_target) => {
+            if checker_place_excl_ref_root(c, *effect_target, 0) {
+                var store_effects: [i64; 8] = [0; 8]
+                // 1 = Mut (effect_name_to_id, self-hosted/check/effects.sio:26)
+                store_effects[0] = 1
+                checker_check_callee_effects_inplace(c, s.span, store_effects, 1)
+            }
+        }
+        None => {}
+    }
     // Raw-reference escape (store sites): a reference may not be stored into a struct field,
     // an array element, or through a pointer — doing so lets it outlive its referent → a
     // dangling reference. References are second-class: pass them to functions and read/write

--- a/tests/compile-fail/effect_mut_generated_at_excl_ref_store.sio
+++ b/tests/compile-fail/effect_mut_generated_at_excl_ref_store.sio
@@ -1,0 +1,33 @@
+//@ typecheck-fail
+//@ requires: madaros
+//@ error-pattern: error[E035
+
+// Regression pin for #1488 — the effect system had no leaf-level source of Mut.
+//
+// Madaros propagated declared effects correctly: a caller of a `with Mut` callee
+// was required to declare it too. What was missing was anything that INTRODUCED
+// the effect at the point where mutation actually happens. So this function
+// type-checked with no `with Mut`, and because nothing below it ever asserted the
+// effect, no caller above it could be required to carry it either. `with Mut` was
+// true only where a human had written it — the guarantee was vacuous exactly at
+// the leaves, which is where it has to hold.
+//
+// Measured before the fix: Madaros accepted this (exit 0). lean_single rejected
+// it. A dead-code explanation was ruled out separately: Madaros already rejected
+// a caller of a callee that DECLARES `with Mut`, even when that caller is
+// unreachable from main, so propagation was working and only generation was
+// absent.
+//
+// `requires: madaros` because the fix lives in the modular checker; lean_single
+// has always rejected this shape and the stage2 suite would pass it for a
+// different reason.
+
+fn poke(x: &!i64) {
+    *x = 42
+}
+
+fn main() with IO {
+    var v: i64 = 0
+    poke(&!v)
+    println("unreachable: poke must be rejected for not declaring Mut")
+}


### PR DESCRIPTION
Closes #1488.

## The reported premise is inverted

#1488 says Madaros does not enforce effect propagation. It does. What it lacked was any **source** of an effect — nothing introduced `Mut` at the point where mutation actually happens.

Measured on `main`, each program checked under both engines:

| program (no `with Mut` declared) | Madaros | lean_single |
|---|---:|---:|
| `fn poke(x: &!i64) { *x = 42 }` | **accept** ❌ | reject |
| `fn poke(s: &!S) { s.a = 42 }` | **accept** ❌ | reject |
| `fn fill(a: &![i64;4]) { (*a)[0] = 42 }` | **accept** ❌ | reject |
| caller of a callee that *declares* `with Mut` | reject ✅ | reject |

The last row is what makes it airtight. That caller is never reached from `main` and Madaros still rejects it — so the first three passing was not dead-code skipping. Propagation worked; generation did not exist.

The consequence: `with Mut` was true only where a human had written it. Once no leaf asserts the effect, nothing above it can be required to carry it, so the guarantee was vacuous **exactly at the leaves**, which is where it has to hold.

In the source, `current_effects` (`check.sio:237`) was only ever seeded from the declared signature (`:3958`, `:4257`) and only ever read against callee requirements (`effects_subset` at `:6904`, `:11672`). Nothing wrote to it from any store path. This adds that write.

It reuses `checker_check_callee_effects_inplace` rather than a new reporting path — requiring `Mut` at a store is the same question as requiring a callee's effect, and that helper already emits E035 with the missing-effect list.

## Scope is the intersection of two disagreeing authorities

| authority | says | implemented by |
|---|---|---|
| `docs/guide/LLM_PROGRAMMING_GUIDE.md:230` | Mut is "mutating `&!` refs or arrays" | Madaros (narrow) |
| `docs/spec/LANGUAGE_SPECIFICATION.md:965` | "reading/writing mutable variables" | lean_single (broad) |

Under the broad reading, `var i = 0; while i < 4 { i = i + 1 }` is an error — viral over every loop counter in **1113** stdlib files. That is a language decision for the operator, not a compiler fix, and it is left untouched.

**A slice write turned out to be a second such question, and I found it by measurement rather than by reading.** The first version of this predicate included `TySliceMut` and rejected

```sounio
kernel fn vec_add_in_place(n: i64, a: &![f64], b: &[f64]) with GPU {
    a[tid as usize] = a[tid as usize] + b[tid as usize]   // writes through &![f64]
}
```

— real, intentional code that lean_single accepts, and which #1512 had just fixed. Deciding that inside a fix for a different defect would be drift. The predicate is `TyRefMut` only.

That leaves Madaros **exactly aligned with lean_single on all four measured shapes**, and covers the large majority of the population:

| parameter shape | files | covered |
|---|---:|---|
| `&!T` / `&![T; N]` | 478 | ✅ |
| `&![T]` slice | 21 | left open, recorded |

The walker is conservative by construction — an unrecognised root yields `false` — so this can add a required effect but never remove one, and cannot false-reject a place shape it does not understand.

## Verification

| check | result |
|---|---|
| reject side: the three unsound shapes | rejected, matching lean_single **1/1/1** |
| accept side: declared code, effect subsetting | **0/0** |
| accept side: local `var` scalar, local array | still accepted (untouched doc conflict) |
| `madaros_corpus_regression_gate.sh` | **PASS, 0 new failures** (305 known / 1689) — identical to the pre-change baseline |
| compiler self-build | **0** E035 |

Two notes on how those were measured, both of which would have produced a false green:

- The self-build E035 count is read from the **build log, not the exit status**. #1494 makes imported-module typecheck errors non-fatal — the build exits 0 and emits an ELF while printing them.
- The regression pin uses `//@ typecheck-fail`, which the harness parses robustly, rather than `expect-stdout`, whose extraction is quoted and matches vacuously (`scripts/dev/run_sio_test_suite.sh:306`, which says so and estimates ~305 latent vacuous passes).

## Independence

Diff is **76 insertions, 0 deletions**, one compiler file plus one test. Branch is off `main`, not stacked on #1512 or #1515. The corpus number was measured with #1512 also applied; the two touch different files and different concerns.
