### PR TITLE
fix(stdlib): rewire ten modules off extern "C" onto a real implementation

### DIFF
--- a/self-hosted/check/defs.sio
+++ b/self-hosted/check/defs.sio
@@ -1352,9 +1352,21 @@ pub struct FnSigTable {
 }
 
 // One zeroed chunk via heap_alloc (calloc): entries start empty, next == 0.
-// 512 * <=1.5KB/FnSig ~= 0.75MB; over-provisioned, mmap-lazy.
+//
+// THIS NUMBER IS NOT CHECKED AGAINST sizeof(FnSigChunk) BY ANYTHING. It was
+// 786432 = 512 * 1536, sized against an FnSig that the comment above called
+// "<=1.5KB" -- and #1622 added a field to FnSig without touching it. That is a
+// silent overflow waiting on one more field, so the budget is raised here to
+// 4 MB = 512 * 8192 B/entry. The pages are mmap-lazy: an oversized chunk costs
+// address space, not memory.
+//
+// Honest note on provenance: this was written while chasing spurious E219
+// diagnostics, on the theory that tail-entry writes were corrupting neighbouring
+// FnSigs. That theory was WRONG -- the diagnostics came from the compiler
+// reading a different stdlib via SOUNIO_STDLIB_PATH. The headroom is kept
+// because the hazard is real, not because it fixed anything.
 fn fn_sig_chunk_alloc() -> *mut FnSigChunk with Alloc {
-    heap_alloc(786432) as *mut FnSigChunk
+    heap_alloc(4194304) as *mut FnSigChunk
 }
 
 // Small table header (head ptr + count); calloc zeroes head to 0 and count to 0.

--- a/stdlib/complex/lib.sio
+++ b/stdlib/complex/lib.sio
@@ -10,18 +10,10 @@
 
 // Madaros registers at most five symbols per extern "C" block (6th is dropped
 // as undeclared). Keep the first five here; put two-arg atan2 in a second block.
-extern "C" {
-    fn sqrt(x: f64) -> f64;
-    fn sin(x: f64) -> f64;
-    fn cos(x: f64) -> f64;
-    fn exp(x: f64) -> f64;
-    fn log(x: f64) -> f64;
-}
-
-extern "C" {
-    fn atan2(y: f64, x: f64) -> f64;
-}
-
+// #1622: these were `extern "C"` bindings to libm. The native backend has no
+// dynamic linker, so every call compiled to a stub returning 0. The builtin
+// names it does implement (sqrt, exp, log, sin, cos) need no declaration.
+use math::libm::{libm_atan2}
 // Polar coordinate result
 pub struct PolarCoord {
     r: f64,
@@ -120,10 +112,10 @@ pub fn complex_norm_sq(z: Complex) -> f64 {
     z.re * z.re + z.im * z.im
 }
 
-// Argument (phase angle): arg(z) = atan2(im, re)
+// Argument (phase angle): arg(z) = libm_atan2(im, re)
 // Returns value in [-π, π]
-pub fn complex_arg(z: Complex) -> f64 {
-    atan2(z.im, z.re)
+pub fn complex_arg(z: Complex) -> f64 with Mut, Div, Panic {
+    libm_atan2(z.im, z.re)
 }
 
 // Complex conjugate: conj(a + bi) = a - bi
@@ -153,7 +145,7 @@ pub fn complex_from_polar(r: f64, theta: f64) -> Complex {
 }
 
 // Convert to polar coordinates: returns (r, theta)
-pub fn complex_to_polar(z: Complex) -> PolarCoord {
+pub fn complex_to_polar(z: Complex) -> PolarCoord with Mut, Div, Panic {
     let r = complex_abs(z)
     let theta = complex_arg(z)
     PolarCoord { r: r, theta: theta }
@@ -174,7 +166,7 @@ pub fn complex_exp(z: Complex) -> Complex {
 
 // Complex natural logarithm: ln(z) = ln|z| + i*arg(z)
 // Principal branch with arg in [-π, π]
-pub fn complex_log(z: Complex) -> Complex {
+pub fn complex_log(z: Complex) -> Complex with Mut, Div, Panic {
     let r = complex_abs(z)
     let theta = complex_arg(z)
     complex_new(log(r), theta)
@@ -182,7 +174,7 @@ pub fn complex_log(z: Complex) -> Complex {
 
 // Complex square root: sqrt(z) = sqrt|z| * e^(i*arg(z)/2)
 // Principal branch (positive real part when possible)
-pub fn complex_sqrt(z: Complex) -> Complex with Div, Panic {
+pub fn complex_sqrt(z: Complex) -> Complex with Div, Mut, Panic {
     if z.re == 0.0 && z.im == 0.0 {
         return complex_zero()
     }
@@ -193,14 +185,14 @@ pub fn complex_sqrt(z: Complex) -> Complex with Div, Panic {
 }
 
 // Complex power: base^exponent = exp(exponent * log(base))
-pub fn complex_pow(base: Complex, exponent: Complex) -> Complex {
+pub fn complex_pow(base: Complex, exponent: Complex) -> Complex with Mut, Div, Panic {
     let log_base = complex_log(base)
     let prod = complex_mul(log_base, exponent)
     complex_exp(prod)
 }
 
 // Complex to real power: z^n where n is real
-pub fn complex_pow_real(z: Complex, n: f64) -> Complex {
+pub fn complex_pow_real(z: Complex, n: f64) -> Complex with Mut, Div, Panic {
     let log_z = complex_log(z)
     let scaled = complex_scale(log_z, n)
     complex_exp(scaled)
@@ -277,7 +269,7 @@ pub fn complex_tanh(z: Complex) -> Complex with Div, Panic {
 // Quadratic formula for ax² + bx + c = 0 over the complex numbers.
 // Returns (root1, root2) using the principal branch of sqrt.
 // Discriminant D = b² - 4ac; roots = (-b ± sqrt(D)) / (2a)
-pub fn complex_quadratic_roots(a: f64, b: f64, c: f64) -> QuadRoots with Div, Panic {
+pub fn complex_quadratic_roots(a: f64, b: f64, c: f64) -> QuadRoots with Div, Mut, Panic {
     // discriminant as complex number (may be negative → imaginary sqrt)
     let disc_re = b * b - 4.0 * a * c
     let disc_c = complex_new(disc_re, 0.0)

--- a/stdlib/connectivity/phase.sio
+++ b/stdlib/connectivity/phase.sio
@@ -13,13 +13,10 @@
 // - Stam et al. (2007): "Phase lag index: Assessment of functional connectivity..."
 // - Vinck et al. (2011): "An improved index of phase-synchronization..."
 
-extern "C" {
-    fn sqrt(x: f64) -> f64;
-    fn sin(x: f64) -> f64;
-    fn cos(x: f64) -> f64;
-    fn atan2(y: f64, x: f64) -> f64;
-}
-
+// #1622: these were `extern "C"` bindings to libm. The native backend has no
+// dynamic linker, so every call compiled to a stub returning 0. The builtin
+// names it does implement (sqrt, exp, log, sin, cos) need no declaration.
+use math::libm::{libm_atan2}
 fn pi() -> f64 { 3.14159265358979323846 }
 
 // ============================================================================
@@ -170,7 +167,7 @@ fn hilbert_transform(signal: [f64; 2048], n: i64) -> ([f64; 2048], [f64; 2048]) 
 }
 
 // Extract instantaneous phase
-fn instantaneous_phase(signal: [f64; 2048], n: i64) -> [f64; 2048] {
+fn instantaneous_phase(signal: [f64; 2048], n: i64) -> [f64; 2048] with Mut, Div, Panic {
     let result = hilbert_transform(signal, n)
     let analytic_re = result.0
     let analytic_im = result.1
@@ -178,7 +175,7 @@ fn instantaneous_phase(signal: [f64; 2048], n: i64) -> [f64; 2048] {
     var phase: [f64; 2048] = [0.0; 2048]
     var i: i64 = 0
     while i < n {
-        phase[i as usize] = atan2(analytic_im[i as usize], analytic_re[i as usize])
+        phase[i as usize] = libm_atan2(analytic_im[i as usize], analytic_re[i as usize])
         i = i + 1
     }
 
@@ -192,7 +189,7 @@ fn instantaneous_phase(signal: [f64; 2048], n: i64) -> [f64; 2048] {
 // Compute Phase Locking Value between two signals
 // PLV = |mean(exp(j*(phi1 - phi2)))|
 // Returns value in [0, 1]: 0 = no synchrony, 1 = perfect synchrony
-fn phase_locking_value(signal1: [f64; 2048], signal2: [f64; 2048], n: i64) -> f64 {
+fn phase_locking_value(signal1: [f64; 2048], signal2: [f64; 2048], n: i64) -> f64 with Mut, Div, Panic {
     let phase1 = instantaneous_phase(signal1, n)
     let phase2 = instantaneous_phase(signal2, n)
 
@@ -240,7 +237,7 @@ fn plv_from_phases(phase1: [f64; 2048], phase2: [f64; 2048], n: i64) -> f64 {
 // Compute Phase Lag Index
 // PLI = |mean(sign(dphi))| where dphi is mapped to [-pi, pi)
 // Robust to volume conduction (zero-lag effects)
-fn phase_lag_index(signal1: [f64; 2048], signal2: [f64; 2048], n: i64) -> f64 {
+fn phase_lag_index(signal1: [f64; 2048], signal2: [f64; 2048], n: i64) -> f64 with Mut, Div, Panic {
     let phase1 = instantaneous_phase(signal1, n)
     let phase2 = instantaneous_phase(signal2, n)
 
@@ -422,7 +419,7 @@ fn abs_f64(x: f64) -> f64 {
     if x < 0.0 { -x } else { x }
 }
 
-fn test_plv_identical_signals() -> bool {
+fn test_plv_identical_signals() -> bool with Mut, Div, Panic {
     // Identical signals should have PLV = 1
     var signal: [f64; 2048] = [0.0; 2048]
     var i: i64 = 0
@@ -436,7 +433,7 @@ fn test_plv_identical_signals() -> bool {
     return abs_f64(plv - 1.0) < 0.01
 }
 
-fn test_plv_orthogonal_signals() -> bool {
+fn test_plv_orthogonal_signals() -> bool with Mut, Div, Panic {
     // 90° phase-shifted signals should have PLV = 1 (constant phase difference)
     var signal1: [f64; 2048] = [0.0; 2048]
     var signal2: [f64; 2048] = [0.0; 2048]
@@ -455,7 +452,7 @@ fn test_plv_orthogonal_signals() -> bool {
     return plv > 0.9
 }
 
-fn test_pli_no_lag() -> bool {
+fn test_pli_no_lag() -> bool with Mut, Div, Panic {
     // Identical signals (no lag) should have PLI near 0
     var signal: [f64; 2048] = [0.0; 2048]
     var i: i64 = 0

--- a/stdlib/fusion/eeg_fmri.sio
+++ b/stdlib/fusion/eeg_fmri.sio
@@ -12,16 +12,10 @@
 // - Debener et al. (2006): "Trial-by-trial coupling of EEG and fMRI"
 // - Cichy et al. (2016): "Similarity-based fusion of MEG and fMRI"
 
-extern "C" {
-    fn sqrt(x: f64) -> f64;
-    fn sin(x: f64) -> f64;
-    fn cos(x: f64) -> f64;
-    fn exp(x: f64) -> f64;
-    fn log(x: f64) -> f64;
-    fn pow(x: f64, y: f64) -> f64;
-    fn fabs(x: f64) -> f64;
-}
-
+// #1622: these were `extern "C"` bindings to libm. The native backend has no
+// dynamic linker, so every call compiled to a stub returning 0. The builtin
+// names it does implement (sqrt, exp, log, sin, cos) need no declaration.
+use math::libm::{libm_fabs, libm_pow}
 fn pi() -> f64 { 3.14159265358979323846 }
 
 // ============================================================================
@@ -44,17 +38,17 @@ fn hrf_params_canonical() -> HRFParams {
 }
 
 // Gamma PDF approximation
-fn gamma_pdf(t: f64, shape: f64, scale: f64) -> f64 {
+fn gamma_pdf(t: f64, shape: f64, scale: f64) -> f64 with Mut, Div, Panic {
     if t <= 0.0 {
         return 0.0
     }
     let x = t / scale
     // Simplified gamma: x^(shape-1) * exp(-x)
-    pow(x, shape - 1.0) * exp(-x)
+    libm_pow(x, shape - 1.0) * exp(-x)
 }
 
 // Compute HRF value at time t
-fn hrf_value(t: f64, params: HRFParams) -> f64 {
+fn hrf_value(t: f64, params: HRFParams) -> f64 with Mut, Div, Panic {
     let peak = gamma_pdf(t, params.peak_delay, 1.0)
     let undershoot = gamma_pdf(t, params.undershoot_delay, 1.0)
     peak - undershoot / params.peak_undershoot_ratio

--- a/stdlib/math/libm.sio
+++ b/stdlib/math/libm.sio
@@ -1,0 +1,218 @@
+//! stdlib/math/libm.sio — libm-equivalent functions with no FFI
+//!
+//! Why this module exists (#1622)
+//! ------------------------------
+//! The native backend has no dynamic linker. An `extern "C"` declaration is
+//! flushed to codegen as an empty stub, and only 27 names are implemented as
+//! builtins, so a call to `fabs`, `pow`, `floor`, `atan2` or `tanh` used to
+//! compile into a function returning whatever sat in rax — 0 — with exit status
+//! 0 and no diagnostic. Since E219 those calls are refused instead, which is
+//! what left twenty-seven stdlib modules unable to compile under Madaros.
+//!
+//! This module implements them on the builtins that do exist (`sqrt`, `exp`,
+//! `log`) so the same source works under both engines.
+//!
+//! Why the names are prefixed
+//! --------------------------
+//! Not style. `pub fn pow` and `pub fn atan2` here were bound to **libm** by
+//! lean_single, with an argument convention that does not match, so
+//! `pow(-2.0, 3.0)` returned 0.0 and `atan2(1.0, 2.0)` returned atan(2.0)
+//! instead of atan(0.5). Renaming the identical bodies to `zpow`/`zatan2` made
+//! both correct immediately. Under Madaros, which has no libm, the same source
+//! was correct all along — so an unprefixed name here is a silent
+//! engine-dependent divergence. The prefix makes both engines run THIS code.
+//!
+//! That collision cost two wrong diagnoses before the rename test, because the
+//! failures look exactly like a register-allocation defect: inserting a `print`
+//! changes the answer, and a minimal two-argument repro does not reproduce.
+//!
+//! Accuracy, measured
+//! ------------------
+//! Worst-case ULP distance from glibc over a 17-point grid spanning 1e-3 to
+//! 1e6, references baked in from CPython rather than called (calling an
+//! in-process `extern atan` returns atan(1/x) for x in (0.268, 1) — the same
+//! collision, seen from the other side):
+//!
+//!     symbol       lean_single   limited by
+//!     libm_fabs         0        exact — a sign flip is exact in IEEE 754
+//!     libm_floor        0        exact — i64 round trip
+//!     libm_atan         2        pure arithmetic
+//!     libm_atan2        2        pure arithmetic
+//!     libm_pow       6455        the exp/log builtins
+//!     libm_tanh       990        the exp builtin
+//!
+//! `pow` and `tanh` are the only two that reach for a builtin, and under
+//! Madaros that is the binding constraint rather than the algorithm: `exp` and
+//! `log` there carry about SEVEN significant digits, not sixteen —
+//! `exp(10.0)` gives 22026.465124 against 22026.465795. Filed as #1626.
+//! `libm_pow` sidesteps it for the common case with exact binary
+//! exponentiation whenever the exponent is an integer, so `libm_pow(10.0, 7.0)`
+//! is exactly 10000000.0 rather than 9999999.950639.
+//!
+//! Relationship to stdlib/math/pure.sio
+//! ------------------------------------
+//! `pure.sio` is not importable — its functions are not `pub`, which is part of
+//! why callers bound libm instead. It also implements `exp`/`ln`/`cos` as Taylor
+//! series (less accurate than the builtins used here) and its `atan` is the
+//! plain Leibniz series, which leaves ~1.2e-2 of error at x = 1.
+
+// =============================================================================
+// Exact — no approximation anywhere in these
+// =============================================================================
+
+/// |x|. Bit-identical to glibc: a sign flip is exact in IEEE 754.
+pub fn libm_fabs(x: f64) -> f64 {
+    if x < 0.0 { return 0.0 - x }
+    x
+}
+
+/// Largest integer <= x. Exact via an i64 round trip, which truncates toward
+/// zero, then corrects for negatives. Magnitudes beyond the i64 range are
+/// already integers in binary64, so they are returned unchanged.
+pub fn libm_floor(x: f64) -> f64 {
+    if x >= 9223372036854775000.0 { return x }
+    if x <= 0.0 - 9223372036854775000.0 { return x }
+    let t = (x as i64) as f64
+    if x < 0.0 && t != x { return t - 1.0 }
+    t
+}
+
+/// Smallest integer >= x.
+pub fn libm_ceil(x: f64) -> f64 {
+    if x >= 9223372036854775000.0 { return x }
+    if x <= 0.0 - 9223372036854775000.0 { return x }
+    let t = (x as i64) as f64
+    if x > 0.0 && t != x { return t + 1.0 }
+    t
+}
+
+// =============================================================================
+// Pure arithmetic — 2 ULP, independent of the transcendental builtins
+// =============================================================================
+
+/// arctangent, two-stage argument reduction.
+///
+/// A plain Taylor series on |x| <= 1 IS the Leibniz series at x = 1: 40 terms
+/// still leave ~1.2e-2 of error, which is what `stdlib/math/pure.sio` does.
+/// Reducing first to |t| <= tan(pi/12) = 0.2679 makes t^2 <= 0.072, so 24 terms
+/// land below 1e-27 and the result is 2 ULP from glibc across the grid.
+///
+/// Iterative rather than recursive: both are correct once the name is prefixed,
+/// and folding the two reductions into flags keeps it to a single frame.
+pub fn libm_atan(x: f64) -> f64 with Mut, Div, Panic {
+    var a = x
+    var negate = false
+    if a < 0.0 {
+        a = 0.0 - a
+        negate = true
+    }
+    var invert = false
+    if a > 1.0 {
+        a = 1.0 / a
+        invert = true
+    }
+    var t = a
+    var offset = 0.0
+    if a > 0.26794919243112270647 {
+        // tan(a - b) with b = pi/6: (a - 1/sqrt3) / (1 + a/sqrt3)
+        let s3 = 1.73205080756887729353
+        t = (a * s3 - 1.0) / (a + s3)
+        offset = 0.52359877559829887308
+    }
+    var sum = t
+    var term = t
+    let t2 = t * t
+    var k: i64 = 1
+    while k < 24 {
+        term = 0.0 - term * t2
+        sum = sum + term / ((2 * k + 1) as f64)
+        k = k + 1
+    }
+    var r = offset + sum
+    if invert { r = 1.57079632679489661923 - r }
+    if negate { r = 0.0 - r }
+    r
+}
+
+/// Full-quadrant arctangent. Sign and quadrant follow C99 atan2(y, x).
+pub fn libm_atan2(y: f64, x: f64) -> f64 with Mut, Div, Panic {
+    if x == 0.0 {
+        if y > 0.0 { return 1.57079632679489661923 }
+        if y < 0.0 { return 0.0 - 1.57079632679489661923 }
+        return 0.0
+    }
+    let r = libm_atan(y / x)
+    if x > 0.0 { return r }
+    if y >= 0.0 { return r + 3.14159265358979323846 }
+    r - 3.14159265358979323846
+}
+
+// =============================================================================
+// Built on the exp/log builtins — see the accuracy note in the header
+// =============================================================================
+
+/// x^y.
+///
+/// An integer exponent takes an exact binary-exponentiation path: every multiply
+/// is a single rounding, so `libm_pow(10.0, 7.0)` is exactly 10000000.0 rather
+/// than the 9999999.950639 that `exp(y * log x)` yields under Madaros (#1626).
+/// Only fractional exponents fall through to the builtins.
+pub fn libm_pow(x: f64, y: f64) -> f64 with Mut, Div, Panic {
+    if y == 0.0 { return 1.0 }
+    if y == 1.0 { return x }
+    if y == 0.5 && x >= 0.0 { return sqrt(x) }
+    if x == 0.0 {
+        if y > 0.0 { return 0.0 }
+        return 1.0e308
+    }
+
+    var base = x
+    var negative_base = false
+    if base < 0.0 {
+        base = 0.0 - base
+        negative_base = true
+    }
+
+    // Bounded at 1024: past that the result has overflowed for any base > 1,
+    // and the loop stops being free.
+    let n = y as i64
+    if (n as f64) == y && n > 0 - 1024 && n < 1024 {
+        var result = 1.0
+        var b = base
+        var e = n
+        if e < 0 { e = 0 - e }
+        while e > 0 {
+            if e % 2 == 1 { result = result * b }
+            b = b * b
+            e = e / 2
+        }
+        if n < 0 { result = 1.0 / result }
+        if negative_base && n % 2 != 0 { return 0.0 - result }
+        return result
+    }
+
+    // A fractional exponent on a negative base is not real-valued.
+    if negative_base { return 0.0 }
+    exp(y * log(base))
+}
+
+/// tanh(x) = (e^2x - 1) / (e^2x + 1), saturating outside |x| > 20 where the
+/// result is 1.0 to within 4e-18 and e^2x starts costing range for nothing.
+pub fn libm_tanh(x: f64) -> f64 with Mut, Div, Panic {
+    if x > 20.0 { return 1.0 }
+    if x < 0.0 - 20.0 { return 0.0 - 1.0 }
+    let e = exp(2.0 * x)
+    (e - 1.0) / (e + 1.0)
+}
+
+/// sinh(x) = (e^x - e^-x) / 2
+pub fn libm_sinh(x: f64) -> f64 with Mut, Div, Panic {
+    let e = exp(x)
+    (e - 1.0 / e) / 2.0
+}
+
+/// cosh(x) = (e^x + e^-x) / 2
+pub fn libm_cosh(x: f64) -> f64 with Mut, Div, Panic {
+    let e = exp(x)
+    (e + 1.0 / e) / 2.0
+}

--- a/stdlib/medlang/codegen.sio
+++ b/stdlib/medlang/codegen.sio
@@ -8,13 +8,10 @@
 //
 // This module bridges the AST representation to numerical computation.
 
-extern "C" {
-    fn sqrt(x: f64) -> f64;
-    fn log(x: f64) -> f64;
-    fn exp(x: f64) -> f64;
-    fn fabs(x: f64) -> f64;
-}
-
+// #1622: these were `extern "C"` bindings to libm. The native backend has no
+// dynamic linker, so every call compiled to a stub returning 0. The builtin
+// names it does implement (sqrt, exp, log, sin, cos) need no declaration.
+use math::libm::{libm_fabs}
 // ============================================================================
 // ODE STATE REPRESENTATION
 // ============================================================================
@@ -443,7 +440,7 @@ fn param_uncertainty_new(value: f64, se: f64) -> ParamUncertainty {
         std_error: se,
         ci_lower: value - k * se,
         ci_upper: value + k * se,
-        cv_percent: if value != 0.0 { 100.0 * se / fabs(value) } else { 0.0 },
+        cv_percent: if value != 0.0 { 100.0 * se / libm_fabs(value) } else { 0.0 },
     }
 }
 
@@ -708,7 +705,7 @@ struct ModelComparison {
 
 fn compare_models(aic1: f64, aic2: f64) -> ModelComparison {
     let delta = aic1 - aic2;
-    let er = exp(-0.5 * fabs(delta));
+    let er = exp(-0.5 * libm_fabs(delta));
     let pref = if aic1 < aic2 { 1 } else { 2 };
 
     ModelComparison {

--- a/stdlib/particle_physics/ml_hep.sio
+++ b/stdlib/particle_physics/ml_hep.sio
@@ -13,14 +13,10 @@ module particle_physics::ml_hep
 
 use particle_physics::lorentz::{LorentzVector, lorentz_new, lorentz_add, lorentz_sub, lorentz_dot, lorentz_mass, lorentz_scale, pt}
 
-extern "C" {
-    fn sqrt(x: f64) -> f64;
-    fn exp(x: f64) -> f64;
-    fn pow(x: f64, y: f64) -> f64;
-    fn log(x: f64) -> f64;
-    fn fabs(x: f64) -> f64;
-    fn tanh(x: f64) -> f64;
-}
+// #1622: these were `extern "C"` bindings to libm. The native backend has no
+// dynamic linker, so every call compiled to a stub returning 0. The builtin
+// names it does implement (sqrt, exp, log, sin, cos) need no declaration.
+use math::libm::{libm_fabs, libm_pow, libm_tanh}
 
 // ============================================================================
 // Activation Functions
@@ -38,8 +34,8 @@ pub fn sigmoid(x: f64) -> f64 {
 }
 
 /// Tanh activation (uses C library tanh).
-pub fn tanh_act(x: f64) -> f64 {
-    return tanh(x)
+pub fn tanh_act(x: f64) -> f64 with Mut, Div, Panic {
+    return libm_tanh(x)
 }
 
 /// Leaky ReLU.
@@ -100,7 +96,7 @@ pub fn dense_layer_new(n_in: i64, n_out: i64, activation: i64) -> DenseLayer {
 }
 
 /// Forward pass through dense layer.
-pub fn dense_forward(layer: &!DenseLayer, input: &[f64; 8], output: &![f64; 8]) with Mut {
+pub fn dense_forward(layer: &!DenseLayer, input: &[f64; 8], output: &![f64; 8]) with Div, Mut, Panic {
     var j: i64 = 0
     while j < layer.n_out {
         var sum: f64 = layer.bias[j as usize]
@@ -268,7 +264,7 @@ pub fn test_softmax() -> bool with Mut {
     return true
 }
 
-pub fn test_dense_layer() -> bool with Mut {
+pub fn test_dense_layer() -> bool with Div, Mut, Panic {
     var layer = dense_layer_new(3, 2, 1)
     if layer.n_in != 3 { return false }
     if layer.n_out != 2 { return false }

--- a/stdlib/particle_physics/statistics.sio
+++ b/stdlib/particle_physics/statistics.sio
@@ -11,14 +11,10 @@
 
 module particle_physics::statistics
 
-extern "C" {
-    fn sqrt(x: f64) -> f64;
-    fn exp(x: f64) -> f64;
-    fn pow(x: f64, y: f64) -> f64;
-    fn log(x: f64) -> f64;
-    fn fabs(x: f64) -> f64;
-}
-
+// #1622: these were `extern "C"` bindings to libm. The native backend has no
+// dynamic linker, so every call compiled to a stub returning 0. The builtin
+// names it does implement (sqrt, exp, log, sin, cos) need no declaration.
+use math::libm::{libm_fabs, libm_pow}
 // ============================================================================
 // Probability Distributions
 // ============================================================================
@@ -51,8 +47,8 @@ pub fn poisson_pmf(k: i64, lambda: f64) -> f64 {
 pub fn chi2_pdf(x: f64, k: i64) -> f64 with Mut, Div, Panic {
     if x <= 0.0 || k <= 0 { return 0.0 }
     let half_k = (k as f64) * 0.5
-    let numer = pow(x, half_k - 1.0) * exp(-x * 0.5)
-    let denom = pow(2.0, half_k) * gamma_half_integer(k)
+    let numer = libm_pow(x, half_k - 1.0) * exp(-x * 0.5)
+    let denom = libm_pow(2.0, half_k) * gamma_half_integer(k)
     return numer / denom
 }
 
@@ -82,7 +78,7 @@ fn gamma_half_integer(n: i64) -> f64 with Mut, Div, Panic {
             den = den * (i as f64)
             i = i + 1
         }
-        return num / (pow(4.0, m as f64) * den) * sqrt(pi)
+        return num / (libm_pow(4.0, m as f64) * den) * sqrt(pi)
     }
 }
 
@@ -230,7 +226,7 @@ pub fn test_gaussian_pdf() -> bool {
 pub fn test_poisson_pmf() -> bool with Mut {
     let p0 = poisson_pmf(0, 3.0)
     let expected = exp(-3.0)
-    if fabs(p0 - expected) > 1.0e-10 { return false }
+    if libm_fabs(p0 - expected) > 1.0e-10 { return false }
     let p3 = poisson_pmf(3, 3.0)
     if p3 < 0.0 || p3 > 1.0 { return false }
     return true

--- a/stdlib/polynomial/lib.sio
+++ b/stdlib/polynomial/lib.sio
@@ -9,11 +9,10 @@
 //!
 //! Polynomials are represented as p(x) = c[0] + c[1]*x + c[2]*x² + ... + c[n]*x^n
 
-extern "C" {
-    fn sqrt(x: f64) -> f64;
-    fn fabs(x: f64) -> f64;
-}
-
+// #1622: these were `extern "C"` bindings to libm. The native backend has no
+// dynamic linker, so every call compiled to a stub returning 0. The builtin
+// names it does implement (sqrt, exp, log, sin, cos) need no declaration.
+use math::libm::{libm_fabs}
 // A polynomial with coefficients stored in ascending order of degree.
 // p(x) = coeffs[0] + coeffs[1]*x + coeffs[2]*x² + ... + coeffs[degree]*x^degree
 pub struct Polynomial {
@@ -312,12 +311,12 @@ pub fn poly_eval_with_error(p: Polynomial, x: f64) -> (f64, f64) with Div, Panic
 
     let abs_x = if x < 0.0 { -x } else { x }
     var result = p.coeffs[p.degree]
-    var error = fabs(result)
+    var error = libm_fabs(result)
 
     var i = p.degree - 1
     while i >= 0 {
         result = result * x + p.coeffs[i]
-        error = error * abs_x + fabs(result)
+        error = error * abs_x + libm_fabs(result)
         i = i - 1
     }
 
@@ -440,7 +439,7 @@ fn pf_newton_iter(p: Polynomial, x: f64) -> f64 with Div, Panic, Mut {
         j = j - 1
     }
     let dfx = dresult
-    if fabs(dfx) < 1.0e-30 { return x }
+    if libm_fabs(dfx) < 1.0e-30 { return x }
     x - fx / dfx
 }
 
@@ -482,7 +481,7 @@ pub fn poly_find_real_roots(p: Polynomial) -> PolyRoots with Div, Panic, Mut {
         var iter = 0
         while iter < 80 {
             let xn = pf_newton_iter(work, x)
-            if fabs(xn - x) < 1.0e-12 {
+            if libm_fabs(xn - x) < 1.0e-12 {
                 x = xn
                 iter = 80
             } else {
@@ -494,7 +493,7 @@ pub fn poly_find_real_roots(p: Polynomial) -> PolyRoots with Div, Panic, Mut {
         // Accept root if residual is small
         let res = pf_eval(work, x)
 
-        if fabs(res) < 1.0e-8 {
+        if libm_fabs(res) < 1.0e-8 {
             out_roots[count] = x
             count = count + 1
             // Deflate work by (x - root)

--- a/stdlib/random/distributions.sio
+++ b/stdlib/random/distributions.sio
@@ -33,16 +33,10 @@
 // - Devroye (1986): "Non-Uniform Random Variate Generation"
 // - Marsaglia & Tsang (2000): "A Simple Method for Generating Gamma Variables"
 
-extern "C" {
-    fn sqrt(x: f64) -> f64;
-    fn log(x: f64) -> f64;
-    fn exp(x: f64) -> f64;
-    fn sin(x: f64) -> f64;
-    fn cos(x: f64) -> f64;
-    fn floor(x: f64) -> f64;
-    fn pow(x: f64, y: f64) -> f64;
-}
-
+// #1622: these were `extern "C"` bindings to libm. The native backend has no
+// dynamic linker, so every call compiled to a stub returning 0. The builtin
+// names it does implement (sqrt, exp, log, sin, cos) need no declaration.
+use math::libm::{libm_floor, libm_pow}
 // ============================================================================
 // RNG (inline from rng.d for self-contained module)
 // ============================================================================
@@ -288,7 +282,7 @@ fn gamma_sample_shape_ge1(shape: f64, rng: DstPcg64) -> (DstPcg64, f64) {
     return (current_rng, shape)
 }
 
-fn gamma_sample(dist: Gamma, rng: DstPcg64) -> (DstPcg64, f64) {
+fn gamma_sample(dist: Gamma, rng: DstPcg64) -> (DstPcg64, f64) with Mut, Div, Panic {
     if dist.shape >= 1.0 {
         let result = gamma_sample_shape_ge1(dist.shape, rng)
         return (result.0, result.1 / dist.rate)
@@ -296,7 +290,7 @@ fn gamma_sample(dist: Gamma, rng: DstPcg64) -> (DstPcg64, f64) {
         // For shape < 1: use Gamma(1+shape) * U^(1/shape)
         let g_result = gamma_sample_shape_ge1(1.0 + dist.shape, rng)
         let u_result = dst_pcg64_next_f64_nonzero(g_result.0)
-        let scale_factor = pow(u_result.1, 1.0 / dist.shape)
+        let scale_factor = libm_pow(u_result.1, 1.0 / dist.shape)
         return (u_result.0, g_result.1 * scale_factor / dist.rate)
     }
 }
@@ -326,7 +320,7 @@ fn beta_jeffreys() -> Beta {
 }
 
 // Sample using ratio of gammas: X/(X+Y) where X~Gamma(alpha,1), Y~Gamma(beta,1)
-fn beta_sample(dist: Beta, rng: DstPcg64) -> (DstPcg64, f64) {
+fn beta_sample(dist: Beta, rng: DstPcg64) -> (DstPcg64, f64) with Mut, Div, Panic {
     let g_a = gamma_new(dist.alpha, 1.0)
     let g_b = gamma_new(dist.beta, 1.0)
 
@@ -387,7 +381,7 @@ fn poisson_sample(dist: Poisson, rng: DstPcg64) -> (DstPcg64, i64) {
         let n = normal_new(dist.rate, sqrt(dist.rate))
         let result = normal_sample(n, rng)
         let val = if result.1 < 0.0 { 0.0 } else { result.1 }
-        let rounded = floor(val + 0.5) as i64
+        let rounded = libm_floor(val + 0.5) as i64
         return (result.0, rounded)
     }
 }

--- a/stdlib/roots/lib.sio
+++ b/stdlib/roots/lib.sio
@@ -13,11 +13,10 @@
 //! use integer f_id to select from built-in test functions without function pointers.
 //! These return RootResult2 which carries epistemic uncertainty from convergence tolerance.
 
-extern "C" {
-    fn fabs(x: f64) -> f64;
-    fn sqrt(x: f64) -> f64;
-}
-
+// #1622: these were `extern "C"` bindings to libm. The native backend has no
+// dynamic linker, so every call compiled to a stub returning 0. The builtin
+// names it does implement (sqrt, exp, log, sin, cos) need no declaration.
+use math::libm::{libm_fabs}
 // Result of a root-finding algorithm
 pub struct RootResult {
     root: f64,
@@ -77,14 +76,14 @@ pub fn bisection(a: f64, b: f64, tol: f64, max_iter: i32, f: fn(f64) -> f64) -> 
     var f_mid = f(mid)
 
     while iter < max_iter {
-        if fabs(hi - lo) < tol {
+        if libm_fabs(hi - lo) < tol {
             return root_success(mid, iter, f_mid)
         }
 
         mid = (lo + hi) / 2.0
         f_mid = f(mid)
 
-        if fabs(f_mid) < tol {
+        if libm_fabs(f_mid) < tol {
             return root_success(mid, iter + 1, f_mid)
         }
 
@@ -126,7 +125,7 @@ pub fn newton_raphson(x0: f64, tol: f64, max_iter: i32, f: fn(f64) -> f64, df: f
     while iter < max_iter {
         let fx = f(x)
 
-        if fabs(fx) < tol {
+        if libm_fabs(fx) < tol {
             return root_success(x, iter, fx)
         }
 
@@ -170,7 +169,7 @@ pub fn secant(x0: f64, x1: f64, tol: f64, max_iter: i32, f: fn(f64) -> f64) -> R
     var iter = 0
 
     while iter < max_iter {
-        if fabs(f_curr) < tol {
+        if libm_fabs(f_curr) < tol {
             return root_success(x_curr, iter, f_curr)
         }
 
@@ -216,7 +215,7 @@ pub fn fixed_point(x0: f64, tol: f64, max_iter: i32, g: fn(f64) -> f64) -> RootR
     while iter < max_iter {
         let x_new = g(x)
 
-        if fabs(x_new - x) < tol {
+        if libm_fabs(x_new - x) < tol {
             return root_success(x_new, iter + 1, x_new - g(x_new))
         }
 
@@ -255,7 +254,7 @@ pub fn brent(a: f64, b: f64, tol: f64, max_iter: i32, f: fn(f64) -> f64) -> Root
     }
 
     // Ensure |f(lo)| >= |f(hi)|
-    if fabs(f_lo) < fabs(f_hi) {
+    if libm_fabs(f_lo) < libm_fabs(f_hi) {
         // Swap
         let tmp = lo
         lo = hi
@@ -272,11 +271,11 @@ pub fn brent(a: f64, b: f64, tol: f64, max_iter: i32, f: fn(f64) -> f64) -> Root
 
     var iter = 0
     while iter < max_iter {
-        if fabs(f_hi) < tol {
+        if libm_fabs(f_hi) < tol {
             return root_success(hi, iter, f_hi)
         }
 
-        if fabs(hi - lo) < tol {
+        if libm_fabs(hi - lo) < tol {
             return root_success(hi, iter, f_hi)
         }
 
@@ -301,7 +300,7 @@ pub fn brent(a: f64, b: f64, tol: f64, max_iter: i32, f: fn(f64) -> f64) -> Root
         // Check if interpolation is acceptable
         if !use_bisection {
             let cond1 = if lo < hi { s < lo || s > hi } else { s < hi || s > lo }
-            let cond2 = fabs(s - hi) >= fabs(e) / 2.0
+            let cond2 = libm_fabs(s - hi) >= libm_fabs(e) / 2.0
             if cond1 || cond2 {
                 use_bisection = true
             }
@@ -331,7 +330,7 @@ pub fn brent(a: f64, b: f64, tol: f64, max_iter: i32, f: fn(f64) -> f64) -> Root
         }
 
         // Ensure |f(lo)| >= |f(hi)|
-        if fabs(f_lo) < fabs(f_hi) {
+        if libm_fabs(f_lo) < libm_fabs(f_hi) {
             let tmp = lo
             lo = hi
             hi = tmp
@@ -359,7 +358,7 @@ pub fn halley(x0: f64, tol: f64, max_iter: i32, f: fn(f64) -> f64, df: fn(f64) -
     while iter < max_iter {
         let fx = f(x)
 
-        if fabs(fx) < tol {
+        if libm_fabs(fx) < tol {
             return root_success(x, iter, fx)
         }
 
@@ -516,7 +515,7 @@ pub fn bisection_id(f_id: i32, a: f64, b: f64, tol: f64, max_iter: i32) -> RootR
 
     if f_lo * f_hi > 0.0 {
         let mid = (lo + hi) / 2.0
-        return rr2_fail(mid, fabs(hi - lo) / 2.0, 0, eval_f(f_id, mid))
+        return rr2_fail(mid, libm_fabs(hi - lo) / 2.0, 0, eval_f(f_id, mid))
     }
     if f_lo == 0.0 { return rr2_ok(lo, 0.0, 0, 0.0) }
     if f_hi == 0.0 { return rr2_ok(hi, 0.0, 0, 0.0) }
@@ -526,12 +525,12 @@ pub fn bisection_id(f_id: i32, a: f64, b: f64, tol: f64, max_iter: i32) -> RootR
     var f_mid = eval_f(f_id, mid)
 
     while iter < max_iter {
-        if fabs(hi - lo) < tol {
-            return rr2_ok(mid, fabs(hi - lo) / 2.0, iter, f_mid)
+        if libm_fabs(hi - lo) < tol {
+            return rr2_ok(mid, libm_fabs(hi - lo) / 2.0, iter, f_mid)
         }
         mid = (lo + hi) / 2.0
         f_mid = eval_f(f_id, mid)
-        if fabs(f_mid) < tol {
+        if libm_fabs(f_mid) < tol {
             return rr2_ok(mid, tol / 2.0, iter + 1, f_mid)
         }
         if f_lo * f_mid < 0.0 {
@@ -543,7 +542,7 @@ pub fn bisection_id(f_id: i32, a: f64, b: f64, tol: f64, max_iter: i32) -> RootR
         }
         iter = iter + 1
     }
-    rr2_fail(mid, fabs(hi - lo) / 2.0, iter, f_mid)
+    rr2_fail(mid, libm_fabs(hi - lo) / 2.0, iter, f_mid)
 }
 
 // Newton-Raphson using function-index dispatch.
@@ -554,9 +553,9 @@ pub fn newton_id(f_id: i32, x0: f64, tol: f64, max_iter: i32) -> RootResult2 wit
 
     while iter < max_iter {
         let fx = eval_f(f_id, x)
-        if fabs(fx) < tol {
+        if libm_fabs(fx) < tol {
             let dfx = eval_df(f_id, x)
-            let unc = if fabs(dfx) > 1.0e-30 { fabs(fx) / fabs(dfx) } else { tol }
+            let unc = if libm_fabs(dfx) > 1.0e-30 { libm_fabs(fx) / libm_fabs(dfx) } else { tol }
             return rr2_ok(x, unc, iter, fx)
         }
         let dfx = eval_df(f_id, x)
@@ -579,8 +578,8 @@ pub fn secant_id(f_id: i32, x0: f64, x1: f64, tol: f64, max_iter: i32) -> RootRe
     var iter = 0
 
     while iter < max_iter {
-        if fabs(f_curr) < tol {
-            return rr2_ok(x_curr, fabs(x_curr - x_prev), iter, f_curr)
+        if libm_fabs(f_curr) < tol {
+            return rr2_ok(x_curr, libm_fabs(x_curr - x_prev), iter, f_curr)
         }
         let denom = f_curr - f_prev
         if denom == 0.0 { return rr2_fail(x_curr, tol, iter, f_curr) }
@@ -591,7 +590,7 @@ pub fn secant_id(f_id: i32, x0: f64, x1: f64, tol: f64, max_iter: i32) -> RootRe
         f_curr = eval_f(f_id, x_curr)
         iter = iter + 1
     }
-    rr2_fail(x_curr, fabs(x_curr - x_prev), iter, f_curr)
+    rr2_fail(x_curr, libm_fabs(x_curr - x_prev), iter, f_curr)
 }
 
 // Brent's method using function-index dispatch (gold-standard bracketed solver).
@@ -604,11 +603,11 @@ pub fn brent_id(f_id: i32, a: f64, b: f64, tol: f64, max_iter: i32) -> RootResul
 
     if f_lo * f_hi > 0.0 {
         let mid = (lo + hi) / 2.0
-        return rr2_fail(mid, fabs(hi - lo) / 2.0, 0, eval_f(f_id, mid))
+        return rr2_fail(mid, libm_fabs(hi - lo) / 2.0, 0, eval_f(f_id, mid))
     }
 
     // Ensure |f(lo)| >= |f(hi)|
-    if fabs(f_lo) < fabs(f_hi) {
+    if libm_fabs(f_lo) < libm_fabs(f_hi) {
         var tmp = lo; lo = hi; hi = tmp
         var tf = f_lo; f_lo = f_hi; f_hi = tf
     }
@@ -620,11 +619,11 @@ pub fn brent_id(f_id: i32, a: f64, b: f64, tol: f64, max_iter: i32) -> RootResul
     var iter = 0
 
     while iter < max_iter {
-        if fabs(f_hi) < tol {
-            return rr2_ok(hi, fabs(hi - lo) / 2.0, iter, f_hi)
+        if libm_fabs(f_hi) < tol {
+            return rr2_ok(hi, libm_fabs(hi - lo) / 2.0, iter, f_hi)
         }
-        if fabs(hi - lo) < tol {
-            return rr2_ok(hi, fabs(hi - lo) / 2.0, iter, f_hi)
+        if libm_fabs(hi - lo) < tol {
+            return rr2_ok(hi, libm_fabs(hi - lo) / 2.0, iter, f_hi)
         }
 
         var use_bisect = true
@@ -644,7 +643,7 @@ pub fn brent_id(f_id: i32, a: f64, b: f64, tol: f64, max_iter: i32) -> RootResul
 
         if !use_bisect {
             let cond1 = if lo < hi { s < lo || s > hi } else { s < hi || s > lo }
-            let cond2 = fabs(s - hi) >= fabs(e) / 2.0
+            let cond2 = libm_fabs(s - hi) >= libm_fabs(e) / 2.0
             if cond1 || cond2 { use_bisect = true }
         }
 
@@ -667,12 +666,12 @@ pub fn brent_id(f_id: i32, a: f64, b: f64, tol: f64, max_iter: i32) -> RootResul
             lo = s; f_lo = f_s
         }
 
-        if fabs(f_lo) < fabs(f_hi) {
+        if libm_fabs(f_lo) < libm_fabs(f_hi) {
             var tmp = lo; lo = hi; hi = tmp
             var tf = f_lo; f_lo = f_hi; f_hi = tf
         }
 
         iter = iter + 1
     }
-    rr2_fail(hi, fabs(hi - lo) / 2.0, iter, f_hi)
+    rr2_fail(hi, libm_fabs(hi - lo) / 2.0, iter, f_hi)
 }

--- a/stdlib/signal/epoch.sio
+++ b/stdlib/signal/epoch.sio
@@ -14,12 +14,10 @@
 // - Luck (2014): "An Introduction to the Event-Related Potential Technique"
 // - Cohen (2014): "Analyzing Neural Time Series Data"
 
-extern "C" {
-    fn sqrt(x: f64) -> f64;
-    fn exp(x: f64) -> f64;
-    fn pow(x: f64, y: f64) -> f64;
-}
-
+// #1622: these were `extern "C"` bindings to libm. The native backend has no
+// dynamic linker, so every call compiled to a stub returning 0. The builtin
+// names it does implement (sqrt, exp, log, sin, cos) need no declaration.
+use math::libm::{libm_pow}
 // ============================================================================
 // EVENT MARKERS
 // ============================================================================
@@ -513,7 +511,7 @@ fn test_event_list() -> bool {
     return events.n_events == 3
 }
 
-fn test_epoch_extraction() -> bool {
+fn test_epoch_extraction() -> bool with Mut, Div, Panic {
     // Generate synthetic ERP signal
     let fs = 256.0
     let signal_len: i64 = 2048
@@ -532,7 +530,7 @@ fn test_epoch_extraction() -> bool {
         while j < 256 {
             let t = (j as f64) / fs
             // P300: Gaussian at 300ms, amplitude 10
-            let p300 = 10.0 * exp(-0.5 * pow((t - 0.3) / 0.05, 2.0))
+            let p300 = 10.0 * exp(-0.5 * libm_pow((t - 0.3) / 0.05, 2.0))
             let idx = ev_idx + j
             if idx < signal_len {
                 signal[idx as usize] = signal[idx as usize] + p300
@@ -559,7 +557,7 @@ fn test_epoch_extraction() -> bool {
     return true
 }
 
-fn test_erp_computation() -> bool {
+fn test_erp_computation() -> bool with Mut, Div, Panic {
     // Generate synthetic epochs
     let fs = 256.0
     var epochs = epochs_new()
@@ -575,7 +573,7 @@ fn test_erp_computation() -> bool {
         while j < 256 {
             let t = -0.2 + (j as f64) / fs
             // P300-like component at 300ms
-            epochs.data[i as usize][j as usize] = 10.0 * exp(-0.5 * pow((t - 0.3) / 0.05, 2.0))
+            epochs.data[i as usize][j as usize] = 10.0 * exp(-0.5 * libm_pow((t - 0.3) / 0.05, 2.0))
             j = j + 1
         }
         epochs.n_samp[i as usize] = 256


### PR DESCRIPTION
#1622 made a call to an `extern "C"` name the native backend cannot link a compile error. That was the right refusal — those calls returned 0 — but it left **27 stdlib modules unable to compile under Madaros**. This fixes the ten whose *only* blocker was that refusal.

## Scope, measured rather than assumed

All 27 were classified against a current-source Madaros:

| bucket | n | meaning |
|---|---:|---|
| **A — only E219** | **17** | the deliverable |
| B — E219 *and* something else | 10 | implementing the externs would not make them compile |

Of the 17, `ffi::library` (dlopen/dlsym/dlclose) cannot be fixed at all — no dynamic linker — and `special::lib` is a separate slice (rewire to the parity-tested `special::{erf,gamma,bessel}`). That leaves the ten here. `sync::mutex` (pthread_*) is in bucket B and is likewise unfixable.

## `stdlib/math/libm.sio` (new)

`fabs`, `floor`, `ceil`, `atan`, `atan2`, `pow`, `tanh`, `sinh`, `cosh`, built only on the builtins that exist (`sqrt`, `exp`, `log`).

Worst ULP distance from glibc over a 17-point grid from 1e-3 to 1e6, references baked in from CPython:

| | ULP | limited by |
|---|---:|---|
| `libm_fabs` | 0 | exact — a sign flip is exact in IEEE 754 |
| `libm_floor` | 0 | exact — i64 round trip |
| `libm_atan` | 2 | pure arithmetic |
| `libm_atan2` | 2 | pure arithmetic |
| `libm_pow` | 6455 | the exp/log builtins |
| `libm_tanh` | 990 | the exp builtin |

Two deserve a note. `atan` uses two-stage argument reduction because a plain Taylor series on |x| ≤ 1 **is** the Leibniz series at x = 1 — 40 terms still leave ~1.2e-2 of error, which is what `stdlib/math/pure.sio` does today. And `pow` peels integer exponents into exact binary exponentiation, so `pow(10.0, 7.0)` is exactly `10000000.0` instead of the `9999999.950639` that `exp(y log x)` gives under Madaros — where `exp`/`log` carry ~7 significant digits, not 16. That is **#1626**, filed from this work: `emit_builtin_exp` is a degree-6 Taylor polynomial (last coefficient `1/720`), and the truncation term r⁷/5040 ≈ 7.6e-8 matches the measured error exactly.

## Why the exports are prefixed

Not style. `pub fn pow` and `pub fn atan2` were **bound to libm** by lean_single, with a mismatched argument convention: `pow(-2.0, 3.0)` returned `0.0`, `atan2(1.0, 2.0)` returned `atan(2.0)`. Renaming the identical bodies to `zpow`/`zatan2` made both correct immediately. Under Madaros, which has no libm, the same source was correct all along — so an unprefixed name is a silent engine-dependent divergence.

The collision cost two wrong diagnoses first, because it presents exactly like a register-allocation defect: inserting a `print` changes the answer, and a minimal two-argument repro does not reproduce.

## Result — 9 of 10, agreeing across engines

`complex::lib` · `connectivity::phase` · `fusion::eeg_fmri` · `medlang::codegen` · `particle_physics::statistics` · `polynomial::lib` · `random::distributions` · `roots::lib` · `signal::epoch`

Byte-identical output between lean_single and Madaros on `gaussian_pdf`, `poisson_pmf`, `chi2_pdf`, `poly_eval`, `complex_arg`, `complex_abs`. **That second half is the regression test that matters** — these modules already worked under lean_single via real libm, and rewiring must not cost that.

`particle_physics::ml_hep` is rewired but still refuses, now with **E175** instead of E219: it is the only one of the ten declaring `module ...`, which turns visibility enforcement on, and the builtin `sqrt` call inside the imported `math::libm` is then rejected as private. Its own `extern "C" fn sqrt` had been doing double duty as the visibility anchor. Filed as **#1627** with all four attempted fixes and why each failed.

## Also here: `fn_sig_chunk_alloc`

`check/defs.sio` allocated `786432 = 512 * 1536` bytes for 512 `FnSig`s with nothing checking that against the struct — and #1622 added a field to `FnSig` without touching it. Raised to 4 MB of mmap-lazy headroom.

Honest provenance, recorded in the comment: this was written on a theory about spurious E219s that turned out to be **wrong** (the compiler was reading a different stdlib via `SOUNIO_STDLIB_PATH`). Kept because the hazard is real, not because it fixed anything.

## Corpus gate

276 failures / 1691. Two entries — `mercyful_chemo_sequencing`, `mercyful_pontryagin_control` — are reported as new. They are not:

| run | result |
|---|---|
| this branch, my stdlib, `madaros-fix` | 276/1691, both fail |
| **control**: pristine stdlib from the branch point, `madaros-main` | **276/1691, both fail** |

Same failures, same count, with none of this change present. They also produce identical output under both compiler binaries and both stdlib trees. That is baseline drift on main, not a regression here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)