### PR TITLE
fix(ir): carry uncertainty across loop back-edges — GUM variance was keeping one iteration (#1535)

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -6004,6 +6004,128 @@ impl Lowerer {
         -1
     }
 
+    // ---- loop-carried uncertainty slots (#1535) ----
+    //
+    // A mutable local's VALUE lives in a fixed vreg and assignment copies into it
+    // (`ir_copy(dst, rhs)` in lower_assign_stmt_ref), so it survives a loop
+    // back-edge. Its variance and its per-channel sensitivities did not: assignment
+    // REBOUND them to the RHS's fresh vregs. A rebind is a compile-time map update,
+    // and a loop body's IR is emitted exactly once, so every iteration recomputed
+    // uncertainty from the pre-loop value and only the last one survived.
+    //
+    // Measured before this: a 20-step Euler accumulator `x = x + 0.1 * cl` reported
+    // var(x) = 0.015376 — one step's contribution — against a GUM truth of 6.1504.
+    //
+    // These helpers give a mutable local a FIXED variance vreg and fixed per-channel
+    // sens vregs, zero-initialised at the declaration, so assignment can copy into
+    // them exactly as the value does.
+
+    // Zero-initialised variance slot. No-op when the local already owns one.
+    fn alloc_variance_slot_for_local(self, name: Name) -> Lowerer with Mut, Panic, Div, Alloc {
+        var lo = self
+        if lo.lookup_local_variance_reg(name) >= 0 {
+            return lo
+        }
+        let z = lo.emit_zero_variance()
+        lo = z.0
+        lo.bind_local_variance_reg(name, z.1)
+    }
+
+    // Row index of `name` in the FO bind table, creating an all-unbound row if
+    // absent. -1 when the table is full (128 locals), in which case callers fall
+    // back to the pre-existing rebind behaviour rather than dropping the sens.
+    fn fo_bind_row_for(self, name: Name) -> (Lowerer, i64) with Mut, Panic, Div {
+        var lo = self
+        var i: i64 = 0
+        while i < lo.fo_bind_count {
+            if ir_name_eq(lo.fo_bind_names[i as usize], name) {
+                return (lo, i)
+            }
+            i = i + 1
+        }
+        if lo.fo_bind_count >= 128 {
+            return (lo, 0 - 1)
+        }
+        let idx = lo.fo_bind_count
+        lo.fo_bind_names[idx as usize] = name
+        var c: i64 = 0
+        while c < 32 {
+            lo.fo_bind_sens[(idx * 32 + c) as usize] = 0 - 1
+            c = c + 1
+        }
+        lo.fo_bind_count = idx + 1
+        (lo, idx)
+    }
+
+    // Zero-initialised sens slots for the channels that exist at this point.
+    // Bounded by fo_nchan rather than 32: channels are seeded by measure(), which
+    // in practice precedes the locals that accumulate through them, and allocating
+    // all 32 would cost register pressure in every program that touches f64.
+    fn fo_alloc_sens_slots_for_local(self, name: Name) -> Lowerer with Mut, Panic, Div {
+        var lo = self
+        if lo.fo_nchan <= 0 {
+            return lo
+        }
+        let row_pair = lo.fo_bind_row_for(name)
+        lo = row_pair.0
+        let row = row_pair.1
+        if row < 0 {
+            return lo
+        }
+        var k: i64 = 0
+        while k < lo.fo_nchan && k < 32 {
+            if lo.fo_bind_sens[(row * 32 + k) as usize] < 0 {
+                let z = lo.emit_f64_const(0.0)
+                lo = z.0
+                lo.fo_bind_sens[(row * 32 + k) as usize] = z.1
+            }
+            k = k + 1
+        }
+        lo
+    }
+
+    // Assignment-side counterpart of fo_bind_local_sens: COPY the expression's sens
+    // into the local's fixed slots instead of rebinding to the expression's vregs.
+    // A channel the new value no longer depends on is zeroed rather than left
+    // holding a stale sensitivity. Returns false when no slot exists, so the caller
+    // can fall back to the old rebind path.
+    fn fo_copy_expr_sens_into_local(self, name: Name) -> (Lowerer, bool) with Mut, Panic, Div {
+        var lo = self
+        var row: i64 = 0 - 1
+        var i: i64 = 0
+        while i < lo.fo_bind_count {
+            if ir_name_eq(lo.fo_bind_names[i as usize], name) {
+                row = i
+                i = lo.fo_bind_count
+            } else {
+                i = i + 1
+            }
+        }
+        if row < 0 {
+            return (lo, false)
+        }
+        var any: bool = false
+        var k: i64 = 0
+        while k < 32 {
+            let slot = lo.fo_bind_sens[(row * 32 + k) as usize]
+            if slot >= 0 {
+                any = true
+                let src = lo.fo_expr_sens[k as usize]
+                if src >= 0 {
+                    if src != slot {
+                        lo = lo.emit(ir_copy(slot, src))
+                    }
+                } else {
+                    let z = lo.emit_f64_const(0.0)
+                    lo = z.0
+                    lo = lo.emit(ir_copy(slot, z.1))
+                }
+            }
+            k = k + 1
+        }
+        (lo, any)
+    }
+
     fn bind_variance_for_base_reg(self, base_reg: i64, variance_reg: i64) -> Lowerer with Mut, Panic, Div {
         var lo = self
         if base_reg < 0 || variance_reg < 0 {
@@ -10195,6 +10317,14 @@ impl Lowerer {
         if bind_as_ref {
             lo = lo.bind_local_ref(s.name)
         }
+        // #1535: a MUTABLE local needs fixed uncertainty slots so a later assignment
+        // can copy into them and the value survives a loop back-edge. Gated on
+        // fo_nchan > 0 so programs that never call measure() pay nothing; a `let` is
+        // never reassigned, so it needs no slot.
+        if is_mut && lo.fo_nchan > 0 && !bind_as_ref && fixed_array_len < 0 {
+            lo = lo.alloc_variance_slot_for_local(s.name)
+            lo = lo.fo_alloc_sens_slots_for_local(s.name)
+        }
         if fixed_array_len >= 0 {
             lo = lo.bind_local_fixed_array_len(s.name, fixed_array_len)
         }
@@ -10471,9 +10601,29 @@ impl Lowerer {
                             }
                             lo = lo.emit(ir_copy(dst, rhs))
                             if rhs_variance >= 0 {
-                                lo = lo.bind_local_variance_reg((*target_expr).name, rhs_variance)
+                                // Copy into the local's fixed uncertainty slots, the
+                                // same discipline the value uses one line above. A
+                                // rebind here is correct in straight-line code and
+                                // silently wrong across a loop back-edge (#1535): the
+                                // body's IR is emitted once, so rebinding is a
+                                // compile-time map update with no runtime data flow,
+                                // and each iteration recomputes from the pre-loop
+                                // uncertainty. Locals with no slot keep the old rebind
+                                // path, which is no worse than before.
+                                let vslot = lo.lookup_local_variance_reg((*target_expr).name)
+                                if vslot >= 0 {
+                                    if vslot != rhs_variance {
+                                        lo = lo.emit(ir_copy(vslot, rhs_variance))
+                                    }
+                                } else {
+                                    lo = lo.bind_local_variance_reg((*target_expr).name, rhs_variance)
+                                }
                                 if lo.fo_expr_has_sens() {
-                                    lo = lo.fo_bind_local_sens((*target_expr).name)
+                                    let sens_pair = lo.fo_copy_expr_sens_into_local((*target_expr).name)
+                                    lo = sens_pair.0
+                                    if !sens_pair.1 {
+                                        lo = lo.fo_bind_local_sens((*target_expr).name)
+                                    }
                                 }
                                 // Re-assert float scalar_kind only when the RHS is
                                 // genuinely float; an int RHS that merely carries a

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -6020,15 +6020,27 @@ impl Lowerer {
     // sens vregs, zero-initialised at the declaration, so assignment can copy into
     // them exactly as the value does.
 
-    // Zero-initialised variance slot. No-op when the local already owns one.
+    // Give the local a PRIVATE variance vreg.
+    //
+    // Not a no-op when a variance reg is already bound: the declaration path binds
+    // the RHS's own vreg (`var x = 6.0 / v`), which may be a shared constant or an
+    // expression temporary. Copying into that reg on a later assignment would write
+    // through an alias. So the existing value is copied into a fresh reg and the
+    // local rebound to it; otherwise the slot starts at zero.
+    //
+    // Missing this is what left rapamycin_iso_budget at var(blood)=0.000000 while a
+    // repro with `var a = 1.2` came out right: only the literal-initialised form had
+    // no prior binding to alias.
     fn alloc_variance_slot_for_local(self, name: Name) -> Lowerer with Mut, Panic, Div, Alloc {
         var lo = self
-        if lo.lookup_local_variance_reg(name) >= 0 {
-            return lo
-        }
+        let existing = lo.lookup_local_variance_reg(name)
         let z = lo.emit_zero_variance()
         lo = z.0
-        lo.bind_local_variance_reg(name, z.1)
+        let slot = z.1
+        if existing >= 0 {
+            lo = lo.emit(ir_copy(slot, existing))
+        }
+        lo.bind_local_variance_reg(name, slot)
     }
 
     // Row index of `name` in the FO bind table, creating an all-unbound row if
@@ -6074,11 +6086,16 @@ impl Lowerer {
         }
         var k: i64 = 0
         while k < lo.fo_nchan && k < 32 {
-            if lo.fo_bind_sens[(row * 32 + k) as usize] < 0 {
-                let z = lo.emit_f64_const(0.0)
-                lo = z.0
-                lo.fo_bind_sens[(row * 32 + k) as usize] = z.1
+            // Same aliasing rule as alloc_variance_slot_for_local: a channel already
+            // bound points at the RHS's vreg, so copy its value into a private reg
+            // rather than reusing it as this local's slot.
+            let existing = lo.fo_bind_sens[(row * 32 + k) as usize]
+            let z = lo.emit_f64_const(0.0)
+            lo = z.0
+            if existing >= 0 {
+                lo = lo.emit(ir_copy(z.1, existing))
             }
+            lo.fo_bind_sens[(row * 32 + k) as usize] = z.1
             k = k + 1
         }
         lo
@@ -10317,14 +10334,6 @@ impl Lowerer {
         if bind_as_ref {
             lo = lo.bind_local_ref(s.name)
         }
-        // #1535: a MUTABLE local needs fixed uncertainty slots so a later assignment
-        // can copy into them and the value survives a loop back-edge. Gated on
-        // fo_nchan > 0 so programs that never call measure() pay nothing; a `let` is
-        // never reassigned, so it needs no slot.
-        if is_mut && lo.fo_nchan > 0 && !bind_as_ref && fixed_array_len < 0 {
-            lo = lo.alloc_variance_slot_for_local(s.name)
-            lo = lo.fo_alloc_sens_slots_for_local(s.name)
-        }
         if fixed_array_len >= 0 {
             lo = lo.bind_local_fixed_array_len(s.name, fixed_array_len)
         }
@@ -10359,6 +10368,22 @@ impl Lowerer {
                 }
                 _ => {}
             }
+        }
+        // #1535: a MUTABLE local needs PRIVATE uncertainty slots so a later
+        // assignment can copy into them and the value survives a loop back-edge.
+        //
+        // This must run AFTER the two binding branches above, not before. Both of
+        // them bind the local's variance/sens to the RHS's own vregs, so allocating
+        // first meant they immediately overwrote the fresh slots — which is why an
+        // expression-initialised accumulator (`var c_blood = 6.0 / v_blood`) still
+        // lost its uncertainty while a literal-initialised one (`var a = 1.2`) did
+        // not: only the literal form leaves nothing for those branches to bind.
+        //
+        // Gated on fo_nchan > 0 so a program that never calls measure() pays
+        // nothing; a `let` is never reassigned and needs no slot.
+        if is_mut && lo.fo_nchan > 0 && !bind_as_ref && fixed_array_len < 0 {
+            lo = lo.alloc_variance_slot_for_local(s.name)
+            lo = lo.fo_alloc_sens_slots_for_local(s.name)
         }
         if lower_opt_type_is_array_of_f64(&s.ty) {
             lo = lo.bind_local_array_elem_float(s.name)
@@ -11883,8 +11908,17 @@ impl Lowerer {
                 let pair_v = self.lower_expr_variance_ref(&(*list).head)
                 var lo = pair_v.0
                 if pair_v.1 >= 0 {
-                    lo = lo.emit(ir_mark_float_reg(pair_v.1))
-                    return (lo, pair_v.1)
+                    // Return a COPY, not the reg itself. For a mutable local that
+                    // reg is now its persistent variance slot (#1535), so handing it
+                    // back would alias: `let snap = variance_of(a)` followed by a
+                    // reassignment of `a` would retroactively change `snap`. Reading
+                    // an uncertainty must yield a value, not a view.
+                    let cp = lo.fresh_reg()
+                    lo = cp.0
+                    let dst = cp.1
+                    lo = lo.emit(ir_copy(dst, pair_v.1))
+                    lo = lo.emit(ir_mark_float_reg(dst))
+                    return (lo, dst)
                 }
                 lo.emit_zero_variance()
             }

--- a/tests/run-pass/epistemic_var_accumulator_slots.sio
+++ b/tests/run-pass/epistemic_var_accumulator_slots.sio
@@ -1,0 +1,101 @@
+//@ run-pass
+//@ requires: madaros
+//@ expect-stdout: VAR_ACCUM_OK
+
+// Regression pin for #1535: a mutable local must carry its uncertainty across
+// reassignment, including when it was initialised from an EXPRESSION and when the
+// reassignment happens inside a loop.
+//
+// Two defects sat here, and the second hid behind the first:
+//
+//   1. Assignment REBOUND the local's variance/sens to the RHS's fresh vregs
+//      instead of copying into fixed slots. A rebind is a compile-time map update
+//      and a loop body's IR is emitted once, so every iteration recomputed from
+//      the pre-loop uncertainty and only one iteration's contribution survived.
+//
+//   2. The fix for (1) allocated those slots BEFORE the branches that bind a
+//      declaration's variance from its RHS, so those branches overwrote them.
+//      Only a literal-initialised local escaped, because a literal leaves those
+//      branches nothing to bind.
+//
+// Truth values below are first-order GUM propagation, computed independently
+// rather than read off either engine. var(cl) = 1.24^2 = 1.5376.
+//
+// TEST 1 deliberately uses NO loop. The defect never needed one — a loop only
+// turned a wrong answer into a catastrophic one. Four loop-based repros failed to
+// separate the two causes; three straight-line assignments did it immediately.
+// If this pin ever regresses, TEST 1 is the one that localises it.
+
+fn approx(actual: f64, expected: f64, tol: f64) -> bool {
+    let d = actual - expected
+    if d < 0.0 { return (0.0 - d) < tol }
+    return d < tol
+}
+
+fn main() with IO, Mut, Div, Epistemic {
+    let k: Knowledge<f64> = measure(12.4, uncertainty: 1.24)
+    let cl = k.value
+    let v0 = 5.0
+
+    // TEST 1 — expression-initialised accumulator, no loop.
+    // Each `+ 0.1*cl` adds 0.1 to d(a)/d(cl), so after n assignments
+    // var = (0.1n)^2 * 1.5376.
+    var a = 6.0 / v0
+    a = a + 0.1 * cl
+    let a1 = variance_of(a)          // (0.1)^2 * 1.5376 = 0.015376
+    a = a + 0.1 * cl
+    let a2 = variance_of(a)          // (0.2)^2 * 1.5376 = 0.061504
+    a = a + 0.1 * cl
+    let a3 = variance_of(a)          // (0.3)^2 * 1.5376 = 0.138384
+
+    let t1 = approx(a1, 0.015376, 0.000001)
+        && approx(a2, 0.061504, 0.000001)
+        && approx(a3, 0.138384, 0.000001)
+
+    // TEST 2 — same accumulation in a loop: 20 steps, d(b)/d(cl) = 2.0,
+    // var = 4 * 1.5376 = 6.1504. Before the fix this read 0.015376 (one step).
+    var b = 6.0 / v0
+    var i: i64 = 0
+    while i < 20 {
+        b = b + 0.1 * cl
+        i = i + 1
+    }
+    let t2 = approx(variance_of(b), 6.150400, 0.000001)
+
+    // TEST 3 — self-dependent accumulation in a loop.
+    // c = (1+u)^2 with u = measure(2.0, 0.5): d(c)/d(u) = 2(1+u) = 6, var = 36*0.25 = 9.
+    let ku: Knowledge<f64> = measure(2.0, uncertainty: 0.5)
+    let u = ku.value
+    var c = 1.0
+    var j: i64 = 0
+    while j < 2 {
+        c = c + u * c
+        j = j + 1
+    }
+    let t3 = approx(variance_of(c), 9.000000, 0.000001)
+
+    // TEST 4 — straight-line correlation must be unaffected by all of the above.
+    let z = cl - cl
+    let s = cl + cl + cl
+    let t4 = approx(variance_of(z), 0.0, 0.000001)
+        && approx(variance_of(s), 13.838400, 0.000001)
+
+    if t1 && t2 && t3 && t4 {
+        println("VAR_ACCUM_OK")
+        return
+    }
+
+    print("VAR_ACCUM_FAIL t1_expr_init_noloop=")
+    print_f64(a1)
+    print(",")
+    print_f64(a2)
+    print(",")
+    print_f64(a3)
+    print(" t2_loop=")
+    print_f64(variance_of(b))
+    print(" t3_selfdep=")
+    print_f64(variance_of(c))
+    print(" t4_straightline=")
+    print_f64(variance_of(s))
+    println("")
+}


### PR DESCRIPTION
Fixes the Madaros half of #1535. Also corrects a claim I made in #1534 and #1535 — see the bottom.

## The defect

A mutable local's **value** lives in a fixed vreg and assignment copies into it (`ir_copy(dst, rhs)`), so it survives a loop back-edge. Its **variance and per-channel sensitivities did not**: assignment rebound them to the RHS's fresh vregs.

A rebind is a compile-time map update. A loop body's IR is emitted exactly once. So every iteration recomputed uncertainty from the pre-loop value, and only one iteration's contribution survived — silently, with the program exiting 0 and printing a well-formed budget.

## Measured

Truth is first-order GUM propagation, computed independently in Python (not read off either engine):

| shape | before | after | truth |
|---|---:|---:|---:|
| `x = x + 0.1*cl`, 20 steps | 0.015376 | **6.150400** | 6.150400 |
| Euler decay, self-dependent | 0.000000 | **0.000007** | 0.000007008 |
| two coupled states | — | **0.000018 / 0.000182** | 0.0000182 / 0.0001825 |
| self-dependent in a loop, 2 steps | — | **9.000000** | 9.000000 |

Straight-line behaviour unchanged: `var(a-a)=0`, `var(a+a+a)=13.8384`, `var(a/a)=0`.

On the self-dependent cases lean_single is wrong where Madaros is now right: **2.5 vs a truth of 9.0** in the loop, **6.5 vs 9.0** unrolled.

## The change — three parts, all in `self-hosted/ir/lower.sio`

- `alloc_variance_slot_for_local` / `fo_alloc_sens_slots_for_local` give a mutable local fixed, zero-initialised uncertainty slots at its declaration. Gated on `fo_nchan > 0`, so a program that never calls `measure()` pays nothing. A `let` is never reassigned and needs no slot.
- `fo_copy_expr_sens_into_local` copies the expression's per-channel sens into those slots. A channel the new value no longer depends on is **zeroed** rather than left holding a stale sensitivity.
- The assignment site copies into the slots instead of rebinding — the same discipline the value already uses one line above. A local with no slot keeps the old rebind path, so this is never worse than before.

Sens slots are bounded by `fo_nchan` rather than 32: channels are seeded by `measure()`, which precedes the accumulators that consume them, and allocating all 32 would cost register pressure in every program that touches `f64`.

## Verification

- `madaros_corpus_regression_gate.sh`: **PASS, 0 new failures** (305 known / 1688)
- five shapes above, each against an independently computed truth
- straight-line control unchanged

## Residual — stated, not hidden

`rapamycin_iso_budget.sio` still prints `var(blood)=0.000000` against an analytic truth of **0.000101**. `var(brain)` does improve (0.000001 → 0.000003, truth 0.0000043). That program's blood compartment has a shape none of the five repros reproduces yet, so this PR does **not** close #1534.

## Correction to #1534 and #1535

I previously treated lean_single's output as the reference for the rapamycin numbers. **That was wrong.** Against the three-channel analytic truth:

| | var(blood) | var(brain) |
|---|---:|---:|
| **truth** | **0.000101** | **0.0000043** |
| lean_single | 0.000073 (−27%) | 0.000172 (**~40×**) |
| Madaros + this PR | 0.000000 | 0.000003 |

Both engines are wrong on that program. Madaros' `var(brain)` is now the closer of the two; its `var(blood)` is still the residual above. Anyone reading #1534 or #1535 should not use lean_single's figures as a target.
