### PR TITLE
chore(ci): refresh the Madaros corpus baseline — one entry, and it is real debt

### DIFF
--- a/tests/madaros_corpus_baseline.txt
+++ b/tests/madaros_corpus_baseline.txt
@@ -215,6 +215,7 @@ pbpk28_m2_hierarchical_prior.sio compile
 pbpk28_m5_gum_4th_order.sio compile
 pbpk28_struct_return.sio compile
 pbpk_rapamycin_second_order.sio compile
+pediatric_pbpk_receipt.sio run
 pkg_manifest_parse_e2e.sio compile
 proof_obligation_basic.sio compile
 proof_search_basic.sio compile


### PR DESCRIPTION
Regenerated against `main` (86f41b96d + #1522) with a current-source build.

**Diff is one line added, none removed:**

```
+ pediatric_pbpk_receipt.sio run
```

## Why that entry exists — it is not an approval

`tests/run-pass/pediatric_pbpk_receipt.sio` arrived **already failing** in #1536 (merged 07:34 today). The previous baseline was generated at **15:04**, after it landed, and recorded it as passing. So the checked-in baseline asserted a green that never existed, and every PR touching that path was told it had caused a regression. That is how it surfaced — it blocked #1522, which turned out to be innocent.

The program **computes correctly**. Its printed values match #1536's own commit message (15.6% fixed / 65.6% noisy / 100% perfect). What fails is the acceptance condition at `:62-63`, which returns 1 from `main`.

**Whether the condition is wrong or the paediatric implementation is, is a clinical call for @agourakis82** — not something to settle by editing a threshold. Filing this as tracked debt keeps the gate usable meanwhile.

## Nothing was removed, and that needs explaining

Four PRs landed today (#1512, #1515, #1522, #1539). The programs they repaired were **never in this baseline**:

| program | baseline entries |
|---|---:|
| `gpu_vec_add.sio` | 0 |
| `rapamycin_iso_budget.sio` | 0 |
| `gpu_epistemic_f64_ossm_parity.sio` | 0 |

This gate compares `timeout 30 "$elf"` exit status, and all of them exit 0 while printing FAIL or a wrong number. Verified on this exact build: `gpu_vec_add` now prints `PASS: GPU vec_add`, and `rapamycin_iso_budget` now prints `var(blood)=0.000100` against an analytic truth of `0.000101`. **Neither is visible to this gate.**

That blind spot is the argument for #1503. Until it lands, a shrinking count here is not evidence of a healthier compiler.

Totals: **306 / 1691** (was 305 / 1689 — the corpus itself grew by two).