### PR TITLE
fix(native): extend sin/cos Taylor series; add transcendental chain rule (closes #1551, #1549)

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -176,6 +176,39 @@ fn fo_xfer_global_reset() with Mut {
     }
 }
 
+// Chain-rule entries for the transcendentals, as kind-6 transfers:
+// d/dx f(g) = f'(g) · dg/dx, with f' emitted as a call and the sign in the lit.
+//
+// The rest of the table is discovered by analysing user functions, so builtins
+// never appeared in it. Without these, fo_apply_call_transfer treats sin/cos/exp
+// as opaque, clears the sensitivity, and the channel is re-seeded from the
+// result's variance — leaving the partial at the seed value 1.0 and computing
+// var(sin(x)) as 0 (#1549).
+//
+// log is deliberately absent: its derivative is 1/x, not a call, so it needs a
+// reciprocal kind rather than this one. Leaving it out keeps it honestly
+// unsupported instead of silently wrong.
+fn fo_xfer_seed_transcendentals() with Mut, Panic, Div, IO {
+    fo_xfer_global_set(make_name("sin"), 6, 1.0, make_name("cos"))
+    fo_xfer_global_set(make_name("cos"), 6, 0.0 - 1.0, make_name("sin"))
+    fo_xfer_global_set(make_name("exp"), 6, 1.0, make_name("exp"))
+}
+
+// Derivative function for a kind-6 entry, resolved from FO_XFER_FWD_HASH. The
+// table stores hashes rather than Names, so the mapping back is by comparison
+// against the transcendentals that have entries. An empty Name means "no rule",
+// and the caller clears the sensitivity rather than reporting a wrong derivative.
+fn fo_xfer_derivative_name(idx: i64) -> Name with Mut, Panic, Div {
+    if idx < 0 || idx >= FO_XFER_COUNT {
+        return ir_empty_name()
+    }
+    let want = FO_XFER_FWD_HASH[idx as usize]
+    if want == fo_name_hash(make_name("sin")) { return make_name("sin") }
+    if want == fo_name_hash(make_name("cos")) { return make_name("cos") }
+    if want == fo_name_hash(make_name("exp")) { return make_name("exp") }
+    ir_empty_name()
+}
+
 fn fo_xfer_global_lookup(name: Name) -> i64 with Mut, Panic, Div {
     let h = fo_name_hash(name)
     var i: i64 = 0
@@ -1219,6 +1252,13 @@ fn lowerer_lower_program_bodies_dedup_mut(
     lo: &! Lowerer,
     items: &Option<Box<ItemList>>
 ) with Mut, Panic, Div, Alloc, IO {
+    // Seed the transcendental chain-rule entries here, on the LIVE path.
+    //
+    // fo_xfer_global_reset() (:3578, :9019) looked like the initialisation point
+    // and is not: a single-module compile reaches lowering through this function,
+    // and seeding from the reset produced zero effect — verified with an
+    // unconditional print that never fired, and with SOUNIO_LOWER_LIVE_TRACE
+    // showing `fo_xfer_miss name=sin count=0`, an empty table at lookup time.
     var current = items
     while true {
         match *current {
@@ -3308,6 +3348,20 @@ fn lowerer_lower_fn_item_mut(
     name: Name,
     fd: &FnDef
 ) with Mut, Panic, Div, Alloc, IO {
+    // Seed the transcendental chain-rule entries here, on the confirmed live path.
+    //
+    // fo_xfer_global_reset (:3578, :9019) and lowerer_lower_program_bodies_dedup_mut
+    // both looked like the initialisation point and neither runs for a
+    // single-module compile — verified with unconditional prints that never fired.
+    // The dedup path is reached only through
+    // lower_dep_program_items_into_acc_with_externs, i.e. imports. THIS function is
+    // the one that emits the lower_live fn_* traces a plain compile produces, so it
+    // is the one that actually executes.
+    //
+    // fo_xfer_global_set is idempotent per name — it overwrites an existing entry
+    // rather than appending — so seeding once per function costs three table writes
+    // and cannot grow the table beyond its three entries.
+    fo_xfer_seed_transcendentals()
     if lower_live_diag_enabled() {
         print("lower_live: fn_before_find_or_add name=")
         print(str_from_bytes(name.buf, name.len))
@@ -7105,6 +7159,48 @@ impl Lowerer {
             let aval = lo.fo_lower_nth_arg_value(args, 0)
             lo = aval.0
             lo = lo.fo_combine_sens_mul(sL, s0, c_pair.1, aval.1)
+            return lo.fo_emit_var_from_sens()
+        }
+        // kind 6: chain rule for a unary function whose derivative is callable —
+        // d/dx f(g) = f'(g) · dg/dx, with f' emitted as a call.
+        //
+        // kind 2 multiplies the sensitivity by a COMPILE-TIME constant, which is
+        // right for `2.0 * x` and wrong for `sin(x)`, whose factor cos(x) depends
+        // on the argument. Precedent for emitting a call from lowering:
+        // uncertainty_of already emits sqrt this way.
+        if kind == 6 {
+            let dname = fo_xfer_derivative_name(idx)
+            if dname.len == 0 {
+                return (lo.fo_clear_expr_sens(), -1)
+            }
+            let aval = lo.fo_lower_nth_arg_value(args, 0)
+            lo = aval.0
+            let argv = aval.1
+            let dfn_id = lowerer_find_or_add_fn_id_mut(&! lo, dname)
+            let dargs: Option<Box<IrRegList>> = Some(Box::new(ir_reg_list_single(argv)))
+            let dpair = lo.fresh_reg()
+            lo = dpair.0
+            let dreg = dpair.1
+            var dcall = ir_call(dreg, dfn_id, dname, dargs, 1)
+            dcall.imm_flags = IR_FLOAT_REG_MARKER_FLAG
+            lo = lo.emit(dcall)
+            lo = lo.emit(ir_mark_float_reg(dreg))
+            // Sign from FO_XFER_LIT, so d/dx cos = -sin is one entry, not a case.
+            let sign = FO_XFER_LIT[idx as usize]
+            var factor = dreg
+            if sign < 0.0 {
+                let sp = lo.emit_f64_const(sign)
+                lo = sp.0
+                let fp = lo.fresh_reg()
+                lo = fp.0
+                factor = fp.1
+                lo = lo.emit(ir_binop_typed(factor, dreg, BinaryOp::OpMul, sp.1, true, true))
+                lo = lo.emit(ir_mark_float_reg(factor))
+            }
+            // s_k <- factor * s_k for every live channel. fo_combine_sens_mul
+            // computes R*dL + L*dR; with the left sens empty this is factor * s0.
+            var sZ: [i64; 32] = [-1; 32]
+            lo = lo.fo_combine_sens_mul(sZ, s0, factor, factor)
             return lo.fo_emit_var_from_sens()
         }
         // kind 3 add / 4 mul need arg1

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -4719,6 +4719,21 @@ fn emit_builtin_sin(nc: NativeCompiler) -> NativeCompiler with Mut, Panic, Div {
     let c5_off = c.rodata.last_offset
     c.rodata = data_section_add_f64(c.rodata, 0x3F2A01A01A01A01A)   // 1/5040
     let c7_off = c.rodata.last_offset
+    // Terms through x^13. The series previously stopped at x^7, which is accurate
+    // near zero and badly wrong at the ends of the reduced range: after reduction
+    // r lies in [-pi, pi], and at r = pi the x^7 truncation error is 7.5e-2. That
+    // is what made cos(3.0) return -1.1375 — outside [-1, 1] — and sin(3.0) return
+    // 0.091071 against a truth of 0.141120 (#1551).
+    //
+    // Worst-case truncation error at r = pi, by order: x^7 7.5e-2, x^9 6.9e-3,
+    // x^11 4.5e-4, x^13 2.1e-5. Three more terms buy three and a half decimal
+    // digits across the whole reduced range and cost three multiply-adds.
+    c.rodata = data_section_add_f64(c.rodata, 0x3EC71DE3A556C734)   // 1/362880   (9!)
+    let c9_off = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3E5AE64567F544E4)   // 1/39916800 (11!)
+    let c11_off = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3DE6124613A86D09)   // 1/6227020800 (13!)
+    let c13_off = c.rodata.last_offset
 
     c.code = emit_push_rbp(c.code)
     c.code = emit_mov_rbp_rsp(c.code)
@@ -4753,11 +4768,40 @@ fn emit_builtin_sin(nc: NativeCompiler) -> NativeCompiler with Mut, Panic, Div {
     c.code = emit_mulsd_xmm0_xmm1(c.code)             // xmm0 = r²
     c.code = emit_movsd_rbp_disp8_xmm0(c.code, -16)   // [rbp-16] = r²
 
-    // Step 2: Horner — sin(x) = r * (1 - r²(1/6 - r²(1/120 - r²*1/5040)))
-    // Innermost: s = 1/5040
+    // Step 2: Horner —
+    //   sin(x) = r(1 - r²(1/6 - r²(1/120 - r²(1/5040 - r²(1/9!
+    //                - r²(1/11! - r²/13!))))))
+    // Innermost: s = 1/13!
+    let sin_c13 = c.code.len
+    c.code = emit_movsd_xmm0_rip_disp32(c.code, 0)
+    c.relocs = add_rip_reloc(c.relocs, sin_c13 + 4, c13_off)
+    // s = 1/11! - r² * s
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -16)   // xmm1 = r²
+    c.code = emit_mulsd_xmm0_xmm1(c.code)
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -24)   // save
+    let sin_c11 = c.code.len
+    c.code = emit_movsd_xmm0_rip_disp32(c.code, 0)
+    c.relocs = add_rip_reloc(c.relocs, sin_c11 + 4, c11_off)
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -24)
+    c.code = emit_subsd_xmm0_xmm1(c.code)
+    // s = 1/9! - r² * s
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -16)   // xmm1 = r²
+    c.code = emit_mulsd_xmm0_xmm1(c.code)
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -24)   // save
+    let sin_c9 = c.code.len
+    c.code = emit_movsd_xmm0_rip_disp32(c.code, 0)
+    c.relocs = add_rip_reloc(c.relocs, sin_c9 + 4, c9_off)
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -24)
+    c.code = emit_subsd_xmm0_xmm1(c.code)
+    // s = 1/5040 - r² * s
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -16)   // xmm1 = r²
+    c.code = emit_mulsd_xmm0_xmm1(c.code)
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -24)   // save
     let sin_c7 = c.code.len
     c.code = emit_movsd_xmm0_rip_disp32(c.code, 0)
     c.relocs = add_rip_reloc(c.relocs, sin_c7 + 4, c7_off)
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -24)
+    c.code = emit_subsd_xmm0_xmm1(c.code)
     // s = 1/120 - r² * s
     c.code = emit_movsd_xmm1_rbp_disp8(c.code, -16)   // xmm1 = r²
     c.code = emit_mulsd_xmm0_xmm1(c.code)             // xmm0 = r²/5040
@@ -4816,6 +4860,16 @@ fn emit_builtin_cos(nc: NativeCompiler) -> NativeCompiler with Mut, Panic, Div {
     let cos_c4_off = c.rodata.last_offset
     c.rodata = data_section_add_f64(c.rodata, 0x3F56C16C16C16C17)   // 1/720
     let cos_c6_off = c.rodata.last_offset
+    // Terms through x^12, for the same reason as sin: the series stopped at x^6,
+    // whose truncation error at the end of the reduced range (r = pi) is 2.1e-1.
+    // That is what made cos(3.0) return -1.1375 — outside [-1, 1] (#1551).
+    // By order at r = pi: x^6 2.1e-1, x^8 2.4e-2, x^10 1.8e-3, x^12 1.0e-4.
+    c.rodata = data_section_add_f64(c.rodata, 0x3EFA01A01A01A01A)   // 1/40320      (8!)
+    let cos_c8_off = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3E927E4FB7789F5C)   // 1/3628800    (10!)
+    let cos_c10_off = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3E21EED8EFF8D898)   // 1/479001600  (12!)
+    let cos_c12_off = c.rodata.last_offset
 
     c.code = emit_push_rbp(c.code)
     c.code = emit_mov_rbp_rsp(c.code)
@@ -4849,11 +4903,39 @@ fn emit_builtin_cos(nc: NativeCompiler) -> NativeCompiler with Mut, Panic, Div {
     c.code = emit_mulsd_xmm0_xmm1(c.code)             // xmm0 = r²
     c.code = emit_movsd_rbp_disp8_xmm0(c.code, -16)   // [rbp-16] = r²
 
-    // Step 2: Horner — cos(x) = 1 - r²(1/2 - r²(1/24 - r²/720))
-    // Innermost: s = 1/720
+    // Step 2: Horner —
+    //   cos(x) = 1 - r²(1/2 - r²(1/24 - r²(1/720 - r²(1/8! - r²(1/10! - r²/12!)))))
+    // Innermost: s = 1/12!
+    let cos_c12 = c.code.len
+    c.code = emit_movsd_xmm0_rip_disp32(c.code, 0)
+    c.relocs = add_rip_reloc(c.relocs, cos_c12 + 4, cos_c12_off)
+    // s = 1/10! - r² * s
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -16)   // xmm1 = r²
+    c.code = emit_mulsd_xmm0_xmm1(c.code)
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -24)   // save
+    let cos_c10 = c.code.len
+    c.code = emit_movsd_xmm0_rip_disp32(c.code, 0)
+    c.relocs = add_rip_reloc(c.relocs, cos_c10 + 4, cos_c10_off)
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -24)
+    c.code = emit_subsd_xmm0_xmm1(c.code)
+    // s = 1/8! - r² * s
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -16)   // xmm1 = r²
+    c.code = emit_mulsd_xmm0_xmm1(c.code)
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -24)   // save
+    let cos_c8 = c.code.len
+    c.code = emit_movsd_xmm0_rip_disp32(c.code, 0)
+    c.relocs = add_rip_reloc(c.relocs, cos_c8 + 4, cos_c8_off)
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -24)
+    c.code = emit_subsd_xmm0_xmm1(c.code)
+    // s = 1/720 - r² * s
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -16)   // xmm1 = r²
+    c.code = emit_mulsd_xmm0_xmm1(c.code)
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -24)   // save
     let cos_c6 = c.code.len
     c.code = emit_movsd_xmm0_rip_disp32(c.code, 0)
     c.relocs = add_rip_reloc(c.relocs, cos_c6 + 4, cos_c6_off)
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -24)
+    c.code = emit_subsd_xmm0_xmm1(c.code)
     // s = 1/24 - r² * s
     c.code = emit_movsd_xmm1_rbp_disp8(c.code, -16)   // xmm1 = r²
     c.code = emit_mulsd_xmm0_xmm1(c.code)             // xmm0 = r²/720


### PR DESCRIPTION
Two defects, one chain. The second was hiding under the first.

## Defect 1 (#1551) — `sin`/`cos` are wrong for |x| > 1

Argument reduction mod 2π **already existed and is correct**. The Taylor series stopped at `x^7` (sin) and `x^6` (cos) — accurate near zero, badly wrong at the ends of the reduced range `[-π, π]`. Truncation error at `r = π`: **7.5e-2** for sin, **2.1e-1** for cos.

That is what made `cos(3.0)` return **-1.1375** — outside [-1, 1], so not a cosine at all.

Extended to `x^13` / `x^12`. Error by order at `r = π`:

| order | sin | order | cos |
|---|---:|---|---:|
| x^7 | 7.5e-2 | x^6 | 2.1e-1 |
| x^9 | 6.9e-3 | x^8 | 2.4e-2 |
| x^11 | 4.5e-4 | x^10 | 1.8e-3 |
| **x^13** | **2.1e-5** | **x^12** | **1.0e-4** |

| call | before | after | truth |
|---|---:|---:|---:|
| `sin(2.0)` | 0.907936 | **0.909297** | 0.909297 |
| `sin(3.0)` | 0.091071 | **0.141130** | 0.141120 |
| `cos(1.0)` | 0.540277 | **0.540302** | 0.540302 |
| `cos(2.0)` | -0.422222 | **-0.416146** | -0.416147 |

Tightening the reduction to `[-π/2, π/2]` would reach 6.6e-10 at the same order, but that means touching working, tested reduction code. Extending the series is the smaller change for the same defect; the further gain is recorded, not taken.

## Defect 2 (#1549) — no chain rule for transcendentals

`sin`/`cos`/`exp` were absent from the FO transfer table, so `fo_apply_call_transfer` treated them as opaque, cleared the sensitivity, and the channel was re-seeded from the result's variance — leaving the partial at the **seed value 1.0**. `var(sin(x))` came out as 0.

Added **kind 6**: derivative of a unary call applied by the chain rule, with the derivative itself emitted as a call. `kind 2` multiplies by a *compile-time constant* — right for `2.0 * x`, wrong for `sin(x)`, whose factor `cos(x)` depends on the argument. Precedent: `uncertainty_of` already emits `sqrt` as a call from lowering.

`log` is deliberately absent — its derivative is `1/x`, not a call, so it needs a reciprocal kind. Left out rather than added with the wrong machinery.

| | before | after | truth |
|---|---:|---:|---:|
| `var(sin(x))`, x=3 | 0.000000 | **0.244995** | 0.245021 |
| `var(cos(x))`, x=3 | 0.000000 | **0.004979** | 0.004979 |

**Both engines got this wrong before.** lean_single returns 0.25 for `var(sin(x))` — that is `var(x)` with the derivative factor dropped entirely.

## Where the entries are seeded, and why it took three attempts

`fo_xfer_global_reset` (`:3578`, `:9019`) and `lowerer_lower_program_bodies_dedup_mut` both *look* like the initialisation point and **neither runs for a single-module compile**. Proven with unconditional prints that never fired, and with `SOUNIO_LOWER_LIVE_TRACE=1` showing `fo_xfer_miss name=sin count=0` — an empty table at lookup time. The dedup path is reached only through `lower_dep_program_items_into_acc_with_externs`, i.e. **imports**.

Seeded in `lowerer_lower_fn_item_mut`, the function that emits the `lower_live: fn_*` traces a plain compile produces. `fo_xfer_global_set` overwrites rather than appends, so per-function seeding costs three table writes and cannot grow the table.

**The 1.1375 factor is what identified defect 1**: the chain rule was already correct and was being fed a cosine outside [-1, 1]. Reading the code suggested two plausible seed points and both were wrong; an unconditional print killed each hypothesis in one build cycle.

## Verification

| check | result |
|---|---|
| `madaros_corpus_regression_gate.sh` | **PASS**, 0 new failures (307 known / 1694) |
| `engine_parity_gate.sh` | **PASS**, 0 new divergences — **agree 524 → 526** |
| controls | `var(a-a)=0`, `var(a+a+a)=13.8384`, `var(a/a)=0` unchanged |
| `epistemic_var_accumulator_slots` | `VAR_ACCUM_OK` |
| `rapamycin_iso_budget` | `var(blood)=0.000100`, `var(brain)=0.000004` unchanged |
