### PR TITLE
fix(gpu): GPU.sync() no longer takes the compiler down with it

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -13961,7 +13961,46 @@ impl Lowerer {
         }
     }
 
+    // GPU.sync() is a no-op on this backend, and it has to be recognised HERE.
+    //
+    // The checker already accepts it and types it as unit
+    // (checker_expr_is_gpu_sync_call), but nothing lowered it, so it fell
+    // through to the ordinary method-call path: receiver `GPU` is not a local,
+    // and find_or_add_fn_id("sync") then minted a BODY-LESS function. That is
+    // the exact failure the comment below this one warns about, and it took the
+    // compiler down with SIGSEGV -- rc=139, no ELF, on four lines of input:
+    //
+    //     fn main() -> i32 with GPU, IO { perform GPU.sync(); 0 }
+    //
+    // lean_single compiles the same file fine (#1594).
+    //
+    // No-op is the honest semantics, not a stub: the kernel lane loop (#1512)
+    // runs every lane inside the launch before it returns, so by the time sync
+    // is reached there is nothing outstanding to wait for. A device backend
+    // that launches asynchronously would need a real barrier here.
+    fn expr_is_gpu_sync_call_ref(self, e: &Expr) -> bool with Mut, Panic, Div {
+        if (*e).kind != ExprKind::ExprMethodCall {
+            return false
+        }
+        if !ir_name_eq((*e).name, make_name("sync")) {
+            return false
+        }
+        match (*e).left {
+            Some(base) => (*base).kind == ExprKind::ExprIdent && ir_name_eq((*base).name, make_name("GPU")),
+            None => false,
+        }
+    }
+
     fn lower_method_call_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        if self.expr_is_gpu_sync_call_ref(e) {
+            // Unit. A plain integer zero -- emit_f64_const would mark the
+            // register as float for a value that is never read.
+            let pair_u = self.fresh_reg()
+            var lo_u = pair_u.0
+            let reg_u = pair_u.1
+            lo_u = lo_u.emit(ir_load_imm(reg_u, 0))
+            return (lo_u, reg_u)
+        }
         // Impl methods are lowered as mangled free functions (ir_mangle_method_name).
         // A `recv.method()` call must resolve to that SAME mangled name; using the bare
         // method name finds/creates a body-less fn -> codegen crash.

--- a/tests/engine_parity_baseline.txt
+++ b/tests/engine_parity_baseline.txt
@@ -80,6 +80,7 @@ DIVERGE	tests/run-pass/global_scalar_f64_print.sio
 DIVERGE	tests/run-pass/global_scalar_init_still_works.sio
 DIVERGE	tests/run-pass/gpu_kernel_basic.sio
 DIVERGE	tests/run-pass/gpu_kernel_lane_loop.sio
+DIVERGE	tests/run-pass/gpu_launch_vec_slices.sio
 DIVERGE	tests/run-pass/gradient_descent_from_compiler.sio
 DIVERGE	tests/run-pass/graphics_epistemic_demo.sio
 DIVERGE	tests/run-pass/gresnigt_family_s3.sio
@@ -269,7 +270,6 @@ LEAN-ONLY	tests/run-pass/generic_struct_nested.sio
 LEAN-ONLY	tests/run-pass/generic_struct_return_structf.sio
 LEAN-ONLY	tests/run-pass/gp_test.sio
 LEAN-ONLY	tests/run-pass/gpu_launch_surface.sio
-LEAN-ONLY	tests/run-pass/gpu_launch_vec_slices.sio
 LEAN-ONLY	tests/run-pass/gpu_sedenion_f3.sio
 LEAN-ONLY	tests/run-pass/graded_eq_wasserstein.sio
 LEAN-ONLY	tests/run-pass/graphics_companion_smoke.sio
@@ -500,6 +500,7 @@ MADAROS-ONLY	tests/run-pass/div_witness_projection3_interval_containment_tiny.si
 MADAROS-ONLY	tests/run-pass/div_witness_projection3_tiny.sio
 MADAROS-ONLY	tests/run-pass/generic_struct_compound_field_inference.sio
 MADAROS-ONLY	tests/run-pass/global_string_lit_init.sio
+MADAROS-ONLY	tests/run-pass/gpu_public_launch_check.sio
 MADAROS-ONLY	tests/run-pass/imported_runtime_lift_contract_imported.sio
 MADAROS-ONLY	tests/run-pass/kernel_replay_evidence_router_imported.sio
 MADAROS-ONLY	tests/run-pass/lorenz_ball_fixed_chain_five_step_tiny.sio
@@ -851,7 +852,6 @@ NEITHER	tests/run-pass/fixtures/large_import_leaf.sio
 NEITHER	tests/run-pass/fixtures/large_import_module.sio
 NEITHER	tests/run-pass/fixtures/pub_use_reexport_leaf.sio
 NEITHER	tests/run-pass/format_idempotent.sio
-NEITHER	tests/run-pass/gpu_public_launch_check.sio
 NEITHER	tests/run-pass/gpu_public_thread_array_params.sio
 NEITHER	tests/run-pass/imported_f64_bss_arith_leaf.sio
 NEITHER	tests/run-pass/imported_f64_global_const_leaf.sio

--- a/tests/madaros_corpus_baseline.txt
+++ b/tests/madaros_corpus_baseline.txt
@@ -91,9 +91,7 @@ generic_struct_instantiate.sio run
 generic_struct_nested.sio run
 generic_struct_return_structf.sio compile
 gp_test.sio run
-gpu_launch_surface.sio compile
-gpu_launch_vec_slices.sio compile
-gpu_public_launch_check.sio compile
+gpu_launch_vec_slices.sio stdout
 gpu_public_thread_array_params.sio compile
 gpu_sedenion_f3.sio compile
 graded_eq_wasserstein.sio compile
@@ -238,6 +236,7 @@ seq_knowledge_nested_generic.sio compile
 seq_knowledge_uncertain.sio compile
 seq_methods.sio compile
 seq_struct_elems.sio compile
+site_screening_selftest.sio compile
 slice_fat_pointers.sio compile
 smt_qflia_basic.sio run
 spearman_holm_bca.sio compile
@@ -266,6 +265,7 @@ trait_bounded_dispatch_multi_call.sio compile
 trajectory_basic.sio compile
 tuple_destructure_let.sio compile
 type_hash_3level_nesting.sio run
+uhs_brine_calcite_selftest.sio compile
 uncertain_eq_bernoulli.sio compile
 unit_cast_compatible.sio compile
 unit_cast_time.sio compile


### PR DESCRIPTION
Closes #1594. Four lines are enough:

```sounio
fn main() -> i32 with GPU, IO {
    perform GPU.sync()
    0
}
```

Madaros: **rc=139**, no ELF. lean_single: rc=0. No kernel, no launch, no tuples needed.

## Cause

`perform` is transparent in the parser — `parse_perform_expr` just reduces to the inner expression — so this is a method call whose receiver is the ident `GPU`.

The checker **accepts** it and types it unit (`checker_expr_is_gpu_sync_call`, `check.sio:13136`). The lowerer had **no handler at all**, so it fell through to the ordinary method-call path, where the receiver is not a local and `find_or_add_fn_id("sync")` minted a **body-less function**.

The comment three lines below that call site already warns about exactly this:

> using the bare method name finds/creates a body-less fn → codegen crash

The warning was written. The GPU receiver walked underneath it.

**No-op is the honest semantics, not a stub**: the kernel lane loop (#1512) runs every lane inside the launch before it returns, so by the time `sync` is reached nothing is outstanding. A backend that launches asynchronously would need a real barrier — the code says so.

## Three files were crashing, not one

Found by sweeping the whole `gpu_*` family instead of stopping at the file the issue named:

```
gpu_launch_surface.sio        rc=139 → compiles AND runs rc=0
gpu_launch_vec_slices.sio     rc=139 → compiles AND runs rc=0
gpu_public_launch_check.sio   rc=139 → compiles AND runs rc=0
```

The other 14 `gpu_*` files are byte-identical to a control built from current main. No regressions.

## Baselines — 6 lines, each attributed

**Corpus, 3 removed** (they compile now, and all three verified *running*, not merely compiling): `gpu_launch_surface`, `gpu_launch_vec_slices`, `gpu_public_launch_check`.

**Corpus, 3 added:**

- `gpu_launch_vec_slices.sio stdout` — **mine**, and it is the honest record. The file now runs and prints its own `FAIL: GPU launch vec_slices`, because kernel writes through `&![f64]` slices never land. Minimal repro and analysis in **#1596**. Crash → loud wrong answer is progress, but it is not a pass, so it stays in the baseline rather than being removed.
- `site_screening_selftest.sio compile` and `uhs_brine_calcite_selftest.sio compile` — **not mine**. Both arrived yesterday in #1590 and were never in the baseline; a control built from current main fails them identically (rc=1).

**Parity, 2 verdicts**: `gpu_launch_vec_slices` LEAN-ONLY → DIVERGE, `gpu_public_launch_check` NEITHER → MADAROS-ONLY. Both now build under Madaros and lean rejects them at compile.

## Gates

```
[madaros-corpus] PASS: no new failures under Madaros (285 known, 0 new)
[engine-parity]  PASS: no new engine divergences (1169 known)
[engine-parity]  agree=537 diverge=213 madaros-only=359 lean-only=269 neither=327 timeout=0
```

## Pattern worth naming

This is the third time today the same shape appeared: **checker and lowerer disagreeing about what exists.** In #1588 the checker bound `hessian_of` to a name the backend never implemented, so it returned a silent zero. Here it is the mirror image — the checker accepts and types `GPU.sync()`, the lowerer does not know it exists, and the result is worse than a silent zero: the compiler dies.

Closes #1594

🤖 Generated with [Claude Code](https://claude.com/claude-code)