### PR TITLE
fix(ir): float-type imported (f64,f64) tuple unpack

### DIFF
--- a/docs/audit/MADAROS_IMPORTED_F64_MUL_2026-07-26.md
+++ b/docs/audit/MADAROS_IMPORTED_F64_MUL_2026-07-26.md
@@ -10,7 +10,9 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-
 # Madaros multimodule: imported f64 prints OK, raw f64*f64 wrong
 
 **Date:** 2026-07-26  
-**Status:** residual open (stdlib workarounds in nonunitary_amp via ep_square)  
+**Status:** **CLOSED** — `lower.sio` marks all-f64 TypeTuple as `returns_float=2`  
+  and float-element FieldGet for tuple unpack (`.0`/`.1`).  
+  Verified: `MADAROS_IMPORTED_F64_MUL_FIXED` (ga*ga=0.25, gv*gv≈0.001412).  
 **Witness:** `tests/multimodule/madaros_imported_f64_mul_{leaf,main}.sio`  
 **Gate:** `scripts/ci/madaros_imported_f64_mul_gate.sh`
 

--- a/docs/audit/MADAROS_TUPLE_F64_FLOAT_FIX_RECIPE_2026-07-26.md
+++ b/docs/audit/MADAROS_TUPLE_F64_FLOAT_FIX_RECIPE_2026-07-26.md
@@ -9,9 +9,9 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-
 
 # Recipe: float-type `(f64, f64)` import unpack (for Claude native/lower)
 
-**Status:** residual open — product mitigates; this is the true lower fix  
-**Witness gate:** `scripts/ci/madaros_imported_f64_mul_gate.sh` → want `MADAROS_IMPORTED_F64_MUL_FIXED`  
-**Owner:** Claude-1 (`lower.sio` claim) — Grok cannot write that file while claimed
+**Status:** **APPLIED** (2026-07-27) — branch `fix/madaros-tuple-f64-float-20260727`  
+**Witness gate:** `scripts/ci/madaros_imported_f64_mul_gate.sh` → `MADAROS_IMPORTED_F64_MUL_FIXED`  
+**Evidence:** rebuilt Madaros; `tuple ga*ga=0.250000`, `tuple gv*gv=0.001412`
 
 ## Mechanism
 

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -3984,15 +3984,50 @@ fn lower_opt_type_is_array_of_f64(opt: &Option<Box<TypeExpr>>) -> bool with Mut,
     }
 }
 
-// returns_float classification for a declared return type: 1 = scalar f64, 2 = an
-// f64 array (`[f64; N]`), 0 = other. The `2` lets a caller's `let r = mk()` (mk
-// returning an f64 array) flag `r` as a float-element local, so `r[i]` reads
-// classify as float instead of taking the integer path (cvtsi2sd corruption).
-// All consumers test `== 1`, so the new `2` value is inert for the scalar path.
+// True iff `te` is TypeTuple and every element is f64 (e.g. `(f64, f64)`).
+// Used so imported tuple returns share returns_float=2 with f64 arrays:
+// `let __tup = ret_pair()` marks __tup as float-element; `.0`/`.1` FieldGet
+// then take the float path (imported f64*f64 residual 2026-07-26).
+fn lower_type_expr_is_tuple_of_all_f64(te: &TypeExpr) -> bool with Mut, Panic, Div {
+    if (*te).kind != TypeExprKind::TypeTuple { return false }
+    match (*te).type_args {
+        Some(list0) => {
+            var cur: Option<Box<TypeExprList>> = Some(list0)
+            var any = false
+            while true {
+                match cur {
+                    Some(list) => {
+                        if !lower_type_expr_is_f64(&(*list).head) { return false }
+                        any = true
+                        cur = (*list).tail
+                    }
+                    None => { break }
+                }
+            }
+            any
+        }
+        None => false,
+    }
+}
+
+fn lower_opt_type_is_tuple_of_all_f64(opt: &Option<Box<TypeExpr>>) -> bool with Mut, Panic, Div {
+    match *opt {
+        Some(te) => lower_type_expr_is_tuple_of_all_f64(&(*te)),
+        None => false,
+    }
+}
+
+// returns_float classification for a declared return type:
+//   1 = scalar f64
+//   2 = f64 array (`[f64; N]`) OR all-f64 TypeTuple (`(f64, f64)`, …)
+//   0 = other
+// The `2` lets a caller's `let r = mk()` flag `r` as a float-element local, so
+// `r[i]` / tuple FieldGet `.0`/`.1` classify as float instead of the integer path.
+// All scalar consumers test `== 1`, so `2` is inert for the scalar return path.
 fn lower_opt_return_float_code(opt: &Option<Box<TypeExpr>>) -> i64 with Mut, Panic, Div {
     if lower_opt_type_is_f64(opt) {
         1
-    } else if lower_opt_type_is_array_of_f64(opt) {
+    } else if lower_opt_type_is_array_of_f64(opt) || lower_opt_type_is_tuple_of_all_f64(opt) {
         2
     } else {
         0
@@ -8525,7 +8560,22 @@ impl Lowerer {
             return false
         }
         if (*e).kind == ExprKind::ExprFieldAccess {
-            return self.field_is_float_for_base_ref(&(*e).left, (*e).name) || self.field_is_float_by_name_simple((*e).name)
+            if self.field_is_float_for_base_ref(&(*e).left, (*e).name) || self.field_is_float_by_name_simple((*e).name) {
+                return true
+            }
+            // Tuple unpack: base is float-element local (`let __tup = ret_pair()`
+            // with returns_float=2) → `.0`/`.1` are f64.
+            match (*e).left {
+                Some(be) => {
+                    if (*be).kind == ExprKind::ExprIdent {
+                        if self.lookup_local_array_elem_float((*be).name) {
+                            return true
+                        }
+                    }
+                }
+                _ => {}
+            }
+            return false
         }
         if (*e).kind == ExprKind::ExprIndex {
             return self.index_base_elem_is_float_ref(&(*e).left)
@@ -12681,7 +12731,19 @@ impl Lowerer {
         let lo1 = pair_b.0
         let base = pair_b.1
         let fidx = lo1.field_idx_for_base_ref(&e.left, e.name)
-        let field_is_float = lo1.field_is_float_for_base_ref(&e.left, e.name) || lo1.field_is_float_by_name_simple(e.name)
+        // Tuple desugar: let __tup = f(); let a = __tup.0 — float-element base
+        // means .0/.1 are f64 even without a struct layout entry.
+        var field_is_float = lo1.field_is_float_for_base_ref(&e.left, e.name) || lo1.field_is_float_by_name_simple(e.name)
+        match e.left {
+            Some(be) => {
+                if (*be).kind == ExprKind::ExprIdent {
+                    if lo1.lookup_local_array_elem_float((*be).name) {
+                        field_is_float = true
+                    }
+                }
+            }
+            _ => {}
+        }
         let field_array_elem_is_float = lo1.field_array_elem_is_float_for_base_ref(&e.left, e.name)
         let base_is_ref = match e.left {
             Some(base_expr_ref) => {


### PR DESCRIPTION
## Summary

Closes the Madaros multimodule residual where **scalar** imported `f64` multiplies correctly but **tuple unpack** elements do not (`ga*ga → 0`).

### Root cause
Parser desugars `let (a,b) = f()` to `__tup.0` / `__tup.1` FieldGets. Without float marks, codegen uses the integer mul path.

### Fix (`self-hosted/ir/lower.sio`)
1. `returns_float = 2` for `TypeTuple` of all `f64` (same flag as f64 arrays)
2. `let __tup = ret_pair()` already binds float-element local when `returns_float==2`
3. FieldGet / `expr_result_is_float_ref`: float if base is `array_elem_float` local

### Evidence (source-fresh Madaros)
```
scalar a*a=0.250000 b*b=0.250000 a*b=-0.250000
ga_only*ga_only=0.250000
tuple ga=-0.500000 tuple ga*ga=0.250000 tuple gv*gv=0.001412
MADAROS_IMPORTED_F64_MUL_FIXED
```

Also re-checked: `madaros_field_if_i64_gate` → **FIXED**.

### Coordination
Claude-1 held an active claim on `lower.sio` (other work). Founder selected this as priority track; handoff message sent. Please restack if needed.

## Test plan
- [x] `MADAROS_RAW_BIN=<fresh> bash scripts/ci/madaros_imported_f64_mul_gate.sh` → FIXED
- [x] field-if gate still FIXED with same binary
- [ ] CI / re-merge if lower.sio conflicts with Claude WIP