### PR TITLE
fix(native): print_f64 rounds instead of truncating

### DIFF
--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -4972,7 +4972,7 @@ fn emit_builtin_cos(nc: NativeCompiler) -> NativeCompiler with Mut, Panic, Div {
     c
 }
 
-// Sprint 118: print_f64 builtin — multiply-and-truncate f64 → stdout
+// Sprint 118: print_f64 builtin — f64 → stdout, fraction rounded (#1573)
 fn emit_builtin_print_f64(nc: NativeCompiler) -> NativeCompiler with Mut, Panic, Div {
     var c = nc
 
@@ -5032,7 +5032,75 @@ fn emit_builtin_print_f64(nc: NativeCompiler) -> NativeCompiler with Mut, Panic,
     c.code = emit_cvttsd2si_rax_xmm0(c.code)
     c.code = emit_store_rax_rbp_disp32(c.code, -56)   // save int_part
 
-    // itoa for integer part
+    // Fractional part
+    c.code = emit_load_rbp_disp32_rax(c.code, -48)
+    c.code = emit_movq_xmm0_rax(c.code)
+    c.code = emit_load_rbp_disp32_rax(c.code, -56)
+    // cvtsi2sd xmm1, rax (F2 48 0F 2A C8)
+    var cb5 = c.code
+    cb5 = emit_byte(cb5, 0xF2)
+    cb5 = emit_byte(cb5, 0x48)
+    cb5 = emit_byte(cb5, 0x0F)
+    cb5 = emit_byte(cb5, 0x2A)
+    cb5 = emit_byte(cb5, 0xC8)
+    c.code = cb5
+
+    c.code = emit_subsd_xmm0_xmm1(c.code)
+
+    // Load 1e6 from .rodata
+    let movsd1_pos = c.code.len
+    c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
+    c.relocs = add_rip_reloc(c.relocs, movsd1_pos + 4, rodata_1e6_offset)
+
+    c.code = emit_mulsd_xmm0_xmm1(c.code)
+    // Round, do not truncate. cvttsd2si biases every printed value downward by
+    // up to one unit in the last digit: 5.76 printed 5.759999, 2.675 printed
+    // 2.674999 (#1573). The integer part above still uses the truncating form,
+    // which is correct there and preserves the printable range (values up to
+    // ~9.2e18 still print; scaling the WHOLE number by 1e6 first would have
+    // capped it at ~9.2e12 and regressed 1e13 and 1e15, which print exactly
+    // today).
+    c.code = emit_cvtsd2si_rax_xmm0(c.code)
+
+    // Ensure non-negative
+    c.code = emit_test_rax_rax(c.code)
+    c.code = emit_jns_rel8(c.code, 3)
+    c.code = emit_xor_rax_rax(c.code)
+
+    // Carry. Rounding can lift the fraction to exactly 1000000 -- 0.9999995
+    // is the smallest case. The 6-digit itoa below emits only six digits, so
+    // an un-carried 1000000 would print as 0.000000: strictly worse than the
+    // truncation this replaces. Subtract the decade and bump the integer part,
+    // which has NOT been written yet -- that is why the integer itoa and the
+    // '.' now follow this block instead of preceding it.
+    c.code = emit_mov_reg_imm(c.code, 3, 1000000)     // mov rbx, 1000000
+    c.code = emit_sub_rax_rbx(c.code)                 // rax -= 1000000
+    c.code = emit_test_rax_rax(c.code)
+    let carry_jns_pos = c.code.len
+    c.code = emit_jns_rel8(c.code, 0)                 // >= 0 means it carried
+    c.code = emit_add_rax_rbx(c.code)                 // no carry: restore
+    let carry_jmp_pos = c.code.len
+    c.code = emit_jmp_rel8(c.code, 0)
+    let carry_target = c.code.len
+    var cbc = c.code                                  // inc qword [rbp-56]
+    cbc = emit_byte(cbc, 0x48)
+    cbc = emit_byte(cbc, 0xFF)
+    cbc = emit_byte(cbc, 0x45)
+    cbc = emit_byte(cbc, 0xC8)
+    c.code = cbc
+    if carry_jns_pos + 1 < nc_code_capacity_bytes() {
+        NC_BIG_CODE[(carry_jns_pos + 1) as usize] = low8(carry_target - (carry_jns_pos + 2)) as i8
+    }
+    if carry_jmp_pos + 1 < nc_code_capacity_bytes() {
+        NC_BIG_CODE[(carry_jmp_pos + 1) as usize] = low8(c.code.len - (carry_jmp_pos + 2)) as i8
+    }
+
+    // Park the fraction; the integer itoa below needs rax.
+    c.code = emit_store_rax_rbp_disp32(c.code, -64)
+
+    // itoa for integer part. Reloaded because the fraction computation above
+    // now runs first and leaves its own result in rax.
+    c.code = emit_load_rbp_disp32_rax(c.code, -56)
     c.code = emit_mov_reg_reg(c.code, 6, 5)           // mov rsi, rbp
     c.code = emit_sub_rsi_imm8(c.code, 1)
     c.code = emit_xor_rcx_rcx(c.code)
@@ -5069,35 +5137,8 @@ fn emit_builtin_print_f64(nc: NativeCompiler) -> NativeCompiler with Mut, Panic,
     c = emit_load_runtime_context_field_rdi(c, runtime_context_field_stdout_fd())
     c = emit_write_syscall_for_target(c, c.target_os_id)
 
-    // Fractional part
-    c.code = emit_load_rbp_disp32_rax(c.code, -48)
-    c.code = emit_movq_xmm0_rax(c.code)
-    c.code = emit_load_rbp_disp32_rax(c.code, -56)
-    // cvtsi2sd xmm1, rax (F2 48 0F 2A C8)
-    var cb5 = c.code
-    cb5 = emit_byte(cb5, 0xF2)
-    cb5 = emit_byte(cb5, 0x48)
-    cb5 = emit_byte(cb5, 0x0F)
-    cb5 = emit_byte(cb5, 0x2A)
-    cb5 = emit_byte(cb5, 0xC8)
-    c.code = cb5
-
-    c.code = emit_subsd_xmm0_xmm1(c.code)
-
-    // Load 1e6 from .rodata
-    let movsd1_pos = c.code.len
-    c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, movsd1_pos + 4, rodata_1e6_offset)
-
-    c.code = emit_mulsd_xmm0_xmm1(c.code)
-    c.code = emit_cvttsd2si_rax_xmm0(c.code)
-
-    // Ensure non-negative
-    c.code = emit_test_rax_rax(c.code)
-    c.code = emit_jns_rel8(c.code, 3)
-    c.code = emit_xor_rax_rax(c.code)
-
-    // 6-digit fixed-width itoa (unrolled)
+    // 6-digit fixed-width itoa (unrolled), reading the parked fraction.
+    c.code = emit_load_rbp_disp32_rax(c.code, -64)
     c.code = emit_mov_reg_reg(c.code, 6, 5)           // mov rsi, rbp
     c.code = emit_sub_rsi_imm8(c.code, 3)
 

--- a/self-hosted/native/encode.sio
+++ b/self-hosted/native/encode.sio
@@ -1980,6 +1980,15 @@ pub fn emit_cvtsi2sd_xmm0_rax(buf: CodeBuffer) -> CodeBuffer with Mut, Panic, Di
 }
 
 // CVTTSD2SI rax, xmm0 — truncate f64 to i64 (Sprint 87: float-to-int)
+pub fn emit_sub_rax_rbx(buf: CodeBuffer) -> CodeBuffer with Mut, Panic, Div {
+    // 48 29 D8 — sub rax, rbx
+    var b = buf
+    b = emit_byte(b, 0x48)
+    b = emit_byte(b, 0x29)
+    b = emit_byte(b, 0xD8)
+    b
+}
+
 pub fn emit_cvttsd2si_rax_xmm0(buf: CodeBuffer) -> CodeBuffer with Mut, Panic, Div {
     // F2 REX.W 0F 2C C0
     var b = buf


### PR DESCRIPTION
Madaros half of #1573.

## The defect

`emit_builtin_print_f64` scaled the fraction by 1e6 and converted with `cvttsd2si` — truncate toward zero. Every printed value was biased downward by up to a full unit in the last digit, systematically and always in the same direction.

| value | before | after | truth (`%.6f`) |
|---|---|---|---|
| 5.76 | **5.759999** | 5.760000 | 5.760000 |
| 2.8944465 | 2.894446 | 2.894446 | 2.894446 |
| 0.0000215 | **0.000021** | 0.000022 | 0.000022 |
| 0.9999995 | **0.999999** | 1.000000 | 1.000000 |
| 1.5 | 1.500000 | 1.500000 | 1.500000 |
| 0.1 | 0.100000 | 0.100000 | 0.100000 |
| 2.675 | **2.674999** | 2.675000 | 2.675000 |
| −5.76 | **−5.759999** | −5.760000 | −5.760000 |

## Why not the one-instruction fix

Swapping `cvttsd2si` for `cvtsd2si` alone introduces a **worse** bug: `0.9999995 * 1e6` rounds to exactly `1000000`, the 6-digit itoa emits only six digits, and the value prints as `0.000000`.

Scaling the whole number by 1e6 and dividing removes the carry but caps the printable range at ~9.2e12. Measured: `1e13` and `1e15` print exactly today. Rejected as a regression.

## What landed

Integer part keeps `cvttsd2si` — range preserved. The fraction rounds. A carry into the integer part is handled when rounding lifts the fraction to `1000000`.

The carry is only possible because **the integer itoa and the `.` now emit after the fraction is computed**. Previously the integer part had already been written to stdout, so a carry had nowhere to go.

Range check, unchanged by this PR:

```
1e12  1000000000000.000000      exact
9e12  9000000000000.000000      exact
1e13  10000000000000.000000     exact
1e15  1000000000000000.000000   exact
1e19  9223372036854775808.000000   saturates, pre-existing
0.0   0.000000                  exact
```

The `jns` patch for the negative-sign block is applied before any of the moved code, so the span it measures is unchanged — verified by probe (`-5.76` → `-5.760000`), which is the way this would most plausibly have broken in silence.

`emit_sub_rax_rbx` added to `encode.sio`; `emit_cvtsd2si_rax_xmm0` already existed there and is reused.

## Gates

```
[madaros-corpus] PASS: no new failures under Madaros (296 known, 0 new)
[engine-parity]  PASS: no new engine divergences (1169 known)
[engine-parity]  agree=533 diverge=203 (was 532 / 204)
```

Build exit 0; 11 duplicate-name warnings and the 3 tolerated typecheck errors are identical counts to a build without this change.

## Two honest qualifications

**The parity delta is one entry, not the slice #1573 predicted.** I got the magnitude wrong there. Measured reason: `lean_single` omits the newline after `println` of an `f64`, so a program printing floats still diverges on formatting regardless of digits. `epistemic_second_order_variance_sanity` remains DIVERGE with an identical value `0.000000` — 9 bytes against 8. The lean half of #1573 has to land before this can move the divergence count.

That half is deliberately **not** in this PR: `lean_single.sio` is the frozen seed `build_modular_madaros.sh` derives the compiler from, and changing the reference engine while changing the engine under test would make the parity delta uninterpretable.

**The corpus gate cannot see stdout changes here.** The harness's `expect-stdout` extraction quotes its regex, so the capture group never captures (Phase 1.1 of the compiler plan, ~305 vacuous passes). Its silence is not evidence that no expected output moved.

Refs #1573

🤖 Generated with [Claude Code](https://claude.com/claude-code)