### PR TITLE
feat(clinical): paediatric PBPK v2 — preterm, AUC-guided, gentamicin

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -3458,3 +3458,11 @@ tracked as issues #862/#864/#865/#890/#901/#913 and audit docs under docs/audit/
 - deepseek review: FAIL (Insufficient Balance)
 - xai math-review: OK — Holford allometry, Rhodin MF, Matzke CL, SS Cmin, AUC24, Knightian corners
 - outcome: proceed; deepseek balance blocked, orthogonal math review clean
+
+## 2026-07-27 — pediatric_pbpk ext (preterm/AUC/gent)
+- target: stdlib/clinical/pediatric_pbpk.sio
+- xai math-review: partial — flagged Cmin ∂/∂V sign as inverted
+- adjudication: REJECT flag. Canonical form Cmin=(D/V)/(e^{kτ}-1), θ=CL·τ/V;
+  h(θ)=e^θ(θ-1)+1 > 0 for θ>0 ⇒ ∂Cmin/∂V > 0 (matches clinical::vancomycin_pbpk).
+  AUC Knightian (CL-only) and maturation math OK.
+- outcome: ship; corners (V_lo,CL_hi)/(V_hi,CL_lo) retained

--- a/docs/audit/PEDIATRIC_PBPK_2026-07-27.md
+++ b/docs/audit/PEDIATRIC_PBPK_2026-07-27.md
@@ -1,10 +1,10 @@
-# Paediatric PBPK — functional maturation + vancomycin receipt
+# Paediatric PBPK — functional maturation + AUC-guided vanco + gentamicin
 
 **Date:** 2026-07-27  
-**Status:** live  
+**Status:** live (v2: preterm + AUC + gentamicin)  
 **Module:** `stdlib/clinical/pediatric_pbpk.sio`  
 **Demo:** `examples/pediatric_pbpk_demo.sio`  
-**Gate:** `scripts/ci/pediatric_pbpk_gate.sh` → `PEDIATRIC_PBPK_GATE_OK`
+**Gate:** `scripts/ci/pediatric_pbpk_gate.sh` → `PEDIATRIC_PBPK_GATE_OK` (9/9)
 
 ## Scope
 
@@ -15,16 +15,20 @@ Educational / compiler-stdlib **paediatric PBPK spine** with:
 3. Hepatic CYP-like maturation (second organ axis)
 4. Mosteller BSA + Schwartz bedside eGFR helper
 5. Vancomycin 1-cmt SS Cmin + AUC24, GUM `Epistemic`, Knightian `PBox`
+6. **Preterm GA28** cohort (PMA 30 wk) vs term neonate
+7. **AUC-guided** dose for mid-target 500 mg·h/L + AUC p-box (↓CL only)
+8. **Gentamicin** on the same renal spine (Vc 0.25 L/kg, CL∝GFR)
 
-**Not medical guidance.** Adult trough window 10–20 mg/L is an educational screen only.
+**Not medical guidance.**
 
-## Expected physiology (same 15 mg/kg q12h)
+## Expected physiology (15 mg/kg q12h vancomycin)
 
-| Subject | Weight | MF_renal | Relative CL | Relative Cmin |
-|---|---:|---:|---|---|
-| Neonate ~2 wk | 3.5 kg | low | lowest | **highest** |
-| Child 5 yr | 20 kg | near mature | mid | mid |
-| Adult 70 kg | 70 kg | ~1 | Matzke@GFR120 | reference |
+| Subject | GA | Weight | MF_renal | CL (order) |
+|---|---:|---:|---:|---|
+| Preterm 2 wk | 28 | 1.2 kg | **lowest** | **lowest** |
+| Term neo 2 wk | 40 | 3.5 kg | low | low |
+| Child 5 yr | — | 20 kg | ~1 | mid |
+| Adult 70 kg | — | 70 kg | ~1 | Matzke@GFR120 |
 
 ## Reproduce
 

--- a/examples/pediatric_pbpk_demo.sio
+++ b/examples/pediatric_pbpk_demo.sio
@@ -1,27 +1,33 @@
 // examples/pediatric_pbpk_demo.sio
 //
-// Paediatric PBPK functional receipt — maturation + vancomycin + Knightian TDM.
+// Paediatric PBPK functional receipt — maturation + AUC-guided vanco + gentamicin.
 //
-// Cohort (all 15 mg/kg q12h IV educational screen):
-//   neonate 2 wk → child 5 yr → adolescent 14 yr → adult 70 kg
+// Cohort: preterm GA28 → term neonate → infant → child → adolescent → adult
 //
-// Pass criteria:
-//   3201  adult CL matches Matzke@GFR120
-//   3202  renal MF: neonate < infant < adult
-//   3203  maturation penalty: neonate CL << allometric MF=1 counterfactual
-//   3204  child AUC24 in plausible band
-//   3205  Knightian pre-TDM REFUSE or wider; post-TDM narrower + gateable
-//   3206  ped_selftest returns 6/6
+// Pass tags:
+//   3201 adult CL Matzke@GFR120
+//   3202 renal MF: preterm < term neo < infant < adult
+//   3203 maturation penalty (term neo CL << MF=1 counterfactual)
+//   3204 child AUC24 band + GUM ep
+//   3205 Knightian Cmin narrows with TDM
+//   3206 ped_selftest == 9
+//   3207 preterm vs term (MF + CL)
+//   3208 AUC-guided dose hits 500 mg·h/L
+//   3209 gentamicin spine (CL order + p-box)
 //
 // Gate: scripts/ci/pediatric_pbpk_gate.sh
 
 use clinical::pediatric_pbpk::{
-    PedSubject, ped_neonate_term_2wk, ped_infant_6mo, ped_child_5yr,
-    ped_adolescent_14yr, ped_adult_ref_70kg,
+    PedSubject, ped_neonate_term_2wk, ped_preterm_ga28_2wk, ped_infant_6mo,
+    ped_child_5yr, ped_adolescent_14yr, ped_adult_ref_70kg,
     ped_pma_weeks, ped_gfr_maturation, ped_physio_model,
-    ped_vanco_pk_mg_per_kg, ped_vanco_cl_l_h_with_mf,
+    ped_vanco_pk, ped_vanco_pk_mg_per_kg, ped_vanco_cl_l_h_with_mf,
     ped_vanco_cmin_knightian, ped_vanco_is_safe_trough,
-    ped_vanco_auc24_ep, ped_selftest,
+    ped_vanco_auc24_ep, ped_vanco_dose_for_auc24, ped_vanco_auc_target_mid,
+    ped_vanco_auc24_knightian, ped_vanco_is_auc_on_target,
+    ped_vanco_auc_target_lo, ped_vanco_auc_target_hi,
+    ped_gent_pk_mg_per_kg, ped_gent_cmin_knightian, ped_gent_is_safe_trough,
+    ped_selftest,
 }
 use epistemic::knowledge::{ep_val, ep_std}
 use epistemic::knightian::{pb_lo_mean, pb_hi_mean, pb_gap, pb_confidence}
@@ -51,6 +57,8 @@ fn dump_subject(label: i64, s: &PedSubject, mgkg: f64, tau: f64) with IO, Mut, D
     print_int(label)
     print(" age_y=")
     print_f64(s.age_years)
+    print(" ga=")
+    print_f64(s.gest_weeks)
     print(" wt=")
     print_f64(s.weight_kg)
     print(" pma_w=")
@@ -61,8 +69,6 @@ fn dump_subject(label: i64, s: &PedSubject, mgkg: f64, tau: f64) with IO, Mut, D
     print_f64(phy.gfr_ml_min)
     print(" cl=")
     print_f64(pk.cl_l_h)
-    print(" vc=")
-    print_f64(pk.vc_l)
     print(" cmin=")
     print_f64(pk.cmin_mg_l)
     print(" auc24=")
@@ -72,15 +78,17 @@ fn dump_subject(label: i64, s: &PedSubject, mgkg: f64, tau: f64) with IO, Mut, D
 
 fn main() -> i32 with IO, Mut, Div, Panic {
     print("PEDIATRIC_PBPK_BEGIN\n")
-    print("CLAIM functional_paediatric_pbpk_maturation_vanco_knightian\n")
+    print("CLAIM paediatric_pbpk_preterm_auc_gentamicin\n")
     var n: i64 = 0
 
+    let preterm = ped_preterm_ga28_2wk()
     let neo = ped_neonate_term_2wk()
     let inf = ped_infant_6mo()
     let child = ped_child_5yr()
     let teen = ped_adolescent_14yr()
     let adult = ped_adult_ref_70kg()
 
+    dump_subject(0, &preterm, 15.0, 12.0)
     dump_subject(1, &neo, 15.0, 12.0)
     dump_subject(2, &inf, 15.0, 12.0)
     dump_subject(3, &child, 15.0, 12.0)
@@ -88,21 +96,22 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     dump_subject(5, &adult, 15.0, 12.0)
 
     let pk_a = ped_vanco_pk_mg_per_kg(&adult, 15.0, 12.0)
-    let p1 = abs_f(pk_a.cl_l_h - 5.1804) < 0.05
-    n = n + pass_if(p1, 3201)
+    n = n + pass_if(abs_f(pk_a.cl_l_h - 5.1804) < 0.05, 3201)
 
+    let mf_p = ped_gfr_maturation(ped_pma_weeks(&preterm))
     let mf_n = ped_gfr_maturation(ped_pma_weeks(&neo))
     let mf_i = ped_gfr_maturation(ped_pma_weeks(&inf))
     let mf_a = ped_gfr_maturation(ped_pma_weeks(&adult))
-    print("PED_MF neo=")
+    print("PED_MF preterm=")
+    print_f64(mf_p)
+    print(" term_neo=")
     print_f64(mf_n)
     print(" infant=")
     print_f64(mf_i)
     print(" adult=")
     print_f64(mf_a)
     print("\n")
-    let p2 = mf_n < mf_i && mf_i < mf_a && mf_a > 0.95
-    n = n + pass_if(p2, 3202)
+    n = n + pass_if(mf_p < mf_n && mf_n < mf_i && mf_i < mf_a && mf_a > 0.95, 3202)
 
     let pk_n = ped_vanco_pk_mg_per_kg(&neo, 15.0, 12.0)
     let pk_c = ped_vanco_pk_mg_per_kg(&child, 15.0, 12.0)
@@ -114,15 +123,10 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     print(" child=")
     print_f64(pk_c.cl_l_h)
     print("\n")
-    print("PED_CMIN neo=")
-    print_f64(pk_n.cmin_mg_l)
-    print(" child=")
-    print_f64(pk_c.cmin_mg_l)
-    print("\n")
-    // Rhodin MF cuts neonatal CL below pure allometry (MF=1); Matzke intercept
-    // softens the ratio — require ≤0.60× and absolute CL < child.
-    let p3 = pk_n.cl_l_h < cl_neo_mf1 * 0.60 && pk_n.cl_l_h < pk_c.cl_l_h && mf_n < 0.45
-    n = n + pass_if(p3, 3203)
+    n = n + pass_if(
+        pk_n.cl_l_h < cl_neo_mf1 * 0.60 && pk_n.cl_l_h < pk_c.cl_l_h && mf_n < 0.45,
+        3203
+    )
 
     print("PED_AUC24_CHILD ")
     print_f64(pk_c.auc24_mg_h_l)
@@ -133,9 +137,11 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     print(" std=")
     print_f64(ep_std(&auc_ep))
     print("\n")
-    let p4 = pk_c.auc24_mg_h_l > 50.0 && pk_c.auc24_mg_h_l < 2000.0
-        && abs_f(ep_val(&auc_ep) - pk_c.auc24_mg_h_l) < 1.0e-9
-    n = n + pass_if(p4, 3204)
+    n = n + pass_if(
+        pk_c.auc24_mg_h_l > 50.0 && pk_c.auc24_mg_h_l < 2000.0
+            && abs_f(ep_val(&auc_ep) - pk_c.auc24_mg_h_l) < 1.0e-9,
+        3204
+    )
 
     let dose_c = 15.0 * child.weight_kg
     let pre = ped_vanco_cmin_knightian(&child, dose_c, 12.0, 0)
@@ -158,32 +164,91 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     let post_safe = ped_vanco_is_safe_trough(&post, 10.0, 20.0, 800)
     if pre_safe { print("PED_PRE_DECISION PRESCRIBE\n") } else { print("PED_PRE_DECISION REFUSE\n") }
     if post_safe { print("PED_POST_DECISION PRESCRIBE\n") } else { print("PED_POST_DECISION REFUSE\n") }
-    // Pre-TDM must be wider; post must be credible. Prefer post safer, but
-    // if both refuse the maturation demo still holds on gap narrowing.
-    let p5 = pb_gap(&pre) > pb_gap(&post)
-        && pb_confidence(&pre) >= 800
-        && pb_confidence(&post) >= 800
-        && (post_safe || !pre_safe)
-    n = n + pass_if(p5, 3205)
+    n = n + pass_if(
+        pb_gap(&pre) > pb_gap(&post)
+            && pb_confidence(&pre) >= 800
+            && pb_confidence(&post) >= 800
+            && (post_safe || !pre_safe),
+        3205
+    )
 
     print("PED_SELFTEST_BEGIN\n")
     let st = ped_selftest()
     print("PED_SELFTEST_PASS ")
     print_int(st)
     print("\n")
-    let p6 = st == 6
-    n = n + pass_if(p6, 3206)
+    n = n + pass_if(st == 9, 3206)
+
+    // 3207 preterm vs term
+    let pk_p = ped_vanco_pk_mg_per_kg(&preterm, 15.0, 12.0)
+    print("PED_PRETERM cl=")
+    print_f64(pk_p.cl_l_h)
+    print(" mf=")
+    print_f64(mf_p)
+    print(" pma=")
+    print_f64(ped_pma_weeks(&preterm))
+    print("\n")
+    n = n + pass_if(
+        mf_p < mf_n && pk_p.cl_l_h < pk_n.cl_l_h && ped_pma_weeks(&preterm) < ped_pma_weeks(&neo),
+        3207
+    )
+
+    // 3208 AUC-guided
+    let d_star = ped_vanco_dose_for_auc24(&child, ped_vanco_auc_target_mid(), 12.0)
+    let pk_star = ped_vanco_pk(&child, d_star, 12.0)
+    print("PED_AUC_GUIDED dose_mg=")
+    print_f64(d_star)
+    print(" auc24=")
+    print_f64(pk_star.auc24_mg_h_l)
+    print("\n")
+    let auc_box = ped_vanco_auc24_knightian(&child, d_star, 12.0, 3)
+    print("PED_AUC_PBOX ")
+    print_f64(pb_lo_mean(&auc_box))
+    print("..")
+    print_f64(pb_hi_mean(&auc_box))
+    print("\n")
+    // Point estimate on target; post-TDM p-box may still span outside 400–600
+    // depending on CL band — require point hit + box contains mid.
+    let auc_ok = abs_f(pk_star.auc24_mg_h_l - 500.0) < 1.0
+        && pb_lo_mean(&auc_box) < 500.0
+        && pb_hi_mean(&auc_box) > 500.0
+    n = n + pass_if(auc_ok, 3208)
+
+    // 3209 gentamicin
+    let g_c = ped_gent_pk_mg_per_kg(&child, 2.5, 8.0)
+    let g_p = ped_gent_pk_mg_per_kg(&preterm, 2.5, 12.0)
+    let gbox = ped_gent_cmin_knightian(&child, 2.5 * child.weight_kg, 8.0, 0)
+    print("PED_GENT child_cl=")
+    print_f64(g_c.cl_l_h)
+    print(" preterm_cl=")
+    print_f64(g_p.cl_l_h)
+    print(" child_cmin=")
+    print_f64(g_c.cmin_mg_l)
+    print("\n")
+    print("PED_GENT_PBOX ")
+    print_f64(pb_lo_mean(&gbox))
+    print("..")
+    print_f64(pb_hi_mean(&gbox))
+    print("\n")
+    let g_safe = ped_gent_is_safe_trough(&gbox, 800)
+    if g_safe { print("PED_GENT_DECISION PRESCRIBE\n") } else { print("PED_GENT_DECISION REFUSE\n") }
+    n = n + pass_if(
+        g_c.cl_l_h > g_p.cl_l_h && g_c.cmin_mg_l > 0.0 && pb_gap(&gbox) > 0.0,
+        3209
+    )
 
     print("PED_LEDGER_JSON {")
-    print("\"schema\":\"sounio.pediatric_pbpk.v1\",")
-    print("\"neo_cmin\":")
-    print_f64(pk_n.cmin_mg_l)
-    print(",\"child_cmin\":")
-    print_f64(pk_c.cmin_mg_l)
+    print("\"schema\":\"sounio.pediatric_pbpk.v2\",")
+    print("\"preterm_cl\":")
+    print_f64(pk_p.cl_l_h)
+    print(",\"neo_cl\":")
+    print_f64(pk_n.cl_l_h)
     print(",\"adult_cl\":")
     print_f64(pk_a.cl_l_h)
-    print(",\"child_auc24\":")
-    print_f64(pk_c.auc24_mg_h_l)
+    print(",\"auc_guided\":")
+    print_f64(pk_star.auc24_mg_h_l)
+    print(",\"gent_child_cl\":")
+    print_f64(g_c.cl_l_h)
     print(",\"pass\":")
     print_int(n)
     print("}\n")
@@ -191,7 +256,7 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     print("PEDIATRIC_PBPK_PASS ")
     print_int(n)
     print("\n")
-    if n == 6 {
+    if n == 9 {
         print("PEDIATRIC_PBPK_OK\n")
         0
     } else {

--- a/scripts/ci/pediatric_pbpk_gate.sh
+++ b/scripts/ci/pediatric_pbpk_gate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Paediatric PBPK functional gate — maturation + vancomycin + Knightian.
+# Paediatric PBPK functional gate — preterm + AUC-guided vanco + gentamicin.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
@@ -20,8 +20,7 @@ if ! grep -q 'PEDIATRIC_PBPK_OK' "$OUT"; then
   rm -f "$OUT"
   exit 1
 fi
-# Require all six pass tags
-for tag in 3201 3202 3203 3204 3205 3206; do
+for tag in 3201 3202 3203 3204 3205 3206 3207 3208 3209; do
   if ! grep -q "PASS $tag" "$OUT"; then
     cat "$OUT" >&2
     echo "[pediatric-pbpk] FAIL: missing PASS $tag" >&2

--- a/stdlib/clinical/pediatric_pbpk.sio
+++ b/stdlib/clinical/pediatric_pbpk.sio
@@ -455,6 +455,12 @@ pub fn ped_neonate_term_2wk() -> PedSubject {
     ped_subject_ga(2.0 / 52.142857, 40.0, 3.5, 50.0, true)
 }
 
+/// Preterm neonate: GA 28 wk, postnatal 2 wk → PMA ≈ 30 wk, ~1.2 kg.
+/// Lower MF_renal than term neonate at the same postnatal age (Rhodin).
+pub fn ped_preterm_ga28_2wk() -> PedSubject {
+    ped_subject_ga(2.0 / 52.142857, 28.0, 1.2, 38.0, true)
+}
+
 pub fn ped_infant_6mo() -> PedSubject {
     ped_subject(0.5, 7.5, 67.0, true)
 }
@@ -470,6 +476,159 @@ pub fn ped_adolescent_14yr() -> PedSubject {
 pub fn ped_adult_ref_70kg() -> PedSubject {
     // age 30, GA ignored (MF→1); used as size reference
     ped_subject_ga(30.0, 40.0, 70.0, 175.0, true)
+}
+
+// ============================================================================
+// AUC-GUIDED VANCOMYCIN (ASHP/IDSA educational targets)
+// ============================================================================
+// AUC24/MIC target band 400–600 mg·h/L at MIC=1 (Rybak 2020).
+// AUC24_ss = 24 · (D/τ) / CL  →  monotone ↓ in CL only (V cancels).
+// Dose for target AUC*:  D* = AUC* · CL · τ / 24
+
+pub fn ped_vanco_auc_target_lo() -> f64 { 400.0 }
+pub fn ped_vanco_auc_target_hi() -> f64 { 600.0 }
+pub fn ped_vanco_auc_target_mid() -> f64 { 500.0 }
+
+/// Absolute dose (mg) that realises AUC24_target for the subject's model CL.
+pub fn ped_vanco_dose_for_auc24(
+    s: &PedSubject, auc24_target: f64, interval_h: f64
+) -> f64 with Mut, Div, Panic {
+    if auc24_target <= 0.0 { return 0.0 }
+    if interval_h <= 0.0 { return 0.0 }
+    let phy = ped_physio_model(s)
+    let cl = ped_vanco_cl_l_h(phy.gfr_ml_min)
+    // D = AUC · CL · τ / 24
+    auc24_target * cl * interval_h / 24.0
+}
+
+/// Knightian AUC24 enclosure: only CL uncertainty (AUC ↓ when CL ↑).
+/// Corners: AUC_lo at CL_hi, AUC_hi at CL_lo.
+pub fn ped_vanco_auc24_knightian(
+    s: &PedSubject,
+    dose_mg: f64,
+    interval_h: f64,
+    tdm_samples: i64,
+) -> PBox with Mut, Div, Panic {
+    if !ped_weight_ok(s.weight_kg) { return pb_vacuous() }
+    if !ped_dose_ok(dose_mg) { return pb_vacuous() }
+    if !ped_tau_ok(interval_h) { return pb_vacuous() }
+    if !ped_age_ok(s.age_years) { return pb_vacuous() }
+    if tdm_samples < 0 { return pb_vacuous() }
+
+    let phy = ped_physio_model(s)
+    let cl0 = ped_vanco_cl_l_h(phy.gfr_ml_min)
+    let bands = ped_band_frac(tdm_samples)
+    let f_cl = bands.1
+    let cl_lo = cl0 * (1.0 - f_cl)
+    let cl_hi = cl0 * (1.0 + f_cl)
+    if cl_lo <= 0.0 { return pb_vacuous() }
+
+    let dose_rate = dose_mg / interval_h
+    let auc_lo = 24.0 * dose_rate / cl_hi
+    let auc_hi = 24.0 * dose_rate / cl_lo
+    if auc_hi < auc_lo { return pb_vacuous() }
+
+    let conf = if tdm_samples >= 3 { 920 } else {
+        if tdm_samples >= 1 { 880 } else { 850 }
+    }
+    pb_new(auc_lo, auc_hi, 0.0, conf)
+}
+
+/// Educational AUC-band gate (default 400–600).
+pub fn ped_vanco_is_auc_on_target(p: &PBox, lo: f64, hi: f64, min_conf: i64) -> bool {
+    if pb_confidence(p) <= 0 { return false }
+    if !pb_is_credible(p, min_conf) { return false }
+    pb_within(p, lo, hi)
+}
+
+// ============================================================================
+// GENTAMICIN — same spine (renal maturation + allometry + Knightian Cmin)
+// ============================================================================
+// Hilf 1989 / Begg 1995 order: Vc ≈ 0.25 L/kg, CL ≈ 0.06 L/h per mL/min GFR.
+// Multi-daily educational trough window 0.5–2.0 mg/L (not extended-interval).
+
+pub struct PedGentPK {
+    dose_mg: f64,
+    interval_h: f64,
+    cl_l_h: f64,
+    vc_l: f64,
+    ke: f64,
+    cmin_mg_l: f64,
+    auc24_mg_h_l: f64,
+    gfr_ml_min: f64,
+    mf_renal: f64,
+}
+
+pub fn ped_gent_cl_l_h(gfr_ml_min: f64) -> f64 {
+    // Already in L/h when coefficient is 0.06 × (mL/min) — matches adult module.
+    0.06 * gfr_ml_min
+}
+
+pub fn ped_gent_vc_l(weight_kg: f64) -> f64 {
+    0.25 * weight_kg
+}
+
+pub fn ped_gent_pk(s: &PedSubject, dose_mg: f64, interval_h: f64) -> PedGentPK with Mut, Div, Panic {
+    let phy = ped_physio_model(s)
+    let cl = ped_gent_cl_l_h(phy.gfr_ml_min)
+    let vc = ped_gent_vc_l(s.weight_kg)
+    let ke = if vc > 0.0 { cl / vc } else { 0.0 }
+    let cmin = ped_cmin_point(vc, cl, dose_mg, interval_h)
+    let dose_rate = if interval_h > 0.0 { dose_mg / interval_h } else { 0.0 }
+    let auc24 = if cl > 0.0 { 24.0 * dose_rate / cl } else { 0.0 }
+    PedGentPK {
+        dose_mg: dose_mg,
+        interval_h: interval_h,
+        cl_l_h: cl,
+        vc_l: vc,
+        ke: ke,
+        cmin_mg_l: cmin,
+        auc24_mg_h_l: auc24,
+        gfr_ml_min: phy.gfr_ml_min,
+        mf_renal: phy.mf_renal,
+    }
+}
+
+pub fn ped_gent_pk_mg_per_kg(
+    s: &PedSubject, mg_per_kg: f64, interval_h: f64
+) -> PedGentPK with Mut, Div, Panic {
+    ped_gent_pk(s, mg_per_kg * s.weight_kg, interval_h)
+}
+
+pub fn ped_gent_cmin_knightian(
+    s: &PedSubject,
+    dose_mg: f64,
+    interval_h: f64,
+    tdm_samples: i64,
+) -> PBox with Mut, Div, Panic {
+    if !ped_weight_ok(s.weight_kg) { return pb_vacuous() }
+    if !ped_dose_ok(dose_mg) { return pb_vacuous() }
+    if !ped_tau_ok(interval_h) { return pb_vacuous() }
+    if !ped_age_ok(s.age_years) { return pb_vacuous() }
+    if tdm_samples < 0 { return pb_vacuous() }
+
+    let phy = ped_physio_model(s)
+    let cl0 = ped_gent_cl_l_h(phy.gfr_ml_min)
+    let vc0 = ped_gent_vc_l(s.weight_kg)
+    let bands = ped_band_frac(tdm_samples)
+    let f_vc = bands.0
+    let f_cl = bands.1
+    let vc_lo = vc0 * (1.0 - f_vc)
+    let vc_hi = vc0 * (1.0 + f_vc)
+    let cl_lo = cl0 * (1.0 - f_cl)
+    let cl_hi = cl0 * (1.0 + f_cl)
+    let c_lo = ped_cmin_point(vc_lo, cl_hi, dose_mg, interval_h)
+    let c_hi = ped_cmin_point(vc_hi, cl_lo, dose_mg, interval_h)
+    if c_hi < c_lo { return pb_vacuous() }
+    let conf = if tdm_samples >= 3 { 920 } else {
+        if tdm_samples >= 1 { 880 } else { 850 }
+    }
+    pb_new(c_lo, c_hi, 0.0, conf)
+}
+
+pub fn ped_gent_is_safe_trough(p: &PBox, min_conf: i64) -> bool {
+    // Multi-daily educational window 0.5–2.0 mg/L
+    ped_vanco_is_safe_trough(p, 0.5, 2.0, min_conf)
 }
 
 // ============================================================================
@@ -556,6 +715,43 @@ pub fn ped_selftest() -> i64 with IO, Mut, Div, Panic {
         print("FAIL ped_adult_cl_matzke cl=")
         print_f64(pk_a.cl_l_h)
         print("\n")
+    }
+
+    // T7: preterm GA28 PMA lower MF and lower absolute CL than term neonate
+    let pre = ped_preterm_ga28_2wk()
+    let mf_p = ped_gfr_maturation(ped_pma_weeks(&pre))
+    let pk_p = ped_vanco_pk_mg_per_kg(&pre, 15.0, 12.0)
+    if mf_p < mf_n && pk_p.cl_l_h < cl_neo && ped_pma_weeks(&pre) < ped_pma_weeks(&neo) {
+        print("PASS ped_preterm_vs_term\n")
+        n = n + 1
+    } else {
+        print("FAIL ped_preterm_vs_term\n")
+    }
+
+    // T8: AUC-guided dose realises ~500 mg·h/L mid-target on child
+    let d_star = ped_vanco_dose_for_auc24(&child, ped_vanco_auc_target_mid(), 12.0)
+    let pk_star = ped_vanco_pk(&child, d_star, 12.0)
+    if ped_abs(pk_star.auc24_mg_h_l - 500.0) < 1.0 && d_star > 0.0 {
+        print("PASS ped_auc_guided_dose\n")
+        n = n + 1
+    } else {
+        print("FAIL ped_auc_guided_dose auc=")
+        print_f64(pk_star.auc24_mg_h_l)
+        print("\n")
+    }
+
+    // T9: gentamicin CL scales with GFR; preterm Cmin machinery finite
+    let g_c = ped_gent_pk_mg_per_kg(&child, 2.5, 8.0)
+    let g_p = ped_gent_pk_mg_per_kg(&pre, 2.5, 12.0)
+    let gbox = ped_gent_cmin_knightian(&child, 2.5 * child.weight_kg, 8.0, 0)
+    if g_c.cl_l_h > g_p.cl_l_h
+        && g_c.cmin_mg_l > 0.0
+        && pb_gap(&gbox) > 0.0
+        && pb_confidence(&gbox) >= 800 {
+        print("PASS ped_gentamicin_spine\n")
+        n = n + 1
+    } else {
+        print("FAIL ped_gentamicin_spine\n")
     }
 
     n


### PR DESCRIPTION
## Summary

Extends [#1524](https://github.com/Sounio-lang/sounio/pull/1524) paediatric PBPK:

| Feature | Evidence |
|---|---|
| **Preterm GA28** | MF=0.17, CL=0.26 L/h < term neo CL=0.43 |
| **AUC-guided vanco** | dose★ → AUC24=**500.000** exact mid-target |
| **AUC p-box** | post-TDM [463, 543] contains 500 |
| **Gentamicin** | child CL 2.81 > preterm 0.058; Knightian Cmin REFUSE pre-TDM |

Gate: **9/9** PASS tags → `PEDIATRIC_PBPK_GATE_OK`

## Test plan
- [x] `bash scripts/ci/pediatric_pbpk_gate.sh`
- [x] xAI math-review (Cmin ∂V flag rejected vs analytic derivative)