### PR TITLE
fix(sync): declare Mut on mutating sync primitives + e2e tests (#1555)

### DIFF
--- a/stdlib/sync/atomic.sio
+++ b/stdlib/sync/atomic.sio
@@ -15,23 +15,23 @@ pub fn atomic_load(a: &AtomicI64) -> i64 {
     a.val
 }
 
-pub fn atomic_store(a: &! AtomicI64, v: i64) {
+pub fn atomic_store(a: &! AtomicI64, v: i64) with Mut {
     a.val = v
 }
 
-pub fn atomic_add(a: &! AtomicI64, delta: i64) -> i64 {
+pub fn atomic_add(a: &! AtomicI64, delta: i64) -> i64 with Mut {
     let old = a.val
     a.val = a.val + delta
     old
 }
 
-pub fn atomic_sub(a: &! AtomicI64, delta: i64) -> i64 {
+pub fn atomic_sub(a: &! AtomicI64, delta: i64) -> i64 with Mut {
     let old = a.val
     a.val = a.val - delta
     old
 }
 
-pub fn atomic_cas(a: &! AtomicI64, expected: i64, desired: i64) -> bool {
+pub fn atomic_cas(a: &! AtomicI64, expected: i64, desired: i64) -> bool with Mut {
     if a.val == expected {
         a.val = desired
         return true

--- a/stdlib/sync/channel.sio
+++ b/stdlib/sync/channel.sio
@@ -56,7 +56,7 @@ pub fn channel_new() -> IntChannel {
     IntChannel { buf: [0; 1024], head: 0, tail: 0, count: 0, closed: 0 }
 }
 
-pub fn channel_send(ch: &! IntChannel, val: i64) -> bool {
+pub fn channel_send(ch: &! IntChannel, val: i64) -> bool with Mut {
     if ch.closed == 1 { return false }
     if ch.count >= CHANNEL_CAP { return false }
     ch.buf[ch.tail] = val
@@ -65,7 +65,7 @@ pub fn channel_send(ch: &! IntChannel, val: i64) -> bool {
     true
 }
 
-pub fn channel_recv(ch: &! IntChannel) -> i64 {
+pub fn channel_recv(ch: &! IntChannel) -> i64 with Mut {
     if ch.count == 0 { return 0 }
     let v = ch.buf[ch.head]
     ch.head = (ch.head + 1) % CHANNEL_CAP
@@ -81,7 +81,7 @@ pub fn channel_len(ch: &IntChannel) -> i64 {
     ch.count
 }
 
-pub fn channel_close(ch: &! IntChannel) {
+pub fn channel_close(ch: &! IntChannel) with Mut {
     ch.closed = 1
 }
 

--- a/stdlib/sync/mutex.sio
+++ b/stdlib/sync/mutex.sio
@@ -48,7 +48,7 @@ pub fn mutex_unlock(m: &! Mutex) {
 
 // Destroy the mutex and free its heap storage.
 // After this call the Mutex must not be used.
-pub fn mutex_destroy(m: &! Mutex) {
+pub fn mutex_destroy(m: &! Mutex) with Mut {
     let _rc = pthread_mutex_destroy(m.ptr)
     free(m.ptr)
     m.ptr = (0 as i64) as *mut u8

--- a/stdlib/sync/rwlock.sio
+++ b/stdlib/sync/rwlock.sio
@@ -49,26 +49,26 @@ pub fn rwlock_new() -> RwLock {
     RwLock { readers: 0, writer: 0 }
 }
 
-pub fn rwlock_read_lock(rw: &! RwLock) -> bool {
+pub fn rwlock_read_lock(rw: &! RwLock) -> bool with Mut {
     if rw.writer != 0 { return false }
     rw.readers = rw.readers + 1
     true
 }
 
-pub fn rwlock_read_unlock(rw: &! RwLock) {
+pub fn rwlock_read_unlock(rw: &! RwLock) with Mut {
     if rw.readers > 0 {
         rw.readers = rw.readers - 1
     }
 }
 
-pub fn rwlock_write_lock(rw: &! RwLock) -> bool {
+pub fn rwlock_write_lock(rw: &! RwLock) -> bool with Mut {
     if rw.writer != 0 { return false }
     if rw.readers != 0 { return false }
     rw.writer = 1
     true
 }
 
-pub fn rwlock_write_unlock(rw: &! RwLock) {
+pub fn rwlock_write_unlock(rw: &! RwLock) with Mut {
     rw.writer = 0
 }
 

--- a/tests/stdlib/sync/test_atomic_e2e.sio
+++ b/tests/stdlib/sync/test_atomic_e2e.sio
@@ -3,7 +3,7 @@
 
 use sync::atomic::*;
 
-fn run_tests(a: &! AtomicI64) -> i32 {
+fn run_tests(a: &! AtomicI64) -> i32 with Mut {
     // Initial value
     if atomic_load(a) != 0 { return 1 }
 
@@ -34,7 +34,7 @@ fn run_tests(a: &! AtomicI64) -> i32 {
     return 0
 }
 
-fn main() -> i32 {
+fn main() -> i32 with Mut {
     var a = atomic_new(0)
     return run_tests(&! a)
 }

--- a/tests/stdlib/sync/test_channel_e2e.sio
+++ b/tests/stdlib/sync/test_channel_e2e.sio
@@ -3,7 +3,7 @@
 
 use sync::channel::*
 
-fn run_tests(ch: &! IntChannel) -> i32 {
+fn run_tests(ch: &! IntChannel) -> i32 with Mut {
     if !channel_is_empty(ch) { return 1 }
 
     if !channel_send(ch, 10) { return 2 }
@@ -24,7 +24,7 @@ fn run_tests(ch: &! IntChannel) -> i32 {
     0
 }
 
-fn main() -> i32 {
+fn main() -> i32 with Mut {
     var ch = channel_new()
     run_tests(&! ch)
 }

--- a/tests/stdlib/sync/test_mutex_e2e.sio
+++ b/tests/stdlib/sync/test_mutex_e2e.sio
@@ -3,7 +3,7 @@
 
 use sync::mutex::{mutex_new, mutex_is_valid, mutex_destroy}
 
-fn main() -> i32 with IO {
+fn main() -> i32 with IO, Mut {
     var m = mutex_new()
     if !mutex_is_valid(&m) { return 1 }
     mutex_destroy(&! m)

--- a/tests/stdlib/sync/test_rwlock_e2e.sio
+++ b/tests/stdlib/sync/test_rwlock_e2e.sio
@@ -3,7 +3,7 @@
 
 use sync::rwlock::*
 
-fn run_tests(rw: &! RwLock) -> i32 {
+fn run_tests(rw: &! RwLock) -> i32 with Mut {
     if !rwlock_read_lock(rw) { return 1 }
     if !rwlock_read_lock(rw) { return 2 }
     if rwlock_reader_count(rw) != 2 { return 3 }
@@ -25,7 +25,7 @@ fn run_tests(rw: &! RwLock) -> i32 {
     0
 }
 
-fn main() -> i32 {
+fn main() -> i32 with Mut {
     var rw = rwlock_new()
     run_tests(&! rw)
 }


### PR DESCRIPTION
Closes #1555.

## Root cause

PR #1522 (closes #1488) made the Madaros checker generate `Mut` at store sites — deliberately matching lean_single, which already rejected these programs. `stdlib/sync` predates that enforcement: 14 store sites inside the modules (`atomic` ×4, `channel` ×6, `rwlock` ×4, `mutex` ×1) are reached through functions with no `Mut` in their effect lists. A Madaros **freshly built from current source** therefore rejects `test_atomic_e2e`, `test_channel_e2e`, `test_mutex_e2e`, `test_rwlock_e2e` with E035 — while the committed prebuilt `bin/madaros-linux-x86_64` (built 2026-06-14, six weeks stale) still passes them. Fresh worktrees lack `artifacts/self-hosted/madaros`, so the suite silently falls back to the stale prebuilt and CI stays green while source and shipped binary disagree. That drift is the subject of #1555; this PR fixes the stdlib/test side of it.

## Changes

- `stdlib/sync/{atomic,channel,rwlock,mutex}.sio`: `with Mut` on the 12 mutating free functions (store sites: `atomic_store/add/sub/cas`, `channel_send/recv/close`, all four rwlock fns, `mutex_destroy`).
- `tests/stdlib/sync/test_*_e2e.sio`: `with Mut` on the entry points that call them.

## Validation (fresh `make build-madaros` on rebased main, env sanitized: `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH`)

- Canonical harness, all four: `test_atomic_e2e` / `test_channel_e2e` / `test_mutex_e2e` / `test_rwlock_e2e` → Pass 1/0 each (`test_mutex_e2e` is `//@ check-only`, correctly not run).
- lean_single: atomic/channel/rwlock unchanged; **mutex rc 1→0** — the fix also repairs the lean_single rejection, exactly #1522's parity intent.
- Suite neighbors checked: the 6 unrelated `--filter channel` failures are epistemic/async tests, pre-existing, none imports `sync::channel`.

## Notes / follow-ups (not in this PR)

- The committed prebuilt still needs a refresh from current source — it predates #1522/#1547/#1548; refreshing flips the whole suite onto the strict checker, so this fix should land first.
- `make build-madaros` segfaults reproducibly when ambient `SOUC_BIN` is set (stale-seed path); `env -u SOUC_BIN` builds fine. Harness also honors ambient `SOUC_BIN`/`SOUNIO_STDLIB_PATH` — worth hardening in a separate lane.