### PR TITLE
fix(ci): corpus gate stops running files that are not programs

### DIFF
--- a/scripts/ci/madaros_corpus_regression_gate.sh
+++ b/scripts/ci/madaros_corpus_regression_gate.sh
@@ -59,9 +59,32 @@ echo "[madaros-corpus] compiler: $MADAROS"
 
 # Only run-pass programs. compile-fail and typecheck-fail tests have their own
 # gates and their verdicts are engine-specific by design.
-mapfile -t PROGRAMS < <(ls tests/run-pass/*.sio 2>/dev/null | sort)
+# Exclude files that are not programs. Library leaves and `//@ ignore` files
+# compile fine and then die with SIGSEGV because the ELF has no entry point --
+# 11 of them sat in the baseline as `run` failures, saying nothing about the
+# compiler. Same blind spot the parity gate had (#1601, #1593).
+#
+# Only these two exclusions. `//@ check-only` is deliberately NOT one: measured
+# on the parity side, 15 check-only files also declare //@ run-pass and have a
+# main, and one check-only file with no run-pass executes and agrees across both
+# engines. The marker says which harness checks the file, not whether it runs.
+#
+# Filtered HERE rather than inside run_one.sh so the count below is the number
+# actually exercised. Reporting 1699 while skipping 11 of them is the kind of
+# misleading instrument this gate exists to catch.
+corpus_is_program() {
+    local f="$1"
+    head -n 8 "$f" | grep -qE '^//@[[:space:]]*ignore\b' && return 1
+    grep -qE '^[[:space:]]*(pub[[:space:]]+)?fn[[:space:]]+main[[:space:]]*\(' "$f"
+}
+mapfile -t ALL_SIO < <(ls tests/run-pass/*.sio 2>/dev/null | sort)
+PROGRAMS=()
+skipped=0
+for f in "${ALL_SIO[@]}"; do
+    if corpus_is_program "$f"; then PROGRAMS+=("$f"); else skipped=$((skipped + 1)); fi
+done
 [[ ${#PROGRAMS[@]} -gt 0 ]] || fail "no programs found under tests/run-pass"
-echo "[madaros-corpus] programs: ${#PROGRAMS[@]}"
+echo "[madaros-corpus] programs: ${#PROGRAMS[@]} (skipped $skipped: //@ ignore or no fn main)"
 
 cat > "$WORK/run_one.sh" <<'INNER'
 #!/usr/bin/env bash

--- a/tests/madaros_corpus_baseline.txt
+++ b/tests/madaros_corpus_baseline.txt
@@ -36,7 +36,6 @@ audit_trail_basic.sio compile
 bdf_stiff.sio compile
 bitwise_not_bootstrap_regression.sio compile
 budget64_test.sio run
-chaotic_effect.sio run
 clinical_deployment_validity_revocable_authority_witness.sio compile
 clinical_proof_carrying_endogenous_observability_witness.sio run
 clinical_proof_carrying_model_contest_witness.sio run
@@ -52,7 +51,6 @@ closure_effect_infer_auto.sio compile
 closure_escape.sio run
 closure_generic_hof.sio compile
 closure_hof.sio compile
-closure_linear.sio run
 closure_returned.sio run
 compress_huffman_fixed.sio run
 connectome_laplacian_eigenvectors.sio compile
@@ -82,7 +80,6 @@ epsilon_comparison_valid.sio compile
 f2_conjugation_swda.sio run
 ffi_integer_return.sio run
 for_in_vec.sio compile
-format_idempotent.sio run
 g2_abide_sounio.sio compile
 g2_bridge_pipeline.sio compile
 g2_cohort_comparison.sio compile
@@ -131,14 +128,6 @@ import_basic.sio compile
 import_basic_main.sio compile
 import_chain_b.sio compile
 import_chain_main.sio compile
-imported_f64_bss_arith_leaf.sio run
-imported_f64_global_const_leaf.sio run
-imported_f64_global_const_pad.sio run
-imported_f64_return_leaf.sio run
-imported_module_f64_const_a.sio run
-imported_module_f64_const_b.sio run
-invariant_homeo_comparable.sio run
-invariant_same_frame_comparable.sio run
 invariant_tests.sio compile
 knightian_syntax.sio compile
 knowledge_acknowledge.sio compile


### PR DESCRIPTION
The other half of #1593, which #1601 left **open rather than assumed**. Same blind spot the parity gate had: it compiled and **ran** library leaves and `//@ ignore` files, whose ELF has no entry point and dies with SIGSEGV.

Eleven of them sat in `tests/madaros_corpus_baseline.txt` as `run` failures. *"A main-less library segfaulted"* says nothing about the compiler, but it counted as a known failure and inflated a number that gets read as capability.

```
failures  284 → 273      exactly the 11
programs 1699 → 1688     11 skipped
```

## Smaller than the parity side

Two reasons, recorded so nobody re-derives them: this gate globs `ls tests/run-pass/*.sio` — **not recursive** — so `fixtures/` was never in its corpus; and it already skipped `//@ requires: (gpu|llvm)` and `//@ known-failure`.

## Rule

`//@ ignore` **or** no `fn main`. Identical to #1601, and **`//@ check-only` is deliberately not included** — measured on the parity side, 15 check-only files also declare `//@ run-pass` and have a `main`, and `clinical_dyadic_non_reduction_witness.sio` is check-only with no run-pass yet executes and **agrees byte-for-byte across both engines**. The marker records which harness checks the file, not whether it runs.

The reasoning is written into both gates so it is not relitigated in six months.

## Baseline — 11 lines, all `run`

The edit script **asserted** that. A main-less file failing at *compile* would be a real compiler defect and must not leave by this route.

## The printed count

The filter lives in the selection loop, not in `run_one.sh`, so the reported number is what is actually exercised:

```
[madaros-corpus] programs: 1688 (skipped 11: //@ ignore or no fn main)
```

Reporting `programs: 1699` while skipping 11 of them is the same species of misleading instrument this gate exists to catch, and it would have gone into CI logs unchallenged.

> **A shrinking baseline here is not the compiler improving.** Eleven entries left because they were never measuring the compiler.

## Gates

```
[madaros-corpus] PASS: no new failures under Madaros (273 known, 0 new)
```

Parity untouched by this change.

Closes #1593

🤖 Generated with [Claude Code](https://claude.com/claude-code)