### PR TITLE
fix(native): classify ref-array slot on implicit borrow — imported-module slice-arg segfault (#1510)

### DIFF
--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -8778,11 +8778,74 @@ pub fn native_v2_core_emit_raw_byte_array_store_into(nc: &! NativeCompiler, base
     nc_emit_store_al_mem_rdx_rbx(nc)
 }
 
-pub fn native_v2_core_emit_ref_array_load_into(nc: &! NativeCompiler, dst: i64, base_ref: i64, idx_reg: i64) with Mut, Panic, Div {
-    // &![T; N] params point at the caller slot that stores the array handle.
+// Upper bound of the BSS window used by ref-array implicit-borrow
+// classification (issue #1510). Heap/runtime mmaps land above 2 GiB and
+// ref cells are stack LEAs (~0x7f..), so [BSS_BASE_LINUX, 0x80000000)
+// contains only raw BSS aggregate data addresses.
+fn native_v2_ref_array_bss_window_end() -> i64 { 2147483648 }
+
+// ref-array base resolution (issue #1510). The ref slot normally holds a
+// pointer to the caller's array cell (explicit &arr / &GG): dereferencing
+// yields the handle-or-raw-object-base. Implicit borrows f(arr) / f(GG)
+// skip cell materialization and hand the callee the array VALUE directly:
+// a bare GC handle (< threshold) for locals, or the raw BSS data address
+// for globals. Classify the slot value V instead of always dereferencing:
+//   V < threshold            -> bare handle: resolve directly
+//   V in BSS window          -> object base = V - object_header
+//   otherwise                -> true &cell: deref, then resolve (legacy)
+fn native_v2_ref_array_resolve_base_rax_into(nc: &! NativeCompiler, base_ref: i64) with Mut, Panic, Div {
     nc_core_load_temp_to_rax(nc, base_ref)
+    nc_emit_mov_rbx_rax(nc)                                  // rbx = V
+    nc_emit_mov_rax_imm(nc, native_v2_handle_raw_ptr_threshold())
+    nc_emit_cmp_rbx_rax(nc)
+    nc_emit_setae_al(nc)
+    nc_emit_movzx_rax_al(nc)
+    nc_emit_test_rax_rax(nc)
+    let not_handle_jnz = (*nc).code.len
+    nc_emit_jnz_rel32(nc)                                    // V >= threshold -> not_handle
+    // bare handle (implicit borrow of a local/heap array): resolve directly
+    nc_emit_mov_rax_rbx(nc)
+    native_v2_resolve_handle_to_object_base_rax_into(nc)
+    let done_jmp1 = (*nc).code.len
+    nc_emit_jmp_rel32(nc)
+    let not_handle = (*nc).code.len
+    nc_patch_u32_le(nc, not_handle_jnz + 2, not_handle - (not_handle_jnz + 6))
+    nc_emit_mov_rax_imm(nc, BSS_BASE_LINUX)
+    nc_emit_cmp_rbx_rax(nc)
+    nc_emit_setae_al(nc)                                     // V >= BSS_BASE ?
+    nc_emit_movzx_rax_al(nc)
+    nc_emit_test_rax_rax(nc)
+    let below_bss_jz = (*nc).code.len
+    nc_emit_jz_rel32(nc)                                     // V < BSS_BASE -> deref
+    nc_emit_mov_rax_imm(nc, native_v2_ref_array_bss_window_end())
+    nc_emit_cmp_rbx_rax(nc)
+    nc_emit_setae_al(nc)                                     // V >= window end ?
+    nc_emit_movzx_rax_al(nc)
+    nc_emit_test_rax_rax(nc)
+    let above_bss_jnz = (*nc).code.len
+    nc_emit_jnz_rel32(nc)                                    // V >= window end -> deref
+    // raw BSS aggregate (implicit borrow of a global array): the data has no
+    // object header, so base = V - header makes the +header step land on V.
+    nc_emit_mov_rax_rbx(nc)
+    nc_emit_sub_rax_imm8(nc, native_v2_object_header_size())
+    let done_jmp2 = (*nc).code.len
+    nc_emit_jmp_rel32(nc)
+    // true &cell (explicit & / re-passed ref param): deref, then resolve
+    let deref = (*nc).code.len
+    nc_patch_u32_le(nc, below_bss_jz + 2, deref - (below_bss_jz + 6))
+    nc_patch_u32_le(nc, above_bss_jnz + 2, deref - (above_bss_jnz + 6))
+    nc_emit_mov_rax_rbx(nc)
     nc_emit_load_rax_mem_rax(nc)
     native_v2_resolve_handle_to_object_base_rax_into(nc)
+    let done = (*nc).code.len
+    nc_patch_u32_le(nc, done_jmp1 + 1, done - (done_jmp1 + 5))
+    nc_patch_u32_le(nc, done_jmp2 + 1, done - (done_jmp2 + 5))
+}
+
+pub fn native_v2_core_emit_ref_array_load_into(nc: &! NativeCompiler, dst: i64, base_ref: i64, idx_reg: i64) with Mut, Panic, Div {
+    // &[T; N] / &![T; N] slots: explicit & points at the caller cell holding
+    // the handle; implicit borrows carry the bare handle / raw BSS address.
+    native_v2_ref_array_resolve_base_rax_into(nc, base_ref)
     nc_emit_mov_reg_reg(nc, 2, 0)
     nc_core_load_temp_to_rax(nc, idx_reg)
     nc_emit_mov_reg_reg(nc, 3, 0)
@@ -8793,10 +8856,9 @@ pub fn native_v2_core_emit_ref_array_load_into(nc: &! NativeCompiler, dst: i64, 
 }
 
 pub fn native_v2_core_emit_ref_array_store_into(nc: &! NativeCompiler, base_ref: i64, idx_reg: i64, src: i64) with Mut, Panic, Div {
-    // &![T; N] params point at the caller slot that stores the array handle.
-    nc_core_load_temp_to_rax(nc, base_ref)
-    nc_emit_load_rax_mem_rax(nc)
-    native_v2_resolve_handle_to_object_base_rax_into(nc)
+    // &[T; N] / &![T; N] slots: explicit & points at the caller cell holding
+    // the handle; implicit borrows carry the bare handle / raw BSS address.
+    native_v2_ref_array_resolve_base_rax_into(nc, base_ref)
     nc_emit_mov_reg_reg(nc, 2, 0)
     nc_core_load_temp_to_rax(nc, idx_reg)
     nc_emit_mov_reg_reg(nc, 3, 0)

--- a/tests/multimodule/madaros_imported_slice_ref_global_leaf.sio
+++ b/tests/multimodule/madaros_imported_slice_ref_global_leaf.sio
@@ -1,0 +1,11 @@
+pub fn sum64(a: &[f64; 64], n: i64) -> f64 with Div {
+    var s = 0.0
+    var i: i64 = 0
+    while i < n { s = s + a[i]; i = i + 1 }
+    s
+}
+
+pub fn bump(a: &![f64; 64], n: i64) with Mut, Div {
+    var i: i64 = 0
+    while i < n { a[i] = a[i] + 10.0; i = i + 1 }
+}

--- a/tests/multimodule/madaros_imported_slice_ref_global_main.sio
+++ b/tests/multimodule/madaros_imported_slice_ref_global_main.sio
@@ -1,0 +1,39 @@
+// #1510: implicit borrow of a caller-owned GLOBAL array into an imported
+// callee taking &[f64; N] / &![f64; N] segfaulted on the Madaros native path
+// (ref-array slot carried the raw BSS data address; the callee dereferenced
+// it as a pointer-to-cell). Fixed by classifying the ref-array slot value in
+// native_v2_core_emit_ref_array_{load,store}_into (codegen_x86_linux.sio).
+use madaros_imported_slice_ref_global_leaf::{sum64, bump}
+
+var G64: [f64; 64] = [0.0; 64]
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() with IO, Div, Mut {
+    G64[0] = 1.0
+    G64[1] = 2.0
+    G64[2] = 3.0
+
+    // implicit borrow, read path (was: segfault, exit 139)
+    let s = sum64(G64, 3)
+    print_f64(s)
+    println("")
+
+    // implicit borrow, mutation path through &! (was: segfault)
+    bump(G64, 2)
+    print_f64(G64[0] + G64[1])
+    println("")
+
+    // explicit-& control (was already green pre-fix; must not regress)
+    let s2 = sum64(&G64, 3)
+    print_f64(s2)
+    println("")
+
+    if abs_f(s - 6.0) < 1.0e-9 && abs_f(G64[0] - 11.0) < 1.0e-9 && abs_f(G64[1] - 12.0) < 1.0e-9 && abs_f(s2 - 26.0) < 1.0e-9 {
+        println("MADAROS_IMPORTED_SLICE_REF_GLOBAL_OK")
+    } else {
+        println("MADAROS_IMPORTED_SLICE_REF_GLOBAL_BROKEN")
+    }
+}


### PR DESCRIPTION
Closes #1510.

## Root cause

A caller passing an array lvalue to a `&[T; N]` / `&![T; N]` parameter **without** an explicit `&` (implicit borrow, e.g. `sum64(G64, 3)`) hands the callee the array **value** directly:

- local array → bare GC handle (small int < 0x100000)
- global array → raw BSS data address (`BSS_BASE_LINUX + off`, no object header)

The callee-side ref-array element access (`native_v2_core_emit_ref_array_load_into` / `_store_into`) unconditionally emitted `mov rax, [rax]` on the ref slot, expecting the pointer-to-cell that explicit `&` produces. With an implicit borrow that deref reads `*handle` (wild read near address 0) or `*bss_addr` (element 0's bits reinterpreted as an object base) → segfault at runtime (exit 139) after a clean compile.

Not import-specific: same-module implicit borrows crashed identically; the module boundary in the issue was incidental. Explicit `&arr` works today in all cases.

## Fix

Classify the ref-slot value `V` in a shared helper (`native_v2_ref_array_resolve_base_rax_into`) used by both ref-array load/store emitters:

- `V < handle_raw_ptr_threshold` → bare handle: resolve directly
- `V ∈ [BSS_BASE_LINUX, 0x80000000)` → raw BSS aggregate data: object base = `V − object_header`
- otherwise → true `&cell`: deref + resolve (**legacy path, byte-identical**)

Legit pointer-to-cell values are stack LEAs (~0x7f…) and heap mmaps sit above 2 GiB, so the classes are disjoint; the explicit-`&` path is provably untouched.

## Validation

Compiler rebuilt from patched source (`make build-madaros`):

- Issue probe (imported callee, global array, implicit borrow): was segfault(139) → prints `6.000000` + `PROBE64_OK`
- same-module global/local implicit borrows: `6.000000` + OK
- imported `&!` mutation through implicit borrow: mutation visible to caller (`23.000000 MUT_OK`)
- explicit-`&` controls: unchanged
- New regression witness: `tests/multimodule/madaros_imported_slice_ref_global_{leaf,main}.sio` → `MADAROS_IMPORTED_SLICE_REF_GLOBAL_OK`
- Regression suites (Madaros default): `--filter global` 11/11; `--filter array` 24 pass / 1 fail; `--filter slice` 1 pass / 3 fail — **all 4 failures reproduce identically with the unmodified prebuilt compiler** (pre-existing on main, unrelated).
- Follow-up: `tests/run-pass/epistemic_sobol_indices_selftest.sio` (PR #1509, lean_single-only until now) **passes on Madaros with this fix**.

## Out of scope (pre-existing, separate defects)

- `var arr: [f64; 64]` without initializer crashes on Madaros at first element store (handle 0); lean_single zero-inits.
- Caller-side auto-borrow in `ir/lower.sio` (would also cover ref-to-struct implicit borrows) remains a possible follow-up.