### PR TITLE
fix(check): refuse a call to an extern "C" the backend cannot link (#1622)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
         run: bash scripts/dev/worktree_branch_audit.sh --check
       - name: Compiler lane status contract
         run: bash scripts/ci/compiler_lane_status_gate.sh
+      - name: Extern builtin allow-list mirror (#1622)
+        run: bash scripts/ci/extern_builtin_mirror_gate.sh
       - name: Live lane coordination self-test
         run: bash scripts/ci/sounio_coord_selftest.sh
 

--- a/scripts/ci/extern_builtin_mirror_gate.sh
+++ b/scripts/ci/extern_builtin_mirror_gate.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Keep the checker's extern allow-list identical to the native backend's.
+#
+# #1622: an `extern "C"` declaration reaches codegen as an instr_count == 0 stub
+# (ir/lower.sio flushes it that way). native_v2_builtin_id_for_func_ref in
+# self-hosted/native/codegen_x86_linux.sio maps such a stub to a builtin id
+# 1..27 and returns 0 -- "emit nothing" -- for every other name, so a call to an
+# unlisted extern reads whatever is in rax. check/check.sio refuses that call at
+# type-check time (E219) using name_is_native_backend_builtin.
+#
+# Two lists, one truth. If the backend gains a builtin and the checker does not
+# hear about it, the checker rejects a name that now works -- a false refusal,
+# strictly worse than the bug E219 was written to kill. If the backend LOSES one,
+# the checker accepts a call that silently returns 0 again. This gate diffs them.
+#
+# Usage: scripts/ci/extern_builtin_mirror_gate.sh
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR" || exit 1
+
+CODEGEN="self-hosted/native/codegen_x86_linux.sio"
+CHECK="self-hosted/check/check.sio"
+
+fail() { echo "[extern-mirror] FAIL: $*" >&2; exit 1; }
+
+[ -f "$CODEGEN" ] || fail "missing $CODEGEN"
+[ -f "$CHECK" ]   || fail "missing $CHECK"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/extern-mirror.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- backend side ----------------------------------------------------------
+# The body of native_v2_builtin_id_for_func_ref, which is the authority. Each
+# arm is `if <pred>((*func).name) { return <id> }` or a name_ref_is_* variant;
+# the predicate name carries the builtin name after the is_ prefix.
+awk '
+    /^fn native_v2_builtin_id_for_func_ref/ { inside = 1; next }
+    inside && /^}/                         { inside = 0 }
+    inside                                 { print }
+' "$CODEGEN" \
+  | grep -oE '(name_is|name_ref_is)_[a-z_0-9]+' \
+  | sed -E 's/^name_ref_is_//; s/^name_is_//' \
+  | sort -u > "$WORK/backend.txt"
+
+# --- checker side ----------------------------------------------------------
+awk '
+    /^fn name_is_native_backend_builtin/ { inside = 1; next }
+    inside && /^}/                       { inside = 0 }
+    inside                               { print }
+' "$CHECK" \
+  | grep -oE 'make_name\("[a-z_0-9]+"\)' \
+  | sed -E 's/^make_name\("//; s/"\)$//' \
+  | sort -u > "$WORK/checker.txt"
+
+BACKEND_N=$(wc -l < "$WORK/backend.txt")
+CHECKER_N=$(wc -l < "$WORK/checker.txt")
+
+# An empty extraction means the source moved and the gate is measuring nothing.
+# That must fail loudly, not pass vacuously -- the exact class this repository
+# keeps rediscovering.
+[ "$BACKEND_N" -ge 20 ] || fail \
+  "extracted only $BACKEND_N names from native_v2_builtin_id_for_func_ref in $CODEGEN.
+  The function was renamed or restructured; this gate is no longer measuring it."
+[ "$CHECKER_N" -ge 20 ] || fail \
+  "extracted only $CHECKER_N names from name_is_native_backend_builtin in $CHECK.
+  The function was renamed or restructured; this gate is no longer measuring it."
+
+if ! diff -u "$WORK/backend.txt" "$WORK/checker.txt" > "$WORK/diff.txt"; then
+    echo "[extern-mirror] backend ($BACKEND_N names) vs checker ($CHECKER_N names):" >&2
+    sed -n '3,$p' "$WORK/diff.txt" >&2
+    echo >&2
+    echo "  -name  the backend implements it; the checker would reject a working call" >&2
+    echo "  +name  the checker allows it; calls compile to an empty stub reading 0" >&2
+    fail "the two builtin lists have drifted.
+  Authority: native_v2_builtin_id_for_func_ref ($CODEGEN)
+  Mirror:    name_is_native_backend_builtin ($CHECK)"
+fi
+
+echo "[extern-mirror] PASS: $BACKEND_N builtin names, checker and backend agree"

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -1732,6 +1732,7 @@ fn checker_lower_fn_type_expr_mut(c: *mut Checker, te: TypeExpr) -> TypeEntry wi
         effect_count: eff_pair.count,
         is_kernel: false,
         is_epistemic_kernel: false,
+        is_extern: false,
         is_linear_closure: false,
         linear_capture_count: 0,
         epistemic_epsilon: 0.0 - 1.0,
@@ -3124,6 +3125,7 @@ fn checker_collect_fn_def_inplace(c: *mut Checker, opt: Option<Box<FnDef> >, vis
                 effect_count: kernel_effect_count,
                 is_kernel: is_kernel_fn,
                 is_epistemic_kernel: has_epistemic_param,
+                is_extern: (*fd).is_extern,
                 is_linear_closure: false,
                 linear_capture_count: 0,
                 epistemic_epsilon: 0.0 - 1.0,
@@ -4062,6 +4064,7 @@ fn checker_collect_impl_method_inplace(c: *mut Checker, item: Item, type_name: N
                 effect_count: fn_effect_count,
                 is_kernel: false,
                 is_epistemic_kernel: false,
+                is_extern: false,
                 is_linear_closure: false,
                 linear_capture_count: 0,
                 epistemic_epsilon: 0.0 - 1.0,
@@ -6085,6 +6088,7 @@ fn checker_check_closure_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry wit
         effect_count: inferred_effect_count,
         is_kernel: false,
         is_epistemic_kernel: false,
+        is_extern: false,
         is_linear_closure: capture_linear,
         linear_capture_count: capture_linear_count,
         epistemic_epsilon: capture_epsilon,
@@ -6878,6 +6882,12 @@ fn checker_check_call_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with M
         }
         let call_start_borrows = (*c).borrows
         let direct_sig = fn_sig_table_get((*c).fn_sigs, direct_sig_id)
+        // #1622: calling an `extern "C"` name the native backend does not
+        // implement. This is the live arm -- a plain ident callee resolves via
+        // direct_sig_id and returns below, never reaching the TyFn fallback.
+        if direct_sig.is_extern && !name_is_native_backend_builtin(direct_sig.name) {
+            checker_report_error_at_inplace(c, e.span, 219, 0, 0, 0)
+        }
         var effective_params = fn_param_list_clone(&direct_sig.params)
         var effective_return_type = direct_sig.return_type
         match call_expr_type_args(e) {
@@ -6955,6 +6965,16 @@ fn checker_check_call_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with M
         let sig = fn_sig_table_get((*c).fn_sigs, callee_ty.fn_sig_id)
         if (*c).enforce_visibility && !checker_fn_sig_visible_inplace(c, callee_ty.fn_sig_id) {
             checker_report_error_at_inplace(c, e.span, 175, 0, 0, 0)
+        }
+        // #1622: calling an `extern "C"` name the native backend does not
+        // implement. Refuse here rather than emit a call that reads 0.
+        // Checked at the CALL, not at the declaration: ffi_libm_call.sio
+        // declares tgamma/pow/floor/ceil and calls only sqrt, and
+        // parser_card_a_raw_pointer_types.sio declares malloc and never calls
+        // it -- both compile and pass today, and a declaration-site refusal
+        // would break them for no gain.
+        if sig.is_extern && !name_is_native_backend_builtin(sig.name) {
+            checker_report_error_at_inplace(c, e.span, 219, 0, 0, 0)
         }
         let call_start_borrows = (*c).borrows
         var effective_params = fn_param_list_clone(&sig.params)
@@ -12108,6 +12128,7 @@ fn print_error_message(code: i64) with IO, Mut, Panic, Div {
     else if code == 216 { print("infinite recursive type") }
     else if code == 217 { print("f128/f256 value conversion is not implemented; wide-float casts fail closed") }
     else if code == 218 { print("f128/f256 is reserved for compiler-owned format identity; source values are unavailable in V0-A") }
+    else if code == 219 { print("call to an `extern \"C\"` function the native backend does not implement") }
     else { print("unknown error") }
 }
 
@@ -12391,6 +12412,9 @@ fn print_error_help(code: i64) with IO, Mut, Panic, Div {
     }
     else if code == 218 {
         print("   |\n   = help: V0-A exposes binary128/binary256 descriptors internally but rejects every source-level use before IR\n")
+    }
+    else if code == 219 {
+        print("   |\n   = help: only these body-less names are implemented: print, print_int, print_char, print_f64, get_arg, get_arg_count, str_len, str_char_at, str_eq, str_slice, starts_with, str_concat, str_from_bytes, read_file, write_file, file_size, sqrt, exp, log, sin, cos, assert, heap_alloc, heap_free, f64_to_bits, bits_to_f64, syscall6\n")
     }
     else {
         // No help available for unknown errors
@@ -12712,6 +12736,9 @@ fn print_error_note(code: i64) with IO, Mut, Panic, Div {
     }
     else if code == 218 {
         print("   = note: no literal, field, alias, binding, signature, conversion, ABI, or native carrier is implemented\n")
+    }
+    else if code == 219 {
+        print("   = note: there is no dynamic linker in this backend; an unimplemented extern compiles to an empty stub whose calls read 0\n")
     }
     else {
         // No note available for unknown errors
@@ -13059,6 +13086,52 @@ fn call_expr_is_syscall6(opt: Option<Box<Expr> >) -> bool with Mut, Panic, Div, 
         }
         None => false
     }
+}
+
+// #1622: the names the native backend implements for a body-less function.
+//
+// MIRROR of native_v2_builtin_id_for_func_ref in
+// self-hosted/native/codegen_x86_linux.sio (~:1116), which is the authority:
+// it maps an instr_count == 0 IrFunction to a builtin id 1..27, and returns 0 —
+// "emit nothing" — for every other name. An `extern "C"` declaration reaches
+// codegen as exactly such a stub (ir/lower.sio:3498 flushes it that way), so a
+// name absent from this list compiles to an empty function and every call to it
+// silently reads 0. That is what this list exists to refuse.
+//
+// Kept in sync by scripts/ci/extern_builtin_mirror_gate.sh, which diffs the two
+// lists and fails if they drift. Verified empirically as well: of 19 non-listed
+// extern names probed under Madaros (fabs, pow, floor, ceil, malloc, getpid,
+// tgamma, ...) all 19 returned 0, and heap_alloc — listed but dispatched
+// elsewhere — returned a real pointer.
+fn name_is_native_backend_builtin(n: Name) -> bool with Mut, Panic, Div, Alloc, IO {
+    if name_eq(n, make_name("print_int")) { return true }        // id 1
+    if name_eq(n, make_name("print_char")) { return true }       // id 2
+    if name_eq(n, make_name("print")) { return true }            // id 3
+    if name_eq(n, make_name("get_arg_count")) { return true }    // id 4
+    if name_eq(n, make_name("get_arg")) { return true }          // id 5
+    if name_eq(n, make_name("str_len")) { return true }          // id 6
+    if name_eq(n, make_name("str_eq")) { return true }           // id 7
+    if name_eq(n, make_name("str_slice")) { return true }        // id 8
+    if name_eq(n, make_name("starts_with")) { return true }      // id 9
+    if name_eq(n, make_name("str_concat")) { return true }       // id 10
+    if name_eq(n, make_name("read_file")) { return true }        // id 11
+    if name_eq(n, make_name("write_file")) { return true }       // id 12
+    if name_eq(n, make_name("file_size")) { return true }        // id 13
+    if name_eq(n, make_name("sqrt")) { return true }             // id 14
+    if name_eq(n, make_name("print_f64")) { return true }        // id 15
+    if name_eq(n, make_name("exp")) { return true }              // id 16
+    if name_eq(n, make_name("log")) { return true }              // id 17
+    if name_eq(n, make_name("sin")) { return true }              // id 18
+    if name_eq(n, make_name("cos")) { return true }              // id 19
+    if name_eq(n, make_name("str_char_at")) { return true }      // id 20
+    if name_eq(n, make_name("assert")) { return true }           // id 21
+    if name_eq(n, make_name("str_from_bytes")) { return true }   // id 22
+    if name_eq(n, make_name("heap_alloc")) { return true }       // id 23
+    if name_eq(n, make_name("heap_free")) { return true }        // id 24
+    if name_eq(n, make_name("f64_to_bits")) { return true }      // id 25
+    if name_eq(n, make_name("bits_to_f64")) { return true }      // id 26
+    if name_eq(n, make_name("syscall6")) { return true }         // id 27
+    false
 }
 
 fn call_expr_is_gpu_builtin(opt: Option<Box<Expr> >) -> bool with Mut, Panic, Div, Alloc, IO {
@@ -15104,6 +15177,7 @@ impl Checker {
             effect_count: effect_count,
             is_kernel: false,
             is_epistemic_kernel: false,
+            is_extern: false,
             is_linear_closure: false,
             linear_capture_count: 0,
             epistemic_epsilon: 0.0 - 1.0,
@@ -17232,6 +17306,7 @@ impl Checker {
                     effect_count: kernel_effect_count,
                     is_kernel: is_kernel_fn,
                     is_epistemic_kernel: has_epistemic_param,
+                    is_extern: (*fd).is_extern,
                     is_linear_closure: false,
                     linear_capture_count: 0,
                     epistemic_epsilon: 0.0 - 1.0,
@@ -18225,6 +18300,7 @@ impl Checker {
                     effect_count: fn_effect_count,
                     is_kernel: false,
                     is_epistemic_kernel: false,
+                    is_extern: false,
                     is_linear_closure: false,
                     linear_capture_count: 0,
                     epistemic_epsilon: 0.0 - 1.0,
@@ -20118,6 +20194,16 @@ impl Checker {
             let sig = fn_sig_table_get(c.fn_sigs, callee_ty.fn_sig_id)
             if c.enforce_visibility && !visibility_allows_access(sig.visibility, sig.defining_module, c.current_module, c.crate_root) {
                 c = c.report_error_at(e.span, 175, 0, 0, 0)
+            }
+            // #1622: calling an `extern "C"` name the native backend does not
+            // implement. Refuse here rather than emit a call that reads 0.
+            // Checked at the CALL, not at the declaration: ffi_libm_call.sio
+            // declares tgamma/pow/floor/ceil and calls only sqrt, and
+            // parser_card_a_raw_pointer_types.sio declares malloc and never
+            // calls it — both compile and pass today, and a declaration-site
+            // refusal would break them for no gain.
+            if sig.is_extern && !name_is_native_backend_builtin(sig.name) {
+                c = c.report_error_at(e.span, 219, 0, 0, 0)
             }
             let call_start_borrows = c.borrows
             var effective_params = fn_param_list_clone(&sig.params)
@@ -23326,6 +23412,7 @@ impl Checker {
             effect_count: inferred_effect_count,
             is_kernel: false,
             is_epistemic_kernel: false,
+            is_extern: false,
             is_linear_closure: capture_linear,
             linear_capture_count: capture_linear_count,
             epistemic_epsilon: capture_epsilon,

--- a/self-hosted/check/defs.sio
+++ b/self-hosted/check/defs.sio
@@ -1286,6 +1286,11 @@ pub struct FnSig {
     effect_count: i64,
     is_kernel: bool,
     is_epistemic_kernel: bool,
+    // #1622: true for a body-less `extern "C"` declaration. The native backend
+    // has no dynamic linker — an extern name it does not implement as a builtin
+    // compiles to an empty stub and every call reads whatever is in rax (0).
+    // Carried here so check_call_expr can refuse the call instead.
+    is_extern: bool,
     // Sprint 231: Unified closure type theory
     is_linear_closure: bool,      // true if captures linear resources => call exactly once
     linear_capture_count: i64,    // number of linear captures
@@ -1310,6 +1315,7 @@ fn empty_fn_sig() -> FnSig {
         effect_count: 0,
         is_kernel: false,
         is_epistemic_kernel: false,
+        is_extern: false,
         is_linear_closure: false,
         linear_capture_count: 0,
         epistemic_epsilon: 0.0 - 1.0,

--- a/tests/compile-fail/extern_c_unimplemented_builtin.sio
+++ b/tests/compile-fail/extern_c_unimplemented_builtin.sio
@@ -1,0 +1,29 @@
+//@ compile-fail
+//@ requires: madaros
+//@ error-pattern: call to an `extern "C"` function the native backend does not implement
+//@ error-pattern: no dynamic linker in this backend
+// requires: madaros because E219 lives in check/check.sio, and the suite's
+// stage2 binary is built by lean_single -- which links malloc and abs for real
+// and compiles this file with exit 0. Measured: without the guard this test is
+// a FALSE RED under CI, not a false green.
+// #1622: the native backend has no dynamic linker. An `extern "C"` declaration
+// is flushed to codegen as an instr_count == 0 stub (ir/lower.sio), and
+// native_v2_builtin_id_for_func_ref implements exactly 27 such names. A call to
+// any other one used to compile into an empty function whose result is whatever
+// sits in rax -- 0 -- so `malloc(64)` returned a null pointer and `abs(-7)`
+// returned 0, both with exit status 0 and no diagnostic.
+//
+// The refusal is at the CALL, not the declaration: see ffi_libm_call.sio, which
+// declares tgamma/pow/floor/ceil, calls only sqrt, and must keep compiling.
+
+extern "C" {
+    fn malloc(size: i64) -> i64;
+    fn abs(x: i64) -> i64;
+}
+
+fn main() -> i64 with IO {
+    let p = malloc(64)
+    print_int(p)
+    print_int(abs(0 - 7))
+    0
+}

--- a/tests/madaros_corpus_baseline.txt
+++ b/tests/madaros_corpus_baseline.txt
@@ -63,7 +63,6 @@ darwin_pop_epistemic_smoke.sio compile
 darwin_sema_sc_depot_smoke.sio compile
 darwin_tmdd_glp1r_smoke.sio compile
 darwin_venlafaxine_xr_pgx_smoke.sio compile
-dataframe_test.sio run
 display_headless.sio compile
 dissertation_midazolam_scenario_smoke.sio run
 dissertation_pbpk14_gum.sio run
@@ -78,7 +77,7 @@ epistemic_nuclear_decay.sio compile
 epistemic_unspecified_epsilon.sio compile
 epsilon_comparison_valid.sio compile
 f2_conjugation_swda.sio run
-ffi_integer_return.sio run
+ffi_integer_return.sio compile
 for_in_vec.sio compile
 g2_abide_sounio.sio compile
 g2_bridge_pipeline.sio compile
@@ -159,7 +158,6 @@ match_patterns_complete.sio compile
 mcmc_integration.sio compile
 mercyful_clinical_sequencing.sio run
 method_intrinsics_native.sio compile
-method_receiver_correct.sio run
 multi_drug_aggregate_test.sio compile
 native_enum_basic.sio compile
 native_tokenizer.sio compile
@@ -194,7 +192,6 @@ pbpk28_extract_only.sio compile
 pbpk28_m2_hierarchical_prior.sio compile
 pbpk28_m5_gum_4th_order.sio compile
 pbpk28_struct_return.sio compile
-pediatric_pbpk_receipt.sio run
 pkg_manifest_parse_e2e.sio compile
 proof_obligation_basic.sio compile
 proof_search_basic.sio compile
@@ -207,7 +204,6 @@ refinement_satisfied.sio compile
 root_finding.sio compile
 sample_uniform_native.sio compile
 scheduler_machine_reorder.sio compile
-scidata_test.sio run
 scientific_io_test.sio run
 second_order_proof.sio compile
 sedenion_embedding_basic.sio compile
@@ -229,8 +225,8 @@ site_screening_selftest.sio compile
 slice_fat_pointers.sio compile
 smt_qflia_basic.sio run
 spearman_holm_bca.sio compile
-stdlib_mem_alloc.sio run
-stdlib_os_process.sio run
+stdlib_mem_alloc.sio compile
+stdlib_os_process.sio compile
 stdlib_time_basic.sio run
 str_index_of.sio compile
 string_len.sio compile

--- a/tests/run-pass/extern_c_declared_not_called.sio
+++ b/tests/run-pass/extern_c_declared_not_called.sio
@@ -1,0 +1,36 @@
+//@ run-pass
+//@ expect-stdout: extern_c_declared_not_called: PASS
+// #1622 companion to tests/compile-fail/extern_c_unimplemented_builtin.sio.
+//
+// E219 fires at the CALL, never at the declaration. Two properties are asserted
+// here, and both were measured before the check was written:
+//
+//   1. Declaring an extern the backend does not implement, without calling it,
+//      is not an error. ffi_libm_call.sio declares tgamma/pow/floor/ceil and
+//      calls only sqrt; parser_card_a_raw_pointer_types.sio declares malloc and
+//      never calls it. Both compile and pass today, and a declaration-site
+//      refusal would have broken them for no gain.
+//
+//   2. An extern name the backend DOES implement still calls through. sqrt is
+//      builtin id 14 in native_v2_builtin_id_for_func_ref.
+
+extern "C" {
+    fn sqrt(x: f64) -> f64;
+    fn tgamma(x: f64) -> f64;
+    fn pow(x: f64, y: f64) -> f64;
+    fn malloc(size: i64) -> i64;
+}
+
+fn main() -> i64 with IO {
+    // sqrt is implemented: this must compute, not read 0.
+    let r = sqrt(9.0)
+    let r_int = (r * 1000000.0) as i64
+    if r_int != 3000000 {
+        print("extern_c_declared_not_called: FAIL sqrt\n")
+        return 1
+    }
+    // tgamma, pow and malloc are declared above and never called. Reaching this
+    // line at all is the assertion.
+    print("extern_c_declared_not_called: PASS\n")
+    0
+}


### PR DESCRIPTION
Closes #1622. Option 1 from the issue, with one measured deviation.

## The bug

The native backend has no dynamic linker. `ir/lower.sio:3498` flushes an `extern "C"` declaration to codegen as an `instr_count == 0` stub, and `native_v2_builtin_id_for_func_ref` implements exactly 27 such names. A call to any other one compiled into an empty function whose result is whatever sits in `rax`:

```
extern "C" { fn malloc(size: i64) -> i64  fn abs(x: i64) -> i64 }
MADAROS: malloc(64) = 0     abs(-7) = 0     exit 0, no diagnostic
LEAN:    malloc(64) != 0    abs(-7) = 7
```

Codegen has no error channel — no `error_count`, no failure field on `NativeCompiler` — which is why two earlier attempts to warn there were abandoned. The checker has one.

## Refused at the call, not at the declaration

The issue says "refuse at the declaration". Measurement overrode the wording. Five `run-pass` files declare a non-builtin extern; only three call one:

| file | declares | calls | today |
|---|---|---|---|
| `ffi_libm_call.sio` | tgamma, pow, floor, ceil | only `sqrt` | **passes** |
| `parser_card_a_raw_pointer_types.sio` | malloc | nothing | **passes** |

A declaration-site refusal breaks both for no gain. The issue's own acceptance criterion is *three* refusals; call-site gives exactly three. Both files are now regression-tested.

## The allow-list is measured, not grepped

The dispatch chain at `codegen_x86_linux.sio:5499` lists 24 names and is **not** the authority. `native_v2_builtin_id_for_func_ref` (~`:1116`) is, with 27 — it adds `heap_alloc`, `heap_free`, `syscall6`.

Probed one extern program per name under Madaros: `sqrt`/`exp`/`log`/`sin`/`cos` returned correct values, `heap_alloc` returned a real pointer, and all 19 non-listed names probed (`fabs`, `pow`, `floor`, `ceil`, `malloc`, `getpid`, `tgamma`, `atan2`, `sinh`, `cosh`, `tanh`, `erf`, `erfc`, `lgamma`, `log2`, `j0`, `y0`, `sqrtf`, `abs`) returned 0. No false refusal in the probed set.

Two lists in two files is the standing risk, so `scripts/ci/extern_builtin_mirror_gate.sh` diffs them and fails on drift. It is not a smoke test: removing one name from the checker makes it fail, and it refuses to pass if either extraction yields fewer than 20 names, so a rename cannot make it green vacuously.

## Baseline delta — 3 kind-changes, 4 stale drops

```
+ ffi_integer_return.sio compile      \  were `run` failures; same
+ stdlib_mem_alloc.sio compile         > programs, refused earlier
+ stdlib_os_process.sio compile       /  and loudly
- dataframe_test.sio run              \
- method_receiver_correct.sio run      > already passed on the PRE-change
- pediatric_pbpk_receipt.sio run       > binary; stale entries, not
- scidata_test.sio run                /  credit from this PR
```

Failures observed: **274/1688 before, 274/1689 after**. No program regressed.

## Unmasked, not regressed

27 stdlib modules call a non-builtin extern and **13 of them compile today**: `mem::box` allocates through `calloc` (returns NULL), `roots::lib` bisects with `fabs` (returns 0), `ffi::library` does `dlopen` (returns 0), `special::lib` computes `erf`/`tgamma` (return 0). None is in any gate; all were already wrong. They will now say so. `self-hosted/gpu/numerical.sio` and `compiler/pkg/registry_client.sio` are in the same position for the eventual Madaros self-host.

## Notes for the reader

The check sits at three sites; **only the first is proven live**. A plain ident callee resolves through `direct_sig_id` and returns at `:6912`, never reaching the `TyFn` fallback — an instrumented build showed the probe firing zero times at the other two. They are kept as belt-and-braces on paths that could not be triggered from source.

The compile-fail test carries `//@ requires: madaros`: the suite's stage2 binary is built by lean_single, which links `malloc` and `abs` for real and compiles that file with exit 0. Without the guard it is a **false red** in CI. Measured, not assumed.

## Verified

- E219 fires for `malloc`/`abs`; `sqrt(9.0)` still prints `3.000000`
- `ffi_libm_call` and `parser_card_a_raw_pointer_types` still compile and exit 0
- the three baseline files refuse (2, 4 and 2 diagnostics respectively)
- the new `run-pass` test agrees byte-for-byte across both engines
- mirror gate passes, and is proven to fail on drift
- LoRA validator and `check_workflow_script_refs.sh` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)