### PR TITLE
agent-bus: shared channel + MCP real-time push between the ten agent slots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,3 +378,29 @@ This repository runs many parallel agents with a single human author. Pre-commit
 Every non-trivial offload appends to `.claude/llm_offload_log.md`. Bug-catching offloads require an `LLM-offload-review:` trailer in the commit message. The policy document lists fallback rules when a provider key is missing or down.
 
 **Codex agents must not skip this step**. If you find yourself about to commit a `vancomycin_*.sio`, a Lean theorem statement, or a paper draft without a logged offload review, stop and run the review first.
+
+## Agent coordination — read the bus before you start
+
+Ten agent slots share this pod (`claude-1..3`, `codex-1..3`, `grok-cli1..2`,
+`kimi-cli1..2`) and one filesystem. Coordination used to be a document that
+nobody wrote to. It is now a channel:
+
+```bash
+scripts/dev/agent-bus.sh brief          # FIRST THING. hazards, leases, recent events
+scripts/dev/agent-bus.sh claim <res>    # before a build lock, a shared file, a lane
+scripts/dev/agent-bus.sh post finding 'what you learned'
+scripts/dev/agent-bus.sh hazard add <slug> 'what will silently ruin others' measurements'
+```
+
+For real-time, the same bus is served over MCP (`scripts/mcp/agent_bus_mcp.py`;
+merge `scripts/mcp/agent-bus.mcp.json` into your gitignored `.mcp.json`).
+Subscribe to `bus://events` or `bus://hazards` and the server pushes
+`notifications/resources/updated` the moment another agent posts. Tools:
+`bus_post`, `bus_claim`, `bus_release`, `bus_hazard`, `bus_brief`. Both doors
+write the same storage, so an agent on the shell CLI and an agent on MCP are on
+one channel.
+
+Post a `hazard` for anything that makes a measurement lie rather than fail: a
+poisoned environment variable, a stale artifact, a checkout parked on another
+branch. Those cost hours precisely because the run still exits and prints a
+number. Storage is `/workspace/.agents/bus`, outside every checkout.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,3 +358,29 @@ Prefer proven wrappers from `ops/lab-ops.sh` over ad hoc `sbatch` or `kubectl`.
 ---
 
 *This file is the AI-assistant entry-point. For the Codex-facing execution contract, see [`AGENTS.md`](AGENTS.md). For governance authority matrix, see [`docs/governance/DOCS_AUTHORITY_MATRIX.md`](docs/governance/DOCS_AUTHORITY_MATRIX.md). Last revised 17 May 2026; check `git log -1 CLAUDE.md` for current state.*
+
+## Agent coordination — read the bus before you start
+
+Ten agent slots share this pod (`claude-1..3`, `codex-1..3`, `grok-cli1..2`,
+`kimi-cli1..2`) and one filesystem. Coordination used to be a document that
+nobody wrote to. It is now a channel:
+
+```bash
+scripts/dev/agent-bus.sh brief          # FIRST THING. hazards, leases, recent events
+scripts/dev/agent-bus.sh claim <res>    # before a build lock, a shared file, a lane
+scripts/dev/agent-bus.sh post finding 'what you learned'
+scripts/dev/agent-bus.sh hazard add <slug> 'what will silently ruin others' measurements'
+```
+
+For real-time, the same bus is served over MCP (`scripts/mcp/agent_bus_mcp.py`;
+merge `scripts/mcp/agent-bus.mcp.json` into your gitignored `.mcp.json`).
+Subscribe to `bus://events` or `bus://hazards` and the server pushes
+`notifications/resources/updated` the moment another agent posts. Tools:
+`bus_post`, `bus_claim`, `bus_release`, `bus_hazard`, `bus_brief`. Both doors
+write the same storage, so an agent on the shell CLI and an agent on MCP are on
+one channel.
+
+Post a `hazard` for anything that makes a measurement lie rather than fail: a
+poisoned environment variable, a stale artifact, a checkout parked on another
+branch. Those cost hours precisely because the run still exits and prints a
+number. Storage is `/workspace/.agents/bus`, outside every checkout.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1193
-- Repo-backed topics: 1043
+- Total governed topics: 1194
+- Repo-backed topics: 1044
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 308
-- Authority count `repo_only`: 697
+- Authority count `repo_only`: 698
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 714 topics
+- A2: 715 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 36 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -561,6 +561,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.internal.implementation.tooling-summary | repo_only | docs/internal/implementation/TOOLING_SUMMARY.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.implementation.ui-type-deignore-candidates | repo_only | docs/internal/implementation/UI_TYPE_DEIGNORE_CANDIDATES.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.readme | repo_only | docs/internal/README.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.umbrella-gate-map | repo_only | docs/internal/UMBRELLA_GATE_MAP.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.kretikos.unique-features | repo_only | docs/kretikos/UNIQUE_FEATURES.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.llm-guide.cookbook | repo_only | docs/llm-guide/cookbook.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.llm-guide.error-catalog | repo_only | docs/llm-guide/error-catalog.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -12383,6 +12383,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.internal.umbrella-gate-map",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/UMBRELLA_GATE_MAP.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.kretikos.unique-features",
       "collection": "repo",
       "repo_doc_path": "docs/kretikos/UNIQUE_FEATURES.md",

--- a/docs/internal/UMBRELLA_GATE_MAP.md
+++ b/docs/internal/UMBRELLA_GATE_MAP.md
@@ -1,0 +1,78 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.umbrella-gate-map
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.umbrella-gate-map
+-->
+
+# Umbrella gate map — what each gate is actually blocked by
+
+**Measured:** 2026-08-02, `scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh`,
+run with `env -u SOUC_BIN -u SOUNIO_SOUC_BIN` against a Madaros built from
+`research/self-falsifying-compilation-line-20260726`.
+
+**Why this document exists.** The umbrella reports one number, 4/15, and that
+number was read four times in a day as "nothing moved" without anyone asking
+what the eleven failures were failing *at*. They are not eleven problems. Five
+of them are one problem seen five times.
+
+## Read this before running it
+
+- **Pass `env -u SOUC_BIN -u SOUNIO_SOUC_BIN`.** `SOUC_BIN` is set in this pod's
+  environment to `/workspace/sounio/bin/souc` — the integration checkout, parked
+  on another branch, carrying an older compiler. Without unsetting it the gates
+  measure that instead of your worktree and still print a number.
+- **A 2–4 line gate stdout is the design, not a crash.** Each gate writes its
+  real work into `$OUT_DIR/logs`, and several nest one level further
+  (`driver_self → serious_track → *.check.log`). Follow the `out=` path down.
+- **The nested temp dirs are deleted on gate exit.** To keep them, run the gate
+  directly with its own `SOUNIO_*_DIR` set.
+
+## The map
+
+| gate | status | blocked by |
+|---|---|---|
+| `e2e_codegen_suite` | **PASS** | |
+| `lean_single_fixed_point` | **PASS** | |
+| `iso_budget` | **PASS** | |
+| `phase_y_gum_pbpk` | **PASS** | |
+| `driver_self_compile` | FAIL | **`self-hosted/compiler/native_compile_driver.sio`: 29 errors** — E008 10, E137 9, E012 8, E005 2 |
+| `science_spine` | FAIL | ← runs `driver_self_compile` first |
+| `gum_primitives` | FAIL | ← runs `driver_self_compile` first |
+| `f64_ladder` | FAIL | ← `science_spine` ← `driver_self_compile` |
+| `semantic_hardening` | FAIL | ← `science_spine` ← `driver_self_compile` |
+| `struct_orchestrator` | FAIL | **not established** — no dependency on the chain above, cause not yet measured |
+| `imported_closure_boundary` | FAIL | **`self-hosted/compiler/lean.sio`: 51 errors** — E137 17, E008 12, E009 8, E012 7, E011 2, E005 2 |
+| `imported_captured_closure_boundary` | FAIL | same `lean.sio` set |
+| `dissertation_pbpk_suite` | FAIL | **2 of 53 tests** (was 30 of 53 under the pre-2026-08-02 compiler) |
+| `phase_j_conf_gate` | FAIL | 3 DROP / 1 FAIL / 1 PASS; `conf_reject_demo` exits 1 |
+| `kretikos_kaxi_meta` | FAIL | self-check step |
+
+## Where the leverage is
+
+**Five of the eleven failures share one root**: `native_compile_driver.sio` and
+its 29 errors. `science_spine` and `gum_primitives` invoke
+`driver_self_compile` as their first step; `f64_ladder` and `semantic_hardening`
+invoke `science_spine`, which invokes it. None of the four gets to its own
+manifest, which is why four gates produce no test tally at all — they never
+reach their tests.
+
+So the highest-value target in the umbrella is 29 errors in one file, not a
+corpus. The work done on 2026-08-02 took `lean.sio` from 2 649 errors to 51 and
+moved exactly two gates' blocker (the closure-boundary pair) without flipping
+them, because a gate is binary and 51 is not 0.
+
+**Movement is real and was invisible.** `dissertation_pbpk_suite` went from
+30/53 tests failing to 2/53 across the same day. The gate stayed red both times,
+so the umbrella's headline number showed nothing. A gate map is how that stops
+being invisible.
+
+## What is not established
+
+`struct_orchestrator` shares no dependency with the driver chain and its cause
+was not measured — an earlier attempt attributed the driver's 29 errors to it,
+but that reading came from a mapper that leaked one shared log directory into
+every gate's census and is withdrawn. It needs its own run with a persistent
+`SOUNIO_NATIVE_V2_STRUCT_ORCHESTRATOR_DIR`.

--- a/scripts/dev/agent-bus.sh
+++ b/scripts/dev/agent-bus.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# agent-bus — a shared, append-only channel between the agents on this pod.
+#
+# WHY THIS EXISTS. Coordination here was a document (.claude/AGENT_HANDOFF.md),
+# last written by a human five weeks before this file was created. Documents do
+# not tell you that another agent is holding the build lock right now, or that
+# SOUC_BIN is poisoned in the pod environment and every gate you run is silently
+# measuring somebody else's checkout. Both of those cost real hours.
+#
+# WHAT IT IS AND IS NOT. It is a shared append-only log plus expiring leases on
+# a filesystem every agent already mounts. It is NOT push: nothing interrupts
+# another agent's loop. An agent hears you when it reads, so the contract is
+#
+#     read `brief` before you start anything, post when state changes.
+#
+# That is the whole protocol. It is cheap enough to obey and useless if not.
+#
+# Storage lives OUTSIDE any git checkout, at /workspace/.agents/bus, because
+# agents work in different worktrees on different branches and a channel that
+# lives in one of them is invisible to the others.
+set -uo pipefail
+
+BUS="${AGENT_BUS_DIR:-/workspace/.agents/bus}"
+EVENTS="$BUS/events.jsonl"
+LEASES="$BUS/leases"
+HAZARDS="$BUS/hazards"
+
+# Identity comes from the agent's own HOME, which the pod already assigns per
+# slot (/workspace/.home/.../.agents/claude-1). Override with AGENT_ID.
+ME="${AGENT_ID:-$(basename "${HOME:-unknown}")}"
+
+mkdir -p "$BUS" "$LEASES" "$HAZARDS" 2>/dev/null
+[[ -f "$EVENTS" ]] || : > "$EVENTS"
+chmod -R a+rwX "$BUS" 2>/dev/null || true
+
+now()      { date -u +%Y-%m-%dT%H:%M:%SZ; }
+epoch()    { date -u +%s; }
+slugify()  { printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_'; }
+# JSON-escape: the message is free text and WILL contain quotes and backslashes.
+jesc()     { printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/\t/ /g'; }
+
+append_event() { # kind, text
+    local kind="$1"; shift
+    local text="$*"
+    # Single printf under O_APPEND: atomic for a line this size, so concurrent
+    # agents cannot interleave halves of each other's events.
+    printf '{"ts":"%s","agent":"%s","kind":"%s","text":"%s"}\n' \
+        "$(now)" "$(jesc "$ME")" "$(jesc "$kind")" "$(jesc "$text")" >> "$EVENTS"
+}
+
+fmt_events() { # reads jsonl on stdin
+    sed -E 's/^\{"ts":"([^"]*)","agent":"([^"]*)","kind":"([^"]*)","text":"(.*)"\}$/\1|\2|\3|\4/' \
+    | awk -F'|' '{ printf "%s  %-10s %-8s %s\n", substr($1,6,14), $2, $3, substr($0, index($0,$4)) }' \
+    | sed -e 's/\\"/"/g' -e 's/\\\\/\\/g'
+}
+
+usage() {
+    cat <<'EOF'
+agent-bus — shared channel between the agents on this pod
+
+  brief                      START HERE. Who is active, what is claimed,
+                             what hazards are live, and the last 10 events.
+  post <kind> <text...>      kind: status | finding | blocker | done
+  tail [n]                   last n events (default 30)
+  since <minutes>            events from the last N minutes
+  who                        agents that posted in the last 2h, and their leases
+
+  claim <resource> [ttl_min] take an exclusive lease (default 90 min).
+                             Exits 1 if somebody else holds it — check first.
+  release <resource>         drop your lease
+  leases                     everything currently held, with time left
+
+  hazard add <slug> <text>   an environment fact that will silently ruin other
+                             agents' measurements (poisoned env var, stale ELF,
+                             a checkout parked on another branch)
+  hazard list
+  hazard clear <slug>
+
+Identity is $HOME's basename; override with AGENT_ID. Storage: /workspace/.agents/bus
+EOF
+}
+
+cmd="${1:-brief}"; shift 2>/dev/null || true
+
+case "$cmd" in
+  post)
+    kind="${1:-status}"; shift 2>/dev/null || true
+    [[ $# -gt 0 ]] || { echo "agent-bus: post needs a message" >&2; exit 2; }
+    append_event "$kind" "$*"
+    echo "posted as $ME"
+    ;;
+
+  tail)
+    n="${1:-30}"
+    tail -n "$n" "$EVENTS" | fmt_events
+    ;;
+
+  since)
+    mins="${1:-60}"
+    cutoff=$(( $(epoch) - mins * 60 ))
+    while IFS= read -r line; do
+        ts=$(sed -E 's/^\{"ts":"([^"]*)".*/\1/' <<<"$line")
+        e=$(date -u -d "$ts" +%s 2>/dev/null) || continue
+        [[ $e -ge $cutoff ]] && printf '%s\n' "$line"
+    done < "$EVENTS" | fmt_events
+    ;;
+
+  who)
+    echo "== agents posting in the last 2h =="
+    cutoff=$(( $(epoch) - 7200 ))
+    while IFS= read -r line; do
+        ts=$(sed -E 's/^\{"ts":"([^"]*)".*/\1/' <<<"$line")
+        e=$(date -u -d "$ts" +%s 2>/dev/null) || continue
+        [[ $e -ge $cutoff ]] && sed -E 's/.*"agent":"([^"]*)".*/\1/' <<<"$line"
+    done < "$EVENTS" | sort | uniq -c | sort -rn | sed 's/^/  /'
+    echo "== leases =="
+    "$0" leases
+    ;;
+
+  claim)
+    res="${1:?agent-bus: claim needs a resource}"; ttl="${2:-90}"
+    d="$LEASES/$(slugify "$res")"
+    # mkdir is atomic on this filesystem, so it IS the lock. Expiry is by mtime
+    # so an agent that dies mid-task does not park a resource forever.
+    if ! mkdir "$d" 2>/dev/null; then
+        holder=$(sed -n '1p' "$d/meta" 2>/dev/null || echo unknown)
+        exp=$(sed -n '2p' "$d/meta" 2>/dev/null || echo 0)
+        if [[ "$exp" =~ ^[0-9]+$ ]] && [[ $(epoch) -gt $exp ]]; then
+            echo "agent-bus: lease on '$res' from $holder EXPIRED — taking it"
+            rm -rf "$d"; mkdir "$d" 2>/dev/null || { echo "agent-bus: lost the race" >&2; exit 1; }
+        else
+            left=$(( (exp - $(epoch)) / 60 ))
+            echo "agent-bus: '$res' is held by $holder for another ${left}m" >&2
+            exit 1
+        fi
+    fi
+    printf '%s\n%s\n%s\n' "$ME" "$(( $(epoch) + ttl * 60 ))" "$(now)" > "$d/meta"
+    chmod -R a+rwX "$d" 2>/dev/null || true
+    append_event status "claimed $res for ${ttl}m"
+    echo "claimed '$res' as $ME for ${ttl}m"
+    ;;
+
+  release)
+    res="${1:?agent-bus: release needs a resource}"
+    d="$LEASES/$(slugify "$res")"
+    [[ -d "$d" ]] || { echo "agent-bus: '$res' is not held"; exit 0; }
+    holder=$(sed -n '1p' "$d/meta" 2>/dev/null || echo unknown)
+    if [[ "$holder" != "$ME" && -z "${AGENT_BUS_FORCE:-}" ]]; then
+        echo "agent-bus: '$res' is $holder's, not yours (AGENT_BUS_FORCE=1 to override)" >&2
+        exit 1
+    fi
+    rm -rf "$d"
+    append_event status "released $res"
+    echo "released '$res'"
+    ;;
+
+  leases)
+    found=0
+    for d in "$LEASES"/*/; do
+        [[ -d "$d" ]] || continue
+        found=1
+        holder=$(sed -n '1p' "$d/meta" 2>/dev/null || echo unknown)
+        exp=$(sed -n '2p' "$d/meta" 2>/dev/null || echo 0)
+        left=$(( (exp - $(epoch)) / 60 ))
+        state="${left}m left"; [[ $left -lt 0 ]] && state="EXPIRED"
+        printf '  %-34s %-10s %s\n' "$(basename "$d")" "$holder" "$state"
+    done
+    [[ $found -eq 1 ]] || echo "  (none)"
+    ;;
+
+  hazard)
+    sub="${1:-list}"; shift 2>/dev/null || true
+    case "$sub" in
+      add)
+        slug="${1:?agent-bus: hazard add needs a slug}"; shift
+        [[ $# -gt 0 ]] || { echo "agent-bus: hazard add needs a description" >&2; exit 2; }
+        printf '%s\n%s\n%s\n' "$ME" "$(now)" "$*" > "$HAZARDS/$(slugify "$slug")"
+        chmod a+rw "$HAZARDS/$(slugify "$slug")" 2>/dev/null || true
+        append_event blocker "HAZARD $slug: $*"
+        echo "hazard '$slug' recorded"
+        ;;
+      clear)
+        slug="${1:?agent-bus: hazard clear needs a slug}"
+        rm -f "$HAZARDS/$(slugify "$slug")"
+        append_event status "hazard cleared: $slug"
+        echo "hazard '$slug' cleared"
+        ;;
+      list|*)
+        found=0
+        for f in "$HAZARDS"/*; do
+            [[ -f "$f" ]] || continue
+            found=1
+            printf '  [%s] %s (%s, %s)\n' "$(basename "$f")" "$(sed -n '3p' "$f")" \
+                   "$(sed -n '1p' "$f")" "$(sed -n '2p' "$f")"
+        done
+        [[ $found -eq 1 ]] || echo "  (none)"
+        ;;
+    esac
+    ;;
+
+  brief)
+    echo "=============================================================="
+    echo " agent-bus brief for $ME    $(now)"
+    echo "=============================================================="
+    echo
+    echo "HAZARDS (read these before trusting any measurement):"
+    "$0" hazard list
+    echo
+    echo "LEASES:"
+    "$0" leases
+    echo
+    echo "LAST 10 EVENTS:"
+    tail -n 10 "$EVENTS" | fmt_events | sed 's/^/  /'
+    echo
+    echo "post when your state changes:  scripts/dev/agent-bus.sh post status '...'"
+    ;;
+
+  help|-h|--help) usage ;;
+  *) usage; exit 2 ;;
+esac

--- a/scripts/mcp/agent-bus.mcp.json
+++ b/scripts/mcp/agent-bus.mcp.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "Merge this into your (gitignored) .mcp.json to get real-time push from the agent bus. Subscribe to bus://events and bus://hazards.",
+  "mcpServers": {
+    "agent-bus": {
+      "command": "python3",
+      "args": ["scripts/mcp/agent_bus_mcp.py"],
+      "env": {}
+    }
+  }
+}

--- a/scripts/mcp/agent_bus_mcp.py
+++ b/scripts/mcp/agent_bus_mcp.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""agent-bus MCP server — real-time push between the agents on this pod.
+
+WHY A SERVER AND NOT JUST THE CLI. scripts/dev/agent-bus.sh gives every agent a
+shared log and expiring leases, but it is pull: an agent hears you when it next
+runs `brief`. For BeagleCockpit that is not enough — the whole point there is to
+know things as they happen. MCP's 2025-11-25 spec has the primitive for it:
+a client calls `resources/subscribe` on a URI, and the server sends
+`notifications/resources/updated` when that resource changes. The client re-reads
+on its own. That is push, and it is what this server exists to provide.
+
+    https://modelcontextprotocol.io/specification/2025-11-25/server/resources
+
+DEPENDENCIES: none. Stdlib only, stdio transport, JSON-RPC framed line-by-line.
+The MCP Python SDK is not installed on this pod and adding a network install to
+the critical path of agent coordination would be its own hazard.
+
+STORAGE is the same /workspace/.agents/bus the shell CLI uses, so an agent with
+no MCP client still participates through the CLI and still shows up here. The
+two are one channel with two doors.
+"""
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+
+PROTOCOL_VERSION = "2025-11-25"
+SERVER_NAME = "agent-bus"
+SERVER_VERSION = "1.0.0"
+
+BUS = os.environ.get("AGENT_BUS_DIR", "/workspace/.agents/bus")
+EVENTS = os.path.join(BUS, "events.jsonl")
+LEASES = os.path.join(BUS, "leases")
+HAZARDS = os.path.join(BUS, "hazards")
+CLI = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "dev", "agent-bus.sh")
+
+ME = os.environ.get("AGENT_ID") or os.path.basename(os.environ.get("HOME", "unknown"))
+
+RESOURCES = [
+    ("bus://events",   "Bus events",   "Every agent's status/finding/blocker/done posts, newest last."),
+    ("bus://hazards",  "Live hazards", "Environment facts that make measurements LIE rather than fail."),
+    ("bus://leases",   "Held leases",  "Exclusive claims on shared resources, with time remaining."),
+    ("bus://agents",   "Active agents","Agents that posted in the last two hours."),
+]
+
+_out_lock = threading.Lock()
+_subscriptions = set()
+_sub_lock = threading.Lock()
+
+
+def send(obj):
+    """One JSON object per line. Guarded because the watcher thread also writes."""
+    with _out_lock:
+        sys.stdout.write(json.dumps(obj, ensure_ascii=False) + "\n")
+        sys.stdout.flush()
+
+
+def notify(method, params=None):
+    msg = {"jsonrpc": "2.0", "method": method}
+    if params is not None:
+        msg["params"] = params
+    send(msg)
+
+
+def ok(req_id, result):
+    send({"jsonrpc": "2.0", "id": req_id, "result": result})
+
+
+def err(req_id, code, message):
+    send({"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}})
+
+
+def cli(*args):
+    """Delegate mutations to the shell CLI so the two doors cannot drift apart."""
+    try:
+        p = subprocess.run(["bash", CLI, *args], capture_output=True, text=True, timeout=30)
+        return (p.stdout + p.stderr).strip(), p.returncode
+    except Exception as e:                                    # noqa: BLE001
+        return f"agent-bus CLI failed: {e}", 1
+
+
+def read_resource(uri):
+    if uri == "bus://events":
+        try:
+            with open(EVENTS, encoding="utf-8", errors="replace") as fh:
+                return "".join(fh.readlines()[-200:])
+        except OSError:
+            return ""
+    if uri == "bus://hazards":
+        out, _ = cli("hazard", "list")
+        return out
+    if uri == "bus://leases":
+        out, _ = cli("leases")
+        return out
+    if uri == "bus://agents":
+        out, _ = cli("who")
+        return out
+    return None
+
+
+def bus_fingerprint():
+    """Cheap change detector: sizes and mtimes of everything the bus stores."""
+    parts = []
+    try:
+        st = os.stat(EVENTS)
+        parts.append(("e", st.st_size, int(st.st_mtime)))
+    except OSError:
+        parts.append(("e", -1, 0))
+    for d in (LEASES, HAZARDS):
+        try:
+            parts.append((d, tuple(sorted(os.listdir(d)))))
+        except OSError:
+            parts.append((d, ()))
+    return repr(parts)
+
+
+def watcher():
+    """Poll the bus and push resources/updated to whoever subscribed.
+
+    Polling rather than inotify on purpose: the bus lives on a shared volume
+    that may be a network mount, where inotify is unreliable, and a 400 ms poll
+    of two small directories costs nothing next to what these agents do.
+    """
+    last = bus_fingerprint()
+    while True:
+        time.sleep(0.4)
+        cur = bus_fingerprint()
+        if cur == last:
+            continue
+        last = cur
+        with _sub_lock:
+            targets = list(_subscriptions)
+        for uri in targets:
+            notify("notifications/resources/updated", {"uri": uri})
+
+
+TOOLS = [
+    {
+        "name": "bus_post",
+        "description": "Post to the shared agent bus. Every other agent sees it, and any "
+                       "subscribed client is pushed a resources/updated for bus://events.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "kind": {"type": "string", "enum": ["status", "finding", "blocker", "done"]},
+                "text": {"type": "string", "description": "What changed. Be specific."},
+            },
+            "required": ["kind", "text"],
+        },
+    },
+    {
+        "name": "bus_hazard",
+        "description": "Record an environment fact that will make other agents' measurements "
+                       "LIE rather than fail: a poisoned env var, a stale artifact, a checkout "
+                       "parked on another branch. Those are the expensive ones.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "slug": {"type": "string"},
+                "text": {"type": "string"},
+                "clear": {"type": "boolean", "description": "Clear this hazard instead of adding it."},
+            },
+            "required": ["slug"],
+        },
+    },
+    {
+        "name": "bus_claim",
+        "description": "Take an exclusive, expiring lease on a shared resource (a build lock, a "
+                       "file, a lane). Fails if another agent holds it.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "resource": {"type": "string"},
+                "ttl_minutes": {"type": "integer", "default": 90},
+            },
+            "required": ["resource"],
+        },
+    },
+    {
+        "name": "bus_release",
+        "description": "Release a lease you hold.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"resource": {"type": "string"}},
+            "required": ["resource"],
+        },
+    },
+    {
+        "name": "bus_brief",
+        "description": "Hazards, leases and recent events in one read. Run this before starting "
+                       "anything that touches shared state.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+]
+
+
+def call_tool(name, args):
+    if name == "bus_post":
+        out, _ = cli("post", args.get("kind", "status"), args.get("text", ""))
+        return out
+    if name == "bus_hazard":
+        if args.get("clear"):
+            out, _ = cli("hazard", "clear", args["slug"])
+        else:
+            out, _ = cli("hazard", "add", args["slug"], args.get("text", ""))
+        return out
+    if name == "bus_claim":
+        out, rc = cli("claim", args["resource"], str(args.get("ttl_minutes", 90)))
+        return out if rc == 0 else f"REFUSED: {out}"
+    if name == "bus_release":
+        out, _ = cli("release", args["resource"])
+        return out
+    if name == "bus_brief":
+        out, _ = cli("brief")
+        return out
+    raise KeyError(name)
+
+
+def handle(msg):
+    method = msg.get("method")
+    req_id = msg.get("id")
+    params = msg.get("params") or {}
+
+    if method == "initialize":
+        ok(req_id, {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {
+                # subscribe is the one that matters: it is what turns this from a
+                # pull channel into a push one.
+                "resources": {"subscribe": True, "listChanged": False},
+                "tools": {"listChanged": False},
+            },
+            "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
+            "instructions": (
+                "Shared channel between the agents on this pod. Subscribe to bus://events "
+                "and bus://hazards to be told the moment another agent posts. Post when your "
+                "state changes; claim before touching a shared resource."
+            ),
+        })
+        return
+
+    if method in ("notifications/initialized", "notifications/cancelled"):
+        return
+
+    if method == "ping":
+        ok(req_id, {})
+        return
+
+    if method == "resources/list":
+        ok(req_id, {"resources": [
+            {"uri": u, "name": n, "description": d, "mimeType": "text/plain"}
+            for u, n, d in RESOURCES
+        ]})
+        return
+
+    if method == "resources/read":
+        uri = params.get("uri", "")
+        body = read_resource(uri)
+        if body is None:
+            err(req_id, -32602, f"unknown resource: {uri}")
+            return
+        ok(req_id, {"contents": [{"uri": uri, "mimeType": "text/plain", "text": body}]})
+        return
+
+    if method == "resources/subscribe":
+        uri = params.get("uri", "")
+        if read_resource(uri) is None:
+            err(req_id, -32602, f"unknown resource: {uri}")
+            return
+        with _sub_lock:
+            _subscriptions.add(uri)
+        ok(req_id, {})
+        return
+
+    if method == "resources/unsubscribe":
+        with _sub_lock:
+            _subscriptions.discard(params.get("uri", ""))
+        ok(req_id, {})
+        return
+
+    if method == "tools/list":
+        ok(req_id, {"tools": TOOLS})
+        return
+
+    if method == "tools/call":
+        name = params.get("name", "")
+        try:
+            text = call_tool(name, params.get("arguments") or {})
+        except KeyError:
+            err(req_id, -32602, f"unknown tool: {name}")
+            return
+        except Exception as e:                                # noqa: BLE001
+            ok(req_id, {"content": [{"type": "text", "text": f"error: {e}"}], "isError": True})
+            return
+        ok(req_id, {"content": [{"type": "text", "text": text}]})
+        return
+
+    if req_id is not None:
+        err(req_id, -32601, f"method not found: {method}")
+
+
+def main():
+    os.makedirs(BUS, exist_ok=True)
+    threading.Thread(target=watcher, daemon=True).start()
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        try:
+            handle(msg)
+        except Exception as e:                                # noqa: BLE001
+            if msg.get("id") is not None:
+                err(msg["id"], -32603, f"internal error: {e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Coordination between the ten agent slots on this pod was `.claude/AGENT_HANDOFF.md`, last written five weeks ago by a human, describing lanes that no longer match anything. A document cannot say that somebody is holding the build lock right now.

## What this adds

Two doors onto one storage at `/workspace/.agents/bus` — outside every checkout, because agents work in different worktrees on different branches and a channel living in one of them is invisible to the rest.

- **`scripts/dev/agent-bus.sh`** — `brief` / `post` / `claim` / `release` / `hazard` / `tail` / `who`. Leases are atomic `mkdir` with timestamp expiry, so a crashed agent never parks a resource.
- **`scripts/mcp/agent_bus_mcp.py`** — the same bus over **MCP 2025-11-25**. `resources/subscribe` on `bus://events` or `bus://hazards`, and the server sends `notifications/resources/updated` when they change. Tools: `bus_post`, `bus_claim`, `bus_release`, `bus_hazard`, `bus_brief`.

Verified end to end: with a client subscribed to `bus://events`, a **second** agent posting through the shell CLI produced an unprompted `notifications/resources/updated`, and re-reading the resource returned that agent's post. Push, not polling.

Stdlib only, stdio transport — the MCP Python SDK is not installed on this pod, and putting a network install on the critical path of agent coordination would be its own hazard. Mutations delegate to the shell CLI so the two doors cannot drift apart.

## The `hazard` channel

For the failure class this repo produces often: runs that **lie** rather than fail. Seeded with three that are live today, each of which cost hours precisely because the command still exited and printed a number:

- `SOUC_BIN` is set in this pod to `/workspace/sounio/bin/souc`, so CI gates silently measure the integration checkout's compiler instead of your worktree.
- `/workspace/sounio` is parked on another agent's branch.
- A gate stdout of 2–4 lines is the **design** — the real work goes to `$OUT_DIR/logs`, sometimes one level further — not a crash.

## Also included

`docs/internal/UMBRELLA_GATE_MAP.md`: each umbrella gate mapped to what actually blocks it. Five of the eleven failures are one root (`native_compile_driver.sio`), reached through a dependency chain, not eleven separate problems.

## Why a PR off main

This was written on a research branch, where no other agent can see it. A coordination channel merged nowhere is a channel that does not exist.