### PR TITLE
feat(clinical): paediatric PBPK v5 — individualisation + accumulation

### DIFF
--- a/docs/audit/PEDIATRIC_PBPK_2026-07-27.md
+++ b/docs/audit/PEDIATRIC_PBPK_2026-07-27.md
@@ -1,10 +1,10 @@
 # Paediatric PBPK — functional maturation + AUC-guided vanco + gentamicin
 
 **Date:** 2026-07-27  
-**Status:** live (v4 deep: C(t) + IIV MC + literature anchors)  
+**Status:** live (v5: AUC individualisation under IIV + multi-dose accumulation)  
 **Module:** `stdlib/clinical/pediatric_pbpk.sio`  
 **Demo:** `examples/pediatric_pbpk_demo.sio`  
-**Gate:** `scripts/ci/pediatric_pbpk_gate.sh` → `PEDIATRIC_PBPK_GATE_OK` (14/14)
+**Gate:** `scripts/ci/pediatric_pbpk_gate.sh` → `PEDIATRIC_PBPK_GATE_OK` (16/16)
 
 ## Scope
 
@@ -25,6 +25,8 @@ Educational / compiler-stdlib **paediatric PBPK spine** with:
 12. **IIV Monte-Carlo** N=32 lognormal CL/V (ω_CL=0.25, ω_V=0.20, seed=42)
 13. **Literature anchors**: size(10 kg)≈0.2324; MF(PMA 40)∈(0.30,0.45)
 14. **IIV grid cohort** (deterministic z∈[-2,2], not RNG — lean-safe)
+15. **Fixed vs AUC-guided** under IIV — %AUC in 400–600 (perfect-CL upper bound)
+16. **Multi-dose accumulation** — Cmin_n/Cmin_ss → 1; doses to 90% SS
 
 **Not medical guidance.**
 

--- a/examples/pediatric_pbpk_demo.sio
+++ b/examples/pediatric_pbpk_demo.sio
@@ -6,11 +6,10 @@
 //
 // Pass tags:
 //   3201–3205 base spine (CL/MF/maturation/AUC/Knightian)
-//   3206 ped_selftest == 14
-//   3207–3211 preterm / AUC / gent / amik / q6-vs-q12
-//   3212 SS C(t) profile (8 points)
-//   3213 IIV Monte-Carlo N=32 child (p5<p50<p95)
-//   3214 literature anchors (size@10kg, MF@PMA40)
+//   3206 ped_selftest == 16
+//   3207–3214 preterm / AUC / gent / amik / q6-q12 / C(t) / IIV / anchors
+//   3215 fixed vs AUC-guided under IIV (% in 400–600)
+//   3216 multi-dose accumulation to SS
 //
 // Gate: scripts/ci/pediatric_pbpk_gate.sh
 
@@ -26,6 +25,7 @@ use clinical::pediatric_pbpk::{
     ped_gent_pk_mg_per_kg, ped_gent_cmin_knightian, ped_gent_is_safe_trough,
     ped_amik_pk_mg_per_kg, ped_amik_cmin_knightian, ped_amik_is_safe_trough,
     ped_vanco_neonate_q6_vs_q12, ped_vanco_ct_ss, ped_vanco_mc_child_default,
+    ped_vanco_indiv_child_default, ped_vanco_accumulation,
     ped_anchor_size_10kg, ped_anchor_mf_pma40,
     ped_selftest,
 }
@@ -177,7 +177,7 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     print("PED_SELFTEST_PASS ")
     print_int(st)
     print("\n")
-    n = n + pass_if(st == 14, 3206)
+    n = n + pass_if(st == 16, 3206)
 
     // 3207 preterm vs term
     let pk_p = ped_vanco_pk_mg_per_kg(&preterm, 15.0, 12.0)
@@ -358,8 +358,54 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     print("\n")
     n = n + pass_if(abs_f(sz10 - 0.232368) < 0.002 && mf40 > 0.30 && mf40 < 0.45, 3214)
 
+    // 3215 individualisation
+    let ind = ped_vanco_indiv_child_default(&child)
+    print("PED_INDIV fixed%=")
+    print_f64(ind.pct_fixed_in_target)
+    print(" guided%=")
+    print_f64(ind.pct_guided_in_target)
+    print(" auc_f_mean=")
+    print_f64(ind.auc_fixed_mean)
+    print(" auc_g_mean=")
+    print_f64(ind.auc_guided_mean)
+    print("\n")
+    print("PED_INDIV fixed_p05=")
+    print_f64(ind.auc_fixed_p05)
+    print(" p95=")
+    print_f64(ind.auc_fixed_p95)
+    print(" guided_p05=")
+    print_f64(ind.auc_guided_p05)
+    print(" p95=")
+    print_f64(ind.auc_guided_p95)
+    print("\n")
+    n = n + pass_if(
+        ind.pct_guided_in_target > ind.pct_fixed_in_target + 20.0
+            && ind.pct_guided_in_target > 95.0
+            && abs_f(ind.auc_guided_mean - 500.0) < 1.0,
+        3215
+    )
+
+    // 3216 accumulation
+    let acc = ped_vanco_accumulation(&child, 15.0 * child.weight_kg, 12.0, 6)
+    print("PED_ACC d90=")
+    print_int(acc.doses_to_90pct_cmin)
+    print(" frac1=")
+    print_f64(acc.frac_cmin_dose1)
+    print(" frac6=")
+    print_f64(acc.frac_cmin_last)
+    print(" cmin_ss=")
+    print_f64(acc.cmin_ss)
+    print("\n")
+    n = n + pass_if(
+        acc.frac_cmin_dose1 < acc.frac_cmin_last
+            && acc.frac_cmin_last > 0.95
+            && acc.doses_to_90pct_cmin >= 1
+            && acc.doses_to_90pct_cmin <= 6,
+        3216
+    )
+
     print("PED_LEDGER_JSON {")
-    print("\"schema\":\"sounio.pediatric_pbpk.v4\",")
+    print("\"schema\":\"sounio.pediatric_pbpk.v5\",")
     print("\"preterm_cl\":")
     print_f64(pk_p.cl_l_h)
     print(",\"neo_cl\":")
@@ -368,14 +414,14 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     print_f64(pk_a.cl_l_h)
     print(",\"auc_guided\":")
     print_f64(pk_star.auc24_mg_h_l)
-    print(",\"mc_cmin_p50\":")
-    print_f64(mc.cmin_p50)
-    print(",\"mc_auc_p50\":")
-    print_f64(mc.auc_p50)
     print(",\"mc_pct_target\":")
     print_f64(mc.pct_auc_400_600)
-    print(",\"ct_c0\":")
-    print_f64(ct.c_mg_l[0])
+    print(",\"indiv_fixed_pct\":")
+    print_f64(ind.pct_fixed_in_target)
+    print(",\"indiv_guided_pct\":")
+    print_f64(ind.pct_guided_in_target)
+    print(",\"acc_d90\":")
+    print_int(acc.doses_to_90pct_cmin)
     print(",\"pass\":")
     print_int(n)
     print("}\n")
@@ -383,7 +429,7 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     print("PEDIATRIC_PBPK_PASS ")
     print_int(n)
     print("\n")
-    if n == 14 {
+    if n == 16 {
         print("PEDIATRIC_PBPK_OK\n")
         0
     } else {

--- a/scripts/ci/pediatric_pbpk_gate.sh
+++ b/scripts/ci/pediatric_pbpk_gate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Paediatric PBPK gate v4 — deep: C(t) + IIV MC + literature anchors.
+# Paediatric PBPK gate v5 — individualisation + multi-dose accumulation.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
@@ -20,7 +20,7 @@ if ! grep -q 'PEDIATRIC_PBPK_OK' "$OUT"; then
   rm -f "$OUT"
   exit 1
 fi
-for tag in 3201 3202 3203 3204 3205 3206 3207 3208 3209 3210 3211 3212 3213 3214; do
+for tag in 3201 3202 3203 3204 3205 3206 3207 3208 3209 3210 3211 3212 3213 3214 3215 3216; do
   if ! grep -q "PASS $tag" "$OUT"; then
     cat "$OUT" >&2
     echo "[pediatric-pbpk] FAIL: missing PASS $tag" >&2

--- a/stdlib/clinical/pediatric_pbpk.sio
+++ b/stdlib/clinical/pediatric_pbpk.sio
@@ -986,6 +986,169 @@ pub fn ped_vanco_mc_child_default(s: &PedSubject) -> PedMcSummary with Mut, Div,
 }
 
 // ============================================================================
+// FIXED mg/kg vs AUC-GUIDED under IIV (why individualisation matters)
+// ============================================================================
+// Same CL grid as ped_vanco_mc_cohort. For each subject:
+//   fixed:  dose = mg_per_kg · WT
+//   guided: dose = AUC* · CL_i · τ / 24   (perfect CL knowledge — upper bound on benefit)
+// Report %AUC in [400,600] under each policy.
+
+pub struct PedIndivCompare {
+    n: i64,
+    seed: i64,
+    omega_cl: f64,
+    mg_per_kg_fixed: f64,
+    auc_target: f64,
+    pct_fixed_in_target: f64,
+    pct_guided_in_target: f64,
+    auc_fixed_mean: f64,
+    auc_guided_mean: f64,
+    auc_fixed_p05: f64,
+    auc_fixed_p95: f64,
+    auc_guided_p05: f64,
+    auc_guided_p95: f64,
+}
+
+/// Compare fixed mg/kg vs perfect-CL AUC-guided dosing under IIV CL grid.
+pub fn ped_vanco_fixed_vs_auc_guided(
+    s: &PedSubject,
+    mg_per_kg_fixed: f64,
+    interval_h: f64,
+    auc_target: f64,
+    n_subj: i64,
+    seed: i64,
+    omega_cl: f64,
+) -> PedIndivCompare with Mut, Div, Panic {
+    var n = n_subj
+    if n < 2 { n = 2 }
+    if n > 32 { n = 32 }
+    let phy = ped_physio_model(s)
+    let cl_typ = ped_vanco_cl_l_h(phy.gfr_ml_min)
+    let dose_fixed = mg_per_kg_fixed * s.weight_kg
+
+    var af: [f64; 32] = [0.0; 32]
+    var ag: [f64; 32] = [0.0; 32]
+    var i: i64 = 0
+    var sum_f: f64 = 0.0
+    var sum_g: f64 = 0.0
+    var n_f: i64 = 0
+    var n_g: i64 = 0
+
+    while i < n {
+        let z = ped_grid_z(i, n)
+        let cl_i = cl_typ * ped_exp(omega_cl * z)
+        let rate_f = dose_fixed / interval_h
+        let auc_f = if cl_i > 0.0 { 24.0 * rate_f / cl_i } else { 0.0 }
+        // guided dose from true CL_i
+        let dose_g = auc_target * cl_i * interval_h / 24.0
+        let rate_g = dose_g / interval_h
+        let auc_g = if cl_i > 0.0 { 24.0 * rate_g / cl_i } else { 0.0 }
+        af[i as usize] = auc_f
+        ag[i as usize] = auc_g
+        sum_f = sum_f + auc_f
+        sum_g = sum_g + auc_g
+        if auc_f >= 400.0 && auc_f <= 600.0 { n_f = n_f + 1 }
+        if auc_g >= 400.0 && auc_g <= 600.0 { n_g = n_g + 1 }
+        i = i + 1
+    }
+
+    let sf = ped_sort32(af, n)
+    let sg = ped_sort32(ag, n)
+    let nf = n as f64
+    PedIndivCompare {
+        n: n,
+        seed: seed,
+        omega_cl: omega_cl,
+        mg_per_kg_fixed: mg_per_kg_fixed,
+        auc_target: auc_target,
+        pct_fixed_in_target: 100.0 * (n_f as f64) / nf,
+        pct_guided_in_target: 100.0 * (n_g as f64) / nf,
+        auc_fixed_mean: sum_f / nf,
+        auc_guided_mean: sum_g / nf,
+        auc_fixed_p05: ped_pct32(sf, n, 0.05),
+        auc_fixed_p95: ped_pct32(sf, n, 0.95),
+        auc_guided_p05: ped_pct32(sg, n, 0.05),
+        auc_guided_p95: ped_pct32(sg, n, 0.95),
+    }
+}
+
+pub fn ped_vanco_indiv_child_default(s: &PedSubject) -> PedIndivCompare with Mut, Div, Panic {
+    ped_vanco_fixed_vs_auc_guided(s, 15.0, 12.0, ped_vanco_auc_target_mid(), 32, 42, 0.25)
+}
+
+// ============================================================================
+// MULTI-DOSE ACCUMULATION TO STEADY STATE (1-cmt bolus)
+// ============================================================================
+// After n doses: Cmax_n = (D/V) · (1 − r^n) / (1 − r),  r = e^{-ke·τ}
+//                Cmin_n = Cmax_n · r
+// As n→∞: Cmin_ss matches ped_cmin_point.
+// Scalar-only return (no embedded arrays) — lean_single stack-safe.
+
+pub struct PedAccumulation {
+    n_tracked: i64,
+    frac_cmin_dose1: f64,
+    frac_cmin_dose2: f64,
+    frac_cmin_dose3: f64,
+    frac_cmin_last: f64,
+    cmin_ss: f64,
+    cmax_ss: f64,
+    doses_to_90pct_cmin: i64,
+    ke: f64,
+    r: f64,
+}
+
+/// Track approach to SS; reports fracs after doses 1,2,3 and last (≤8).
+pub fn ped_vanco_accumulation(
+    s: &PedSubject, dose_mg: f64, interval_h: f64, n_doses: i64
+) -> PedAccumulation with Mut, Div, Panic {
+    var nt = n_doses
+    if nt < 1 { nt = 1 }
+    if nt > 8 { nt = 8 }
+    let pk = ped_vanco_pk(s, dose_mg, interval_h)
+    let ke = pk.ke
+    let r = ped_exp(0.0 - ke * interval_h)
+    let dv = if pk.vc_l > 0.0 { dose_mg / pk.vc_l } else { 0.0 }
+    let one_m_r = 1.0 - r
+    var cmax_ss = 0.0
+    var cmin_ss = 0.0
+    if one_m_r > 1.0e-12 {
+        cmax_ss = dv / one_m_r
+        cmin_ss = cmax_ss * r
+    }
+    // Geometric: frac_cmin after k doses = 1 - r^k
+    // Cmin_k / Cmin_ss = (1 - r^k)  when Cmin_ss = Cmax_ss * r and Cmax_k = Cmax_ss*(1-r^k)
+    var f1 = 0.0
+    var f2 = 0.0
+    var f3 = 0.0
+    var flast = 0.0
+    var d90: i64 = nt
+    var k: i64 = 1
+    var rk = r
+    while k <= nt {
+        let frac = 1.0 - rk
+        if k == 1 { f1 = frac }
+        if k == 2 { f2 = frac }
+        if k == 3 { f3 = frac }
+        if k == nt { flast = frac }
+        if d90 == nt && frac >= 0.90 { d90 = k }
+        rk = rk * r
+        k = k + 1
+    }
+    PedAccumulation {
+        n_tracked: nt,
+        frac_cmin_dose1: f1,
+        frac_cmin_dose2: f2,
+        frac_cmin_dose3: f3,
+        frac_cmin_last: flast,
+        cmin_ss: cmin_ss,
+        cmax_ss: cmax_ss,
+        doses_to_90pct_cmin: d90,
+        ke: ke,
+        r: r,
+    }
+}
+
+// ============================================================================
 // LITERATURE ANCHOR CHECKS (algebraic, not clinical targets)
 // ============================================================================
 
@@ -1194,6 +1357,37 @@ pub fn ped_selftest() -> i64 with IO, Mut, Div, Panic {
         print_f64(sz10)
         print(" mf40=")
         print_f64(mf40)
+        print("\n")
+    }
+
+    // T15: AUC-guided individualisation beats fixed mg/kg under IIV
+    let ind = ped_vanco_indiv_child_default(&child)
+    if ind.pct_guided_in_target > ind.pct_fixed_in_target + 20.0
+        && ind.pct_guided_in_target > 95.0
+        && ped_abs(ind.auc_guided_mean - 500.0) < 1.0 {
+        print("PASS ped_indiv_auc_vs_fixed\n")
+        n = n + 1
+    } else {
+        print("FAIL ped_indiv_auc_vs_fixed fixed%=")
+        print_f64(ind.pct_fixed_in_target)
+        print(" guided%=")
+        print_f64(ind.pct_guided_in_target)
+        print("\n")
+    }
+
+    // T16: multi-dose accumulation — frac1 < frac_last ≈ 1, d90 in range
+    let acc = ped_vanco_accumulation(&child, 15.0 * child.weight_kg, 12.0, 6)
+    if acc.frac_cmin_dose1 < acc.frac_cmin_last
+        && acc.frac_cmin_last > 0.95
+        && acc.doses_to_90pct_cmin >= 1
+        && acc.doses_to_90pct_cmin <= 6 {
+        print("PASS ped_accumulation\n")
+        n = n + 1
+    } else {
+        print("FAIL ped_accumulation last=")
+        print_f64(acc.frac_cmin_last)
+        print(" d90=")
+        print_int(acc.doses_to_90pct_cmin)
         print("\n")
     }
 


### PR DESCRIPTION
## Summary

### Fixed mg/kg vs AUC-guided under IIV (child, N=32, ω_CL=0.25)

| Policy | % AUC ∈ [400,600] | mean AUC |
|---|---:|---:|
| Fixed 15 mg/kg | **15.6%** | 291 |
| AUC-guided (perfect CL) | **100%** | **500.0** |

This is the educational upper bound on TDM benefit.

### Multi-dose accumulation
\(C_{\min,n}/C_{\min,ss} = 1-r^n\), \(r=e^{-k_e\tau}\).  
Child q12: already ≥90% SS after **1** dose (short t½ vs τ).

Gate: **16/16** → `PEDIATRIC_PBPK_GATE_OK`

## Test plan
- [x] `bash scripts/ci/pediatric_pbpk_gate.sh`