### PR TITLE
fix(epistemic): stop the FO channel leaking through arithmetic operands

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -3338,6 +3338,7 @@ fn checker_collect_runtime_builtins_inplace(c: *mut Checker) with Mut, Panic, Di
     checker_bind_import_unknown_inplace(c, make_name("panic"))
     checker_bind_import_unknown_inplace(c, make_name("exit"))
     checker_bind_import_unknown_inplace(c, make_name("variance_of"))
+    checker_bind_import_unknown_inplace(c, make_name("sensitivity_of"))
     checker_bind_import_unknown_inplace(c, make_name("uncertainty_of"))
     checker_bind_import_unknown_inplace(c, make_name("hessian_of"))
     checker_bind_import_unknown_inplace(c, make_name("chain_to_knowledge_into"))
@@ -6299,6 +6300,7 @@ fn call_expr_should_bridge_by_value(e: Expr) -> bool with Mut, Panic, Div, Alloc
     if call_expr_is_builtin_measure(e.left) { return true }
     if call_expr_is_builtin_variance_of(e.left) { return true }
     if call_expr_is_builtin_uncertainty_of(e.left) { return true }
+    if call_expr_is_builtin_sensitivity_of(e.left) { return true }
     if call_expr_contest_witness_kind(e.left) >= 0 { return true }
     false
 }
@@ -6472,6 +6474,23 @@ fn checker_check_variance_metric_expr_inplace(c: *mut Checker, e: Expr) -> TypeE
     match second_arg {
         Some(_) => checker_report_error_at_inplace(c, e.span, 10, 0, 0, 0)
         None => {}
+    }
+    checker_check_expr_list_no_type_no_linear_consume_inplace(c, e.args)
+    ty_f64()
+}
+
+// sensitivity_of(x, k) -> f64. TWO arguments, so it cannot reuse
+// checker_check_variance_metric_expr_inplace, which reports E010 on a second one.
+fn checker_check_sensitivity_metric_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
+    let first_arg = expr_list_head(e.args)
+    let second_arg = expr_list_second(e.args)
+    match first_arg {
+        None => checker_report_error_at_inplace(c, e.span, 10, 0, 0, 0)
+        Some(_) => {}
+    }
+    match second_arg {
+        None => checker_report_error_at_inplace(c, e.span, 10, 0, 0, 0)
+        Some(_) => {}
     }
     checker_check_expr_list_no_type_no_linear_consume_inplace(c, e.args)
     ty_f64()
@@ -6728,6 +6747,9 @@ fn checker_check_call_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with M
     }
     if call_expr_is_builtin_uncertainty_of(e.left) {
         return checker_check_variance_metric_expr_inplace(c, e)
+    }
+    if call_expr_is_builtin_sensitivity_of(e.left) {
+        return checker_check_sensitivity_metric_expr_inplace(c, e)
     }
     if call_expr_is_builtin_slice_len(e.left) {
         return checker_check_slice_len_expr_inplace(c, e)
@@ -12941,6 +12963,18 @@ fn call_expr_is_builtin_variance_of(opt: Option<Box<Expr> >) -> bool with Mut, P
                 return false
             }
             name_matches_str11((*expr).name, 118, 97, 114, 105, 97, 110, 99, 101, 95, 111, 102)
+        }
+        None => false
+    }
+}
+
+fn call_expr_is_builtin_sensitivity_of(opt: Option<Box<Expr> >) -> bool with Mut, Panic, Div, Alloc, IO {
+    match opt {
+        Some(expr) => {
+            if (*expr).kind != ExprKind::ExprIdent {
+                return false
+            }
+            name_matches_str14((*expr).name, 115, 101, 110, 115, 105, 116, 105, 118, 105, 116, 121, 95, 111, 102)
         }
         None => false
     }

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -6395,6 +6395,17 @@ impl Lowerer {
         && n.buf[10] == 102 as i8
     }
 
+    fn name_is_sensitivity_of(self, n: Name) -> bool with Div {
+        n.len == 14
+        && n.buf[0] == 115 as i8 && n.buf[1] == 101 as i8
+        && n.buf[2] == 110 as i8 && n.buf[3] == 115 as i8
+        && n.buf[4] == 105 as i8 && n.buf[5] == 116 as i8
+        && n.buf[6] == 105 as i8 && n.buf[7] == 118 as i8
+        && n.buf[8] == 105 as i8 && n.buf[9] == 116 as i8
+        && n.buf[10] == 121 as i8 && n.buf[11] == 95 as i8
+        && n.buf[12] == 111 as i8 && n.buf[13] == 102 as i8
+    }
+
     fn name_is_uncertainty_of(self, n: Name) -> bool with Div {
         n.len == 14
         && n.buf[0] == 117 as i8 && n.buf[1] == 110 as i8
@@ -7595,6 +7606,38 @@ impl Lowerer {
             }
             return (self.fo_clear_expr_sens(), -1)
         }
+        // Unary negation. Var(-x) = Var(x), but ∂(-x)/∂k = -∂x/∂k, so the variance
+        // passes through unchanged while every live channel flips sign. Without this
+        // case `-(a.value * b.value)` fell off the FO path entirely and read 0 for
+        // both variance and every sensitivity; `-a.value` read +1 instead of -1,
+        // because the projection's pending channel leaked past the operator and the
+        // sign was simply lost.
+        if (*e).kind == ExprKind::ExprUnary && (*e).un_op == UnaryOp::OpNeg {
+            let pair_in = match (*e).left {
+                Some(inner) => self.lower_expr_variance_ref(&(*inner)),
+                _ => (self.fo_clear_expr_sens(), -1),
+            }
+            var lo = pair_in.0
+            let vin = pair_in.1
+            var k: i64 = 0
+            while k < 32 {
+                let sk = lo.fo_expr_sens[k as usize]
+                if sk >= 0 {
+                    let zp = lo.emit_f64_const(0.0)
+                    lo = zp.0
+                    let zr = zp.1
+                    lo = lo.emit(ir_mark_float_reg(zr))
+                    let np = lo.fresh_reg()
+                    lo = np.0
+                    let nr = np.1
+                    lo = lo.emit(ir_binop_typed(nr, zr, BinaryOp::OpSub, sk, true, true))
+                    lo = lo.emit(ir_mark_float_reg(nr))
+                    lo.fo_expr_sens[k as usize] = nr
+                }
+                k = k + 1
+            }
+            return (lo, vin)
+        }
         if (*e).kind == ExprKind::ExprBinary {
             let same_ident = self.expr_is_same_ident_ref(&(*e).left, &(*e).right)
             if same_ident && (*e).bin_op == BinaryOp::OpSub {
@@ -8714,7 +8757,9 @@ impl Lowerer {
             match (*e).left {
                 Some(callee_expr) => {
                     let callee_name = self.expr_to_callee_name_ref(&(*callee_expr))
-                    if self.name_is_variance_of(callee_name) || self.name_is_uncertainty_of(callee_name) {
+                    if self.name_is_variance_of(callee_name)
+                        || self.name_is_uncertainty_of(callee_name)
+                        || self.name_is_sensitivity_of(callee_name) {
                         return true
                     }
                     let fn_id = lowerer_lookup_fn_id_by_name_ref(&self, callee_name)
@@ -12282,6 +12327,50 @@ impl Lowerer {
         }
     }
 
+    // sensitivity_of(x, k): read channel k out of the per-channel partials that
+    // lower_expr_variance_ref leaves in fo_expr_sens — the same array variance_of
+    // squares and sums. The index must be a literal, matching lean_single: channels
+    // are compile-time slots assigned by measure(). A channel with no recorded
+    // partial is a genuine zero: x does not depend on input k.
+    fn lower_sensitivity_of_call_ref(self, args: &Option<Box<ExprList>>) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        match *args {
+            Some(list) => {
+                let pair_v = self.lower_expr_variance_ref(&(*list).head)
+                var lo = pair_v.0
+                var chan: i64 = 0 - 1
+                match (*list).tail {
+                    Some(rest) => {
+                        if (*rest).head.kind == ExprKind::ExprIntLit && (*rest).head.int_val >= 0 {
+                            chan = (*rest).head.int_val
+                        }
+                    }
+                    _ => {}
+                }
+                if chan >= 0 && chan < 32 {
+                    let sens = lo.fo_expr_sens[chan as usize]
+                    if sens >= 0 {
+                        let cp = lo.fresh_reg()
+                        lo = cp.0
+                        let dst = cp.1
+                        lo = lo.emit(ir_copy(dst, sens))
+                        lo = lo.emit(ir_mark_float_reg(dst))
+                        return (lo, dst)
+                    }
+                }
+                let z = lo.emit_f64_const(0.0)
+                var lo_z = z.0
+                lo_z = lo_z.emit(ir_mark_float_reg(z.1))
+                (lo_z, z.1)
+            }
+            _ => {
+                let z = self.emit_f64_const(0.0)
+                var lo_z = z.0
+                lo_z = lo_z.emit(ir_mark_float_reg(z.1))
+                (lo_z, z.1)
+            }
+        }
+    }
+
     fn lower_uncertainty_of_call_ref(self, args: &Option<Box<ExprList>>) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
         let pair_v = self.lower_variance_of_call_ref(args)
         var lo = pair_v.0
@@ -12703,6 +12792,9 @@ impl Lowerer {
         if self.name_is_uncertainty_of(callee_name) {
             return self.lower_uncertainty_of_call_ref(&e.args)
         }
+        if self.name_is_sensitivity_of(callee_name) {
+            return self.lower_sensitivity_of_call_ref(&e.args)
+        }
         if self.contest_witness_kind_from_callee(callee_name) >= 0 {
             return self.lower_contest_witness_call(e.span, callee_name)
         }
@@ -12823,7 +12915,10 @@ impl Lowerer {
             return (lo_ext, dst)
         }
         let pair_call = lo3.ir_lower_prepend_validated_arg(fn_id, args, argc)
-        let lo4 = pair_call.lo
+        var lo4 = pair_call.lo
+        // Same rule as the binary-operand site: a call consumes its arguments'
+        // pending variance and must not let it escape into an enclosing let.
+        lo4.pending_variance_reg = -1
         let final_args = pair_call.args
         let final_argc = pair_call.argc
         var call_instr = ir_call(dst, fn_id, callee_name, final_args, final_argc)
@@ -12847,8 +12942,22 @@ impl Lowerer {
         let lhs = pair_l.1
         let rhs_expr_is_float = lo1.opt_expr_result_is_float_ref(&e.right)
         let pair_r = lo1.lower_opt_expr_ref(&e.right)
-        let lo2 = pair_r.0
+        var lo2 = pair_r.0
         let rhs = pair_r.1
+        // A binary expression CONSUMES its operands' pending variance, exactly as a
+        // call consumes its arguments'. Lowering `k.value` sets pending_variance_reg
+        // to that Knowledge's raw channel so `let x = k.value` inherits it; leaving
+        // it set here lets the LAST operand's channel escape into an enclosing let.
+        //
+        // For `let y = k0.value * k1.value + k2.value * k3.value` the binding then
+        // took the pending-reg branch, which never calls lower_expr_variance_ref and
+        // so never runs the product/sum sensitivity rules: sensitivity_of(y, k) read
+        // 0, 0, 0, 1 against truths 3, 2, 7, 5 — the unit seed of whichever channel
+        // happened to be lowered last (#1549).
+        //
+        // The result's variance must be DERIVED from both operands, never inherited
+        // from one of them.
+        lo2.pending_variance_reg = -1
         let cmp_op = lower_binary_op_to_wide_cmp(e.bin_op)
         let limbs = lower_wide_limb_count(wide_bits)
         var alloc_limbs = limbs
@@ -13260,8 +13369,16 @@ impl Lowerer {
             false
         }
         let pair_s = self.lower_opt_expr_ref(&e.left)
-        let lo1 = pair_s.0
+        var lo1 = pair_s.0
         let src = pair_s.1
+        // Arithmetic negation CONSUMES its operand's pending variance, exactly as a
+        // binary operator and a call do. Leaving it set let `let d = -a.value` bind
+        // a's RAW channel: sensitivity_of(d, 0) read +1.0 where truth is -1.0, the
+        // sign silently dropped. The negated channels come from the OpNeg case in
+        // lower_expr_variance_ref, which the else-branch of the let now reaches.
+        if e.un_op == UnaryOp::OpNeg {
+            lo1.pending_variance_reg = -1
+        }
         let src_is_float = if e.un_op == UnaryOp::OpNeg {
             lo1.opt_expr_result_is_float_ref(&e.left)
         } else {
@@ -13412,7 +13529,10 @@ impl Lowerer {
         let lo3 = pair_fn.0
         let fn_id = pair_fn.1
         let pair_call = lo3.ir_lower_prepend_validated_arg(fn_id, args2, arg_count + 1)
-        let lo4 = pair_call.lo
+        var lo4 = pair_call.lo
+        // Same rule as the binary-operand site: a call consumes its arguments'
+        // pending variance and must not let it escape into an enclosing let.
+        lo4.pending_variance_reg = -1
         let final_args = pair_call.args
         let final_argc = pair_call.argc
         let pair_d = lo4.fresh_reg()

--- a/tests/engine_parity_baseline.txt
+++ b/tests/engine_parity_baseline.txt
@@ -56,6 +56,7 @@ DIVERGE	tests/run-pass/epistemic_molecule_h2o.sio
 DIVERGE	tests/run-pass/epistemic_ode_14comp.sio
 DIVERGE	tests/run-pass/epistemic_pbpk_multidrug.sio
 DIVERGE	tests/run-pass/epistemic_pbpk_native.sio
+DIVERGE	tests/run-pass/epistemic_second_order_variance_sanity.sio
 DIVERGE	tests/run-pass/epistemic_var_accumulator_slots.sio
 DIVERGE	tests/run-pass/f2_conjugation_swda.sio
 DIVERGE	tests/run-pass/ffi_integer_return.sio
@@ -80,6 +81,7 @@ DIVERGE	tests/run-pass/global_scalar_f64_print.sio
 DIVERGE	tests/run-pass/global_scalar_init_still_works.sio
 DIVERGE	tests/run-pass/gpu_kernel_basic.sio
 DIVERGE	tests/run-pass/gpu_kernel_lane_loop.sio
+DIVERGE	tests/run-pass/gradient_descent_from_compiler.sio
 DIVERGE	tests/run-pass/graphics_epistemic_demo.sio
 DIVERGE	tests/run-pass/gresnigt_family_s3.sio
 DIVERGE	tests/run-pass/gresnigt_g2s3.sio
@@ -119,7 +121,6 @@ DIVERGE	tests/run-pass/mc_struct_basic.sio
 DIVERGE	tests/run-pass/mc_struct_field_write.sio
 DIVERGE	tests/run-pass/mc_struct_large.sio
 DIVERGE	tests/run-pass/medlang_pk_model.sio
-DIVERGE	tests/run-pass/method_receiver_correct.sio
 DIVERGE	tests/run-pass/multi_agent.sio
 DIVERGE	tests/run-pass/native_struct_call.sio
 DIVERGE	tests/run-pass/native_struct_smoke.sio
@@ -129,6 +130,7 @@ DIVERGE	tests/run-pass/octonion_mul_test.sio
 DIVERGE	tests/run-pass/octonion_nonfano_census_168.sio
 DIVERGE	tests/run-pass/optimization_nelder_mead.sio
 DIVERGE	tests/run-pass/pbpk_analytical_crossvalidation.sio
+DIVERGE	tests/run-pass/pbpk_rapamycin_second_order.sio
 DIVERGE	tests/run-pass/pbpk_validation_euler.sio
 DIVERGE	tests/run-pass/pbpk_validation_rk4.sio
 DIVERGE	tests/run-pass/pediatric_pbpk_receipt.sio
@@ -180,6 +182,7 @@ DIVERGE	tests/run-pass/special_functions.sio
 DIVERGE	tests/run-pass/sprint235_print_f64_bytecode.sio
 DIVERGE	tests/run-pass/sprint235_print_f64_e2e.sio
 DIVERGE	tests/run-pass/sret_forwarding_tuple_aggregate.sio
+DIVERGE	tests/run-pass/stdlib_mem_alloc.sio
 DIVERGE	tests/run-pass/stdlib_os_process.sio
 DIVERGE	tests/run-pass/stdlib_time_basic.sio
 DIVERGE	tests/run-pass/struct_array_field_name_collision_dispatch.sio
@@ -246,7 +249,6 @@ LEAN-ONLY	tests/run-pass/epistemic_guarded_nested_measure_call.sio
 LEAN-ONLY	tests/run-pass/epistemic_hessian_transcendentals.sio
 LEAN-ONLY	tests/run-pass/epistemic_hessian_two_arg.sio
 LEAN-ONLY	tests/run-pass/epistemic_nuclear_decay.sio
-LEAN-ONLY	tests/run-pass/epistemic_second_order_variance_sanity.sio
 LEAN-ONLY	tests/run-pass/epistemic_unspecified_epsilon.sio
 LEAN-ONLY	tests/run-pass/epsilon_comparison_valid.sio
 LEAN-ONLY	tests/run-pass/for_in_vec.sio
@@ -262,7 +264,6 @@ LEAN-ONLY	tests/run-pass/gpu_launch_surface.sio
 LEAN-ONLY	tests/run-pass/gpu_launch_vec_slices.sio
 LEAN-ONLY	tests/run-pass/gpu_sedenion_f3.sio
 LEAN-ONLY	tests/run-pass/graded_eq_wasserstein.sio
-LEAN-ONLY	tests/run-pass/gradient_descent_from_compiler.sio
 LEAN-ONLY	tests/run-pass/graphics_companion_smoke.sio
 LEAN-ONLY	tests/run-pass/graphics_degenerate_smoke.sio
 LEAN-ONLY	tests/run-pass/graphics_epistemic_advanced_smoke.sio
@@ -378,7 +379,6 @@ LEAN-ONLY	tests/run-pass/ontology_typed_bridge_qm.sio
 LEAN-ONLY	tests/run-pass/ontology_typed_bridge_snomed.sio
 LEAN-ONLY	tests/run-pass/order_spread_exact_n4.sio
 LEAN-ONLY	tests/run-pass/pbpk28_struct_return.sio
-LEAN-ONLY	tests/run-pass/pbpk_rapamycin_second_order.sio
 LEAN-ONLY	tests/run-pass/pkg_manifest_parse_e2e.sio
 LEAN-ONLY	tests/run-pass/proof_obligation_basic.sio
 LEAN-ONLY	tests/run-pass/proof_search_basic.sio
@@ -395,12 +395,7 @@ LEAN-ONLY	tests/run-pass/second_order_proof.sio
 LEAN-ONLY	tests/run-pass/sedenion_embedding_basic.sio
 LEAN-ONLY	tests/run-pass/sedenion_zero_divisor.sio
 LEAN-ONLY	tests/run-pass/sedenion_zero_divisor_demo.sio
-LEAN-ONLY	tests/run-pass/sensitivity_4channel.sio
-LEAN-ONLY	tests/run-pass/sensitivity_chain_product.sio
-LEAN-ONLY	tests/run-pass/sensitivity_div.sio
-LEAN-ONLY	tests/run-pass/sensitivity_multi_channel.sio
 LEAN-ONLY	tests/run-pass/sensitivity_transcendental.sio
-LEAN-ONLY	tests/run-pass/sensitivity_trig.sio
 LEAN-ONLY	tests/run-pass/seq_basic.sio
 LEAN-ONLY	tests/run-pass/seq_borrow.sio
 LEAN-ONLY	tests/run-pass/seq_count.sio
@@ -436,7 +431,6 @@ LEAN-ONLY	tests/run-pass/solver_portfolio_v16_acceptance_receipt_imported.sio
 LEAN-ONLY	tests/run-pass/solver_portfolio_v16_audit_receipt_imported.sio
 LEAN-ONLY	tests/run-pass/solver_portfolio_v16_checker_family_coverage_imported.sio
 LEAN-ONLY	tests/run-pass/solver_portfolio_v16_coverage_imported.sio
-LEAN-ONLY	tests/run-pass/stdlib_mem_alloc.sio
 LEAN-ONLY	tests/run-pass/string_len.sio
 LEAN-ONLY	tests/run-pass/study_with_audit.sio
 LEAN-ONLY	tests/run-pass/tac_compile_gate_pass.sio
@@ -843,6 +837,7 @@ MADAROS-ONLY	tests/run-pass/solver_portfolio_v16_acceptance_receipt_tiny.sio
 MADAROS-ONLY	tests/run-pass/solver_portfolio_v16_audit_receipt_tiny.sio
 MADAROS-ONLY	tests/run-pass/solver_portfolio_v16_checker_family_coverage_tiny.sio
 MADAROS-ONLY	tests/run-pass/solver_portfolio_v16_coverage_tiny.sio
+MADAROS-ONLY	tests/run-pass/uninit_fixed_array_zero_init.sio
 MADAROS-ONLY	tests/run-pass/wide_i128_fn_abi_known_failure.sio
 NEITHER	tests/run-pass/audit_trail_basic.sio
 NEITHER	tests/run-pass/chaotic_effect.sio

--- a/tests/madaros_corpus_baseline.txt
+++ b/tests/madaros_corpus_baseline.txt
@@ -77,7 +77,6 @@ epistemic_guarded_nested_measure_call.sio compile
 epistemic_hessian_transcendentals.sio compile
 epistemic_hessian_two_arg.sio compile
 epistemic_nuclear_decay.sio compile
-epistemic_second_order_variance_sanity.sio compile
 epistemic_unspecified_epsilon.sio compile
 epsilon_comparison_valid.sio compile
 f2_conjugation_swda.sio run
@@ -98,7 +97,6 @@ gpu_public_launch_check.sio compile
 gpu_public_thread_array_params.sio compile
 gpu_sedenion_f3.sio compile
 graded_eq_wasserstein.sio compile
-gradient_descent_from_compiler.sio compile
 graphics_companion_smoke.sio compile
 graphics_degenerate_smoke.sio compile
 graphics_epistemic_advanced_smoke.sio compile
@@ -240,12 +238,7 @@ second_order_proof.sio compile
 sedenion_embedding_basic.sio compile
 sedenion_zero_divisor.sio compile
 sedenion_zero_divisor_demo.sio compile
-sensitivity_4channel.sio compile
-sensitivity_chain_product.sio compile
-sensitivity_div.sio compile
-sensitivity_multi_channel.sio compile
 sensitivity_transcendental.sio compile
-sensitivity_trig.sio compile
 seq_basic.sio compile
 seq_borrow.sio compile
 seq_count.sio compile
@@ -260,7 +253,7 @@ seq_struct_elems.sio compile
 slice_fat_pointers.sio compile
 smt_qflia_basic.sio run
 spearman_holm_bca.sio compile
-stdlib_mem_alloc.sio compile
+stdlib_mem_alloc.sio run
 stdlib_os_process.sio run
 stdlib_time_basic.sio run
 str_index_of.sio compile


### PR DESCRIPTION
## The defect

`.value` sets `pending_variance_reg` so `let x = k.value` inherits the Knowledge's channel. Nothing cleared it when the projection appeared as an **operand**, so the last operand lowered won and the enclosing `let` took the pending branch — which never calls `lower_expr_variance_ref`, so the chain rule never ran.

```sounio
let y = k0.value * k1.value + k2.value * k3.value
sensitivity_of(y, 0..3)  ->  0, 0, 0, 1     truth 3, 2, 7, 5
```

The `1` is the unit seed of whichever channel happened to lower last.

## Measured, from runs

| pin | before | after | truth |
|---|---|---|---|
| s0 / s1 / s2 / s3 | 0 / 0 / 0 / 1 | 3.0 / 2.0 / 7.0 / 5.0 | 3 / 2 / 7 / 5 |
| `var(y)` | — | 0.870000 | 0.87 |
| `var(k0.value * k1.value)` | wrong | 0.130000 | 0.13 |
| `var(c)` where `c = a.value` | 0.25 | 0.250000 | 0.25 |

The last row is the pin against my own risk: clearing pending could have killed the inheritance the flag exists for. It did not — the `else` branch of the `let` calls `lower_expr_variance_ref`, which handles a bare projection. The third row is the one that verifies the leak fix **without** depending on `sensitivity_of`.

## Unary held two defects, not one

`lower_expr_variance_ref` had no `OpNeg` case at all, so `-(a.value * b.value)` fell off the FO path entirely; and `-a.value` inherited the raw channel with the sign silently dropped.

| | before | after | truth |
|---|---|---|---|
| `-(a·b)` s0 / s1 | 0 / 0 | −3.0 / −4.0 | −3 / −4 |
| `-(a·b)` var | 0 | 6.25 | 6.25 |
| `-a.value` s0 | **+1.0** | −1.0 | −1 |

Clearing alone would have traded a wrong sign for a wrong magnitude, so the `OpNeg` rule (`Var(-x) = Var(x)`, `∂(-x)/∂k = -∂x/∂k`) lands with it. Comparison operands were probed and do not leak.

## Regressions, all on truth

`var(scale(a))`=1.0 and s0=2.0 (kind-6 chain rule) · `var(sin(x))`=0.007701 vs 0.0077015 · `var(a+a+a)`=2.25 · `var(b.value)`=0.25 · loop-carried (#1539)=1.25.

## `sensitivity_of` returns, and why it is safe this time

#1564 shipped it while `sensitivity_4channel.sio` still returned 0,0,0,1 — I read the corpus gate's class change from `compile` to `run` as an improvement without running the program. #1566 reverted it. That test now exits 0 **with its asserts actually holding**, and every number above comes from a run.

## Baselines: 15 lines, each attributed with two binaries

Hand-edited, not regenerated — a wholesale refresh would launder unrelated drift into the record. Every line was attributed against the clean-main ELF at `4ae36a83a`.

**Not caused by this change** (md5-identical output from clean main at the same commit):

- `stdlib_mem_alloc` — clean main compiles it too and prints `FAIL`. Entry claimed compile-failure; reclassified `compile` → `run`.
- `uninit_fixed_array_zero_init` — became a known-failure in #1548 (2026-07-29); the parity baseline is from #1544 (2026-07-28), so it predates the change.
- `method_receiver_correct`, `dataframe_test`, `pediatric_pbpk_receipt`, `scidata_test` — clean main already compiles them; left alone, informational only.

**Caused by this change, verified to compile *and run* correctly**: 5× `sensitivity_*`, `epistemic_second_order_variance_sanity`, `gradient_descent_from_compiler`.

**Newly comparable, so newly divergent**:

- `epistemic_second_order_variance_sanity` — same value `0.000000`; differs only by a trailing newline (9 bytes vs 8).
- `gradient_descent_from_compiler` — two separate things. lean emits a spurious newline after `iter 0` (Madaros better); and Madaros **truncates where lean rounds to nearest** (`5.759999` vs `5.760000`, `2.894446` vs `2.894447`) — a pre-existing `print_f64` divergence, only now visible because the file builds. Not a win.
- `pbpk_rapamycin_second_order` — **lean is the reference**: `1.2400001` vs Madaros `1.000000` followed by `0`, which is the program's own gate saying it failed. Cause is `hessian_of` returning 0 (#1502), a different unimplemented builtin; `sensitivity_of(r,0)`/`(r,1)` read 2.0/1.0, both correct.

### Left in the baseline on purpose

`pbpk_rapamycin_second_order.sio compile` stays. Removing it would make the corpus gate require compile+run, the program exits 0, and that would be a permanent vacuous green over wrong science. It is recorded as a divergence with lean as the reference instead. The dissertation PBPK lane forces `SOUNIO_SOUC_ENGINE=lean_single`, so the cost is a recorded divergence, not a corrupted result path.

## Gates

```
[madaros-corpus] PASS: no new failures under Madaros (296 known, 5 newly fixed)
[engine-parity]  PASS: no new engine divergences (1169 known)
[engine-parity]  agree=532 diverge=204 madaros-only=358 lean-only=279 neither=328
```

Build exit 0; the 3 tolerated typecheck errors in the log are byte-identical to a clean-main build (pre-existing #1494 class).

Refs #1549, #1502

🤖 Generated with [Claude Code](https://claude.com/claude-code)