### PR TITLE
fix(ci): close the three gaps the seed audit left open

### DIFF
--- a/scripts/ci/engine_parity_gate.sh
+++ b/scripts/ci/engine_parity_gate.sh
@@ -112,6 +112,10 @@ trap 'rm -rf "$WORK"' EXIT
 #   MADAROS-ONLY   only Madaros produced a running binary
 #   LEAN-ONLY      only lean_single did
 #   NEITHER        neither did
+#   NONDETERMINISTIC  the program does not agree with ITSELF across two runs of
+#                  the same engine, so no byte comparison between engines can
+#                  mean anything (typically `println` of a struct, which prints
+#                  an address)
 #   TIMEOUT        at least one engine was killed by the clock -- "too slow to
 #                  measure" is NOT "neither engine builds this", and conflating
 #                  them made a slow program read as a rejected one (#1591)
@@ -171,7 +175,25 @@ if [ "$ok_m" = 1 ] && [ "$ok_l" = 1 ]; then
     if cmp -s "$work/${tag}_mad.out" "$work/${tag}_lean.out"; then
         printf 'AGREE\t%s\n' "$src"
     else
-        printf 'DIVERGE\t%s\n' "$src"
+        # Before calling it a divergence, check the program is comparable at all.
+        # `println` of a struct prints its ADDRESS, so such a program prints
+        # something different on every run under EITHER engine -- three in the
+        # corpus do (covid_2020_kernel, epsilon_comparison_valid,
+        # knightian_syntax, all `println(<Knowledge struct>)`). Byte-comparing
+        # those says nothing about the engines, and pinning three filenames would
+        # go stale, so the property is MEASURED: run each engine a second time and
+        # see whether it still agrees with itself.
+        cp "$work/${tag}_mad.out" "$work/${tag}_mad.out1" 2>/dev/null
+        cp "$work/${tag}_lean.out" "$work/${tag}_lean.out1" 2>/dev/null
+        nondet=0
+        run_engine mad  && { cmp -s "$work/${tag}_mad.out"  "$work/${tag}_mad.out1"  || nondet=1; }
+        run_engine lean && { cmp -s "$work/${tag}_lean.out" "$work/${tag}_lean.out1" || nondet=1; }
+        rm -f "$work/${tag}_mad.out1" "$work/${tag}_lean.out1"
+        if [ "$nondet" = 1 ]; then
+            printf 'NONDETERMINISTIC\t%s\n' "$src"
+        else
+            printf 'DIVERGE\t%s\n' "$src"
+        fi
     fi
 elif [ "$ok_m" = 1 ]; then
     printf 'MADAROS-ONLY\t%s\n' "$src"
@@ -265,8 +287,9 @@ mad_only=$(grep -c '^MADAROS-ONLY' "$WORK/results.tsv" || true)
 lean_only=$(grep -c '^LEAN-ONLY'   "$WORK/results.tsv" || true)
 neither=$(grep -c '^NEITHER'       "$WORK/results.tsv" || true)
 timedout=$(grep -c '^TIMEOUT'      "$WORK/results.tsv" || true)
+nondet_n=$(grep -c '^NONDETERMINISTIC' "$WORK/results.tsv" || true)
 
-echo "[engine-parity] agree=$agree diverge=$diverge madaros-only=$mad_only lean-only=$lean_only neither=$neither timeout=$timedout"
+echo "[engine-parity] agree=$agree diverge=$diverge madaros-only=$mad_only lean-only=$lean_only neither=$neither timeout=$timedout nondet=$nondet_n"
 
 # The baseline records every non-AGREE verdict. AGREE is the goal state and is
 # deliberately not recorded, so the file shrinks as the engines converge.

--- a/scripts/ci/verify_lean_seed.sh
+++ b/scripts/ci/verify_lean_seed.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Rebuild bin/souc-lean-single-x86_64 from source and verify the committed blob.
+#
+# A 2.5 MB ELF cannot be reviewed by reading it. This reproduces it, and checks
+# the two properties that make it trustworthy:
+#
+#   FIXED POINT   the artifact compiles lean_single.sio into ITSELF, bit for bit.
+#                 Without this, the committed binary carries the code generation
+#                 of whatever bootstrap ELF happened to build it rather than the
+#                 code generation the source describes. #1606 nearly shipped a
+#                 generation-1 artifact for exactly that reason.
+#
+#   DDC           diverse double-compilation. Starting from a DIFFERENT seed and
+#                 iterating to ITS fixed point must land on the same bytes. A
+#                 fixed point alone proves self-consistency, not correctness: a
+#                 miscompile injected by the bootstrap and reproduced by the
+#                 compiler it builds survives unnoticed. Two independent paths
+#                 converging is what rules that out (trusting-trust).
+#
+# Both were run by hand for #1606; this makes them repeatable. The old-seed path
+# there began at a binary carrying five known miscompiles (6f9c20b85) and still
+# converged on the committed artifact, so those defects do not self-perpetuate.
+#
+# Usage:
+#   scripts/ci/verify_lean_seed.sh                  # fixed point only (fast)
+#   SOUNIO_SEED_DDC=1 scripts/ci/verify_lean_seed.sh   # + diverse double-compilation
+#
+# Environment:
+#   SOUNIO_SEED_BOOTSTRAP  ELF used to derive generation 1 (default bin/souc-linux-x86_64)
+#   SOUNIO_SEED_DDC        set to 1 to also run the DDC leg (slower: 3 more compiles)
+#   SOUNIO_SEED_DDC_FROM   ELF to start the DDC leg from (default: the committed
+#                          seed at HEAD~ if it differs, else skipped with a notice)
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR" || exit 1
+
+SRC="self-hosted/compiler/lean_single.sio"
+SEED="bin/souc-lean-single-x86_64"
+BOOTSTRAP="${SOUNIO_SEED_BOOTSTRAP:-bin/souc-linux-x86_64}"
+
+fail() { echo "[seed-verify] FAIL: $*" >&2; exit 1; }
+note() { echo "[seed-verify] $*"; }
+
+[ -f "$SRC" ]  || fail "missing $SRC"
+[ -x "$SEED" ] || fail "missing or non-executable $SEED"
+[ -x "$BOOTSTRAP" ] || fail "missing or non-executable $BOOTSTRAP (set SOUNIO_SEED_BOOTSTRAP)"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/seed-verify.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+sha() { sha256sum "$1" | cut -d' ' -f1; }
+short() { sha "$1" | cut -c1-16; }
+
+note "source:    $SRC"
+note "committed: $SEED  $(short "$SEED")"
+note "bootstrap: $BOOTSTRAP  $(short "$BOOTSTRAP")"
+
+# --- fixed point ------------------------------------------------------------
+# The committed seed compiling the source must reproduce the committed seed.
+"$SEED" "$SRC" "$WORK/self.elf" >/dev/null 2>&1
+[ -s "$WORK/self.elf" ] || fail "committed seed could not compile $SRC"
+chmod +x "$WORK/self.elf"
+
+if [ "$(sha "$WORK/self.elf")" != "$(sha "$SEED")" ]; then
+    echo "[seed-verify] committed $(short "$SEED")" >&2
+    echo "[seed-verify] rebuilt   $(short "$WORK/self.elf")" >&2
+    fail "NOT a fixed point -- the committed seed is not what the source produces.
+  Derive it properly:
+    $BOOTSTRAP $SRC /tmp/gen1.elf && chmod +x /tmp/gen1.elf
+    /tmp/gen1.elf $SRC /tmp/gen2.elf     # gen2 is the fixed point
+    cp /tmp/gen2.elf $SEED"
+fi
+note "FIXED POINT ok: the committed seed reproduces itself bit for bit"
+
+# Determinism: the same input twice must give the same bytes, or "bit for bit"
+# above means nothing.
+"$SEED" "$SRC" "$WORK/self2.elf" >/dev/null 2>&1
+[ -s "$WORK/self2.elf" ] || fail "second self-compile produced no output"
+[ "$(sha "$WORK/self2.elf")" = "$(sha "$WORK/self.elf")" ] \
+    || fail "NON-DETERMINISTIC: two identical compiles differ"
+note "DETERMINISTIC ok: two identical compiles agree"
+
+# --- diverse double-compilation --------------------------------------------
+if [ "${SOUNIO_SEED_DDC:-0}" != "1" ]; then
+    note "PASS (set SOUNIO_SEED_DDC=1 to also run diverse double-compilation)"
+    exit 0
+fi
+
+DDC_FROM="${SOUNIO_SEED_DDC_FROM:-}"
+if [ -z "$DDC_FROM" ]; then
+    if git rev-parse "HEAD~1:$SEED" >/dev/null 2>&1; then
+        git show "HEAD~1:$SEED" > "$WORK/prev_seed.elf" 2>/dev/null
+        chmod +x "$WORK/prev_seed.elf" 2>/dev/null
+        if [ -s "$WORK/prev_seed.elf" ] \
+           && [ "$(sha "$WORK/prev_seed.elf")" != "$(sha "$SEED")" ]; then
+            DDC_FROM="$WORK/prev_seed.elf"
+        fi
+    fi
+fi
+if [ -z "$DDC_FROM" ]; then
+    note "DDC skipped: no distinct second starting point (set SOUNIO_SEED_DDC_FROM)"
+    exit 0
+fi
+
+note "DDC start: $(short "$DDC_FROM")"
+"$DDC_FROM" "$SRC" "$WORK/a1.elf" >/dev/null 2>&1
+[ -s "$WORK/a1.elf" ] || fail "DDC: starting seed could not compile $SRC"
+chmod +x "$WORK/a1.elf"
+"$WORK/a1.elf" "$SRC" "$WORK/a2.elf" >/dev/null 2>&1
+[ -s "$WORK/a2.elf" ] || fail "DDC: generation 1 could not compile $SRC"
+chmod +x "$WORK/a2.elf"
+
+note "DDC path:  $(short "$DDC_FROM") -> $(short "$WORK/a1.elf") -> $(short "$WORK/a2.elf")"
+if [ "$(sha "$WORK/a2.elf")" != "$(sha "$SEED")" ]; then
+    fail "DDC MISMATCH: an independent path reaches a DIFFERENT fixed point.
+  That is the trusting-trust signature -- a defect that survives self-compilation
+  would look exactly like this. Do not ship the seed until it is explained."
+fi
+note "DDC ok: an independent starting point converges on the committed artifact"
+note "PASS"


### PR DESCRIPTION
A re-review of #1606 with **`deepseek-v4-pro`** named three things I had not verified. Two were tooling; one was a measurement I had skipped — and that one found something.

## Why there was a re-review

Both reviews I ran during #1606 were served by **`deepseek-coder`**, which the API accepts and silently maps to `v4-flash`. `bb68f21` pinned `v4-pro` on 02/08 23:43; my runs were 01/08 21:47 and 02/08 20:18 — **both before it.**

An identifier accepted that silently serves something else. That is the same defect class the seed refresh existed to fix, and I was inside it without noticing.

## 1. No reproducible build → `scripts/ci/verify_lean_seed.sh`

A 2.5 MB ELF cannot be reviewed by reading it. The script rebuilds it and checks:

- **fixed point** — the artifact compiles the source into *itself*, bit for bit. #1606 nearly shipped a generation-1 artifact carrying the code generation of whatever bootstrap built it. The failure message carries the derivation recipe.
- **determinism** — two identical compiles must agree, or "bit for bit" is empty.
- **DDC** — diverse double-compilation, behind `SOUNIO_SEED_DDC=1`.

The DDC leg is the review's real point: **a fixed point proves self-consistency, not correctness.** A miscompile injected by the bootstrap and faithfully reproduced by the compiler it builds survives unnoticed — trusting trust. My #1606 commit message overstated the guarantee.

```
6bb6278d (old seed) → 8017a010 → f330d612 == the committed artifact
```

The old seed carries the five miscompiles of `6f9c20b85` and **still converges**, so they do not self-perpetuate.

## 2. Nondeterministic programs in the corpus

Three programs `println` a struct, which prints its **address** — so they print something different every run under *either* engine. Byte-comparing them says nothing.

The review suggested excluding them. Pinning three filenames goes stale, so the property is **measured**: on a divergence the gate re-runs each engine once and checks whether it still agrees with **itself**. If not → `NONDETERMINISTIC` instead of `DIVERGE`. Costs nothing on the ~1600 that agree, and catches the fourth such program nobody has written yet.

*(I earlier reported this as ASLR. It is not — it is `println` of an aggregate printing a pointer, in both engines.)*

## 3. Coverage was `tests/run-pass` only — and the gap was real

Compared both seeds across the **1034** files in `compile-fail`, `frontend`, `native-v2`, `multimodule`, `gpu`, `selfhost-driver-output`, `known_failures`:

```
IGUAL   1024
DIFERE    10
```

All ten attributed, **none a regression**:

- **9 newline-only** — the `print_int` fix (#1579) reaching the reference. Verified with newlines stripped; e.g. `thin_inline_main.sio` prints `5\n` under the old seed, `5` under the new.
- **1** — `option_box_ptr_witness.sio` prints **heap pointers**. The same binary gives `21827720052752` / `11502652227600` / `21047434805264` across three runs. Not a seed difference at all — the class item 2 now detects.

> The seed swap has no unmeasured effect outside `run-pass`. That is the claim #1606 should have made and could not, because I had only swept one directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
