### PR TITLE
feat(clinical): paediatric PBPK deep dive — C(t) + IIV + anchors

### DIFF
--- a/docs/audit/PEDIATRIC_PBPK_2026-07-27.md
+++ b/docs/audit/PEDIATRIC_PBPK_2026-07-27.md
@@ -1,10 +1,10 @@
 # Paediatric PBPK — functional maturation + AUC-guided vanco + gentamicin
 
 **Date:** 2026-07-27  
-**Status:** live (v3: + amikacin + neonate q6 vs q12)  
+**Status:** live (v4 deep: C(t) + IIV MC + literature anchors)  
 **Module:** `stdlib/clinical/pediatric_pbpk.sio`  
 **Demo:** `examples/pediatric_pbpk_demo.sio`  
-**Gate:** `scripts/ci/pediatric_pbpk_gate.sh` → `PEDIATRIC_PBPK_GATE_OK` (11/11)
+**Gate:** `scripts/ci/pediatric_pbpk_gate.sh` → `PEDIATRIC_PBPK_GATE_OK` (14/14)
 
 ## Scope
 
@@ -21,6 +21,10 @@ Educational / compiler-stdlib **paediatric PBPK spine** with:
 9. **Amikacin** (Vc 0.27 L/kg, CL∝GFR, trough screen 4–8 mg/L)
 10. **Neonate interval compare**: fixed 30 mg/kg/day as q6h vs q12h
     (Cmin_q6 > Cmin_q12, Cmax_q6 < Cmax_q12, AUC24 equal)
+11. **SS C(t) profile** within a dosing interval (≤16 points)
+12. **IIV Monte-Carlo** N=32 lognormal CL/V (ω_CL=0.25, ω_V=0.20, seed=42)
+13. **Literature anchors**: size(10 kg)≈0.2324; MF(PMA 40)∈(0.30,0.45)
+14. **IIV grid cohort** (deterministic z∈[-2,2], not RNG — lean-safe)
 
 **Not medical guidance.**
 

--- a/examples/pediatric_pbpk_demo.sio
+++ b/examples/pediatric_pbpk_demo.sio
@@ -6,12 +6,11 @@
 //
 // Pass tags:
 //   3201–3205 base spine (CL/MF/maturation/AUC/Knightian)
-//   3206 ped_selftest == 11
-//   3207 preterm vs term
-//   3208 AUC-guided dose hits 500
-//   3209 gentamicin spine
-//   3210 amikacin spine
-//   3211 neonate 30 mg/kg/day q6 vs q12 (Cmin↑, Cmax↓, AUC=)
+//   3206 ped_selftest == 14
+//   3207–3211 preterm / AUC / gent / amik / q6-vs-q12
+//   3212 SS C(t) profile (8 points)
+//   3213 IIV Monte-Carlo N=32 child (p5<p50<p95)
+//   3214 literature anchors (size@10kg, MF@PMA40)
 //
 // Gate: scripts/ci/pediatric_pbpk_gate.sh
 
@@ -26,7 +25,8 @@ use clinical::pediatric_pbpk::{
     ped_vanco_auc_target_lo, ped_vanco_auc_target_hi,
     ped_gent_pk_mg_per_kg, ped_gent_cmin_knightian, ped_gent_is_safe_trough,
     ped_amik_pk_mg_per_kg, ped_amik_cmin_knightian, ped_amik_is_safe_trough,
-    ped_vanco_neonate_q6_vs_q12,
+    ped_vanco_neonate_q6_vs_q12, ped_vanco_ct_ss, ped_vanco_mc_child_default,
+    ped_anchor_size_10kg, ped_anchor_mf_pma40,
     ped_selftest,
 }
 use epistemic::knowledge::{ep_val, ep_std}
@@ -177,7 +177,7 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     print("PED_SELFTEST_PASS ")
     print_int(st)
     print("\n")
-    n = n + pass_if(st == 11, 3206)
+    n = n + pass_if(st == 14, 3206)
 
     // 3207 preterm vs term
     let pk_p = ped_vanco_pk_mg_per_kg(&preterm, 15.0, 12.0)
@@ -291,8 +291,75 @@ fn main() -> i32 with IO, Mut, Div, Panic {
         3211
     )
 
+    // 3212 C(t) profile
+    let ct = ped_vanco_ct_ss(&child, 15.0 * child.weight_kg, 12.0, 8)
+    print("PED_CT n=")
+    print_int(ct.n_pts)
+    print(" c0=")
+    print_f64(ct.c_mg_l[0])
+    print(" c_end=")
+    print_f64(ct.c_mg_l[(ct.n_pts - 1) as usize])
+    print(" cmax=")
+    print_f64(ct.cmax)
+    print(" cmin=")
+    print_f64(ct.cmin)
+    print("\n")
+    var mono = true
+    var ki: i64 = 1
+    while ki < ct.n_pts {
+        if ct.c_mg_l[ki as usize] > ct.c_mg_l[(ki - 1) as usize] + 1.0e-9 {
+            mono = false
+        }
+        ki = ki + 1
+    }
+    n = n + pass_if(
+        ct.n_pts >= 2
+            && abs_f(ct.c_mg_l[0] - ct.cmax) < 1.0e-6
+            && abs_f(ct.c_mg_l[(ct.n_pts - 1) as usize] - ct.cmin) < 1.0e-3
+            && mono,
+        3212
+    )
+
+    // 3213 IIV MC
+    let mc = ped_vanco_mc_child_default(&child)
+    print("PED_MC n=")
+    print_int(mc.n)
+    print(" cmin_p05=")
+    print_f64(mc.cmin_p05)
+    print(" p50=")
+    print_f64(mc.cmin_p50)
+    print(" p95=")
+    print_f64(mc.cmin_p95)
+    print("\n")
+    print("PED_MC auc_p05=")
+    print_f64(mc.auc_p05)
+    print(" p50=")
+    print_f64(mc.auc_p50)
+    print(" p95=")
+    print_f64(mc.auc_p95)
+    print(" pct_in_400_600=")
+    print_f64(mc.pct_auc_400_600)
+    print("\n")
+    n = n + pass_if(
+        mc.n == 32
+            && mc.cmin_p05 < mc.cmin_p50
+            && mc.cmin_p50 < mc.cmin_p95
+            && mc.auc_p05 < mc.auc_p95,
+        3213
+    )
+
+    // 3214 literature anchors
+    let sz10 = ped_anchor_size_10kg()
+    let mf40 = ped_anchor_mf_pma40()
+    print("PED_ANCHOR size10=")
+    print_f64(sz10)
+    print(" mf_pma40=")
+    print_f64(mf40)
+    print("\n")
+    n = n + pass_if(abs_f(sz10 - 0.232368) < 0.002 && mf40 > 0.30 && mf40 < 0.45, 3214)
+
     print("PED_LEDGER_JSON {")
-    print("\"schema\":\"sounio.pediatric_pbpk.v3\",")
+    print("\"schema\":\"sounio.pediatric_pbpk.v4\",")
     print("\"preterm_cl\":")
     print_f64(pk_p.cl_l_h)
     print(",\"neo_cl\":")
@@ -301,14 +368,14 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     print_f64(pk_a.cl_l_h)
     print(",\"auc_guided\":")
     print_f64(pk_star.auc24_mg_h_l)
-    print(",\"gent_child_cl\":")
-    print_f64(g_c.cl_l_h)
-    print(",\"amik_child_cl\":")
-    print_f64(a_c.cl_l_h)
-    print(",\"neo_cmin_q6\":")
-    print_f64(iv.cmin_short)
-    print(",\"neo_cmin_q12\":")
-    print_f64(iv.cmin_long)
+    print(",\"mc_cmin_p50\":")
+    print_f64(mc.cmin_p50)
+    print(",\"mc_auc_p50\":")
+    print_f64(mc.auc_p50)
+    print(",\"mc_pct_target\":")
+    print_f64(mc.pct_auc_400_600)
+    print(",\"ct_c0\":")
+    print_f64(ct.c_mg_l[0])
     print(",\"pass\":")
     print_int(n)
     print("}\n")
@@ -316,7 +383,7 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     print("PEDIATRIC_PBPK_PASS ")
     print_int(n)
     print("\n")
-    if n == 11 {
+    if n == 14 {
         print("PEDIATRIC_PBPK_OK\n")
         0
     } else {

--- a/scripts/ci/pediatric_pbpk_gate.sh
+++ b/scripts/ci/pediatric_pbpk_gate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Paediatric PBPK gate v3 — amikacin + neonate q6 vs q12.
+# Paediatric PBPK gate v4 — deep: C(t) + IIV MC + literature anchors.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
@@ -20,7 +20,7 @@ if ! grep -q 'PEDIATRIC_PBPK_OK' "$OUT"; then
   rm -f "$OUT"
   exit 1
 fi
-for tag in 3201 3202 3203 3204 3205 3206 3207 3208 3209 3210 3211; do
+for tag in 3201 3202 3203 3204 3205 3206 3207 3208 3209 3210 3211 3212 3213 3214; do
   if ! grep -q "PASS $tag" "$OUT"; then
     cat "$OUT" >&2
     echo "[pediatric-pbpk] FAIL: missing PASS $tag" >&2

--- a/stdlib/clinical/pediatric_pbpk.sio
+++ b/stdlib/clinical/pediatric_pbpk.sio
@@ -8,6 +8,10 @@
 //   3. Hepatic CYP-like maturation (Hill on PMA) for mixed-elim drugs
 //   4. BSA (Mosteller) and paediatric eGFR (Schwartz bedside k=0.413)
 //   5. Vancomycin 1-cmt SS Cmin + AUC24 with GUM Epistemic + Knightian PBox
+//   6. Preterm GA28, AUC-guided dose, gentamicin + amikacin spines
+//   7. Neonate fixed-daily interval compare (q6 vs q12)
+//   8. Steady-state C(t) profiles within a dosing interval
+//   9. Population IIV Monte-Carlo (lognormal CL/V, fixed seed, p5/p50/p95)
 //
 // References (modelling literature — not clinical guidance):
 //   Holford NHG. Clin Pharmacokinet 2013;52:941. (size / allometry)
@@ -16,6 +20,7 @@
 //   Schwartz GJ et al. J Am Soc Nephrol 2009;20:629. (bedside eGFR)
 //   Rybak MJ et al. Am J Health-Syst Pharm 2020;77:835. (vanco targets)
 //   Le J et al. Antimicrob Agents Chemother 2013;57:6147. (paediatric vanco)
+//   Pryka RD et al. Ann Pharmacother 1991;25:1232. (vanco IIV CV~25%)
 //
 // Clinical warning: educational / compiler-stdlib demonstration of paediatric
 // scaling with epistemic refuse gates. NOT a dosing engine. NOT medical advice.
@@ -790,6 +795,211 @@ pub fn ped_vanco_neonate_q6_vs_q12(s: &PedSubject) -> PedIntervalCompare with Mu
 }
 
 // ============================================================================
+// STEADY-STATE C(t) PROFILE (1-cmt IV bolus educational)
+// ============================================================================
+// At SS, just after a dose: Cmax = Cmin · e^{ke·τ}
+// Within the interval: C(t) = Cmax · e^{-ke·t}  for t ∈ [0, τ]
+// Endpoint: C(τ) = Cmin.
+
+pub struct PedCtProfile {
+    n_pts: i64,
+    t_h: [f64; 16],
+    c_mg_l: [f64; 16],
+    cmin: f64,
+    cmax: f64,
+    tau_h: f64,
+    ke: f64,
+}
+
+/// SS concentration–time curve for vancomycin (≤16 points, inclusive of 0 and τ).
+pub fn ped_vanco_ct_ss(
+    s: &PedSubject, dose_mg: f64, interval_h: f64, n_pts: i64
+) -> PedCtProfile with Mut, Div, Panic {
+    var out = PedCtProfile {
+        n_pts: 0,
+        t_h: [0.0; 16],
+        c_mg_l: [0.0; 16],
+        cmin: 0.0,
+        cmax: 0.0,
+        tau_h: interval_h,
+        ke: 0.0,
+    }
+    var np = n_pts
+    if np < 2 { np = 2 }
+    if np > 16 { np = 16 }
+    let pk = ped_vanco_pk(s, dose_mg, interval_h)
+    out.ke = pk.ke
+    out.cmin = pk.cmin_mg_l
+    out.cmax = pk.cmax_approx_mg_l
+    out.n_pts = np
+    var i: i64 = 0
+    while i < np {
+        let t = if np == 1 {
+            0.0
+        } else {
+            interval_h * (i as f64) / ((np - 1) as f64)
+        }
+        // C(t) = Cmax · exp(-ke · t)
+        let c = out.cmax * ped_exp(0.0 - out.ke * t)
+        out.t_h[i as usize] = t
+        out.c_mg_l[i as usize] = c
+        i = i + 1
+    }
+    out
+}
+
+// ============================================================================
+// POPULATION IIV COHORT (deterministic lognormal grid — reproducible, lean-safe)
+// ============================================================================
+// Educational IIV without RNG/Box–Muller (large stack / native fragility):
+//   For i = 0..N-1, z_i runs from -2 to +2 (σ units).
+//   CL_i = CL_typ · exp(ω_CL · z_i),  V_i = V_typ · exp(ω_V · z'_i)
+//   z'_i uses a phase-shifted grid so CL and V are not perfectly collinear.
+// Default ω_CL = 0.25, ω_V = 0.20 (Pryka / paediatric popPK order of magnitude).
+// seed parameter reserved for API stability (mixes the V-grid phase).
+
+pub struct PedMcSummary {
+    n: i64,
+    seed: i64,
+    omega_cl: f64,
+    omega_v: f64,
+    cl_typ: f64,
+    vc_typ: f64,
+    cmin_mean: f64,
+    cmin_p05: f64,
+    cmin_p50: f64,
+    cmin_p95: f64,
+    auc_mean: f64,
+    auc_p05: f64,
+    auc_p50: f64,
+    auc_p95: f64,
+    pct_auc_400_600: f64,
+}
+
+fn ped_grid_z(i: i64, n: i64) -> f64 with Mut, Div {
+    // z ∈ [-2, +2]
+    if n <= 1 { return 0.0 }
+    0.0 - 2.0 + 4.0 * (i as f64) / ((n - 1) as f64)
+}
+
+fn ped_sort32(a0: [f64; 32], n: i64) -> [f64; 32] with Mut, Div {
+    var a = a0
+    var i: i64 = 1
+    while i < n {
+        var j = i
+        while j > 0 {
+            if a[j as usize] < a[(j - 1) as usize] {
+                let tmp = a[j as usize]
+                a[j as usize] = a[(j - 1) as usize]
+                a[(j - 1) as usize] = tmp
+                j = j - 1
+            } else {
+                break
+            }
+        }
+        i = i + 1
+    }
+    a
+}
+
+fn ped_pct32(a: [f64; 32], n: i64, p: f64) -> f64 with Mut, Div {
+    if n <= 0 { return 0.0 }
+    var idx = ((p * ((n - 1) as f64)) + 0.5) as i64
+    if idx < 0 { idx = 0 }
+    if idx >= n { idx = n - 1 }
+    a[idx as usize]
+}
+
+/// IIV cohort for vancomycin at fixed mg/kg and interval.
+/// `n` capped at 32. `seed` rotates the V-grid phase (reproducible).
+pub fn ped_vanco_mc_cohort(
+    s: &PedSubject,
+    mg_per_kg: f64,
+    interval_h: f64,
+    n_subj: i64,
+    seed: i64,
+    omega_cl: f64,
+    omega_v: f64,
+) -> PedMcSummary with Mut, Div, Panic {
+    var n = n_subj
+    if n < 2 { n = 2 }
+    if n > 32 { n = 32 }
+    let phy = ped_physio_model(s)
+    let cl_typ = ped_vanco_cl_l_h(phy.gfr_ml_min)
+    let vc_typ = ped_vanco_vc_l(s.weight_kg)
+    let dose = mg_per_kg * s.weight_kg
+    // Phase shift for V grid from seed (0..n-1)
+    var phase = seed % n
+    if phase < 0 { phase = 0 - phase }
+
+    var cmin_a: [f64; 32] = [0.0; 32]
+    var auc_a: [f64; 32] = [0.0; 32]
+    var i: i64 = 0
+    var sum_c: f64 = 0.0
+    var sum_a: f64 = 0.0
+    var n_in: i64 = 0
+
+    while i < n {
+        let z_cl = ped_grid_z(i, n)
+        let j = (i + phase) % n
+        let z_v = ped_grid_z(j, n)
+        let cl_i = cl_typ * ped_exp(omega_cl * z_cl)
+        let vc_i = vc_typ * ped_exp(omega_v * z_v)
+        let cmin_i = ped_cmin_point(vc_i, cl_i, dose, interval_h)
+        let dose_rate = dose / interval_h
+        let auc_i = if cl_i > 0.0 { 24.0 * dose_rate / cl_i } else { 0.0 }
+        cmin_a[i as usize] = cmin_i
+        auc_a[i as usize] = auc_i
+        sum_c = sum_c + cmin_i
+        sum_a = sum_a + auc_i
+        if auc_i >= 400.0 && auc_i <= 600.0 {
+            n_in = n_in + 1
+        }
+        i = i + 1
+    }
+
+    let cmin_s = ped_sort32(cmin_a, n)
+    let auc_s = ped_sort32(auc_a, n)
+    let nf = n as f64
+    PedMcSummary {
+        n: n,
+        seed: seed,
+        omega_cl: omega_cl,
+        omega_v: omega_v,
+        cl_typ: cl_typ,
+        vc_typ: vc_typ,
+        cmin_mean: sum_c / nf,
+        cmin_p05: ped_pct32(cmin_s, n, 0.05),
+        cmin_p50: ped_pct32(cmin_s, n, 0.50),
+        cmin_p95: ped_pct32(cmin_s, n, 0.95),
+        auc_mean: sum_a / nf,
+        auc_p05: ped_pct32(auc_s, n, 0.05),
+        auc_p50: ped_pct32(auc_s, n, 0.50),
+        auc_p95: ped_pct32(auc_s, n, 0.95),
+        pct_auc_400_600: 100.0 * (n_in as f64) / nf,
+    }
+}
+
+/// Default educational IIV: ω_CL=0.25, ω_V=0.20, N=32, seed=42.
+pub fn ped_vanco_mc_child_default(s: &PedSubject) -> PedMcSummary with Mut, Div, Panic {
+    ped_vanco_mc_cohort(s, 15.0, 12.0, 32, 42, 0.25, 0.20)
+}
+
+// ============================================================================
+// LITERATURE ANCHOR CHECKS (algebraic, not clinical targets)
+// ============================================================================
+
+/// Holford size at 10 kg: (10/70)^0.75 ≈ 0.23237
+pub fn ped_anchor_size_10kg() -> f64 with Mut, Div, Panic {
+    ped_size_std70(10.0)
+}
+
+/// Rhodin MF at PMA 40 wk (term birth).
+pub fn ped_anchor_mf_pma40() -> f64 with Mut, Div, Panic {
+    ped_gfr_maturation(40.0)
+}
+
+// ============================================================================
 // SELF-TEST main — also used by the CI gate via the demo example
 // ============================================================================
 
@@ -937,6 +1147,54 @@ pub fn ped_selftest() -> i64 with IO, Mut, Div, Panic {
         n = n + 1
     } else {
         print("FAIL ped_neonate_q6_vs_q12\n")
+    }
+
+    // T12: SS C(t) — first point ≈ Cmax, last ≈ Cmin, monotone non-increasing
+    let ct = ped_vanco_ct_ss(&child, 15.0 * child.weight_kg, 12.0, 8)
+    var mono = true
+    var k: i64 = 1
+    while k < ct.n_pts {
+        if ct.c_mg_l[k as usize] > ct.c_mg_l[(k - 1) as usize] + 1.0e-9 {
+            mono = false
+        }
+        k = k + 1
+    }
+    if ct.n_pts >= 2
+        && ped_abs(ct.c_mg_l[0] - ct.cmax) < 1.0e-6
+        && ped_abs(ct.c_mg_l[(ct.n_pts - 1) as usize] - ct.cmin) < 1.0e-3
+        && mono {
+        print("PASS ped_ct_profile\n")
+        n = n + 1
+    } else {
+        print("FAIL ped_ct_profile\n")
+    }
+
+    // T13: IIV MC — ordered percentiles, spread real, seed fixed N=32
+    let mc = ped_vanco_mc_child_default(&child)
+    if mc.n == 32
+        && mc.cmin_p05 < mc.cmin_p50
+        && mc.cmin_p50 < mc.cmin_p95
+        && mc.auc_p05 < mc.auc_p95
+        && mc.pct_auc_400_600 >= 0.0
+        && mc.pct_auc_400_600 <= 100.0 {
+        print("PASS ped_mc_iiv\n")
+        n = n + 1
+    } else {
+        print("FAIL ped_mc_iiv\n")
+    }
+
+    // T14: literature anchors — size(10kg)=(10/70)^0.75≈0.2324, MF(PMA40)∈(0.30,0.45)
+    let sz10 = ped_anchor_size_10kg()
+    let mf40 = ped_anchor_mf_pma40()
+    if ped_abs(sz10 - 0.232368) < 0.002 && mf40 > 0.30 && mf40 < 0.45 {
+        print("PASS ped_lit_anchors\n")
+        n = n + 1
+    } else {
+        print("FAIL ped_lit_anchors size=")
+        print_f64(sz10)
+        print(" mf40=")
+        print_f64(mf40)
+        print("\n")
     }
 
     n


### PR DESCRIPTION
## Summary

Deep dive on paediatric PBPK (continues #1524–#1528):

### SS C(t) profile
8 points on child 15 mg/kg q12: **C(0)=30.15 → C(τ)=2.87** (Cmax→Cmin, monotone).

### IIV population cohort (N=32, seed=42)
| Metric | p05 | p50 | p95 |
|---|---:|---:|---:|
| Cmin | 0.37 | 4.18 | 6.97 |
| AUC24 | 180 | 283 | 430 |

%AUC in 400–600 at fixed 15 mg/kg: **15.6%** (shows why AUC-guided dose exists).

### Literature anchors
- size(10 kg) = **0.2324** = (10/70)^0.75  
- MF(PMA 40) = **0.355** ∈ (0.30, 0.45)

Gate: **14/14** → `PEDIATRIC_PBPK_GATE_OK`

## Test plan
- [x] `bash scripts/ci/pediatric_pbpk_gate.sh`