### PR TITLE
docs(demos): fix Stamatakis citations — RenEn 147:164-178, CYRUS S.A., drop CALIPSO

### DIFF
--- a/demos/hydrogen/README.md
+++ b/demos/hydrogen/README.md
@@ -1,7 +1,7 @@
 # demos/hydrogen — Metal-Hydride Hydrogen Compression, Uncertainty-Quantified
 
 A Sounio demonstration written for **Dr. Emmanuel Stamatakis** (NCSR Demokritos,
-Integrated Hydrogen Laboratory / H2Lab; CYRUS P.C.).
+Integrated Hydrogen Laboratory / H2Lab; CYRUS S.A.).
 
 It takes the single-stage core of the metal-hydride (MH) thermal compression
 concept he has published on for a decade — and shows what Sounio adds on top of
@@ -351,8 +351,8 @@ extrapolation has become a guess.* Both engines → `VANTHOFF_GATE_OK`.
 - His techno-economic analyses run sensitivity by hand; here uncertainty
   is part of the program's value, and the run is a reproducible receipt.
 - For dual-use / safety contexts (INRASTES is an Energy & **Safety**
-  institute; CALIPSO is EDF): deterministic receipts plus epistemic labels
-  are the audit trail.
+  institute, and he leads innovation at CYRUS S.A.): deterministic receipts
+  plus epistemic labels are the audit trail.
 
 ## Honest boundaries
 

--- a/demos/hydrogen/mh_cascade_uq.sio
+++ b/demos/hydrogen/mh_cascade_uq.sio
@@ -6,7 +6,8 @@
 //
 // Written for Dr. Emmanuel Stamatakis (NCSR Demokritos, H2Lab): the cascade
 // architecture follows his multi-stage MH compression work (Renewable Energy
-// 148 (2020) 1118-1130); the design question it answers is one his
+// 147 (2020) 164-178, DOI 10.1016/j.renene.2019.08.104); the design question it
+// answers is one his
 // techno-economic studies face: given alloy batch uncertainty, what fraction
 // of hydride batches still reach the 200 bar refuelling target?
 //

--- a/demos/hydrogen/mh_stage_uq.sio
+++ b/demos/hydrogen/mh_stage_uq.sio
@@ -6,7 +6,7 @@
 //
 // Written for Dr. Emmanuel Stamatakis (NCSR Demokritos, Integrated Hydrogen
 // Laboratory): the model is the single-stage core of the multi-stage MH
-// compression systems in his Renewable Energy 148 (2020) 1118-1130 work.
+// compression systems in his Renewable Energy 147 (2020) 164-178 (DOI 10.1016/j.renene.2019.08.104) work.
 //
 // Physics (van't Hoff equilibrium, P in bar):
 //     ln P = ΔS/R − ΔH/(R·T)


### PR DESCRIPTION
Deep-research verification (ORCID 0000-0003-4293-6838, Crossref, CORDIS):

- `mh_stage_uq.sio` / `mh_cascade_uq.sio` headers cited "Renewable Energy 148 (2020) 1118-1130" — his multi-stage MH compression paper is **Renewable Energy 147 (2020) 164-178**, DOI 10.1016/j.renene.2019.08.104.
- README said "CYRUS P.C." — ORCID says **CYRUS S.A.**
- README asserted "CALIPSO is EDF" — no EU/EDF hydrogen project of that name is verifiable (closest real entity: HyPSTER, GA 101006751); replaced with his verified innovation role at CYRUS S.A.

Docs-only; external-facing accuracy for the package's intended reader.