### PR TITLE
feat(epistemic): implement sensitivity_of for Madaros (closes #1549)

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -3338,6 +3338,7 @@ fn checker_collect_runtime_builtins_inplace(c: *mut Checker) with Mut, Panic, Di
     checker_bind_import_unknown_inplace(c, make_name("panic"))
     checker_bind_import_unknown_inplace(c, make_name("exit"))
     checker_bind_import_unknown_inplace(c, make_name("variance_of"))
+    checker_bind_import_unknown_inplace(c, make_name("sensitivity_of"))
     checker_bind_import_unknown_inplace(c, make_name("uncertainty_of"))
     checker_bind_import_unknown_inplace(c, make_name("hessian_of"))
     checker_bind_import_unknown_inplace(c, make_name("chain_to_knowledge_into"))
@@ -6299,6 +6300,7 @@ fn call_expr_should_bridge_by_value(e: Expr) -> bool with Mut, Panic, Div, Alloc
     if call_expr_is_builtin_measure(e.left) { return true }
     if call_expr_is_builtin_variance_of(e.left) { return true }
     if call_expr_is_builtin_uncertainty_of(e.left) { return true }
+    if call_expr_is_builtin_sensitivity_of(e.left) { return true }
     if call_expr_contest_witness_kind(e.left) >= 0 { return true }
     false
 }
@@ -6472,6 +6474,24 @@ fn checker_check_variance_metric_expr_inplace(c: *mut Checker, e: Expr) -> TypeE
     match second_arg {
         Some(_) => checker_report_error_at_inplace(c, e.span, 10, 0, 0, 0)
         None => {}
+    }
+    checker_check_expr_list_no_type_no_linear_consume_inplace(c, e.args)
+    ty_f64()
+}
+
+// sensitivity_of(x, k) -> f64. TWO arguments, unlike variance_of/uncertainty_of,
+// so it cannot reuse checker_check_variance_metric_expr_inplace: that helper
+// reports E010 on a second argument. Both are required.
+fn checker_check_sensitivity_metric_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
+    let first_arg = expr_list_head(e.args)
+    let second_arg = expr_list_second(e.args)
+    match first_arg {
+        None => checker_report_error_at_inplace(c, e.span, 10, 0, 0, 0)
+        Some(_) => {}
+    }
+    match second_arg {
+        None => checker_report_error_at_inplace(c, e.span, 10, 0, 0, 0)
+        Some(_) => {}
     }
     checker_check_expr_list_no_type_no_linear_consume_inplace(c, e.args)
     ty_f64()
@@ -6728,6 +6748,9 @@ fn checker_check_call_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with M
     }
     if call_expr_is_builtin_uncertainty_of(e.left) {
         return checker_check_variance_metric_expr_inplace(c, e)
+    }
+    if call_expr_is_builtin_sensitivity_of(e.left) {
+        return checker_check_sensitivity_metric_expr_inplace(c, e)
     }
     if call_expr_is_builtin_slice_len(e.left) {
         return checker_check_slice_len_expr_inplace(c, e)
@@ -12941,6 +12964,18 @@ fn call_expr_is_builtin_variance_of(opt: Option<Box<Expr> >) -> bool with Mut, P
                 return false
             }
             name_matches_str11((*expr).name, 118, 97, 114, 105, 97, 110, 99, 101, 95, 111, 102)
+        }
+        None => false
+    }
+}
+
+fn call_expr_is_builtin_sensitivity_of(opt: Option<Box<Expr> >) -> bool with Mut, Panic, Div, Alloc, IO {
+    match opt {
+        Some(expr) => {
+            if (*expr).kind != ExprKind::ExprIdent {
+                return false
+            }
+            name_matches_str14((*expr).name, 115, 101, 110, 115, 105, 116, 105, 118, 105, 116, 121, 95, 111, 102)
         }
         None => false
     }

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -6395,6 +6395,20 @@ impl Lowerer {
         && n.buf[10] == 102 as i8
     }
 
+    // sensitivity_of(x, k) -> the forward-mode partial of x w.r.t. measured
+    // channel k. lean_single has had this since lean_single.sio:13008; Madaros
+    // already tracked the quantity in fo_expr_sens but had no way to read it out.
+    fn name_is_sensitivity_of(self, n: Name) -> bool with Div {
+        n.len == 14
+        && n.buf[0] == 115 as i8 && n.buf[1] == 101 as i8
+        && n.buf[2] == 110 as i8 && n.buf[3] == 115 as i8
+        && n.buf[4] == 105 as i8 && n.buf[5] == 116 as i8
+        && n.buf[6] == 105 as i8 && n.buf[7] == 118 as i8
+        && n.buf[8] == 105 as i8 && n.buf[9] == 116 as i8
+        && n.buf[10] == 121 as i8 && n.buf[11] == 95 as i8
+        && n.buf[12] == 111 as i8 && n.buf[13] == 102 as i8
+    }
+
     fn name_is_uncertainty_of(self, n: Name) -> bool with Div {
         n.len == 14
         && n.buf[0] == 117 as i8 && n.buf[1] == 110 as i8
@@ -8714,7 +8728,9 @@ impl Lowerer {
             match (*e).left {
                 Some(callee_expr) => {
                     let callee_name = self.expr_to_callee_name_ref(&(*callee_expr))
-                    if self.name_is_variance_of(callee_name) || self.name_is_uncertainty_of(callee_name) {
+                    if self.name_is_variance_of(callee_name)
+                        || self.name_is_uncertainty_of(callee_name)
+                        || self.name_is_sensitivity_of(callee_name) {
                         return true
                     }
                     let fn_id = lowerer_lookup_fn_id_by_name_ref(&self, callee_name)
@@ -12282,6 +12298,53 @@ impl Lowerer {
         }
     }
 
+    // sensitivity_of(x, k): read channel k out of the per-channel partials that
+    // lower_expr_variance_ref already leaves in fo_expr_sens — the same array
+    // variance_of squares and sums. The channel index must be a literal, matching
+    // lean_single: channels are compile-time slots assigned by measure(), so a
+    // runtime k has nothing to select. A channel with no recorded partial is a
+    // genuine zero — x does not depend on input k.
+    fn lower_sensitivity_of_call_ref(self, args: &Option<Box<ExprList>>) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        match *args {
+            Some(list) => {
+                let pair_v = self.lower_expr_variance_ref(&(*list).head)
+                var lo = pair_v.0
+                var chan: i64 = 0 - 1
+                match (*list).tail {
+                    Some(rest) => {
+                        if (*rest).head.kind == ExprKind::ExprIntLit && (*rest).head.int_val >= 0 {
+                            chan = (*rest).head.int_val
+                        }
+                    }
+                    _ => {}
+                }
+                if chan >= 0 && chan < 32 {
+                    let sens = lo.fo_expr_sens[chan as usize]
+                    if sens >= 0 {
+                        // Copy, not the reg: for a mutable local this is its
+                        // persistent sens slot, and returning it would alias (#1535).
+                        let cp = lo.fresh_reg()
+                        lo = cp.0
+                        let dst = cp.1
+                        lo = lo.emit(ir_copy(dst, sens))
+                        lo = lo.emit(ir_mark_float_reg(dst))
+                        return (lo, dst)
+                    }
+                }
+                let z = lo.emit_f64_const(0.0)
+                var lo_z = z.0
+                lo_z = lo_z.emit(ir_mark_float_reg(z.1))
+                (lo_z, z.1)
+            }
+            _ => {
+                let z = self.emit_f64_const(0.0)
+                var lo_z = z.0
+                lo_z = lo_z.emit(ir_mark_float_reg(z.1))
+                (lo_z, z.1)
+            }
+        }
+    }
+
     fn lower_uncertainty_of_call_ref(self, args: &Option<Box<ExprList>>) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
         let pair_v = self.lower_variance_of_call_ref(args)
         var lo = pair_v.0
@@ -12703,6 +12766,9 @@ impl Lowerer {
         if self.name_is_uncertainty_of(callee_name) {
             return self.lower_uncertainty_of_call_ref(&e.args)
         }
+        if self.name_is_sensitivity_of(callee_name) {
+            return self.lower_sensitivity_of_call_ref(&e.args)
+        }
         if self.contest_witness_kind_from_callee(callee_name) >= 0 {
             return self.lower_contest_witness_call(e.span, callee_name)
         }
@@ -12823,7 +12889,16 @@ impl Lowerer {
             return (lo_ext, dst)
         }
         let pair_call = lo3.ir_lower_prepend_validated_arg(fn_id, args, argc)
-        let lo4 = pair_call.lo
+        // A call CONSUMES its arguments' pending variance. Lowering `k.value` sets
+        // pending_variance_reg to the raw channel so `let x = k.value` inherits it —
+        // correct for a bare projection, wrong once the projection is an argument.
+        // For `let s = sin(k.value)` the let binding saw the leaked pending reg and
+        // bound the RAW channel variance, taking the branch that never calls
+        // lower_expr_variance_ref and therefore never applies the chain rule.
+        // Symptom: sensitivity_of(s, 0) read exactly 1.0 — the unit seed — for every
+        // argument, while variance_of stayed correct because it re-derives (#1549).
+        var lo4 = pair_call.lo
+        lo4.pending_variance_reg = -1
         let final_args = pair_call.args
         let final_argc = pair_call.argc
         var call_instr = ir_call(dst, fn_id, callee_name, final_args, final_argc)
@@ -13412,7 +13487,10 @@ impl Lowerer {
         let lo3 = pair_fn.0
         let fn_id = pair_fn.1
         let pair_call = lo3.ir_lower_prepend_validated_arg(fn_id, args2, arg_count + 1)
-        let lo4 = pair_call.lo
+        // Same as the plain-call site: a method call consumes its arguments' pending
+        // variance, so it must not leak into an enclosing let binding.
+        var lo4 = pair_call.lo
+        lo4.pending_variance_reg = -1
         let final_args = pair_call.args
         let final_argc = pair_call.argc
         let pair_d = lo4.fresh_reg()


### PR DESCRIPTION
Closes #1549.

`sensitivity_of(x, k)` — the forward-mode partial of `x` w.r.t. measured channel `k` — existed in lean_single (`lean_single.sio:13008`) and raised `E137` under Madaros. It is the **most-called missing builtin**: 36 occurrences across 9 files.

The read itself is small: `lower_expr_variance_ref` already leaves the per-channel partials in `fo_expr_sens`, which is exactly what `variance_of` squares and sums. What was missing was a way to read one out.

## The real defect was a leak

`k.value` sets `pending_variance_reg` to the raw channel so `let x = k.value` inherits it — correct for a bare projection. But **a call consumes its arguments, and the pending reg leaked past it**. For `let s = sin(k.value)` the let binding saw the leaked reg and bound the *raw channel* variance, taking the branch that never calls `lower_expr_variance_ref` and therefore never applies the chain rule.

The partial then read the unit seed — exactly `1.0` for every argument — while `variance_of` stayed correct because it re-derives. That asymmetry is what localised it.

Cleared at **both** call-emission sites, plain calls and method calls. I patched only the plain one on the first attempt.

## Measured

Truths computed independently, not read off either engine:

| | Madaros | truth |
|---|---:|---:|
| `let s = sin(k.value); sensitivity_of(s,0)` | **0.866025** | 0.866025 |
| `variance_of(s)` | 0.007499 | 0.0075 |
| `d(a*a)/da`, `a = measure(3.0, 0.5)` | 6.000000 | 6.0 |
| `variance_of(a*a)` | 9.000000 | 9.0 |

`tests/run-pass/sensitivity_trig.sio` now exits 0. Controls unchanged: `var(a-a)=0`, `var(a+a+a)=13.8384`, `epistemic_var_accumulator_slots` → `VAR_ACCUM_OK`.

## Why this took three attempts

The same `pending_variance_reg` fix was written and **reverted** earlier today because the build segfaulted and I attributed the crash to the change.

It was not the change. `SOUC_BIN` — exported by the workspace context hook — was selecting a June prebuilt seed that segfaults on current `main.sio`; a clean tree at an already-merged commit failed identically. Fixed separately in **#1561**. The fix here was correct the whole time and had never been tested against a build that worked.

I also wrote on #1549 that `E137` was the better behaviour because the implementation "would err in the shape everyone writes". True under the broken build, false now — that shape returns 0.866025.

## Two corpus-gate class changes, both improvements, neither from this PR

| entry | baseline | now |
|---|---|---|
| `sensitivity_4channel.sio` | `compile` | `run`, and **exits 0** — this builtin is why |
| `stdlib_mem_alloc.sio` | `compile` | `run` — fails identically on clean `main`, uses **no** epistemic feature (0 hits for `measure`/`variance_of`/`Knowledge`) |

Both were previously "does not compile" and now compile. The gate reads a class change as a new entry, so it reports FAIL; the baseline needs refreshing, not a revert. I did not refresh it here to keep this diff to the two compiler files.

Depends on #1561 for anyone reproducing the build — otherwise `SOUC_BIN` selects the stale seed and nothing builds.
