### PR TITLE
feat(wasm): source-fresh Madaros backend closure

### DIFF
--- a/bin/madaros
+++ b/bin/madaros
@@ -12,7 +12,7 @@
 #   madaros --version
 #   madaros info
 #   madaros check input.sio
-#   madaros build input.sio [-o OUT] [--backend native|gpu]
+#   madaros build input.sio [-o OUT] [--backend native|gpu|wasm]
 #   madaros run input.sio
 #   madaros pkg ...
 #
@@ -75,8 +75,8 @@ Usage:
   madaros info                          print resolution path
   madaros check <source.sio|project-dir>
                                       parse, resolve and typecheck
-  madaros build <source.sio|project-dir> [-o OUT] [--backend native|gpu]
-                                      compile source to native ELF or GPU artifact
+  madaros build <source.sio|project-dir> [-o OUT] [--backend native|gpu|wasm]
+                                      compile source to native ELF, GPU, or WebAssembly
   madaros compile <source.sio|project-dir> [-o OUT]
                                       alias for build
   madaros run <source.sio|project-dir>
@@ -91,6 +91,9 @@ Common modular-compiler modes:
   madaros --native-v2-emit-scalar N     emit a scalar witness
   madaros --version-json                emit version metadata
   madaros pkg ...                       package manager commands
+
+WebAssembly build options:
+  --backend wasm                        emit a WebAssembly module
 
 GPU build options:
   --backend gpu                         emit PTX via the public GPU build path
@@ -465,7 +468,7 @@ _parse_build_options() {
         ;;
       --backend)
         if [[ $# -lt 2 ]]; then
-          echo "error: madaros build: --backend requires native or gpu" >&2
+          echo "error: madaros build: --backend requires native, gpu, or wasm" >&2
           return 2
         fi
         BUILD_BACKEND="$2"
@@ -510,7 +513,7 @@ _parse_build_options() {
   done
   case "$BUILD_BACKEND" in
     native|"") BUILD_BACKEND="native" ;;
-    gpu) ;;
+    gpu|wasm) ;;
     *)
       echo "error: madaros build: unsupported backend: $BUILD_BACKEND" >&2
       return 2
@@ -521,6 +524,22 @@ _parse_build_options() {
 _compile_source_to_artifact() {
   local src="$1"
   local out="$2"
+  if [[ "$BUILD_BACKEND" == "wasm" ]]; then
+    # Guard: bounded vmem + 300 s timeout. The modular compiler owns lowering;
+    # the launcher verifies that the claimed artifact is actually WebAssembly.
+    ( ulimit -v "$MADAROS_VMEM_LIMIT_KB" 2>/dev/null || true; exec timeout 300 "$RAW_MADAROS" "$src" -t wasm -o "$out" )
+    if [[ ! -s "$out" ]]; then
+      echo "error: madaros build: compiler produced no WASM artifact at $out" >&2
+      return 1
+    fi
+    local wasm_magic
+    wasm_magic="$(od -An -tx1 -N4 "$out" 2>/dev/null | tr -d '[:space:]')"
+    if [[ "$wasm_magic" != "0061736d" ]]; then
+      echo "error: madaros build: invalid WASM magic at $out" >&2
+      return 1
+    fi
+    return 0
+  fi
   if [[ "$BUILD_BACKEND" == "gpu" ]]; then
     local gpu_args=("$src" -o "$out" --gpu-target "$BUILD_GPU_TARGET")
     if [[ -n "$BUILD_GPU_BINARY_FORMAT" ]]; then

--- a/bin/souc
+++ b/bin/souc
@@ -133,6 +133,8 @@ Usage:
                                       compile source to a native ELF
   souc build <file.sio> --backend gpu -o OUT
                                       emit a public GPU artifact (PTX by default)
+  souc build <file.sio> --backend wasm -o OUT
+                                      emit a WebAssembly module
   souc run <file.sio|project-dir>     run source (compile to a temp ELF and execute)
   souc init <name>                    create a minimal sounio.toml project
   souc format <file.sio>              format Sounio source on stdout

--- a/scripts/ci/bootstrap_chain_gate.sh
+++ b/scripts/ci/bootstrap_chain_gate.sh
@@ -62,12 +62,52 @@ else
 fi
 
 # ── S6: Memory usage < 100MB ────────────────────────────────────────────────
-mem_kb=$(/usr/bin/time -v "$TMPDIR/stage0" bootstrap/boot1.sio "$TMPDIR/boot1_mem.elf" 2>&1 | grep "Maximum resident" | awk '{print $NF}')
-if [ -n "$mem_kb" ] && [ "$mem_kb" -lt 102400 ]; then
-    echo "PASS  S6  stage0 memory ${mem_kb}KB < 100MB"
+# Capture ru_maxrss directly so the gate does not depend on GNU /usr/bin/time.
+cat > "$TMPDIR/maxrss.c" << 'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+    if (argc < 2) return 2;
+    pid_t pid = fork();
+    if (pid < 0) return 3;
+    if (pid == 0) {
+        execv(argv[1], &argv[1]);
+        _exit(127);
+    }
+    int status = 0;
+    struct rusage usage;
+    if (wait4(pid, &status, 0, &usage) < 0) return 4;
+    long maxrss_kb = usage.ru_maxrss;
+#if defined(__APPLE__)
+    maxrss_kb /= 1024;
+#endif
+    printf("%ld\n", maxrss_kb);
+    if (WIFEXITED(status)) return WEXITSTATUS(status);
+    if (WIFSIGNALED(status)) return 128 + WTERMSIG(status);
+    return 5;
+}
+EOF
+
+mem_kb=""
+if cc -O2 -o "$TMPDIR/maxrss" "$TMPDIR/maxrss.c" 2>/dev/null; then
+    set +e
+    mem_kb=$("$TMPDIR/maxrss" "$TMPDIR/stage0" bootstrap/boot1.sio "$TMPDIR/boot1_mem.elf" 2>/dev/null)
+    mem_rc=$?
+    set -e
+else
+    mem_rc=1
+fi
+
+if [ "$mem_rc" -eq 0 ] && [ -n "$mem_kb" ] && [ "$mem_kb" -lt 102400 ]; then
+    echo "PASS  S6  stage0 peak RSS ${mem_kb}KB < 100MB"
     pass=$((pass+1))
 else
-    echo "FAIL  S6  stage0 memory ${mem_kb}KB >= 100MB"
+    echo "FAIL  S6  stage0 peak RSS '${mem_kb}'KB (runner exit $mem_rc)"
     fail=$((fail+1))
 fi
 

--- a/scripts/ci/build_modular_madaros.sh
+++ b/scripts/ci/build_modular_madaros.sh
@@ -18,10 +18,12 @@
 # scripts/dev/souc-build-lock.sh so multiple agents do not stampede the workspace pod.
 #
 # Environment:
-#   SOUC_BIN / SOUNIO_SOUC_BIN — override the bootstrap ELF. If it already points at
-#                                a fresh source-tracking seed (e.g. a gen3.elf from
-#                                `make build`), it is used directly for main.sio with
-#                                no extra lean_single derivation.
+#   SOUC_BIN / SOUNIO_SOUC_BIN — override the bootstrap ELF used only when a
+#                                source-tracking seed must be derived.
+#   SOUNIO_MADAROS_SEED        — pin the exact executable used to compile main.sio.
+#   SOUNIO_MADAROS_REQUIRE_PINNED_SEED=1
+#                              — fail instead of deriving a replacement if the
+#                                explicitly pinned seed cannot build main.sio.
 #   SOUNIO_STDLIB_PATH         — forwarded to the seed compiler
 #   SOUNIO_BUILD_LOCK          — override the global build lock path
 
@@ -70,6 +72,7 @@ fi
 mkdir -p "$(dirname "$OUT")"
 rm -f "$OUT"
 
+BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/madaros-build.XXXXXX.log")"
 # Derive a source-tracking seed. If SOUC_BIN/SOUNIO_SOUC_BIN was explicitly set we
 # trust it as an already-fresh seed (e.g. a gen3.elf) and use it directly. Otherwise
 # the bootstrap ELF is a committed binary that may lag the source, so we first
@@ -77,6 +80,7 @@ rm -f "$OUT"
 # current source's features (arena/vmem #719 etc.), then compile main.sio with that.
 TMP_SEED_DIR=""
 cleanup() {
+    rm -f "$BUILD_LOG"
     if [[ -n "$TMP_SEED_DIR" && -d "$TMP_SEED_DIR" ]]; then
         rm -rf "$TMP_SEED_DIR"
     fi
@@ -133,6 +137,21 @@ echo "  seed:  $SEED"
 echo "  src:   $SRC"
 echo "  out:   $OUT"
 
+run_seed_build() {
+    local seed="$1"
+    rm -f "$BUILD_LOG"
+    set +e
+    scripts/dev/souc-build-lock.sh "$seed" "$SRC" "$OUT" >"$BUILD_LOG" 2>&1
+    local rc=$?
+    set -e
+    cat "$BUILD_LOG"
+    if grep -Eq '^(error(\[[^]]+\])?:|Error:)' "$BUILD_LOG"; then
+        echo "error: modular compiler emitted an error diagnostic despite exit $rc" >&2
+        return 86
+    fi
+    return "$rc"
+}
+
 # Serialize heavy build via the global workspace lock.
 #
 # `|| true` so a seed that crashes is diagnosed here rather than aborting under
@@ -140,13 +159,17 @@ echo "  out:   $OUT"
 # useful response is to say which seed died and try a good one — not to hand the
 # caller a bare exit 139.
 set +e
-scripts/dev/souc-build-lock.sh "$SEED" "$SRC" "$OUT"
-BUILD_RC=$?
+run_seed_build "$SEED"; BUILD_RC=$?
 set -e
 
 if [[ "$BUILD_RC" -ne 0 || ! -s "$OUT" ]]; then
     echo "warning: seed failed to build the compiler (exit $BUILD_RC, output $([[ -s "$OUT" ]] && echo present || echo absent))" >&2
     echo "warning:   seed was: $SEED" >&2
+    if [[ "${PINNED_SEED:-0}" == "1" &&
+          "${SOUNIO_MADAROS_REQUIRE_PINNED_SEED:-0}" == "1" ]]; then
+        echo "error: pinned seed is required; refusing automatic seed derivation" >&2
+        exit 1
+    fi
     if [[ "${PINNED_SEED:-0}" == "1" && -f "$LEAN_SRC" ]]; then
         # A pinned seed that cannot compile main.sio is stale, not fatal: derive a
         # fresh one from lean_single.sio and retry once. This is the exact recovery
@@ -162,8 +185,7 @@ if [[ "$BUILD_RC" -ne 0 || ! -s "$OUT" ]]; then
         chmod +x "$SEED"
         rm -f "$OUT"
         set +e
-        scripts/dev/souc-build-lock.sh "$SEED" "$SRC" "$OUT"
-        BUILD_RC=$?
+        run_seed_build "$SEED"; BUILD_RC=$?
         set -e
     fi
 fi

--- a/scripts/ci/item_kind_dispatch_gate.mjs
+++ b/scripts/ci/item_kind_dispatch_gate.mjs
@@ -1,0 +1,47 @@
+import {readFileSync} from 'node:fs';
+
+const ast = readFileSync('self-hosted/parser/ast.sio', 'utf8');
+const checker = readFileSync('self-hosted/check/check.sio', 'utf8');
+const enumBlock = ast.match(/pub enum ItemKind\s*\{([\s\S]*?)\n\}/);
+const dispatchBlock = checker.match(
+  /fn check_item\(self, item: Item\)[\s\S]*?match item\.kind\s*\{([\s\S]*?)\n\s*\}\n\s*\}/,
+);
+
+if (!enumBlock || !dispatchBlock) {
+  throw new Error('unable to locate ItemKind declaration or Checker.check_item');
+}
+
+const variants = enumBlock[1]
+  .split('\n')
+  .map((line) => line.replace(/\/\/.*$/, '').replace(/,$/, '').trim())
+  .filter((line) => /^Item[A-Za-z0-9_]+$/.test(line));
+const dispatched = [
+  ...dispatchBlock[1].matchAll(/ItemKind::(Item[A-Za-z0-9_]+)/g),
+].map((match) => match[1]);
+const declared = new Set(variants);
+const seen = new Set(dispatched);
+const missing = variants.filter((variant) => !seen.has(variant));
+const unknown = dispatched.filter((variant) => !declared.has(variant));
+const duplicates = dispatched.filter(
+  (variant, index) => dispatched.indexOf(variant) !== index,
+);
+const hasDefensiveArm = /^\s*_\s*=>/m.test(dispatchBlock[1]);
+const verified =
+  variants.length > 0 &&
+  missing.length === 0 &&
+  unknown.length === 0 &&
+  duplicates.length === 0 &&
+  hasDefensiveArm;
+
+process.stdout.write(`${JSON.stringify({
+  schema: 'sounio.item-kind-dispatch-coverage.v1',
+  declaredCount: variants.length,
+  dispatchedCount: dispatched.length,
+  missing,
+  unknown,
+  duplicates,
+  hasDefensiveArm,
+  verified,
+}, null, 2)}\n`);
+
+if (!verified) process.exitCode = 1;

--- a/scripts/ci/madaros_version_json_gate.mjs
+++ b/scripts/ci/madaros_version_json_gate.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { accessSync, constants } from "node:fs";
+
+const compiler = process.argv[2];
+if (!compiler) {
+  console.error("usage: madaros_version_json_gate.mjs <compiler>");
+  process.exit(2);
+}
+
+try {
+  accessSync(compiler, constants.X_OK);
+} catch {
+  console.error(`compiler is not executable: ${compiler}`);
+  process.exit(2);
+}
+
+const run = spawnSync(compiler, ["--version-json"], {
+  encoding: "utf8",
+  timeout: 30_000,
+});
+
+if (run.error || run.status !== 0) {
+  console.error(run.error?.message ?? run.stderr.trim());
+  process.exit(run.status ?? 1);
+}
+
+const raw = run.stdout.trim();
+let parsed;
+try {
+  parsed = JSON.parse(raw);
+} catch (error) {
+  console.error(`invalid version JSON: ${error.message}`);
+  console.error(raw);
+  process.exit(1);
+}
+
+const expected = {
+  abi_version: 1,
+  runtime_version: "1.0.0",
+  ir_max_funcs: 1024,
+  ir_max_instrs: 128,
+  supports_ffi: true,
+  supports_gpu: false,
+};
+
+const mismatches = Object.entries(expected)
+  .filter(([key, value]) => parsed[key] !== value)
+  .map(([key, value]) => ({ key, expected: value, actual: parsed[key] }));
+
+const report = {
+  schema: "sounio.madaros-version-json-gate.v1",
+  compiler,
+  parsed,
+  mismatches,
+  verified: mismatches.length === 0,
+};
+
+console.log(JSON.stringify(report));
+process.exit(report.verified ? 0 : 1);

--- a/scripts/ci/madaros_wasm_backend_gate.mjs
+++ b/scripts/ci/madaros_wasm_backend_gate.mjs
@@ -1,0 +1,43 @@
+import {readFile} from 'node:fs/promises';
+
+const artifactPath = process.argv[2];
+if (!artifactPath) {
+  throw new Error('usage: node scripts/ci/madaros_wasm_backend_gate.mjs <artifact.wasm>');
+}
+
+const bytes = await readFile(artifactPath);
+if (bytes.length < 8) {
+  throw new Error(`WASM artifact is too small: ${bytes.length}`);
+}
+if (!bytes.subarray(0, 4).equals(Buffer.from([0x00, 0x61, 0x73, 0x6d]))) {
+  throw new Error('WASM artifact has an invalid magic header');
+}
+if (!WebAssembly.validate(bytes)) {
+  throw new Error('WebAssembly.validate rejected the artifact');
+}
+
+const module = await WebAssembly.compile(bytes);
+const imports = WebAssembly.Module.imports(module);
+if (imports.length !== 0) {
+  throw new Error(`fixture unexpectedly requires ${imports.length} host import(s)`);
+}
+
+const instance = await WebAssembly.instantiate(module, {});
+const exportedMain = instance.exports.main;
+if (typeof exportedMain !== 'function') {
+  throw new Error('WASM artifact does not export main');
+}
+const result = exportedMain();
+if (result !== 3n) {
+  throw new Error(`WASM main returned ${String(result)} instead of 3`);
+}
+
+const exports = WebAssembly.Module.exports(module).map((entry) => entry.name).sort();
+process.stdout.write(`${JSON.stringify({
+  schema: 'sounio.madaros-wasm-backend-gate.v1',
+  artifactBytes: bytes.length,
+  imports: [],
+  exports,
+  mainResult: String(result),
+  validated: true,
+}, null, 2)}\n`);

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -18306,6 +18306,8 @@ impl Checker {
             ItemKind::ItemAlgebra => self  // Already handled in collect pass
             ItemKind::ItemStudy => self  // Already handled in collect pass
             ItemKind::ItemOntology => self  // Already handled in collect pass
+            ItemKind::ItemClaim => self  // Claim metadata is removed before checking
+            _ => self  // Structural gate requires every declared variant above.
         }
     }
 

--- a/self-hosted/compiler/module_native_driver.sio
+++ b/self-hosted/compiler/module_native_driver.sio
@@ -17,6 +17,7 @@ use native::codegen_x86_linux::{
 }
 use module_frontend::{imported_simple_ir_global_fn_count, imported_simple_ir_global_fn_kind, imported_simple_ir_global_fn_name_hash, imported_simple_ir_global_fn_target_hash, imported_simple_ir_global_fn_value, load_multimodule_ir, load_multimodule_imported_simple_ir_global, module_frontend_compile_imported_to_file, module_frontend_eval_imported_main_i64, module_frontend_file_maybe_has_use}
 use io::env::{read_env}
+use wasm::lower::{wasm_lower_module_to_file}
 use module_native_streaming::{compile_multimodule_native_maybe_streaming}
 
 fn native_driver_print_dispatch(
@@ -1225,10 +1226,12 @@ pub fn compile_multimodule_native_with_ir(
     gpu_strict_parity: bool
 ) -> i32 with IO, Mut, Div, Panic, Alloc {
     if str_eq(requested_target, "wasm") {
-        print("WASM backend is not yet split into module_native_driver: ")
+        print("WASM dispatch: source=")
         print(main_path)
+        print(" output=")
+        print(output_path)
         print("\n")
-        return 1
+        return wasm_lower_module_to_file(preloaded_ir, output_path)
     }
 
     let target_spec = native_resolve_target(requested_target, requested_matrix, explicit_target)

--- a/self-hosted/io/file_write.sio
+++ b/self-hosted/io/file_write.sio
@@ -449,6 +449,42 @@ fn io_write_kernel_response_json(path: string, resp: KernelResponse) -> bool wit
     io_write_bytes_to_file(path, buf, p)
 }
 
+// Append numeric metadata directly into the caller-owned buffer. Returning a
+// string backed by a local byte array would leave the generated code holding a
+// dead stack address after this helper returns.
+fn io_version_append_i64(buf: [i8; 65536], pos: i64, v: i64) -> ([i8; 65536], i64) with Mut, Panic, Div {
+    var out = buf
+    var p = pos
+    if v == 0 {
+        out[p as usize] = 48 as i8
+        return (out, p + 1)
+    }
+
+    var n = v
+    if n < 0 {
+        out[p as usize] = 45 as i8
+        p = p + 1
+        n = 0 - n
+    }
+
+    var rev: [i8; 32] = [0; 32]
+    var rev_len: i64 = 0
+    while n > 0 && rev_len < 31 {
+        rev[rev_len as usize] = (48 + (n % 10)) as i8
+        rev_len = rev_len + 1
+        n = n / 10
+    }
+
+    var i = rev_len - 1
+    while i >= 0 {
+        out[p as usize] = rev[i as usize]
+        p = p + 1
+        if i == 0 { break }
+        i = i - 1
+    }
+    (out, p)
+}
+
 fn io_write_version_json(path: string) -> bool with IO, Mut, Panic, Div {
     var buf: [i8; 65536] = [0; 65536]
     var p: i64 = 0
@@ -456,21 +492,21 @@ fn io_write_version_json(path: string) -> bool with IO, Mut, Panic, Div {
     buf = p0.0; p = p0.1
     let p1 = io_trace_append_string(buf, p, "\"abi_version\":")
     buf = p1.0; p = p1.1
-    let p2 = io_trace_append_string(buf, p, io_trace_i64_string(SOUNIO_ABI_VERSION))
+    let p2 = io_version_append_i64(buf, p, SOUNIO_ABI_VERSION)
     buf = p2.0; p = p2.1
     let p3 = io_trace_append_string(buf, p, ",")
     buf = p3.0; p = p3.1
     let p4 = io_trace_append_string(buf, p, "\"runtime_version\":\"")
     buf = p4.0; p = p4.1
-    let p5 = io_trace_append_string(buf, p, io_trace_i64_string(SOUNIO_RUNTIME_VERSION_MAJOR))
+    let p5 = io_version_append_i64(buf, p, SOUNIO_RUNTIME_VERSION_MAJOR)
     buf = p5.0; p = p5.1
     let p6 = io_trace_append_string(buf, p, ".")
     buf = p6.0; p = p6.1
-    let p7 = io_trace_append_string(buf, p, io_trace_i64_string(SOUNIO_RUNTIME_VERSION_MINOR))
+    let p7 = io_version_append_i64(buf, p, SOUNIO_RUNTIME_VERSION_MINOR)
     buf = p7.0; p = p7.1
     let p8 = io_trace_append_string(buf, p, ".")
     buf = p8.0; p = p8.1
-    let p9 = io_trace_append_string(buf, p, io_trace_i64_string(SOUNIO_RUNTIME_VERSION_PATCH))
+    let p9 = io_version_append_i64(buf, p, SOUNIO_RUNTIME_VERSION_PATCH)
     buf = p9.0; p = p9.1
     let p10 = io_trace_append_string(buf, p, "\",")
     buf = p10.0; p = p10.1

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -1871,6 +1871,7 @@ fn lowerer_preseed_external_items_into_acc_mut(
                                                 name: (*flist).head.name,
                                                 index: fc,
                                                 is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_integer(&(*flist).head.ty) { 3 } else { 0 },
+                                                elem_type_name: lower_type_expr_array_elem_name(&(*flist).head.ty),
                                             }
                                             fc = fc + 1
                                             fcur = (*flist).tail

--- a/self-hosted/resolve/imports.sio
+++ b/self-hosted/resolve/imports.sio
@@ -282,6 +282,7 @@ fn collect_module_exports_item(
         ItemKind::ItemImpl => (exports, count)
         ItemKind::ItemUse => (exports, count)
         ItemKind::ItemUnit => (exports, count)
+        ItemKind::ItemClaim => (exports, count)
     }
 }
 

--- a/self-hosted/wasm/lower.sio
+++ b/self-hosted/wasm/lower.sio
@@ -61,6 +61,8 @@ struct WasmLowerCtx {
     loop_labels: [i64; 512],    // loop_labels[label_id] = 1 if backward-jump target
     loop_exit: [i64; 512],      // loop_exit[loop_lid] = exit_lid  (-1 = none found)
     is_loop_exit: [i64; 512],   // is_loop_exit[exit_lid] = loop_lid (-1 = not an exit)
+    forward_labels: [i64; 512], // labels targeted by a forward branch
+    preopened_labels: [i64; 512], // acyclic target blocks opened before lowering
     local_count: i64,
     func_map: [i64; 256],
     func_count: i64,
@@ -86,6 +88,8 @@ fn wasm_lower_ctx_new() -> WasmLowerCtx {
         out.loop_labels[i as usize] = 0
         out.loop_exit[i as usize] = 0 - 1
         out.is_loop_exit[i as usize] = 0 - 1
+        out.forward_labels[i as usize] = 0
+        out.preopened_labels[i as usize] = 0
         out.string_offsets[i as usize] = 0 - 1
         i = i + 1
     }
@@ -109,6 +113,8 @@ fn wasm_lower_ctx_reset_body(ctx: WasmLowerCtx) -> WasmLowerCtx with Mut, Panic,
         out.loop_labels[i as usize] = 0
         out.loop_exit[i as usize] = 0 - 1
         out.is_loop_exit[i as usize] = 0 - 1
+        out.forward_labels[i as usize] = 0
+        out.preopened_labels[i as usize] = 0
         i = i + 1
     }
     out
@@ -243,6 +249,8 @@ fn wasm_lower_detect_loops(ctx: WasmLowerCtx, func: IrFunction) -> WasmLowerCtx 
         out.loop_labels[j as usize] = 0
         out.loop_exit[j as usize] = 0 - 1
         out.is_loop_exit[j as usize] = 0 - 1
+        out.forward_labels[j as usize] = 0
+        out.preopened_labels[j as usize] = 0
         j = j + 1
     }
 
@@ -317,9 +325,51 @@ fn wasm_lower_detect_loops(ctx: WasmLowerCtx, func: IrFunction) -> WasmLowerCtx 
                         k = k + 1
                     }
                 }
+            } else if lpos > i {
+                out.forward_labels[tgt as usize] = 1
             }
         }
         i = i + 1
+    }
+    out
+}
+
+// In an acyclic function, open every forward target block before its first
+// branch. Farthest targets are opened first so nearer targets sit on top of the
+// WASM label stack and close in lexical order.
+fn wasm_lower_preopen_acyclic_forward_blocks(
+    ctx: WasmLowerCtx,
+    func: IrFunction
+) -> WasmLowerCtx with Mut, Panic, Div {
+    var out = ctx
+    var lid: i64 = 0
+    while lid < WASM_LOWER_MAX_LOCALS {
+        if out.loop_labels[lid as usize] == 1 {
+            return out
+        }
+        lid = lid + 1
+    }
+
+    var i: i64 = func.instr_count - 1
+    while i >= 0 && out.error_count == 0 {
+        let instr = func.instrs[i as usize]
+        match instr.op {
+            IrOpcode::IrLabel => {
+                let target = instr.label_id
+                if target >= 0 && target < WASM_LOWER_MAX_LOCALS &&
+                   out.forward_labels[target as usize] == 1 {
+                    if out.label_depth >= WASM_LOWER_MAX_LABELS {
+                        out.error_count = out.error_count + 1
+                    } else {
+                        out.body = wasm_body_emit_block(out.body, WASM_BLOCK_VOID)
+                        out = wasm_lower_push_label(out, target, WASM_LABEL_BLOCK)
+                        out.preopened_labels[target as usize] = 1
+                    }
+                }
+            }
+            _ => {}
+        }
+        i = i - 1
     }
     out
 }
@@ -687,7 +737,7 @@ fn wasm_lower_jump(ctx: WasmLowerCtx, instr: IrInstr) -> WasmLowerCtx with Mut, 
     if depth >= 0 {
         out.body = wasm_body_emit_br(out.body, depth)
     } else {
-        // Label not found on stack; emit unreachable as fallback
+        out.error_count = out.error_count + 1
         out.body = wasm_body_emit_unreachable(out.body)
     }
     out
@@ -705,6 +755,9 @@ fn wasm_lower_branch_true(ctx: WasmLowerCtx, instr: IrInstr) -> WasmLowerCtx wit
     let depth = wasm_lower_find_label_depth(out, instr.label_id)
     if depth >= 0 {
         out.body = wasm_body_emit_br_if(out.body, depth)
+    } else {
+        out.error_count = out.error_count + 1
+        out.body = wasm_body_emit_unreachable(out.body)
     }
     out
 }
@@ -722,6 +775,9 @@ fn wasm_lower_branch_false(ctx: WasmLowerCtx, instr: IrInstr) -> WasmLowerCtx wi
     let depth = wasm_lower_find_label_depth(out, instr.label_id)
     if depth >= 0 {
         out.body = wasm_body_emit_br_if(out.body, depth)
+    } else {
+        out.error_count = out.error_count + 1
+        out.body = wasm_body_emit_unreachable(out.body)
     }
     out
 }
@@ -749,7 +805,17 @@ fn wasm_lower_label(ctx: WasmLowerCtx, instr: IrInstr) -> WasmLowerCtx with Mut,
     let lid = instr.label_id
     if lid >= 0 && lid < 512 {
         let loop_owner = out.is_loop_exit[lid as usize]
-        if loop_owner >= 0 {
+        if out.preopened_labels[lid as usize] == 1 {
+            if out.label_depth > 0 &&
+               out.label_stack[(out.label_depth - 1) as usize].ir_label_id == lid {
+                out.body = wasm_body_emit_end(out.body)
+                out = wasm_lower_pop_label(out)
+                out.preopened_labels[lid as usize] = 0
+            } else {
+                out.error_count = out.error_count + 1
+            }
+
+        } else if loop_owner >= 0 {
             // ── Case A: this label is the exit point of a loop ────────────────
             // Close all open scopes up to and including the loop-owner scope,
             // then close the exit wrapper block that was pre-opened below it.
@@ -784,8 +850,10 @@ fn wasm_lower_label(ctx: WasmLowerCtx, instr: IrInstr) -> WasmLowerCtx with Mut,
             out.body = wasm_body_emit_loop(out.body, WASM_BLOCK_VOID)
             out = wasm_lower_push_label(out, lid, WASM_LABEL_LOOP)
 
-        } else {
+        } else if out.forward_labels[lid as usize] == 1 {
             // ── Case C: forward label ─────────────────────────────────────────
+            // Loop-bearing functions retain the legacy local opener. Acyclic
+            // forward targets were already opened before instruction lowering.
             out.body = wasm_body_emit_block(out.body, WASM_BLOCK_VOID)
             out = wasm_lower_push_label(out, lid, WASM_LABEL_BLOCK)
         }
@@ -1202,14 +1270,26 @@ fn wasm_lower_function(ctx: WasmLowerCtx, func: IrFunction) -> WasmLowerCtx with
     // Pre-scan to allocate WASM locals for all IR registers
     out = wasm_lower_prescan_locals(out, func)
 
-    // Declare extra locals (beyond parameters) one-by-one by type.
-    // This correctly handles mixed i64/f64 extra locals.
+    // WASM encodes locals as (count, type) groups. Coalesce adjacent locals of
+    // the same type so functions with more than 32 locals do not silently hit
+    // WasmFuncBody's 32-group capacity.
     var e: i64 = func.param_count
-    while e < out.local_count {
+    while e < out.local_count && out.error_count == 0 {
         let ltype = out.local_type[e as usize]
-        out.body = wasm_body_add_local(out.body, 1, ltype)
-        e = e + 1
+        var run_count: i64 = 1
+        while e + run_count < out.local_count &&
+              out.local_type[(e + run_count) as usize] == ltype {
+            run_count = run_count + 1
+        }
+        if out.body.local_count >= 32 {
+            out.error_count = out.error_count + 1
+        } else {
+            out.body = wasm_body_add_local(out.body, run_count, ltype)
+            e = e + run_count
+        }
     }
+
+    out = wasm_lower_preopen_acyclic_forward_blocks(out, func)
 
     // Lower all instructions
     out = wasm_lower_basic_block(out, func, 0, func.instr_count)
@@ -1515,6 +1595,46 @@ fn wasm_lower_module(module: IrModule) -> WasmLowerResult with Mut, Panic, Div {
         func_count: module.fn_count,
         error_count: ctx.error_count,
     }
+}
+
+// Keep the lowering representation private while exposing the only supported
+// compiler boundary: validate the result and write an immutable WASM artifact.
+pub fn wasm_lower_module_to_file(
+    module: IrModule,
+    output_path: string
+) -> i32 with IO, Mut, Panic, Div {
+    if module.fn_count <= 0 {
+        print("Error: IR module has no functions (wasm_lowering_empty_module)\n")
+        return 1
+    }
+
+    let result = wasm_lower_module(module)
+    if result.error_count > 0 {
+        print("WASM lowering failed: ")
+        print_int(result.error_count)
+        print(" error(s)\n")
+        return 1
+    }
+    if result.buf.len <= 0 || result.buf.len > 262144 {
+        print("WASM lowering produced invalid byte length: ")
+        print_int(result.buf.len)
+        print("\n")
+        return 1
+    }
+    if write_file(output_path, result.buf.data, result.buf.len) < 0 {
+        print("Error: Failed to write WASM binary to ")
+        print(output_path)
+        print("\n")
+        return 1
+    }
+
+    print("WASM binary size: ")
+    print_int(result.buf.len)
+    print(" bytes\n")
+    print("Written to ")
+    print(output_path)
+    print("\n")
+    0
 }
 
 // ============================================================================
@@ -1892,6 +2012,50 @@ fn test_wasm_lower_prescan() -> bool with Mut, Panic, Div {
         && wasm_lower_get_local(ctx, 2) == 2
 }
 
+// Regression: local declarations are groups, not one entry per IR register.
+fn test_wasm_lower_large_i64_local_set() -> bool with Mut, Panic, Div {
+    var func = ir_empty_function()
+    func.param_count = 0
+    func.reg_count = 40
+
+    var i: i64 = 0
+    while i < 40 {
+        func.instrs[i as usize] = ir_load_imm(i, i)
+        i = i + 1
+    }
+    func.instrs[40 as usize] = ir_return(39)
+    func.instr_count = 41
+
+    var ctx = wasm_lower_ctx_new()
+    ctx = wasm_lower_function(ctx, func)
+    ctx.error_count == 0
+        && ctx.local_count == 40
+        && ctx.body.local_count == 1
+        && ctx.body.locals[0 as usize].count == 40
+        && ctx.body.locals[0 as usize].val_type == WASM_TYPE_I64
+}
+
+fn test_wasm_lower_acyclic_forward_jump() -> bool with Mut, Panic, Div {
+    var func = ir_empty_function()
+    func.reg_count = 1
+    func.instrs[0 as usize] = ir_jump(7)
+    func.instrs[1 as usize] = ir_load_imm(0, 99)
+    func.instrs[2 as usize] = ir_label(7)
+    func.instrs[3 as usize] = ir_load_imm(0, 3)
+    func.instrs[4 as usize] = ir_return(0)
+    func.instr_count = 5
+
+    var ctx = wasm_lower_ctx_new()
+    ctx = wasm_lower_function(ctx, func)
+    ctx.error_count == 0
+        && ctx.label_depth == 0
+        && ctx.body.code_len >= 6
+        && (ctx.body.code[0 as usize] as i64) == 0x02
+        && (ctx.body.code[1 as usize] as i64) == 0x40
+        && (ctx.body.code[2 as usize] as i64) == 0x0C
+        && (ctx.body.code[3 as usize] as i64) == 0
+}
+
 // ============================================================================
 // Test runner
 // ============================================================================
@@ -1916,6 +2080,8 @@ fn wasm_lower_run_tests() -> i64 with Mut, Panic, Div {
     if test_wasm_lower_module_header() { passed = passed + 1 } else { failed = failed + 1 }
     if test_wasm_lower_compare_lt() { passed = passed + 1 } else { failed = failed + 1 }
     if test_wasm_lower_prescan() { passed = passed + 1 } else { failed = failed + 1 }
+    if test_wasm_lower_large_i64_local_set() { passed = passed + 1 } else { failed = failed + 1 }
+    if test_wasm_lower_acyclic_forward_jump() { passed = passed + 1 } else { failed = failed + 1 }
 
     print_int(passed)
     print_int(failed)

--- a/tests/wasm/deontic_transport_finite_wasm_v0_3.sio
+++ b/tests/wasm/deontic_transport_finite_wasm_v0_3.sio
@@ -1,0 +1,132 @@
+//@ run-pass
+// Deontic transportability: bounded finite-family WASM ABI witness v0.3.
+//
+// Decision masks: 0 = empty/refuse, 1 = A, 2 = B, 3 = A or B.
+// The ABI accepts at most eight already-contextualized decision masks. Invalid
+// counts return -1 and must be refused by the caller. No function performs IO.
+//
+// Abstract research only. No action has a clinical meaning, clinical use is
+// refused, and production is not authorized.
+
+fn dt_contains_a(mask: i64) -> i64 {
+    if mask == 1 || mask == 3 { return 1 }
+    return 0
+}
+
+fn dt_contains_b(mask: i64) -> i64 {
+    if mask == 2 || mask == 3 { return 1 }
+    return 0
+}
+
+fn dt_union_masks(left: i64, right: i64) -> i64 {
+    var result: i64 = 0
+    if dt_contains_a(left) == 1 || dt_contains_a(right) == 1 {
+        result = result + 1
+    }
+    if dt_contains_b(left) == 1 || dt_contains_b(right) == 1 {
+        result = result + 2
+    }
+    return result
+}
+
+fn dt_intersect_masks(left: i64, right: i64) -> i64 {
+    var result: i64 = 0
+    if dt_contains_a(left) == 1 && dt_contains_a(right) == 1 {
+        result = result + 1
+    }
+    if dt_contains_b(left) == 1 && dt_contains_b(right) == 1 {
+        result = result + 2
+    }
+    return result
+}
+
+fn dt_union_many8(
+    d0: i64, d1: i64, d2: i64, d3: i64,
+    d4: i64, d5: i64, d6: i64, d7: i64,
+    count: i64
+) -> i64 with Mut {
+    if count < 0 || count > 8 { return -1 }
+    var result: i64 = 0
+    if count > 0 { result = dt_union_masks(result, d0) }
+    if count > 1 { result = dt_union_masks(result, d1) }
+    if count > 2 { result = dt_union_masks(result, d2) }
+    if count > 3 { result = dt_union_masks(result, d3) }
+    if count > 4 { result = dt_union_masks(result, d4) }
+    if count > 5 { result = dt_union_masks(result, d5) }
+    if count > 6 { result = dt_union_masks(result, d6) }
+    if count > 7 { result = dt_union_masks(result, d7) }
+    return result
+}
+
+fn dt_intersect_many8(
+    d0: i64, d1: i64, d2: i64, d3: i64,
+    d4: i64, d5: i64, d6: i64, d7: i64,
+    count: i64
+) -> i64 with Mut {
+    if count < 0 || count > 8 { return -1 }
+    var result: i64 = 3
+    if count > 0 { result = dt_intersect_masks(result, d0) }
+    if count > 1 { result = dt_intersect_masks(result, d1) }
+    if count > 2 { result = dt_intersect_masks(result, d2) }
+    if count > 3 { result = dt_intersect_masks(result, d3) }
+    if count > 4 { result = dt_intersect_masks(result, d4) }
+    if count > 5 { result = dt_intersect_masks(result, d5) }
+    if count > 6 { result = dt_intersect_masks(result, d6) }
+    if count > 7 { result = dt_intersect_masks(result, d7) }
+    return result
+}
+
+fn dt_classify(identified: i64, core: i64) -> i64 {
+    if identified == 0 { return 0 }
+    if identified == 1 && core == 1 { return 1 }
+    if identified == 2 && core == 2 { return 2 }
+    return 3
+}
+
+fn dt_case_code(
+    d0: i64, d1: i64, d2: i64, d3: i64,
+    d4: i64, d5: i64, d6: i64, d7: i64,
+    count: i64
+) -> i64 with Mut {
+    let identified = dt_union_many8(d0, d1, d2, d3, d4, d5, d6, d7, count)
+    let core = dt_intersect_many8(d0, d1, d2, d3, d4, d5, d6, d7, count)
+    if identified < 0 || core < 0 { return -1 }
+    let state = dt_classify(identified, core)
+    return identified + core * 4 + state * 16
+}
+
+fn dt_verify_case(actual: i64, expected: i64) -> i64 {
+    if actual == expected { return 0 }
+    return 1
+}
+
+fn main() -> i64 with Mut {
+    var failures: i64 = 0
+    failures = failures + dt_verify_case(
+        dt_case_code(1, 1, 2, 1, 0, 0, 0, 0, 4),
+        51
+    )
+    failures = failures + dt_verify_case(
+        dt_case_code(1, 1, 1, 0, 0, 0, 0, 0, 3),
+        21
+    )
+    failures = failures + dt_verify_case(
+        dt_case_code(2, 2, 0, 0, 0, 0, 0, 0, 2),
+        42
+    )
+    failures = failures + dt_verify_case(
+        dt_case_code(0, 0, 0, 0, 0, 0, 0, 0, 0),
+        12
+    )
+    failures = failures + dt_verify_case(
+        dt_union_many8(0, 0, 0, 0, 0, 0, 0, 0, -1),
+        -1
+    )
+    failures = failures + dt_verify_case(
+        dt_intersect_many8(0, 0, 0, 0, 0, 0, 0, 0, 9),
+        -1
+    )
+
+    if failures == 0 { return 87 }
+    return 1
+}

--- a/tests/wasm/deontic_transport_finite_wasm_v0_4.sio
+++ b/tests/wasm/deontic_transport_finite_wasm_v0_4.sio
@@ -1,0 +1,247 @@
+//@ run-pass
+// Deontic transportability: bounded finite-family WASM ABI witness v0.4.
+//
+// Decision masks: 0 = empty/refuse, 1 = A, 2 = B, 3 = A or B.
+// The ABI accepts at most eight already-contextualized decision masks. Invalid
+// counts or active masks return -1 and must be refused by the caller. Padded
+// values beyond count are outside the active family and are ignored. No
+// function performs IO.
+//
+// Abstract research only. No action has a clinical meaning, clinical use is
+// refused, and production is not authorized.
+
+fn dt_valid_mask(mask: i64) -> i64 {
+    if mask == 0 || mask == 1 || mask == 2 || mask == 3 { return 1 }
+    return 0
+}
+
+fn dt_contains_a(mask: i64) -> i64 {
+    if mask == 1 || mask == 3 { return 1 }
+    return 0
+}
+
+fn dt_contains_b(mask: i64) -> i64 {
+    if mask == 2 || mask == 3 { return 1 }
+    return 0
+}
+
+fn dt_union_masks(left: i64, right: i64) -> i64 {
+    var result: i64 = 0
+    if dt_contains_a(left) == 1 || dt_contains_a(right) == 1 {
+        result = result + 1
+    }
+    if dt_contains_b(left) == 1 || dt_contains_b(right) == 1 {
+        result = result + 2
+    }
+    return result
+}
+
+fn dt_intersect_masks(left: i64, right: i64) -> i64 {
+    var result: i64 = 0
+    if dt_contains_a(left) == 1 && dt_contains_a(right) == 1 {
+        result = result + 1
+    }
+    if dt_contains_b(left) == 1 && dt_contains_b(right) == 1 {
+        result = result + 2
+    }
+    return result
+}
+
+fn dt_active_masks_valid8(
+    d0: i64, d1: i64, d2: i64, d3: i64,
+    d4: i64, d5: i64, d6: i64, d7: i64,
+    count: i64
+) -> i64 {
+    if count < 0 || count > 8 { return 0 }
+    if count > 0 && dt_valid_mask(d0) == 0 { return 0 }
+    if count > 1 && dt_valid_mask(d1) == 0 { return 0 }
+    if count > 2 && dt_valid_mask(d2) == 0 { return 0 }
+    if count > 3 && dt_valid_mask(d3) == 0 { return 0 }
+    if count > 4 && dt_valid_mask(d4) == 0 { return 0 }
+    if count > 5 && dt_valid_mask(d5) == 0 { return 0 }
+    if count > 6 && dt_valid_mask(d6) == 0 { return 0 }
+    if count > 7 && dt_valid_mask(d7) == 0 { return 0 }
+    return 1
+}
+
+fn dt_union_many8(
+    d0: i64, d1: i64, d2: i64, d3: i64,
+    d4: i64, d5: i64, d6: i64, d7: i64,
+    count: i64
+) -> i64 with Mut {
+    if dt_active_masks_valid8(d0, d1, d2, d3, d4, d5, d6, d7, count) == 0 {
+        return -1
+    }
+    var result: i64 = 0
+    if count > 0 { result = dt_union_masks(result, d0) }
+    if count > 1 { result = dt_union_masks(result, d1) }
+    if count > 2 { result = dt_union_masks(result, d2) }
+    if count > 3 { result = dt_union_masks(result, d3) }
+    if count > 4 { result = dt_union_masks(result, d4) }
+    if count > 5 { result = dt_union_masks(result, d5) }
+    if count > 6 { result = dt_union_masks(result, d6) }
+    if count > 7 { result = dt_union_masks(result, d7) }
+    return result
+}
+
+fn dt_intersect_many8(
+    d0: i64, d1: i64, d2: i64, d3: i64,
+    d4: i64, d5: i64, d6: i64, d7: i64,
+    count: i64
+) -> i64 with Mut {
+    if dt_active_masks_valid8(d0, d1, d2, d3, d4, d5, d6, d7, count) == 0 {
+        return -1
+    }
+    var result: i64 = 3
+    if count > 0 { result = dt_intersect_masks(result, d0) }
+    if count > 1 { result = dt_intersect_masks(result, d1) }
+    if count > 2 { result = dt_intersect_masks(result, d2) }
+    if count > 3 { result = dt_intersect_masks(result, d3) }
+    if count > 4 { result = dt_intersect_masks(result, d4) }
+    if count > 5 { result = dt_intersect_masks(result, d5) }
+    if count > 6 { result = dt_intersect_masks(result, d6) }
+    if count > 7 { result = dt_intersect_masks(result, d7) }
+    return result
+}
+
+fn dt_classify(identified: i64, core: i64) -> i64 {
+    if identified == 0 { return 0 }
+    if identified == 1 && core == 1 { return 1 }
+    if identified == 2 && core == 2 { return 2 }
+    return 3
+}
+
+fn dt_case_code(
+    d0: i64, d1: i64, d2: i64, d3: i64,
+    d4: i64, d5: i64, d6: i64, d7: i64,
+    count: i64
+) -> i64 with Mut {
+    let identified = dt_union_many8(d0, d1, d2, d3, d4, d5, d6, d7, count)
+    let core = dt_intersect_many8(d0, d1, d2, d3, d4, d5, d6, d7, count)
+    if identified < 0 || core < 0 { return -1 }
+    let state = dt_classify(identified, core)
+    return identified + core * 4 + state * 16
+}
+
+fn dt_verify_case(actual: i64, expected: i64) -> i64 {
+    if actual == expected { return 0 }
+    return 1
+}
+
+// Independent finite-domain oracle. The executable implementation above uses
+// membership predicates; this reference uses integer bitwise set algebra.
+fn dt_reference_case_code(
+    d0: i64, d1: i64, d2: i64, d3: i64,
+    d4: i64, d5: i64, d6: i64, d7: i64,
+    count: i64
+) -> i64 with Mut {
+    if dt_active_masks_valid8(d0, d1, d2, d3, d4, d5, d6, d7, count) == 0 {
+        return -1
+    }
+    var identified: i64 = 0
+    var core: i64 = 3
+    if count > 0 { identified = identified | d0; core = core & d0 }
+    if count > 1 { identified = identified | d1; core = core & d1 }
+    if count > 2 { identified = identified | d2; core = core & d2 }
+    if count > 3 { identified = identified | d3; core = core & d3 }
+    if count > 4 { identified = identified | d4; core = core & d4 }
+    if count > 5 { identified = identified | d5; core = core & d5 }
+    if count > 6 { identified = identified | d6; core = core & d6 }
+    if count > 7 { identified = identified | d7; core = core & d7 }
+
+    var state: i64 = 3
+    if identified == 0 {
+        state = 0
+    } else if identified == 1 && core == 1 {
+        state = 1
+    } else if identified == 2 && core == 2 {
+        state = 2
+    }
+    return identified + core * 4 + state * 16
+}
+
+fn dt_exhaustive_walk(
+    count: i64,
+    depth: i64,
+    encoded: i64,
+    place: i64
+) -> i64 with Mut, Div {
+    if depth >= count {
+        let d0 = encoded % 4
+        let d1 = (encoded / 4) % 4
+        let d2 = (encoded / 16) % 4
+        let d3 = (encoded / 64) % 4
+        let d4 = (encoded / 256) % 4
+        let d5 = (encoded / 1024) % 4
+        let d6 = (encoded / 4096) % 4
+        let d7 = (encoded / 16384) % 4
+        let actual = dt_case_code(d0, d1, d2, d3, d4, d5, d6, d7, count)
+        let expected = dt_reference_case_code(d0, d1, d2, d3, d4, d5, d6, d7, count)
+        if actual != expected { return 1 }
+        return 0
+    }
+
+    let next_depth = depth + 1
+    let next_place = place * 4
+    return
+        dt_exhaustive_walk(count, next_depth, encoded, next_place) +
+        dt_exhaustive_walk(count, next_depth, encoded + place, next_place) +
+        dt_exhaustive_walk(count, next_depth, encoded + place * 2, next_place) +
+        dt_exhaustive_walk(count, next_depth, encoded + place * 3, next_place)
+}
+
+fn dt_exhaustive_bounded_self_check() -> i64 with Mut, Div {
+    return
+        dt_exhaustive_walk(0, 0, 0, 1) +
+        dt_exhaustive_walk(1, 0, 0, 1) +
+        dt_exhaustive_walk(2, 0, 0, 1) +
+        dt_exhaustive_walk(3, 0, 0, 1) +
+        dt_exhaustive_walk(4, 0, 0, 1) +
+        dt_exhaustive_walk(5, 0, 0, 1) +
+        dt_exhaustive_walk(6, 0, 0, 1) +
+        dt_exhaustive_walk(7, 0, 0, 1) +
+        dt_exhaustive_walk(8, 0, 0, 1)
+}
+
+fn main() -> i64 with Mut, Div {
+    var failures: i64 = dt_exhaustive_bounded_self_check()
+    failures = failures + dt_verify_case(
+        dt_case_code(1, 1, 2, 1, 0, 0, 0, 0, 4),
+        51
+    )
+    failures = failures + dt_verify_case(
+        dt_case_code(1, 1, 1, 0, 0, 0, 0, 0, 3),
+        21
+    )
+    failures = failures + dt_verify_case(
+        dt_case_code(2, 2, 0, 0, 0, 0, 0, 0, 2),
+        42
+    )
+    failures = failures + dt_verify_case(
+        dt_case_code(0, 0, 0, 0, 0, 0, 0, 0, 0),
+        12
+    )
+    failures = failures + dt_verify_case(
+        dt_union_many8(0, 0, 0, 0, 0, 0, 0, 0, -1),
+        -1
+    )
+    failures = failures + dt_verify_case(
+        dt_intersect_many8(0, 0, 0, 0, 0, 0, 0, 0, 9),
+        -1
+    )
+    failures = failures + dt_verify_case(
+        dt_case_code(4, 0, 0, 0, 0, 0, 0, 0, 1),
+        -1
+    )
+    failures = failures + dt_verify_case(
+        dt_case_code(-1, 0, 0, 0, 0, 0, 0, 0, 1),
+        -1
+    )
+    failures = failures + dt_verify_case(
+        dt_case_code(0, 0, 0, 0, 0, 0, 0, 99, 0),
+        12
+    )
+
+    if failures == 0 { return 87 }
+    return 1
+}

--- a/tests/wasm/madaros_wasm_i64_fold.sio
+++ b/tests/wasm/madaros_wasm_i64_fold.sio
@@ -1,0 +1,30 @@
+//@ run-pass
+// A no-IO fixture for public Madaros WebAssembly build and runtime validation.
+// Decision masks: 0 = empty, 1 = A, 2 = B, 3 = both.
+
+fn contains_a(mask: i64) -> i64 {
+    if mask == 1 || mask == 3 { return 1 }
+    return 0
+}
+
+fn contains_b(mask: i64) -> i64 {
+    if mask == 2 || mask == 3 { return 1 }
+    return 0
+}
+
+fn union_masks(left: i64, right: i64) -> i64 {
+    var result: i64 = 0
+    if contains_a(left) == 1 || contains_a(right) == 1 {
+        result = result + 1
+    }
+    if contains_b(left) == 1 || contains_b(right) == 1 {
+        result = result + 2
+    }
+    return result
+}
+
+fn main() -> i64 {
+    let first = union_masks(1, 1)
+    let second = union_masks(first, 2)
+    return union_masks(second, 1)
+}


### PR DESCRIPTION
## Summary\n\n- expose the Madaros WebAssembly backend through the public build surface\n- fail closed on hidden compiler errors and unsupported WASM control flow\n- make version JSON and bootstrap S1-S8 independently verifiable\n- add generic and deontic bounded-kernel WASM fixtures\n\n## Verification\n\n- lean_single stage1 = stage2 = stage3; canonical compiler gate passes\n- bootstrap chain S1-S8 passes; peak RSS 3104 KB\n- three clean Madaros builds are byte-identical: b5208b7a82bf5a369d1188858a3ab57ceba3bdd83cceb28f30cc90f05b94322d\n- error diagnostics: 0 (warnings remain visible)\n- public generic WASM: 585 bytes, zero imports, main = 3\n- deontic v0.4 native/WASM builds are deterministic; both runtimes return 87\n\n## Boundary\n\nLoop-bearing control flow remains unsupported by this backend patch and must fail closed. The deontic fixtures are abstract research witnesses and authorize no clinical or production use.