### PR TITLE
ci(parity): refresh the engine-parity baseline; document how not to wait on the gate

### DIFF
--- a/scripts/ci/engine_parity_gate.sh
+++ b/scripts/ci/engine_parity_gate.sh
@@ -167,6 +167,16 @@ if [ "$total" -eq 0 ]; then
     exit 1
 fi
 echo "[engine-parity] corpus=$total jobs=$JOBS timeout=${TIMEOUT}s"
+# Progress is checkable without polling the process table. A full run compiles and
+# executes every program under BOTH engines and takes ~13 min on a 6-job pod, which
+# is long enough that callers reach for a wait loop.
+#
+# Do NOT wait with `until ! pgrep -f engine_parity_gate`: that pattern matches the
+# waiting shell's own command line, so two such loops see each other and block
+# forever. Measured 2026-07-28 — three of them deadlocked for 5h13 on a gate that
+# had already exited. Poll this file instead, or run the gate in the foreground
+# and read its exit status.
+echo "[engine-parity] progress: wc -l $WORK/results.tsv   (of $total)"
 echo "[engine-parity] madaros=$MADAROS"
 echo "[engine-parity] lean   =$LEAN"
 

--- a/tests/engine_parity_baseline.txt
+++ b/tests/engine_parity_baseline.txt
@@ -17,7 +17,9 @@ DIVERGE	tests/run-pass/bignat_selftest_signed.sio
 DIVERGE	tests/run-pass/causal_identified.sio
 DIVERGE	tests/run-pass/cd_exact_generic_i64.sio
 DIVERGE	tests/run-pass/cd_tower_seam.sio
+DIVERGE	tests/run-pass/closure_arity_2.sio
 DIVERGE	tests/run-pass/closure_effect_checked.sio
+DIVERGE	tests/run-pass/closure_effect_transparent_hof.sio
 DIVERGE	tests/run-pass/closure_epistemic.sio
 DIVERGE	tests/run-pass/closure_escape.sio
 DIVERGE	tests/run-pass/closure_fn_ref.sio
@@ -54,6 +56,7 @@ DIVERGE	tests/run-pass/epistemic_molecule_h2o.sio
 DIVERGE	tests/run-pass/epistemic_ode_14comp.sio
 DIVERGE	tests/run-pass/epistemic_pbpk_multidrug.sio
 DIVERGE	tests/run-pass/epistemic_pbpk_native.sio
+DIVERGE	tests/run-pass/epistemic_var_accumulator_slots.sio
 DIVERGE	tests/run-pass/f2_conjugation_swda.sio
 DIVERGE	tests/run-pass/ffi_integer_return.sio
 DIVERGE	tests/run-pass/furey_charge_g2.sio
@@ -128,6 +131,7 @@ DIVERGE	tests/run-pass/optimization_nelder_mead.sio
 DIVERGE	tests/run-pass/pbpk_analytical_crossvalidation.sio
 DIVERGE	tests/run-pass/pbpk_validation_euler.sio
 DIVERGE	tests/run-pass/pbpk_validation_rk4.sio
+DIVERGE	tests/run-pass/pediatric_pbpk_receipt.sio
 DIVERGE	tests/run-pass/pk_uncertainty.sio
 DIVERGE	tests/run-pass/pkg_registry_basic.sio
 DIVERGE	tests/run-pass/plot3d_test.sio
@@ -217,7 +221,6 @@ LEAN-ONLY	tests/run-pass/bdf_stiff.sio
 LEAN-ONLY	tests/run-pass/bitwise_not_bootstrap_regression.sio
 LEAN-ONLY	tests/run-pass/budget64_test.sio
 LEAN-ONLY	tests/run-pass/clinical_deployment_validity_revocable_authority_witness.sio
-LEAN-ONLY	tests/run-pass/closure_arity_2.sio
 LEAN-ONLY	tests/run-pass/closure_capture.sio
 LEAN-ONLY	tests/run-pass/closure_effect_infer.sio
 LEAN-ONLY	tests/run-pass/closure_effect_infer_auto.sio
@@ -237,6 +240,7 @@ LEAN-ONLY	tests/run-pass/dissertation_pbpk14_gum.sio
 LEAN-ONLY	tests/run-pass/dissertation_pbpk14_hessian.sio
 LEAN-ONLY	tests/run-pass/dissertation_pbpk28_confidence_gate.sio
 LEAN-ONLY	tests/run-pass/dissertation_pbpk28_parity_ref_semaglutide.sio
+LEAN-ONLY	tests/run-pass/div_witness_projection3_interval_containment_imported.sio
 LEAN-ONLY	tests/run-pass/dossier_smoke.sio
 LEAN-ONLY	tests/run-pass/epistemic_guarded_nested_measure_call.sio
 LEAN-ONLY	tests/run-pass/epistemic_hessian_transcendentals.sio
@@ -495,6 +499,7 @@ MADAROS-ONLY	tests/run-pass/cardinality_proof_log_tiny.sio
 MADAROS-ONLY	tests/run-pass/clinical_dyadic_non_reduction_native_witness.sio
 MADAROS-ONLY	tests/run-pass/colouring_k3_lrat_tiny.sio
 MADAROS-ONLY	tests/run-pass/cpc2026_scientific_float_parser.sio
+MADAROS-ONLY	tests/run-pass/deref_indexed_elem_field_store.sio
 MADAROS-ONLY	tests/run-pass/div_witness_checker_tiny.sio
 MADAROS-ONLY	tests/run-pass/div_witness_projection3_directed_round_tiny.sio
 MADAROS-ONLY	tests/run-pass/div_witness_projection3_interval_containment_tiny.sio


### PR DESCRIPTION
Regenerated against `main` (cd237b4a8) with a current-source build.

**524 agree / 201 diverge / 357 madaros-only / 288 lean-only / 328 neither** — 1169 → 1174 entries.

## Five of six new entries are first observations, not regressions

Files that did not exist when the baseline was taken:

| entry | verdict | added by |
|---|---|---|
| `epistemic_var_accumulator_slots.sio` | DIVERGE | #1539 |
| `deref_indexed_elem_field_store.sio` | MADAROS-ONLY | #1479 |
| `pediatric_pbpk_receipt.sio` | DIVERGE | #1536 |
| `closure_effect_transparent_hof.sio` | DIVERGE | e8b7e2d65 |
| `div_witness_projection3_..._imported.sio` | LEAN-ONLY | e8b7e2d65 |

`epistemic_var_accumulator_slots` is DIVERGE **for a good reason** and should be read rather than cleared: Madaros prints `VAR_ACCUM_OK`, lean_single fails all four assertions. Its numbers are a complete diagnostic of the #1535 seed defect — `var(a+a+a)` at exactly **1/3** of truth, a 20-step accumulator at exactly **1/20**. The pin written to lock the Madaros fix doubles as the seed's repro. Recorded on #1535.

## One entry genuinely changed verdict — a regression

```
closure_arity_2.sio    LEAN-ONLY  ->  DIVERGE
```

From *"Madaros cannot build it"* to *"builds, prints zero bytes, exits 1"* while lean_single prints `PASS`. That is a **worse** state: it now looks like it works up to the point of producing output.

Attributed to #1541 by elimination — no `measure`/`variance_of`/`Knowledge`, no `kernel fn`, typechecks clean, and it is entirely arity-2 closures and tuple-shaped expressions. Filed as **#1542**. Baselining it here **records** the debt; it does not accept it.

## Operational trap, now documented in the gate

A full run takes ~13 min — long enough that callers reach for a wait loop. The obvious one:

```bash
until ! pgrep -f engine_parity_gate; do sleep 30; done   # DO NOT
```

matches the **waiting shell's own command line**. Two such loops see each other and block forever. Three of them deadlocked for **5h13** here, on a gate that had already exited. The gate now prints the path of its results file so progress is checkable without touching the process table.