### PR TITLE
docs(demos): hydrogen cascade runs on Madaros — drop lean_single engine note

### DIFF
--- a/demos/hydrogen/README.md
+++ b/demos/hydrogen/README.md
@@ -11,22 +11,18 @@ reproducibility living inside the language itself**, not in an external toolbox.
 ## Run
 
 ```bash
-bin/souc run demos/hydrogen/mh_stage_uq.sio                              # stage model (any engine)
-SOUNIO_SOUC_ENGINE=lean_single bin/souc run demos/hydrogen/mh_cascade_uq.sio  # cascade (see note)
+bin/souc run demos/hydrogen/mh_stage_uq.sio                              # stage model
+bin/souc run demos/hydrogen/mh_cascade_uq.sio                            # cascade
 bin/souc run demos/hydrogen/bayes_pilot.sio                              # value of pilot data (IDM)
 bin/souc run demos/hydrogen/hub_chain.sio                                # full chain: delivered EUR/kg
 ```
 
 Deterministic (seeded xorshift PRNG): every run prints the same numbers and
-ends with `MH_STAGE_UQ_OK` / `MH_CASCADE_UQ_OK`.
-
-**Engine note (hit live while building this demo):** the cascade file imports
-Sounio's own `stdlib/epistemic/pce.sio`, which calls libm through
-`extern "C"`. On the default Madaros engine the native path currently
-mis-lowers extern f64 returns (exp→0, observed 2026-07-26; the suite keeps
-its FFI tests on the lean_single stage2 engine). Until that lands, run the
-cascade with `SOUNIO_SOUC_ENGINE=lean_single` as above. The stage file uses
-pure-Sounio math only and runs on both engines with identical numbers.
+ends with `MH_STAGE_UQ_OK` / `MH_CASCADE_UQ_OK`. All demos run on the default
+Madaros engine as well as lean_single. (Historical note: the cascade imports
+`stdlib/epistemic/pce.sio`, which calls libm through `extern "C"`; until
+#1550 the Madaros native path dropped all but the first extern decl and
+mis-evaluated the exp/log builtins — issue #1547, fixed.)
 
 ## The model (`mh_stage_uq.sio`)
 


### PR DESCRIPTION
Follow-up to #1550 (which closed #1547).

The cascade demo (`mh_cascade_uq.sio` via `stdlib/epistemic/pce.sio` → libm `extern "C"`) no longer needs `SOUNIO_SOUC_ENGINE=lean_single`: with the extern-decl retention + exp/log builtin fixes merged, it runs on the default Madaros engine with numbers matching lean_single (PCE mean 370.280115 vs 370.280165, std 212.659193 vs 212.659204, `MH_CASCADE_UQ_OK`).

This removes the last engine caveat from the hydrogen demo suite: every demo and every epistemic self-test now runs on the default engine. Verified locally with a fresh `make build-madaros` on current main.