### PR TITLE
feat(gpu): GPU.launch actually calls the kernel; gpu.thread_id.x stops segfaulting

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -13131,11 +13131,85 @@ impl Lowerer {
         }
     }
 
+    // `perform GPU.launch(k, grid, block)(args)` -> `k(args)`.
+    //
+    // Returns the kernel's name, or the empty name when this is not a launch
+    // invocation. The shape mirrors checker_expr_is_gpu_launch_invocation_call:
+    // an outer Call whose callee is the descriptor `GPU.launch(k, grid, block)`.
+    //
+    // Nothing lowered this before, so the launch emitted no call at all and the
+    // kernel silently never ran. Measured on a 4-element in-place add: direct
+    // call gives a[1] = 3.0, the same kernel through launch left a[1] = 1.0,
+    // untouched (#1596).
+    //
+    // grid and block are IGNORED, deliberately. On a CPU host there is no launch
+    // geometry to honour: the kernel body already carries the lane loop (#1512),
+    // whose bound is the kernel's first i64 parameter, so one call runs every
+    // lane. A device backend would have to read them; this one has nothing to
+    // read them for, and silently accepting them beats pretending to a geometry
+    // that does not exist. Same reasoning as GPU.sync() lowering to a no-op.
+    fn gpu_launch_kernel_name_ref(self, e: &Expr) -> Name with Mut, Panic, Div, Alloc, IO {
+        if (*e).kind != ExprKind::ExprCall {
+            return ir_empty_name()
+        }
+        match (*e).left {
+            Some(desc) => {
+                var ok = false
+                if (*desc).kind == ExprKind::ExprMethodCall && ir_name_eq((*desc).name, make_name("launch")) {
+                    match (*desc).left {
+                        Some(base) => {
+                            if (*base).kind == ExprKind::ExprIdent && ir_name_eq((*base).name, make_name("GPU")) {
+                                ok = true
+                            }
+                        }
+                        None => {}
+                    }
+                }
+                if !ok {
+                    return ir_empty_name()
+                }
+                match (*desc).args {
+                    Some(list) => {
+                        if (*list).head.kind == ExprKind::ExprIdent {
+                            return (*list).head.name
+                        }
+                        ir_empty_name()
+                    }
+                    None => ir_empty_name(),
+                }
+            }
+            None => ir_empty_name(),
+        }
+    }
+
     fn lower_call_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
         let callee_opt_ref = &e.left
         let callee_name = match *callee_opt_ref {
             Some(c) => self.expr_to_callee_name_ref(&(*c)),
             None => ir_empty_name(),
+        }
+        let launch_name = self.gpu_launch_kernel_name_ref(e)
+        if launch_name.len > 0 {
+            var lo_k = self
+            let fn_id_k = lowerer_find_or_add_fn_id_mut(&! lo_k, launch_name)
+            let pair_args_k: LowerExprArgsResult = lo_k.lower_expr_args_ref(&e.args)
+            let lo_args_k = pair_args_k.lowerer
+            let args_k: Option<Box<IrRegList>> = if pair_args_k.count <= 0 { None } else { Some(Box::new(pair_args_k.regs)) }
+            let pair_dst_k = lo_args_k.fresh_reg()
+            let lo_dst_k = pair_dst_k.0
+            let dst_k = pair_dst_k.1
+            // grid/block carry no meaning on this backend, and that is a data
+            // difference, not a scheduling one: the lane count comes from the
+            // kernel's first i64 parameter, so a descriptor of (1,1,1)x(2,1,1)
+            // against an extent of 4 runs FOUR lanes. Measured. Silence there
+            // would be a wrong answer nobody is told about, which is the exact
+            // failure mode this file keeps being bitten by, so it is announced
+            // at compile time. (Compiler stdout, not the program's -- stdout
+            // assertions in the corpus are unaffected.)
+            print("warning: GPU.launch grid/block ignored on the CPU lane path")
+            print(" -- lane count comes from the kernel's first i64 parameter, not the descriptor\n")
+            let lo_call_k = lo_dst_k.emit(ir_call(dst_k, fn_id_k, launch_name, args_k, pair_args_k.count))
+            return (lo_call_k, dst_k)
         }
         if name_eq(callee_name, make_name("print")) || name_eq(callee_name, make_name("print_int")) || name_eq(callee_name, make_name("print_char")) {
             // Redirect bare print(<int literal>) to the print_int builtin: print
@@ -13524,7 +13598,63 @@ impl Lowerer {
         (lo4, dst)
     }
 
+    // `gpu.thread_id.x` is the field spelling of `gpu_thread_id_x()`.
+    //
+    // The checker understands the chain (checker_expr_gpu_axis_base_kind walks
+    // gpu -> .thread_id -> .x); the lowerer only ever handled the CALL form, so
+    // the field form fell through to ordinary struct field access on an ident
+    // that is not a local. Measured on identical kernels differing ONLY in this
+    // spelling: gpu_thread_id_x() gives a[1] = 3.0, gpu.thread_id.x segfaults
+    // the program at rc=139 (#1596).
+    //
+    // Only the x axis is mapped, matching the call form: the lane loop (#1512)
+    // is one-dimensional, so y and z have no counter to read and keep their
+    // previous behaviour rather than silently aliasing x.
+    fn expr_is_gpu_thread_id_x_ref(self, e: &Expr) -> bool with Mut, Panic, Div {
+        if (*e).kind != ExprKind::ExprFieldAccess {
+            return false
+        }
+        if !ir_name_eq((*e).name, make_name("x")) {
+            return false
+        }
+        match (*e).left {
+            Some(mid) => {
+                if (*mid).kind != ExprKind::ExprFieldAccess {
+                    return false
+                }
+                if !ir_name_eq((*mid).name, make_name("thread_id")) {
+                    return false
+                }
+                match (*mid).left {
+                    Some(root) => (*root).kind == ExprKind::ExprIdent && ir_name_eq((*root).name, make_name("gpu")),
+                    None => false,
+                }
+            }
+            None => false,
+        }
+    }
+
     fn lower_field_access_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        if self.expr_is_gpu_thread_id_x_ref(e) {
+            let pair_t = self.fresh_reg()
+            var lo_t = pair_t.0
+            let dst_t = pair_t.1
+            if LOWER_KERNEL_TID_REG >= 0 {
+                lo_t = lo_t.emit(ir_copy(dst_t, LOWER_KERNEL_TID_REG))
+                return (lo_t, dst_t)
+            }
+            // Outside a kernel lane loop there is no counter to read. Falling
+            // through to ordinary field access is what SEGFAULTED (rc=139) on
+            // `fn helper() -> i64 with GPU { gpu.thread_id.x }` -- the checker
+            // accepts that program, so the path is reachable and a guard that
+            // only covers the in-kernel case leaves the original defect alive.
+            // Degrade to 0 and SAY SO, mirroring gpu_thread_id_x()'s existing
+            // behaviour rather than inventing a second one.
+            print("warning: gpu.thread_id.x outside a `kernel fn` reads 0")
+            print(" -- inline it into the kernel body; a helper cannot see the lane counter (#1504)\n")
+            lo_t = lo_t.emit(ir_load_imm(dst_t, 0))
+            return (lo_t, dst_t)
+        }
         let pair_b = self.lower_opt_expr_ref(&e.left)
         let lo1 = pair_b.0
         let base = pair_b.1

--- a/tests/madaros_corpus_baseline.txt
+++ b/tests/madaros_corpus_baseline.txt
@@ -91,7 +91,6 @@ generic_struct_instantiate.sio run
 generic_struct_nested.sio run
 generic_struct_return_structf.sio compile
 gp_test.sio run
-gpu_launch_vec_slices.sio stdout
 gpu_public_thread_array_params.sio compile
 gpu_sedenion_f3.sio compile
 graded_eq_wasserstein.sio compile


### PR DESCRIPTION
Closes #1596 — **whose premise, including my own first analysis, was wrong.**

The issue said "kernel writes through `&![f64]` slices never land". Slice writes were never broken: `gpu_vec_add.sio` already exercised them through a **direct call** over 1024 elements and passed.

Twelve ~600ms probes across a four-way matrix (`gpu_thread_id_x()` vs `gpu.thread_id.x`, direct call vs launch) found **three separate defects, none about slices**:

```
direct call + gpu_thread_id_x()   a[1] = 3.0    correct
direct call + gpu.thread_id.x     rc=139        SIGSEGV
perform GPU.launch(...)           a[1] = 1.0    kernel never ran
```

All three are one mechanism — the same one behind #1594: **the checker accepts a syntax form and the lowerer has no handler for it.**

## What landed

1. `perform GPU.launch(k, grid, block)(args)` lowers to `k(args)`. Nothing lowered it before, so the launch emitted no call at all.
2. `gpu.thread_id.x` maps to the lane counter, as `gpu_thread_id_x()` already did. The checker walks the chain (`checker_expr_gpu_axis_base_kind`); the lowerer only knew the call spelling.

```
gpu_launch_vec_slices.sio    FAIL → PASS
gpu_public_launch_check.sio  segfault at run → rc=0
```

## Review found two real blockers in my first cut

Sent to DeepSeek and Grok 4.3. They independently flagged the same two, and **both survived measurement** — I verified rather than relaying.

**A. `grid`/`block` ignored is a data difference, not a scheduling one.** Measured: `launch(k, (1,1,1), (2,1,1))(4, &!a)` — descriptor says 2, four lanes run, `a[3] = 1.0`. DeepSeek's sharpest point: my "same reasoning as `GPU.sync()`" comment is a **false equivalence** — `sync` has no data semantics, `launch` decides how many times the kernel runs.

Kept per owner decision, but no longer **silent**: the lowerer now warns at compile time that grid/block are ignored and the lane count comes from the kernel's first `i64` parameter. Compiler stdout, not the program's, so corpus stdout assertions are unaffected.

**B. My guard left the segfault alive.** It was `expr_is_gpu_thread_id_x_ref(e) && LOWER_KERNEL_TID_REG >= 0`. Measured: `fn helper() -> i64 with GPU { gpu.thread_id.x }` → **rc=139, still**. My own fix was incomplete at exactly the point it existed to fix. Now degrades to 0 with a warning, mirroring `gpu_thread_id_x()` rather than inventing a second behaviour.

*Not taken*: their suggestion to make it a hard error — that would break the call spelling, which works today and the checker accepts. A language change does not belong inside a segfault fix.

In-kernel uses emit **zero** warnings: the diagnostic fires only where information is actually lost.

**Also declined, with reasons**: erroring on non-`ExprIdent` kernel arguments (that is not a launch today and falls through normally — a language change); emitting an `ir_gpu_launch` node carrying the geometry (right design for a device backend, out of scope); guarding against a local named `gpu` shadowing the builtin (could not reproduce).

One DeepSeek point was **factually wrong** — it said no regression coverage was added, when `gpu_launch_vec_slices.sio` going FAIL → PASS is exactly that. My prompt omitted the baseline state, so that one is on me.

## Baseline — one line

`gpu_launch_vec_slices.sio stdout` removed, verified **running and PASSing**, not merely compiling. Second honest removal of an entry I deliberately kept one PR ago (#1597), when the file ran and loudly failed.

## Gates

```
[madaros-corpus] PASS: no new failures under Madaros (284 known, 0 new; was 285)
[engine-parity]  PASS: no new engine divergences (1169 known)
[engine-parity]  agree=538 diverge=212 madaros-only=359 lean-only=269 neither=327 timeout=0
```

Nothing needed **adding**. The previous run's `gpu_public_launch_check.sio run` failure was real — my launch fix made the kernel body execute and the thread_id defect surfaced — and fixing the cause removed it rather than recording the symptom.

## Still open

`gpu.thread_id.y` / `.z` have no lane counter to read (the loop is one-dimensional) and keep their previous behaviour rather than silently aliasing x.

Closes #1596

🤖 Generated with [Claude Code](https://claude.com/claude-code)