### PR TITLE
Revert sensitivity_of (#1564): it returns wrong sensitivities for inline .value in arithmetic

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -3338,7 +3338,6 @@ fn checker_collect_runtime_builtins_inplace(c: *mut Checker) with Mut, Panic, Di
     checker_bind_import_unknown_inplace(c, make_name("panic"))
     checker_bind_import_unknown_inplace(c, make_name("exit"))
     checker_bind_import_unknown_inplace(c, make_name("variance_of"))
-    checker_bind_import_unknown_inplace(c, make_name("sensitivity_of"))
     checker_bind_import_unknown_inplace(c, make_name("uncertainty_of"))
     checker_bind_import_unknown_inplace(c, make_name("hessian_of"))
     checker_bind_import_unknown_inplace(c, make_name("chain_to_knowledge_into"))
@@ -6300,7 +6299,6 @@ fn call_expr_should_bridge_by_value(e: Expr) -> bool with Mut, Panic, Div, Alloc
     if call_expr_is_builtin_measure(e.left) { return true }
     if call_expr_is_builtin_variance_of(e.left) { return true }
     if call_expr_is_builtin_uncertainty_of(e.left) { return true }
-    if call_expr_is_builtin_sensitivity_of(e.left) { return true }
     if call_expr_contest_witness_kind(e.left) >= 0 { return true }
     false
 }
@@ -6474,24 +6472,6 @@ fn checker_check_variance_metric_expr_inplace(c: *mut Checker, e: Expr) -> TypeE
     match second_arg {
         Some(_) => checker_report_error_at_inplace(c, e.span, 10, 0, 0, 0)
         None => {}
-    }
-    checker_check_expr_list_no_type_no_linear_consume_inplace(c, e.args)
-    ty_f64()
-}
-
-// sensitivity_of(x, k) -> f64. TWO arguments, unlike variance_of/uncertainty_of,
-// so it cannot reuse checker_check_variance_metric_expr_inplace: that helper
-// reports E010 on a second argument. Both are required.
-fn checker_check_sensitivity_metric_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
-    let first_arg = expr_list_head(e.args)
-    let second_arg = expr_list_second(e.args)
-    match first_arg {
-        None => checker_report_error_at_inplace(c, e.span, 10, 0, 0, 0)
-        Some(_) => {}
-    }
-    match second_arg {
-        None => checker_report_error_at_inplace(c, e.span, 10, 0, 0, 0)
-        Some(_) => {}
     }
     checker_check_expr_list_no_type_no_linear_consume_inplace(c, e.args)
     ty_f64()
@@ -6748,9 +6728,6 @@ fn checker_check_call_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with M
     }
     if call_expr_is_builtin_uncertainty_of(e.left) {
         return checker_check_variance_metric_expr_inplace(c, e)
-    }
-    if call_expr_is_builtin_sensitivity_of(e.left) {
-        return checker_check_sensitivity_metric_expr_inplace(c, e)
     }
     if call_expr_is_builtin_slice_len(e.left) {
         return checker_check_slice_len_expr_inplace(c, e)
@@ -12964,18 +12941,6 @@ fn call_expr_is_builtin_variance_of(opt: Option<Box<Expr> >) -> bool with Mut, P
                 return false
             }
             name_matches_str11((*expr).name, 118, 97, 114, 105, 97, 110, 99, 101, 95, 111, 102)
-        }
-        None => false
-    }
-}
-
-fn call_expr_is_builtin_sensitivity_of(opt: Option<Box<Expr> >) -> bool with Mut, Panic, Div, Alloc, IO {
-    match opt {
-        Some(expr) => {
-            if (*expr).kind != ExprKind::ExprIdent {
-                return false
-            }
-            name_matches_str14((*expr).name, 115, 101, 110, 115, 105, 116, 105, 118, 105, 116, 121, 95, 111, 102)
         }
         None => false
     }

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -6395,20 +6395,6 @@ impl Lowerer {
         && n.buf[10] == 102 as i8
     }
 
-    // sensitivity_of(x, k) -> the forward-mode partial of x w.r.t. measured
-    // channel k. lean_single has had this since lean_single.sio:13008; Madaros
-    // already tracked the quantity in fo_expr_sens but had no way to read it out.
-    fn name_is_sensitivity_of(self, n: Name) -> bool with Div {
-        n.len == 14
-        && n.buf[0] == 115 as i8 && n.buf[1] == 101 as i8
-        && n.buf[2] == 110 as i8 && n.buf[3] == 115 as i8
-        && n.buf[4] == 105 as i8 && n.buf[5] == 116 as i8
-        && n.buf[6] == 105 as i8 && n.buf[7] == 118 as i8
-        && n.buf[8] == 105 as i8 && n.buf[9] == 116 as i8
-        && n.buf[10] == 121 as i8 && n.buf[11] == 95 as i8
-        && n.buf[12] == 111 as i8 && n.buf[13] == 102 as i8
-    }
-
     fn name_is_uncertainty_of(self, n: Name) -> bool with Div {
         n.len == 14
         && n.buf[0] == 117 as i8 && n.buf[1] == 110 as i8
@@ -8728,9 +8714,7 @@ impl Lowerer {
             match (*e).left {
                 Some(callee_expr) => {
                     let callee_name = self.expr_to_callee_name_ref(&(*callee_expr))
-                    if self.name_is_variance_of(callee_name)
-                        || self.name_is_uncertainty_of(callee_name)
-                        || self.name_is_sensitivity_of(callee_name) {
+                    if self.name_is_variance_of(callee_name) || self.name_is_uncertainty_of(callee_name) {
                         return true
                     }
                     let fn_id = lowerer_lookup_fn_id_by_name_ref(&self, callee_name)
@@ -12298,53 +12282,6 @@ impl Lowerer {
         }
     }
 
-    // sensitivity_of(x, k): read channel k out of the per-channel partials that
-    // lower_expr_variance_ref already leaves in fo_expr_sens — the same array
-    // variance_of squares and sums. The channel index must be a literal, matching
-    // lean_single: channels are compile-time slots assigned by measure(), so a
-    // runtime k has nothing to select. A channel with no recorded partial is a
-    // genuine zero — x does not depend on input k.
-    fn lower_sensitivity_of_call_ref(self, args: &Option<Box<ExprList>>) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
-        match *args {
-            Some(list) => {
-                let pair_v = self.lower_expr_variance_ref(&(*list).head)
-                var lo = pair_v.0
-                var chan: i64 = 0 - 1
-                match (*list).tail {
-                    Some(rest) => {
-                        if (*rest).head.kind == ExprKind::ExprIntLit && (*rest).head.int_val >= 0 {
-                            chan = (*rest).head.int_val
-                        }
-                    }
-                    _ => {}
-                }
-                if chan >= 0 && chan < 32 {
-                    let sens = lo.fo_expr_sens[chan as usize]
-                    if sens >= 0 {
-                        // Copy, not the reg: for a mutable local this is its
-                        // persistent sens slot, and returning it would alias (#1535).
-                        let cp = lo.fresh_reg()
-                        lo = cp.0
-                        let dst = cp.1
-                        lo = lo.emit(ir_copy(dst, sens))
-                        lo = lo.emit(ir_mark_float_reg(dst))
-                        return (lo, dst)
-                    }
-                }
-                let z = lo.emit_f64_const(0.0)
-                var lo_z = z.0
-                lo_z = lo_z.emit(ir_mark_float_reg(z.1))
-                (lo_z, z.1)
-            }
-            _ => {
-                let z = self.emit_f64_const(0.0)
-                var lo_z = z.0
-                lo_z = lo_z.emit(ir_mark_float_reg(z.1))
-                (lo_z, z.1)
-            }
-        }
-    }
-
     fn lower_uncertainty_of_call_ref(self, args: &Option<Box<ExprList>>) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
         let pair_v = self.lower_variance_of_call_ref(args)
         var lo = pair_v.0
@@ -12766,9 +12703,6 @@ impl Lowerer {
         if self.name_is_uncertainty_of(callee_name) {
             return self.lower_uncertainty_of_call_ref(&e.args)
         }
-        if self.name_is_sensitivity_of(callee_name) {
-            return self.lower_sensitivity_of_call_ref(&e.args)
-        }
         if self.contest_witness_kind_from_callee(callee_name) >= 0 {
             return self.lower_contest_witness_call(e.span, callee_name)
         }
@@ -12889,16 +12823,7 @@ impl Lowerer {
             return (lo_ext, dst)
         }
         let pair_call = lo3.ir_lower_prepend_validated_arg(fn_id, args, argc)
-        // A call CONSUMES its arguments' pending variance. Lowering `k.value` sets
-        // pending_variance_reg to the raw channel so `let x = k.value` inherits it —
-        // correct for a bare projection, wrong once the projection is an argument.
-        // For `let s = sin(k.value)` the let binding saw the leaked pending reg and
-        // bound the RAW channel variance, taking the branch that never calls
-        // lower_expr_variance_ref and therefore never applies the chain rule.
-        // Symptom: sensitivity_of(s, 0) read exactly 1.0 — the unit seed — for every
-        // argument, while variance_of stayed correct because it re-derives (#1549).
-        var lo4 = pair_call.lo
-        lo4.pending_variance_reg = -1
+        let lo4 = pair_call.lo
         let final_args = pair_call.args
         let final_argc = pair_call.argc
         var call_instr = ir_call(dst, fn_id, callee_name, final_args, final_argc)
@@ -13487,10 +13412,7 @@ impl Lowerer {
         let lo3 = pair_fn.0
         let fn_id = pair_fn.1
         let pair_call = lo3.ir_lower_prepend_validated_arg(fn_id, args2, arg_count + 1)
-        // Same as the plain-call site: a method call consumes its arguments' pending
-        // variance, so it must not leak into an enclosing let binding.
-        var lo4 = pair_call.lo
-        lo4.pending_variance_reg = -1
+        let lo4 = pair_call.lo
         let final_args = pair_call.args
         let final_argc = pair_call.argc
         let pair_d = lo4.fresh_reg()


### PR DESCRIPTION
Reverts #1564. **I merged a silent wrong answer.**

## The defect

`tests/run-pass/sensitivity_4channel.sio`, on `main` after that merge:

```sounio
let y = k0.value * k1.value + k2.value * k3.value
```

| | returned | truth |
|---|---:|---:|
| `sensitivity_of(y, 0)` | **0.000000** | 3.0 |
| `sensitivity_of(y, 1)` | **0.000000** | 2.0 |
| `sensitivity_of(y, 2)` | **0.000000** | 7.0 |
| `sensitivity_of(y, 3)` | **1.000000** | 5.0 |

Before the merge that program **did not compile at all** — E137, and it sits in the corpus baseline as `compile`. So the change traded an honest refusal for four plausible wrong numbers in an epistemic builtin. That is the exact trade I refused twice earlier today and then shipped anyway.

## Why the gap survived

The fix cleared `pending_variance_reg` at the two **call** emission sites. `.value` also leaks through **arithmetic operands**, which this program uses and none of my probes did — every one of them either bound `.value` to a let first or applied a single transcendental. Two channels with let-bound values still measure correct (`dy/da=7`, `dy/db=3`), which is why it looked complete.

## Two process failures worth naming

**The corpus gate caught this and I talked past it.** It reported FAIL on #1564 and named this exact file. I read the class change (`compile` → `run`) as an improvement and never ran the program.

**I claimed a number I had not re-measured.** The PR says `sensitivity_4channel` "now exits 0". It exits 1 on merged main. The rc=0 came from a build in a different worktree against a different base.

## Why revert rather than fix forward

The leak needs handling at every site that consumes a projection, not only calls. That is wider than a hotfix should be, and `E137` is the correct behaviour meanwhile. #1549 stays open with all the measurements.