### PR TITLE
fix(parser): a module path segment may be a contextual-identifier keyword

### DIFF
--- a/scripts/ci/parser_contextual_ident_routing_gate.sh
+++ b/scripts/ci/parser_contextual_ident_routing_gate.sh
@@ -14,6 +14,15 @@
 # A research branch went the other way and inlined the list into each caller.
 # Three copies later they had drifted, and the drift is what this gate exists to
 # make impossible: with one list there is nothing to diverge.
+#
+# parse_module_item is the fourth caller, and it was found the expensive way:
+# by building Madaros from this tree and discovering it could not parse three
+# files of its OWN source — self-hosted/resolve/{scope,mod,resolve}.sio. Its
+# path loop tested `== TokenKind::Ident` and nothing else, so `module
+# resolve::scope` stopped at `scope`, handed the keyword to the item dispatcher
+# and died. `module x::study` was worse: `study` HAS a dispatcher branch, so it
+# began parsing a study item from inside a module header. The shipped binary
+# predates the loop, which is why no gate and no test had ever seen it.
 set -uo pipefail
 
 cd "$(git rev-parse --show-toplevel)" || exit 9
@@ -23,6 +32,7 @@ CALLERS=(
     "self-hosted/parser/exprs.sio:parse_prefix"
     "self-hosted/parser/patterns.sio:parse_pattern_atom"
     "self-hosted/parser/parser.sio:at_expr_start"
+    "self-hosted/parser/items.sio:parse_module_item"
 )
 
 fail() { echo "PARSER_CONTEXTUAL_IDENT_ROUTING_GATE_FAIL: $*" >&2; exit 1; }

--- a/self-hosted/parser/items.sio
+++ b/self-hosted/parser/items.sio
@@ -1247,10 +1247,30 @@ impl Parser {
         // "consume until Newline" loop ran to EOF and swallowed the entire file as a
         // single item — leaving every subsequent fn/struct unparsed in multi-module
         // compilation (the imported typecheck then saw 0 functions for these modules).
-        while parser_peek(p) == TokenKind::Ident
-            || parser_peek(p) == TokenKind::ColonColon
-            || parser_peek(p) == TokenKind::Ontology {
+        //
+        // A path SEGMENT may be a contextual-identifier keyword, so ask the one
+        // list rather than carrying a fourth copy of it. `module resolve::scope`
+        // is not hypothetical: it is self-hosted/resolve/scope.sio, and with a
+        // bare `== TokenKind::Ident` test the loop stopped at `scope`, left the
+        // keyword to the item dispatcher, and the compiler refused to parse three
+        // files of its own source tree. `study` was worse than a refusal — it has
+        // a branch in the dispatcher (items.sio:1154), so `module x::study` began
+        // parsing a study item from the middle of a module header.
+        //
+        // The shape is an alternation, not a free loop: segment, then (:: segment)*.
+        // The old loop would also have swallowed `module a b c` as one path.
+        if parser_peek(p) == TokenKind::Ident
+            || parser_peek(p) == TokenKind::Ontology
+            || tk_is_contextual_ident(parser_peek(p)) {
             p = p.advance_raw()
+            while parser_peek(p) == TokenKind::ColonColon {
+                p = p.advance_raw()
+                if parser_peek(p) == TokenKind::Ident
+                    || parser_peek(p) == TokenKind::Ontology
+                    || tk_is_contextual_ident(parser_peek(p)) {
+                    p = p.advance_raw()
+                }
+            }
         }
         if parser_peek(p) == TokenKind::Newline {
             p = p.advance_raw()


### PR DESCRIPTION
**A compiler built from main cannot parse `self-hosted/resolve/scope.sio` — a file in its own source tree.**

`parse_module_item` (items.sio:1250) consumed the module path with a fourth hand-written copy of the identifier list:

    while parser_peek(p) == TokenKind::Ident
        || parser_peek(p) == TokenKind::ColonColon
        || parser_peek(p) == TokenKind::Ontology

Any segment that lexes as some other keyword stops the loop. The keyword falls through to the item dispatcher and the parse dies. `module resolve::scope` is that file's second line.

## Five words reproduce it

Measured against two Madaros ELFs built from the same tree, with and without this fix:

| | before | after |
|---|---|---|
| `module x::scope` | FAILS | ok |
| `module x::level` | FAILS | ok |
| `module x::is` | FAILS | ok |
| `module x::study` | FAILS | ok |
| `module x::policy` | FAILS | ok |

**`study` was worse than a refusal.** It HAS a dispatcher branch (items.sio:1154), so `module x::study` began parsing a *study item* from inside a module header.

## Why nothing was red

The shipped `artifacts/self-hosted/madaros` predates the loop — it still uses the "consume until Newline" version this code's own comment describes replacing. The bug is reachable only by rebuilding Madaros and re-checking the tree, and no gate does that. I found it while trying to verify something else entirely.

## The fix

Ask `tk_is_contextual_ident` — the one list — instead of carrying a fourth copy. Same defect class as `at_expr_start`, which is what the base PR fixes.

It also makes the shape an alternation, `segment (:: segment)*`, rather than a free loop. The old loop would equally have swallowed `module a b c` as a single path.

`parser_contextual_ident_routing_gate.sh` now lists `parse_module_item` as a fourth caller. Verified it goes red when the call is stripped — a gate that cannot fail is decoration.

## Verification

Two ELFs, same tree, one flag apart:

    resolve/scope.sio      FAILS -> ok
    resolve/mod.sio        FAILS -> ok
    resolve/resolve.sio    FAILS -> ok
    sweep of resolve+lexer+parser    3 of 25 rejected -> 0 of 25

**Correcting my own earlier count:** I first reported this as three broken files. It is one. `mod.sio` and `resolve.sio` import `scope` and both name `scope.sio` in the failure — one cause, three reports.

**Controls, because a fix that only adds acceptance can over-consume:** `module x::{symbol,imports,token}` still parse, and an item following a module line still parses.

## Base

Stacked on #1611 because the helper only lists `scope`, `level`, `is` and `study` there. On main today this fix would close `policy` alone; with #1611 it closes all five.