### PR TITLE
fix(ir): every closure in a module got the same synthetic name

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -14956,8 +14956,20 @@ impl Lowerer {
         n.buf[8] = 101   // 'e'
         n.buf[9] = 95    // '_'
         n.len = 10
-        // Append fn_count as suffix for uniqueness
-        let suffix = self.module.fn_count
+        // Append fn_count as suffix for uniqueness.
+        //
+        // `self.module.fn_count` -- field access on the Box WITHOUT a deref -- read
+        // garbage, and the same garbage every time, so every closure in a module
+        // was named `__closure_L960`. find_or_add_fn_id then handed the second
+        // closure the FIRST one's fn_id and its body overwrote it, which is why
+        // every closure fn-ref in a program resolved to the last closure lowered:
+        //
+        //     ap_a(|x| x * 2, 5)  and  ap_b(|x| 99, 7)   ->  99 and 99
+        //
+        // Named functions were unaffected, which is what made this look like a
+        // closure-passing defect rather than a naming one. The rest of the file
+        // spells it `(*self.module).fn_count` (e.g. lower_function_is_transparent_hof).
+        let suffix = (*self.module).fn_count
         if suffix < 10 {
             n.buf[10] = (48 + suffix) as i8
             n.len = 11


### PR DESCRIPTION
`make_closure_name` built its uniqueness suffix from `self.module.fn_count` — field access on the Box **without a deref**. That read garbage, and the *same* garbage every time, because the Box pointer is stable. **Every closure in a module was named `__closure_L960`:**

```
HOFDBG name=__closure_L960 fn_count_before=5 fn_id=5 fn_count_after=6
HOFDBG name=__closure_L960 fn_count_before=6 fn_id=5 fn_count_after=6
```

`find_or_add_fn_id` then handed the second closure the **first one's fn_id**, and its body overwrote it. So every closure fn-ref in a program resolved to whichever closure was lowered **last**.

| probe | before | after |
|---|---|---|
| `ap_a(\|x\| x * 2, 5)` and `ap_b(\|x\| 99, 7)` | 99 and 99 | **10 and 99** |
| `apply1(\|x\| x * 2, 5)` | 15 | **10** |
| five distinct closures | all 42 | **10, 2, 20, 7, 42** |

The rest of the file spells it `(*self.module).fn_count` — see `lower_function_is_transparent_hof`. One character.

## The symptom did not look like the cause

It only showed through higher-order calls. Named function refs were fine. A *single* closure was fine. That pointed at HOF specialisation, at `ir_call_indirect`, at the capture flag — none of which were involved.

What exposed it was printing the **name**. Printing only the `fn_id` would have shown `5` and `5`, and the "fix" would have been a private counter — papering over a deref error instead of removing it.

## Relation to #1607

That one taught the capture scanner to look inside block bodies, and incidentally fixed arity-2 HOF calls. This fixes arity-1 and the multiple-closure case.

Of the three defects mapped in the print-nothing cluster, what remains is **escaping closures having no environment** — the *"captures are TBD (Phase 2)"* the code itself declares.

## Gate

```
[madaros-corpus] PASS: no new failures under Madaros (273 known, 0 new, 1688 programs)
```

The specific risk checked for: the fix gives every closure its own `fn_id` where they previously collapsed into one, so a program with many closures now allocates more module functions. Nothing in the corpus raised table pressure.

## Not claimed

There are ~150 other `self.<box>.<field>` accesses without a deref in this file. Whether any of them are wrong is **unverified** — the probe I wrote to test Box-field access segfaulted in all three arms, including the known-correct `(*o.b).n` form, so it was measuring something else. Recording the observation without the conclusion.

Refs #1542

🤖 Generated with [Claude Code](https://claude.com/claude-code)
