### PR TITLE
fix(madaros): evaluate fused let-initializer calls once (#1569)

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -4291,6 +4291,51 @@ fn lower_expr_has_float_source_ref(e: &Expr) -> bool with Mut, Panic, Div {
     false
 }
 
+// #1569: conservative "subtree may evaluate a call" predicate. The legacy
+// scalar-variance algebra in lower_expr_variance_ref re-lowers operand
+// VALUES (lower_opt_expr_ref) to feed emit_variance_independent_product/div;
+// when the operand contains an effectful call (e.g. a Mut RNG) that
+// re-lowering executes the call a SECOND time, so
+// `let d = W[k] * (2.0 * rand_u() - 1.0)` advanced the PRNG twice per
+// iteration and Madaros diverged from lean_single. Whitelist the pure,
+// recursable kinds; everything else (Call/MethodCall, If, Block, Closure,
+// Match, literals-of-aggregate, ...) conservatively counts as "may call".
+fn lower_opt_expr_contains_call(opt: &Option<Box<Expr>>) -> bool with Mut, Panic, Div {
+    match *opt {
+        Some(e) => lower_expr_contains_call_ref(&(*e)),
+        None => false,
+    }
+}
+
+fn lower_expr_contains_call_ref(e: &Expr) -> bool with Mut, Panic, Div {
+    if (*e).kind == ExprKind::ExprIntLit { return false }
+    if (*e).kind == ExprKind::ExprFloatLit { return false }
+    if (*e).kind == ExprKind::ExprBoolTrue { return false }
+    if (*e).kind == ExprKind::ExprBoolFalse { return false }
+    if (*e).kind == ExprKind::ExprStringLit { return false }
+    if (*e).kind == ExprKind::ExprCharLit { return false }
+    if (*e).kind == ExprKind::ExprIdent { return false }
+    if (*e).kind == ExprKind::ExprPath { return false }
+    if (*e).kind == ExprKind::ExprBinary {
+        if lower_opt_expr_contains_call(&(*e).left) { return true }
+        return lower_opt_expr_contains_call(&(*e).right)
+    }
+    if (*e).kind == ExprKind::ExprUnary {
+        return lower_opt_expr_contains_call(&(*e).left)
+    }
+    if (*e).kind == ExprKind::ExprCast {
+        return lower_opt_expr_contains_call(&(*e).left)
+    }
+    if (*e).kind == ExprKind::ExprIndex {
+        if lower_opt_expr_contains_call(&(*e).left) { return true }
+        return lower_opt_expr_contains_call(&(*e).right)
+    }
+    if (*e).kind == ExprKind::ExprFieldAccess {
+        return lower_opt_expr_contains_call(&(*e).left)
+    }
+    true
+}
+
 fn lower_expr_is_f64_array_literal_ref(e: &Expr) -> bool with Mut, Panic, Div {
     if (*e).kind != ExprKind::ExprArrayLit { return false }
     match (*e).left {
@@ -7707,6 +7752,14 @@ impl Lowerer {
                     return corr_pair
                 }
                 lo = corr_pair.0
+                // #1569: the value re-lowering below would execute any
+                // effectful call in the operands a SECOND time (the first
+                // evaluation already happened in lower_let_stmt_ref).
+                // Variance of a call result is untracked anyway, so bail
+                // instead of re-emitting.
+                if lower_opt_expr_contains_call(&(*e).left) || lower_opt_expr_contains_call(&(*e).right) {
+                    return (lo, -1)
+                }
                 let lhs_val_pair = lo.lower_opt_expr_ref(&(*e).left)
                 lo = lhs_val_pair.0
                 let lhs_v = lhs_val_pair.1
@@ -7726,6 +7779,11 @@ impl Lowerer {
                         }
                     }
                     _ => {}
+                }
+                // #1569: same double-evaluation hazard as OpMul above —
+                // never re-lower an operand that may contain a call.
+                if lower_opt_expr_contains_call(&(*e).left) || lower_opt_expr_contains_call(&(*e).right) {
+                    return (lo, -1)
                 }
                 let lhs_val_pair = lo.lower_opt_expr_ref(&(*e).left)
                 lo = lhs_val_pair.0

--- a/tests/run-pass/rng_fused_global_read_single_eval.sio
+++ b/tests/run-pass/rng_fused_global_read_single_eval.sio
@@ -1,0 +1,92 @@
+//@ run-pass
+//@ description: effectful call fused with an array read in one let evaluates ONCE (#1569)
+//@ known-failure: committed prebuilt bin/madaros-linux-x86_64 predates the #1569 lowering fix; xpasses once the prebuilt is refreshed from current source
+// #1569: the legacy scalar-variance algebra in lower_expr_variance_ref
+// re-lowered operand VALUES to feed emit_variance_independent_product/div.
+// When the operand held an effectful call, the call ran TWICE per
+// evaluation, so `let d = W[k] * (rng_next() % 10000)` advanced the PRNG
+// twice per iteration on Madaros and the stream diverged from lean_single.
+// The fix skips the value re-lowering whenever an operand subtree may
+// contain a call (variance of a call result is untracked anyway).
+//
+// Witness: the same computation runs fused (the #1569 shape) and hoisted
+// (call in its own let); the two sequences must match element for element.
+// Integer arithmetic only, so the pin is exact on every engine. The global
+// array is zero-initialised and runtime-assigned on purpose — a separate,
+// pre-existing lean_single defect reads literal-initialised GLOBAL arrays
+// as element 0 in fused expressions (out of scope here; see the #1569
+// discussion), so a literal initialiser would pin the WRONG value on lean.
+
+var RNG_A: i64 = 0
+var RNG_B: i64 = 0
+var W: [i64; 7] = [0; 7]
+
+fn rng_seed(a: i64, b: i64) with Mut {
+    RNG_A = a
+    RNG_B = b
+}
+
+fn rng_next() -> i64 with Mut {
+    var x = RNG_A
+    let y = RNG_B
+    RNG_A = y
+    x = x ^ (x << 23)
+    x = x ^ (x >> 17)
+    x = x ^ (y ^ (y >> 26))
+    RNG_B = x
+    let r = x + y
+    if r < 0 { 0 - r } else { r }
+}
+
+fn fill_w() with Mut {
+    W[0] = 10
+    W[1] = 20
+    W[2] = 30
+    W[3] = 40
+    W[4] = 50
+    W[5] = 60
+    W[6] = 70
+}
+
+fn main() -> i64 with Mut, Div {
+    fill_w()
+    var F: [i64; 7] = [0; 7]
+    var G: [i64; 7] = [0; 7]
+
+    // pass 1 (fused mul): the exact #1569 shape
+    rng_seed(314159265, 271828182)
+    var k: i64 = 0
+    while k < 7 {
+        let d = W[k] * (rng_next() % 10000)
+        F[k] = d
+        k = k + 1
+    }
+    // pass 2 (hoisted mul): same stream, call in its own statement
+    rng_seed(314159265, 271828182)
+    k = 0
+    while k < 7 {
+        let u = rng_next() % 10000
+        let d = W[k] * u
+        if d != F[k] { return 10 + k }
+        k = k + 1
+    }
+
+    // pass 3 (fused div): the OpDiv arm of the same defect
+    rng_seed(314159265, 271828182)
+    k = 0
+    while k < 7 {
+        let q = 1000000 / (1 + rng_next() % 1000)
+        G[k] = q
+        k = k + 1
+    }
+    // pass 4 (hoisted div)
+    rng_seed(314159265, 271828182)
+    k = 0
+    while k < 7 {
+        let u = rng_next() % 1000
+        let q = 1000000 / (1 + u)
+        if q != G[k] { return 100 + k }
+        k = k + 1
+    }
+    return 0
+}


### PR DESCRIPTION
## Root cause

`lower_expr_variance_ref`'s legacy scalar-variance algebra in `self-hosted/ir/lower.sio` re-lowers operand **values** via `lower_opt_expr_ref` to feed `emit_variance_independent_product/div` — running from `lower_let_stmt_ref`'s variance-bind block **after** the RHS was already lowered once. An effectful call inside a product/quotient operand therefore executed twice: `W[k] * (2.0*rand_u() - 1.0)` advanced the PRNG twice per iteration, silently diverging seeded Monte-Carlo streams from lean_single.

## Fix (minimal, +58 lines, one file)

- New pure predicate `lower_expr_contains_call_ref` (+ `lower_opt_expr_contains_call` wrapper): literals/ident/path are call-free; binary/unary/cast/index/field-access recurse; everything else conservatively "may call".
- OpMul arm (`lower.sio:7760`) and OpDiv arm (`lower.sio:7785`): if either operand subtree may contain a call, return variance-unknown `(lo, -1)` instead of re-lowering values. Variance of a call result is untracked anyway — this only drops an approximation whose cost was a duplicated effect.

Deliberate trade-off (in commit body): a pure/effectful callee split is impossible today because declared effects don't separate them (`cm_get` declares `with Mut` for local `var` mutation); a transitive body-purity analysis is not minimal. Known limitation: FO-sens OpMul/OpDiv arms still re-lower (only reachable with live FO sens seeds) — noted, untouched.

## Validation (all `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH`)

- Witness `tests/run-pass/rng_fused_global_read_single_eval.sio`: integer-exact fused-vs-hoisted stream comparison for both OpMul and OpDiv shapes. Base binary rc=11 → patched rc=0; lean_single rc=0 both. Carries `//@ known-failure:` (prebuilt madaros predates the fix; XPAS→pass on refresh).
- **Full suite A/B**: patched vs stashed-control rebuild — failure lists byte-identical (491 pre-existing fails each; baseline is independently red). 3 extra patched-run entries were 30s timeouts under concurrent load; all pass in isolation.
- Demos regression: `mh7_reliability` and `trieres_chain` outputs **byte-identical** patched-madaros × lean_single — the fix does not change correct-code semantics.
- #1557-pinned diagnostics untouched.

## Related

- Closes #1569.
- Surfaced a separate lean_single bug filed as #1574 (literal-initialized global arrays read element 0 regardless of index) — the original #1569 repro masked it; witness deliberately uses zero-init + runtime assignment.