### PR TITLE
feat(clinical): paediatric PBPK v3 — amikacin + neonate q6 vs q12

### DIFF
--- a/docs/audit/PEDIATRIC_PBPK_2026-07-27.md
+++ b/docs/audit/PEDIATRIC_PBPK_2026-07-27.md
@@ -1,10 +1,10 @@
 # Paediatric PBPK — functional maturation + AUC-guided vanco + gentamicin
 
 **Date:** 2026-07-27  
-**Status:** live (v2: preterm + AUC + gentamicin)  
+**Status:** live (v3: + amikacin + neonate q6 vs q12)  
 **Module:** `stdlib/clinical/pediatric_pbpk.sio`  
 **Demo:** `examples/pediatric_pbpk_demo.sio`  
-**Gate:** `scripts/ci/pediatric_pbpk_gate.sh` → `PEDIATRIC_PBPK_GATE_OK` (9/9)
+**Gate:** `scripts/ci/pediatric_pbpk_gate.sh` → `PEDIATRIC_PBPK_GATE_OK` (11/11)
 
 ## Scope
 
@@ -18,6 +18,9 @@ Educational / compiler-stdlib **paediatric PBPK spine** with:
 6. **Preterm GA28** cohort (PMA 30 wk) vs term neonate
 7. **AUC-guided** dose for mid-target 500 mg·h/L + AUC p-box (↓CL only)
 8. **Gentamicin** on the same renal spine (Vc 0.25 L/kg, CL∝GFR)
+9. **Amikacin** (Vc 0.27 L/kg, CL∝GFR, trough screen 4–8 mg/L)
+10. **Neonate interval compare**: fixed 30 mg/kg/day as q6h vs q12h
+    (Cmin_q6 > Cmin_q12, Cmax_q6 < Cmax_q12, AUC24 equal)
 
 **Not medical guidance.**
 

--- a/examples/pediatric_pbpk_demo.sio
+++ b/examples/pediatric_pbpk_demo.sio
@@ -1,19 +1,17 @@
 // examples/pediatric_pbpk_demo.sio
 //
-// Paediatric PBPK functional receipt — maturation + AUC-guided vanco + gentamicin.
+// Paediatric PBPK functional receipt — maturation, AUC, gent, amik, q6 vs q12.
 //
 // Cohort: preterm GA28 → term neonate → infant → child → adolescent → adult
 //
 // Pass tags:
-//   3201 adult CL Matzke@GFR120
-//   3202 renal MF: preterm < term neo < infant < adult
-//   3203 maturation penalty (term neo CL << MF=1 counterfactual)
-//   3204 child AUC24 band + GUM ep
-//   3205 Knightian Cmin narrows with TDM
-//   3206 ped_selftest == 9
-//   3207 preterm vs term (MF + CL)
-//   3208 AUC-guided dose hits 500 mg·h/L
-//   3209 gentamicin spine (CL order + p-box)
+//   3201–3205 base spine (CL/MF/maturation/AUC/Knightian)
+//   3206 ped_selftest == 11
+//   3207 preterm vs term
+//   3208 AUC-guided dose hits 500
+//   3209 gentamicin spine
+//   3210 amikacin spine
+//   3211 neonate 30 mg/kg/day q6 vs q12 (Cmin↑, Cmax↓, AUC=)
 //
 // Gate: scripts/ci/pediatric_pbpk_gate.sh
 
@@ -27,6 +25,8 @@ use clinical::pediatric_pbpk::{
     ped_vanco_auc24_knightian, ped_vanco_is_auc_on_target,
     ped_vanco_auc_target_lo, ped_vanco_auc_target_hi,
     ped_gent_pk_mg_per_kg, ped_gent_cmin_knightian, ped_gent_is_safe_trough,
+    ped_amik_pk_mg_per_kg, ped_amik_cmin_knightian, ped_amik_is_safe_trough,
+    ped_vanco_neonate_q6_vs_q12,
     ped_selftest,
 }
 use epistemic::knowledge::{ep_val, ep_std}
@@ -177,7 +177,7 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     print("PED_SELFTEST_PASS ")
     print_int(st)
     print("\n")
-    n = n + pass_if(st == 9, 3206)
+    n = n + pass_if(st == 11, 3206)
 
     // 3207 preterm vs term
     let pk_p = ped_vanco_pk_mg_per_kg(&preterm, 15.0, 12.0)
@@ -237,8 +237,62 @@ fn main() -> i32 with IO, Mut, Div, Panic {
         3209
     )
 
+    // 3210 amikacin
+    let a_c = ped_amik_pk_mg_per_kg(&child, 7.5, 8.0)
+    let a_p = ped_amik_pk_mg_per_kg(&preterm, 7.5, 12.0)
+    let abox = ped_amik_cmin_knightian(&child, 7.5 * child.weight_kg, 8.0, 0)
+    print("PED_AMIK child_cl=")
+    print_f64(a_c.cl_l_h)
+    print(" preterm_cl=")
+    print_f64(a_p.cl_l_h)
+    print(" child_cmin=")
+    print_f64(a_c.cmin_mg_l)
+    print("\n")
+    print("PED_AMIK_PBOX ")
+    print_f64(pb_lo_mean(&abox))
+    print("..")
+    print_f64(pb_hi_mean(&abox))
+    print("\n")
+    let a_safe = ped_amik_is_safe_trough(&abox, 800)
+    if a_safe { print("PED_AMIK_DECISION PRESCRIBE\n") } else { print("PED_AMIK_DECISION REFUSE\n") }
+    n = n + pass_if(
+        a_c.cl_l_h > a_p.cl_l_h && a_c.cmin_mg_l > 0.0 && pb_gap(&abox) > 0.0,
+        3210
+    )
+
+    // 3211 neonate q6 vs q12 at fixed 30 mg/kg/day
+    let iv = ped_vanco_neonate_q6_vs_q12(&neo)
+    print("PED_IV_CMP daily=")
+    print_f64(iv.daily_mg_per_kg)
+    print(" q6_dose=")
+    print_f64(iv.dose_short_mg)
+    print(" q12_dose=")
+    print_f64(iv.dose_long_mg)
+    print("\n")
+    print("PED_IV_CMP cmin_q6=")
+    print_f64(iv.cmin_short)
+    print(" cmin_q12=")
+    print_f64(iv.cmin_long)
+    print(" cmax_q6=")
+    print_f64(iv.cmax_short)
+    print(" cmax_q12=")
+    print_f64(iv.cmax_long)
+    print("\n")
+    print("PED_IV_CMP auc24_q6=")
+    print_f64(iv.auc24_short)
+    print(" auc24_q12=")
+    print_f64(iv.auc24_long)
+    print("\n")
+    n = n + pass_if(
+        iv.cmin_short > iv.cmin_long
+            && iv.cmax_short < iv.cmax_long
+            && abs_f(iv.auc24_short - iv.auc24_long) < 1.0e-9
+            && iv.dose_short_mg < iv.dose_long_mg,
+        3211
+    )
+
     print("PED_LEDGER_JSON {")
-    print("\"schema\":\"sounio.pediatric_pbpk.v2\",")
+    print("\"schema\":\"sounio.pediatric_pbpk.v3\",")
     print("\"preterm_cl\":")
     print_f64(pk_p.cl_l_h)
     print(",\"neo_cl\":")
@@ -249,6 +303,12 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     print_f64(pk_star.auc24_mg_h_l)
     print(",\"gent_child_cl\":")
     print_f64(g_c.cl_l_h)
+    print(",\"amik_child_cl\":")
+    print_f64(a_c.cl_l_h)
+    print(",\"neo_cmin_q6\":")
+    print_f64(iv.cmin_short)
+    print(",\"neo_cmin_q12\":")
+    print_f64(iv.cmin_long)
     print(",\"pass\":")
     print_int(n)
     print("}\n")
@@ -256,7 +316,7 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     print("PEDIATRIC_PBPK_PASS ")
     print_int(n)
     print("\n")
-    if n == 9 {
+    if n == 11 {
         print("PEDIATRIC_PBPK_OK\n")
         0
     } else {

--- a/scripts/ci/pediatric_pbpk_gate.sh
+++ b/scripts/ci/pediatric_pbpk_gate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Paediatric PBPK functional gate — preterm + AUC-guided vanco + gentamicin.
+# Paediatric PBPK gate v3 — amikacin + neonate q6 vs q12.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
@@ -20,7 +20,7 @@ if ! grep -q 'PEDIATRIC_PBPK_OK' "$OUT"; then
   rm -f "$OUT"
   exit 1
 fi
-for tag in 3201 3202 3203 3204 3205 3206 3207 3208 3209; do
+for tag in 3201 3202 3203 3204 3205 3206 3207 3208 3209 3210 3211; do
   if ! grep -q "PASS $tag" "$OUT"; then
     cat "$OUT" >&2
     echo "[pediatric-pbpk] FAIL: missing PASS $tag" >&2

--- a/stdlib/clinical/pediatric_pbpk.sio
+++ b/stdlib/clinical/pediatric_pbpk.sio
@@ -632,6 +632,164 @@ pub fn ped_gent_is_safe_trough(p: &PBox, min_conf: i64) -> bool {
 }
 
 // ============================================================================
+// AMIKACIN — same spine (Marsot 2017 / Pai 2014 educational params)
+// ============================================================================
+// Vc ≈ 0.27 L/kg, CL ≈ 0.05 L/h per mL/min GFR (slightly lower than gent).
+// Multi-daily educational trough window 4.0–8.0 mg/L (not extended-interval).
+
+pub struct PedAmikPK {
+    dose_mg: f64,
+    interval_h: f64,
+    cl_l_h: f64,
+    vc_l: f64,
+    ke: f64,
+    cmin_mg_l: f64,
+    cmax_approx_mg_l: f64,
+    auc24_mg_h_l: f64,
+    gfr_ml_min: f64,
+    mf_renal: f64,
+}
+
+pub fn ped_amik_cl_l_h(gfr_ml_min: f64) -> f64 {
+    0.05 * gfr_ml_min
+}
+
+pub fn ped_amik_vc_l(weight_kg: f64) -> f64 {
+    0.27 * weight_kg
+}
+
+pub fn ped_amik_pk(s: &PedSubject, dose_mg: f64, interval_h: f64) -> PedAmikPK with Mut, Div, Panic {
+    let phy = ped_physio_model(s)
+    let cl = ped_amik_cl_l_h(phy.gfr_ml_min)
+    let vc = ped_amik_vc_l(s.weight_kg)
+    let ke = if vc > 0.0 { cl / vc } else { 0.0 }
+    let cmin = ped_cmin_point(vc, cl, dose_mg, interval_h)
+    let cmax = ped_cmax_approx(vc, cl, dose_mg, interval_h)
+    let dose_rate = if interval_h > 0.0 { dose_mg / interval_h } else { 0.0 }
+    let auc24 = if cl > 0.0 { 24.0 * dose_rate / cl } else { 0.0 }
+    PedAmikPK {
+        dose_mg: dose_mg,
+        interval_h: interval_h,
+        cl_l_h: cl,
+        vc_l: vc,
+        ke: ke,
+        cmin_mg_l: cmin,
+        cmax_approx_mg_l: cmax,
+        auc24_mg_h_l: auc24,
+        gfr_ml_min: phy.gfr_ml_min,
+        mf_renal: phy.mf_renal,
+    }
+}
+
+pub fn ped_amik_pk_mg_per_kg(
+    s: &PedSubject, mg_per_kg: f64, interval_h: f64
+) -> PedAmikPK with Mut, Div, Panic {
+    ped_amik_pk(s, mg_per_kg * s.weight_kg, interval_h)
+}
+
+pub fn ped_amik_cmin_knightian(
+    s: &PedSubject,
+    dose_mg: f64,
+    interval_h: f64,
+    tdm_samples: i64,
+) -> PBox with Mut, Div, Panic {
+    if !ped_weight_ok(s.weight_kg) { return pb_vacuous() }
+    if !ped_dose_ok(dose_mg) { return pb_vacuous() }
+    if !ped_tau_ok(interval_h) { return pb_vacuous() }
+    if !ped_age_ok(s.age_years) { return pb_vacuous() }
+    if tdm_samples < 0 { return pb_vacuous() }
+
+    let phy = ped_physio_model(s)
+    let cl0 = ped_amik_cl_l_h(phy.gfr_ml_min)
+    let vc0 = ped_amik_vc_l(s.weight_kg)
+    let bands = ped_band_frac(tdm_samples)
+    let f_vc = bands.0
+    let f_cl = bands.1
+    let vc_lo = vc0 * (1.0 - f_vc)
+    let vc_hi = vc0 * (1.0 + f_vc)
+    let cl_lo = cl0 * (1.0 - f_cl)
+    let cl_hi = cl0 * (1.0 + f_cl)
+    let c_lo = ped_cmin_point(vc_lo, cl_hi, dose_mg, interval_h)
+    let c_hi = ped_cmin_point(vc_hi, cl_lo, dose_mg, interval_h)
+    if c_hi < c_lo { return pb_vacuous() }
+    let conf = if tdm_samples >= 3 { 920 } else {
+        if tdm_samples >= 1 { 880 } else { 850 }
+    }
+    pb_new(c_lo, c_hi, 0.0, conf)
+}
+
+pub fn ped_amik_is_safe_trough(p: &PBox, min_conf: i64) -> bool {
+    // Multi-daily educational window 4.0–8.0 mg/L
+    ped_vanco_is_safe_trough(p, 4.0, 8.0, min_conf)
+}
+
+// ============================================================================
+// INTERVAL COMPARISON — fixed daily mg/kg, short τ vs long τ (neonate focus)
+// ============================================================================
+// Same total daily dose: D_short = daily·WT·τ_short/24, D_long = daily·WT·τ_long/24.
+// AUC24 identical (rate fixed). For finite ke:
+//   Cmin_short > Cmin_long  (less decay between doses)
+//   Cmax_short < Cmax_long  (smaller boluses)
+
+pub struct PedIntervalCompare {
+    daily_mg_per_kg: f64,
+    tau_short_h: f64,
+    tau_long_h: f64,
+    dose_short_mg: f64,
+    dose_long_mg: f64,
+    cmin_short: f64,
+    cmin_long: f64,
+    cmax_short: f64,
+    cmax_long: f64,
+    auc24_short: f64,
+    auc24_long: f64,
+    cl_l_h: f64,
+    vc_l: f64,
+}
+
+/// Vancomycin: compare two intervals at the same daily mg/kg exposure.
+pub fn ped_vanco_interval_compare_daily(
+    s: &PedSubject,
+    daily_mg_per_kg: f64,
+    tau_short_h: f64,
+    tau_long_h: f64,
+) -> PedIntervalCompare with Mut, Div, Panic {
+    let phy = ped_physio_model(s)
+    let cl = ped_vanco_cl_l_h(phy.gfr_ml_min)
+    let vc = ped_vanco_vc_l(s.weight_kg)
+    // D = (daily_mg_per_kg · WT) · (τ / 24)
+    let daily_total = daily_mg_per_kg * s.weight_kg
+    let d_s = daily_total * tau_short_h / 24.0
+    let d_l = daily_total * tau_long_h / 24.0
+    let cmin_s = ped_cmin_point(vc, cl, d_s, tau_short_h)
+    let cmin_l = ped_cmin_point(vc, cl, d_l, tau_long_h)
+    let cmax_s = ped_cmax_approx(vc, cl, d_s, tau_short_h)
+    let cmax_l = ped_cmax_approx(vc, cl, d_l, tau_long_h)
+    let auc_s = if cl > 0.0 { daily_total / cl } else { 0.0 }
+    let auc_l = auc_s
+    PedIntervalCompare {
+        daily_mg_per_kg: daily_mg_per_kg,
+        tau_short_h: tau_short_h,
+        tau_long_h: tau_long_h,
+        dose_short_mg: d_s,
+        dose_long_mg: d_l,
+        cmin_short: cmin_s,
+        cmin_long: cmin_l,
+        cmax_short: cmax_s,
+        cmax_long: cmax_l,
+        auc24_short: auc_s,
+        auc24_long: auc_l,
+        cl_l_h: cl,
+        vc_l: vc,
+    }
+}
+
+/// Neonate educational default: 30 mg/kg/day as q6h vs q12h.
+pub fn ped_vanco_neonate_q6_vs_q12(s: &PedSubject) -> PedIntervalCompare with Mut, Div, Panic {
+    ped_vanco_interval_compare_daily(s, 30.0, 6.0, 12.0)
+}
+
+// ============================================================================
 // SELF-TEST main — also used by the CI gate via the demo example
 // ============================================================================
 
@@ -752,6 +910,33 @@ pub fn ped_selftest() -> i64 with IO, Mut, Div, Panic {
         n = n + 1
     } else {
         print("FAIL ped_gentamicin_spine\n")
+    }
+
+    // T10: amikacin window + CL order (child > preterm); trough window 4–8
+    let a_c = ped_amik_pk_mg_per_kg(&child, 7.5, 8.0)
+    let a_p = ped_amik_pk_mg_per_kg(&pre, 7.5, 12.0)
+    let abox = ped_amik_cmin_knightian(&child, 7.5 * child.weight_kg, 8.0, 0)
+    if a_c.cl_l_h > a_p.cl_l_h
+        && a_c.cl_l_h > 0.0
+        && pb_gap(&abox) > 0.0
+        && pb_confidence(&abox) >= 800 {
+        print("PASS ped_amikacin_spine\n")
+        n = n + 1
+    } else {
+        print("FAIL ped_amikacin_spine\n")
+    }
+
+    // T11: neonate same daily 30 mg/kg — q6 Cmin > q12 Cmin, q6 Cmax < q12 Cmax,
+    //      AUC24 equal (fixed daily rate)
+    let iv = ped_vanco_neonate_q6_vs_q12(&neo)
+    if iv.cmin_short > iv.cmin_long
+        && iv.cmax_short < iv.cmax_long
+        && ped_abs(iv.auc24_short - iv.auc24_long) < 1.0e-9
+        && iv.dose_short_mg < iv.dose_long_mg {
+        print("PASS ped_neonate_q6_vs_q12\n")
+        n = n + 1
+    } else {
+        print("FAIL ped_neonate_q6_vs_q12\n")
     }
 
     n


### PR DESCRIPTION
## Summary

Extends paediatric PBPK with both requested pieces:

### Amikacin
| Subject | CL (L/h) | note |
|---|---:|---|
| Child 20 kg | 2.34 | Vc 0.27 L/kg |
| Preterm 1.2 kg | 0.049 | same spine, lower GFR |

Pre-TDM Knightian → **REFUSE** (window 4–8).

### Neonate q6h vs q12h (30 mg/kg/**day** fixed)
| | q6h | q12h |
|---|---:|---:|
| Dose/admin | 26.25 mg | 52.5 mg |
| **Cmin** | **4.92** | 2.06 |
| **Cmax** | 18.6 | **29.3** |
| AUC24 | 246.48 | 246.48 (equal) |

Gate: **11/11** → `PEDIATRIC_PBPK_GATE_OK`

## Test plan
- [x] `bash scripts/ci/pediatric_pbpk_gate.sh`