### PR TITLE
fix(compiler): say which of the three preflight failures happened, and where

### DIFF
--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -2049,14 +2049,32 @@ fn compiler_visibility_preflight(source_path: string) -> bool with IO, Mut, Pani
         unresolved_count: 0,
         saturated: false,
         parse_failed: false,
+        parse_failed_path: "",
     }
     if !module_frontend_collect_ast_closure_into(source_path, &!closure) {
+        // Report the field that EXPLAINS the failure, not only the three that
+        // happen to look healthy.
+        //
+        // A dependency parse failure short-circuits the closure walk, so
+        // unresolved_count stays 0 and saturated stays false — the exact values a
+        // healthy-but-small closure has. Printing only those three said "something
+        // is wrong somewhere" and sent readers looking at import resolution, which
+        // was fine. The cause is parse_failed, and it names a file.
+        if closure.parse_failed {
+            print("run_check_mode: module failed to parse: ")
+            print(closure.parse_failed_path)
+            print("\n")
+            print("  note: the closure walk stops at the first parse failure, so the")
+            print(" node/unresolved/saturated counts below describe only what was reached\n")
+        }
         print("run_check_mode: AST closure incomplete nodes=")
         print_int(closure.node_count)
         print(" unresolved=")
         print_int(closure.unresolved_count)
         print(" saturated=")
         if closure.saturated { print("true") } else { print("false") }
+        print(" parse_failed=")
+        if closure.parse_failed { print("true") } else { print("false") }
         print("\n")
         return false
     }
@@ -2120,6 +2138,16 @@ fn compiler_visibility_preflight(source_path: string) -> bool with IO, Mut, Pani
     print("run_check_mode: verdict=")
     print_int(verdict)
     print("\n")
+    // A non-zero verdict is a TYPE error across the merged modules, not a
+    // visibility or parse problem. The caller turns `false` into
+    // "error: visibility preflight failed", which names the stage that ran rather
+    // than the thing that went wrong — a program whose only fault is a bad type
+    // gets told its visibility failed. Say so here, where the distinction is known.
+    if verdict != 0 {
+        print("run_check_mode: type checking failed across ")
+        print_int(closure.node_count)
+        print(" module(s); the diagnostics above name the offending declarations\n")
+    }
     verdict == 0
 }
 
@@ -2139,6 +2167,7 @@ fn run_science_boundary_closure_report(
         unresolved_count: 0,
         saturated: false,
         parse_failed: false,
+        parse_failed_path: "",
     }
     let complete = module_frontend_collect_ast_closure_into(source_path, &!closure)
     println("SOUNIO_BOUNDARY_CLOSURE_V1")
@@ -5178,7 +5207,12 @@ fn compile(opts: CompilerOptions) -> CompileResult with IO, Mut, Panic, Div, All
 
     if !compiler_visibility_preflight(opts.input_file) {
         var visibility_errors = compile_errors_new()
-        visibility_errors = compile_errors_push(visibility_errors, "error: visibility preflight failed")
+        // The preflight covers three distinct failures — a module that will not
+        // parse, an AST closure that could not be completed, and a type error
+        // across the merged modules — and this one message described only the
+        // stage. run_check_mode prints which of the three it was just above; say
+        // that here too, so the final line a user sees is not misleading on its own.
+        visibility_errors = compile_errors_push(visibility_errors, "error: preflight failed (parse, module closure, or type check — see run_check_mode output above)")
         return CompileResult {
             success: false,
             errors: visibility_errors,

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -2394,6 +2394,13 @@ pub struct ModuleClosure {
     pub unresolved_count: i64,
     pub saturated: bool,
     pub parse_failed: bool,
+    // Path of the module whose parse failed. Empty when parse_failed is false.
+    //
+    // Without this a caller can report THAT the closure is incomplete but not
+    // WHY or WHERE: a dependency parse failure short-circuits the walk, leaving
+    // unresolved_count at 0 and saturated at false, so every field the diagnostic
+    // prints looks healthy while the one that explains the failure is absent.
+    pub parse_failed_path: string,
 }
 
 pub fn module_frontend_collect_ast_closure_into(
@@ -2405,11 +2412,13 @@ pub fn module_frontend_collect_ast_closure_into(
     (*out).unresolved_count = 0
     (*out).saturated = false
     (*out).parse_failed = false
+    (*out).parse_failed_path = ""
 
     parser_reset_last_errors()
     let main_prog = load_module_file(main_path)
     if parser_last_error_count() > 0 {
         (*out).parse_failed = true
+        (*out).parse_failed_path = main_path
         return false
     }
     (*out).paths[0] = main_path
@@ -2423,6 +2432,7 @@ pub fn module_frontend_collect_ast_closure_into(
         let work_prog = load_module_file(caller_path)
         if parser_last_error_count() > 0 {
             (*out).parse_failed = true
+            (*out).parse_failed_path = caller_path
             work_front = (*out).node_count
         }
         let imports = extract_imports_from_ast(work_prog)


### PR DESCRIPTION
`compiler_visibility_preflight` covers **three distinct failures** — a module that will not parse, an AST closure that could not be completed, and a type error across the merged modules — and all three exited with one message:

```
error: visibility preflight failed
```

That names the **stage that ran**, not the thing that went wrong. A program whose only fault is a type error is told its visibility failed.

## How I found it

I hit it myself. A twelve-line program calling `gum_k95()` from `epistemic::gum` produced exactly that line and nothing else. Tracing with the compiler's own output: it parses fine, completes a 2-module closure, and dies at `verdict=1` — a **type error**. Nothing in the message said so.

## The change

**1.** `ModuleClosure` gains `parse_failed_path`, set at the two sites that already knew the path (`main_path`, `caller_path`). The information existed and was being dropped.

**2.** `run_check_mode` prints *which* failure occurred:

| failure | message |
|---|---|
| parse | `module failed to parse: <path>` + note that the walk stops there |
| type check | `type checking failed across N module(s)` |
| closure | the existing counts, now including `parse_failed` |

**The counts were the trap.** A dependency parse failure short-circuits the walk, leaving `unresolved_count` at 0 and `saturated` at false — the *same values a healthy small closure has*. Every printed field looked fine while the one that explained the failure was absent.

**3.** The caller's message points at that detail instead of asserting a stage.

## Measured

| case | before | after |
|---|---|---|
| type error | `error: visibility preflight failed` | `run_check_mode: type checking failed across 2 module(s)` |
| parse error | `error: visibility preflight failed` | `run_check_mode: module failed to parse: <exact path>` |
| healthy program | — | unchanged |

## One thing worth recording

This nearly shipped covering the wrong case. I assumed from the issue text that the bare message always meant a hidden parse failure, wrote the parse half, verified it against a deliberately broken file, and **it worked**. The real case that motivated the work still printed the bare line — because it is a type error, not a parse error.

A synthetic repro confirmed the fix and would have concealed that two thirds of the defect were untouched. The check that caught it was re-running the *original* symptom rather than the one I had built to test against.

## Verification

`madaros_corpus_regression_gate.sh`: **PASS**, no new failures (307 known / 1692). `pediatric_pbpk_receipt.sio` now passes — unrelated to this change, tracked in #1536 discussion.

Engine-parity gate was still running when this was opened; I will post its result as a comment.