### PR TITLE
fix(codegen): exp and log were single-precision through a double signature

### DIFF
--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -4389,140 +4389,152 @@ fn emit_builtin_f64_bits_identity(nc: NativeCompiler) -> NativeCompiler with Mut
 // Algorithm: x = n*ln(2) + r, exp(r) via Horner, scale by 2^n
 // Stack layout: [rbp-8]=input x, [rbp-16]=r, [rbp-24]=n_float, [rbp-32]=result
 // Uses only xmm0/xmm1 with stack temps for intermediates
+// Shared Horner step for the exp/log polynomial chains (#1626).
+//
+// acc = coeff + v * acc, with `v` and `acc` in rbp-relative slots and `coeff`
+// in .rodata. Factored out because the previous emitters open-coded one copy of
+// these five instructions per term -- which is why they stopped at degree 6 and
+// degree 4. The code, not the mathematics, was setting the accuracy.
+fn emit_horner_step(nc: NativeCompiler, v_slot: i64, acc_slot: i64, coeff_off: i64) -> NativeCompiler with Mut, Panic, Div {
+    var c = nc
+    c.code = emit_movsd_xmm0_rbp_disp8(c.code, v_slot)     // xmm0 = v
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, acc_slot)   // xmm1 = acc
+    c.code = emit_mulsd_xmm0_xmm1(c.code)                  // xmm0 = v * acc
+    let pos = c.code.len
+    c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
+    c.relocs = add_rip_reloc(c.relocs, pos + 4, coeff_off)
+    c.code = emit_addsd_xmm0_xmm1(c.code)                  // xmm0 = coeff + v*acc
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, acc_slot)
+    c
+}
+
+// exp builtin (#1626).
+//
+// Was: n = TRUNCATE(x/ln2), r = x - n*ln2 with a single-double ln2, degree-6
+// Taylor. Three independent errors, each dominant somewhere:
+//
+//   truncate     |r| < ln2 = 0.693 rather than ln2/2, so the r^7/5040
+//                truncation term ran to 1.5e-5 instead of 7.6e-8 -- 128x
+//   single ln2   n*ln2 for x = 1000 (n = 1443) rounds at ~1e-13 absolute, and
+//                that lands directly in r, hence RELATIVELY in the result
+//   degree 6     7.6e-8 even at the smaller |r|
+//
+// Now: n = ROUND(x/ln2), so |r| <= ln2/2 = 0.3466; Cody-Waite two-part ln2 with
+// 40 significant bits in the high half, so n*ln2_hi is exact for |n| < 2^13
+// (x out past the whole binary64 exponent range); degree 13, whose truncation
+// term r^14/14! is 4.1e-18 -- under half an ULP.
+//
+// Constants are generated, not typed. Hand-typing is how a constant ends up
+// right to 15 digits and wrong in the 16th.
+//
+// UNCHANGED, and still wrong at the edges: the 2^n scaling is a raw
+// `bits + (n << 52)`, which neither produces a denormal on underflow nor
+// saturates to infinity on overflow.
+//
+// Stack: [rbp-8]=x  [rbp-16]=r  [rbp-24]=n_f64  [rbp-32]=n  [rbp-40]=acc
+//        [rbp-48]=scratch  [rbp-56]=result bits
 fn emit_builtin_exp(nc: NativeCompiler) -> NativeCompiler with Mut, Panic, Div {
     var c = nc
 
-    // Store constants in .rodata
-    // 1/ln(2) = 0x3FF71547652B82FE
-    c.rodata = data_section_add_f64(c.rodata, 0x3FF71547652B82FE)
+    c.rodata = data_section_add_f64(c.rodata, 0x3FF71547652B82FE)   // 1/ln2
     let inv_ln2_off = c.rodata.last_offset
-    // ln(2) = 0x3FE62E42FEFA39EF
-    c.rodata = data_section_add_f64(c.rodata, 0x3FE62E42FEFA39EF)
-    let ln2_off = c.rodata.last_offset
-    // c6 = 1/720 = 0x3F56C16C16C16C17
-    c.rodata = data_section_add_f64(c.rodata, 0x3F56C16C16C16C17)
-    let c6_off = c.rodata.last_offset
-    // c5 = 1/120 = 0x3F81111111111111
-    c.rodata = data_section_add_f64(c.rodata, 0x3F81111111111111)
-    let c5_off = c.rodata.last_offset
-    // c4 = 1/24 = 0x3FA5555555555555
-    c.rodata = data_section_add_f64(c.rodata, 0x3FA5555555555555)
-    let c4_off = c.rodata.last_offset
-    // c3 = 1/6 = 0x3FC5555555555555
-    c.rodata = data_section_add_f64(c.rodata, 0x3FC5555555555555)
-    let c3_off = c.rodata.last_offset
-    // c2 = 0.5 = 0x3FE0000000000000
-    c.rodata = data_section_add_f64(c.rodata, 0x3FE0000000000000)
-    let c2_off = c.rodata.last_offset
-    // 1.0 = 0x3FF0000000000000
-    c.rodata = data_section_add_f64(c.rodata, 0x3FF0000000000000)
-    let one_off = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FE62E42FEFA3000)   // ln2, high 40 bits
+    let ln2_hi_off = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3D53DE6AF278ECE6)   // ln2 - ln2_hi
+    let ln2_lo_off = c.rodata.last_offset
+
+    // 1/k! for k = 0..13, indexed by k.
+    var cf: [i64; 14] = [0; 14]
+    c.rodata = data_section_add_f64(c.rodata, 0x3FF0000000000000)   // 1/0!
+    cf[0] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FF0000000000000)   // 1/1!
+    cf[1] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FE0000000000000)   // 1/2!
+    cf[2] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FC5555555555555)   // 1/3!
+    cf[3] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FA5555555555555)   // 1/4!
+    cf[4] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3F81111111111111)   // 1/5!
+    cf[5] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3F56C16C16C16C17)   // 1/6!
+    cf[6] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3F2A01A01A01A01A)   // 1/7!
+    cf[7] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3EFA01A01A01A01A)   // 1/8!
+    cf[8] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3EC71DE3A556C734)   // 1/9!
+    cf[9] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3E927E4FB7789F5C)   // 1/10!
+    cf[10] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3E5AE64567F544E4)   // 1/11!
+    cf[11] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3E21EED8EFF8D898)   // 1/12!
+    cf[12] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3DE6124613A86D09)   // 1/13!
+    cf[13] = c.rodata.last_offset
 
     c.code = emit_push_rbp(c.code)
     c.code = emit_mov_rbp_rsp(c.code)
-    c.code = emit_sub_rsp_imm32(c.code, 64)
+    c.code = emit_sub_rsp_imm32(c.code, 128)
 
-    // rdi = f64 bit pattern of x
-    c.code = emit_mov_reg_reg(c.code, 0, 7)       // mov rax, rdi
-    c.code = emit_movq_xmm0_rax(c.code)           // xmm0 = x
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -8)   // [rbp-8] = x
+    c.code = emit_mov_reg_reg(c.code, 0, 7)          // rax = rdi = bits(x)
+    c.code = emit_movq_xmm0_rax(c.code)
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, 0 - 8)
 
-    // Step 1: n_float = x * (1/ln2)
-    let load_inv_ln2_pos = c.code.len
+    // n = round(x / ln2) -- ROUND, not truncate: this alone halves |r|.
+    let p_inv = c.code.len
     c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, load_inv_ln2_pos + 4, inv_ln2_off)
-    c.code = emit_mulsd_xmm0_xmm1(c.code)         // xmm0 = x / ln(2)
+    c.relocs = add_rip_reloc(c.relocs, p_inv + 4, inv_ln2_off)
+    c.code = emit_mulsd_xmm0_xmm1(c.code)
+    c.code = emit_cvtsd2si_rax_xmm0(c.code)
+    c.code = emit_store_rax_rbp_disp32(c.code, 0 - 32)
+    c.code = emit_cvtsi2sd_xmm0_rax(c.code)
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, 0 - 24)   // n_f64
 
-    // Step 2: n = truncate to integer, n_f64 = convert back
-    c.code = emit_cvttsd2si_rax_xmm0(c.code)      // rax = trunc(x/ln2)
-    c.code = emit_store_rax_rbp_disp32(c.code, -32) // [rbp-32] = n (integer)
-    c.code = emit_cvtsi2sd_xmm0_rax(c.code)        // xmm0 = n_f64
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -24) // [rbp-24] = n_f64
-
-    // Step 3: r = x - n_f64 * ln2
-    let load_ln2_pos = c.code.len
+    // r = (x - n*ln2_hi) - n*ln2_lo    (Cody-Waite)
+    let p_hi = c.code.len
     c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, load_ln2_pos + 4, ln2_off)
-    c.code = emit_mulsd_xmm0_xmm1(c.code)         // xmm0 = n_f64 * ln2
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -16) // save n*ln2 to [rbp-16] temporarily
-    c.code = emit_movsd_xmm0_rbp_disp8(c.code, -8)  // xmm0 = x
-    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -16) // xmm1 = n*ln2
-    c.code = emit_subsd_xmm0_xmm1(c.code)         // xmm0 = r = x - n*ln2
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -16) // [rbp-16] = r
+    c.relocs = add_rip_reloc(c.relocs, p_hi + 4, ln2_hi_off)
+    c.code = emit_mulsd_xmm0_xmm1(c.code)                // n * ln2_hi, exact
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, 0 - 48)
+    c.code = emit_movsd_xmm0_rbp_disp8(c.code, 0 - 8)
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, 0 - 48)
+    c.code = emit_subsd_xmm0_xmm1(c.code)                // x - n*ln2_hi
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, 0 - 16)
+    c.code = emit_movsd_xmm0_rbp_disp8(c.code, 0 - 24)
+    let p_lo = c.code.len
+    c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
+    c.relocs = add_rip_reloc(c.relocs, p_lo + 4, ln2_lo_off)
+    c.code = emit_mulsd_xmm0_xmm1(c.code)                // n * ln2_lo
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, 0 - 48)
+    c.code = emit_movsd_xmm0_rbp_disp8(c.code, 0 - 16)
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, 0 - 48)
+    c.code = emit_subsd_xmm0_xmm1(c.code)                // r
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, 0 - 16)
 
-    // Step 4: Horner's method
-    // result = 1 + r*(1 + r*(c2 + r*(c3 + r*(c4 + r*(c5 + r*c6)))))
-    // Start from innermost: acc = c6
-    let load_c6_pos = c.code.len
+    // Horner from the top coefficient down: acc = 1/13!, then acc = 1/k! + r*acc
+    let p_top = c.code.len
     c.code = emit_movsd_xmm0_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, load_c6_pos + 4, c6_off)
-    // acc = c5 + r * c6
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -40)  // [rbp-40] = acc (c6)
-    c.code = emit_movsd_xmm0_rbp_disp8(c.code, -16)  // xmm0 = r
-    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -40)  // xmm1 = acc
-    c.code = emit_mulsd_xmm0_xmm1(c.code)             // xmm0 = r * acc
-    let load_c5_pos = c.code.len
-    c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, load_c5_pos + 4, c5_off)
-    c.code = emit_addsd_xmm0_xmm1(c.code)             // xmm0 = c5 + r*c6
-    // acc = c4 + r * (c5 + r*c6)
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -40)
-    c.code = emit_movsd_xmm0_rbp_disp8(c.code, -16)
-    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -40)
-    c.code = emit_mulsd_xmm0_xmm1(c.code)
-    let load_c4_pos = c.code.len
-    c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, load_c4_pos + 4, c4_off)
-    c.code = emit_addsd_xmm0_xmm1(c.code)
-    // acc = c3 + r * acc
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -40)
-    c.code = emit_movsd_xmm0_rbp_disp8(c.code, -16)
-    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -40)
-    c.code = emit_mulsd_xmm0_xmm1(c.code)
-    let load_c3_pos = c.code.len
-    c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, load_c3_pos + 4, c3_off)
-    c.code = emit_addsd_xmm0_xmm1(c.code)
-    // acc = c2 + r * acc
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -40)
-    c.code = emit_movsd_xmm0_rbp_disp8(c.code, -16)
-    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -40)
-    c.code = emit_mulsd_xmm0_xmm1(c.code)
-    let load_c2_pos = c.code.len
-    c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, load_c2_pos + 4, c2_off)
-    c.code = emit_addsd_xmm0_xmm1(c.code)
-    // acc = 1.0 + r * acc
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -40)
-    c.code = emit_movsd_xmm0_rbp_disp8(c.code, -16)
-    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -40)
-    c.code = emit_mulsd_xmm0_xmm1(c.code)
-    let load_one1_pos = c.code.len
-    c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, load_one1_pos + 4, one_off)
-    c.code = emit_addsd_xmm0_xmm1(c.code)
-    // acc = 1.0 + r * acc  (outermost)
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -40)
-    c.code = emit_movsd_xmm0_rbp_disp8(c.code, -16)
-    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -40)
-    c.code = emit_mulsd_xmm0_xmm1(c.code)
-    let load_one2_pos = c.code.len
-    c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, load_one2_pos + 4, one_off)
-    c.code = emit_addsd_xmm0_xmm1(c.code)
-    // xmm0 = exp(r) approx
+    c.relocs = add_rip_reloc(c.relocs, p_top + 4, cf[13])
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, 0 - 40)
+    var k: i64 = 12
+    while k >= 0 {
+        c = emit_horner_step(c, 0 - 16, 0 - 40, cf[k as usize])
+        k = k - 1
+    }
 
-    // Step 5: Scale by 2^n — add n<<52 to IEEE 754 exponent bits
-    c.code = emit_movq_rax_xmm0(c.code)           // rax = result bits
-    c.code = emit_store_rax_rbp_disp32(c.code, -48) // [rbp-48] = result bits
-    c.code = emit_load_rbp_disp32_rax(c.code, -32)  // rax = n (integer)
-    // shl rax, 52: mov cl, 52; shl rax, cl
-    c.code = emit_mov_reg_imm(c.code, 1, 52)      // mov rcx, 52
-    c.code = emit_shl_rax_cl(c.code)               // rax = n << 52
-    c.code = emit_mov_reg_reg(c.code, 3, 0)        // mov rbx, rax
-    c.code = emit_load_rbp_disp32_rax(c.code, -48)  // rax = result bits
-    c.code = emit_add_rax_rbx(c.code)              // rax = result + (n<<52)
-    c.code = emit_add_rsp_imm32(c.code, 64)
+    // result = poly * 2^n, by adding n to the exponent field
+    c.code = emit_movsd_xmm0_rbp_disp8(c.code, 0 - 40)
+    c.code = emit_movq_rax_xmm0(c.code)
+    c.code = emit_store_rax_rbp_disp32(c.code, 0 - 56)
+    c.code = emit_load_rbp_disp32_rax(c.code, 0 - 32)
+    c.code = emit_mov_reg_imm(c.code, 1, 52)
+    c.code = emit_shl_rax_cl(c.code)
+    c.code = emit_mov_reg_reg(c.code, 3, 0)
+    c.code = emit_load_rbp_disp32_rax(c.code, 0 - 56)
+    c.code = emit_add_rax_rbx(c.code)
+    c.code = emit_add_rsp_imm32(c.code, 128)
     c.code = emit_pop_rbp(c.code)
     c.code = emit_ret(c.code)
     c
@@ -4532,172 +4544,192 @@ fn emit_builtin_exp(nc: NativeCompiler) -> NativeCompiler with Mut, Panic, Div {
 // Algorithm: log(x) = e*ln(2) + 2*f*(1 + f^2/3 + f^4/5 + f^6/7)
 // where e = exponent, m = mantissa in [1,2), f = (m-1)/(m+1)
 // Stack layout: [rbp-8]=input bits, [rbp-16]=e_f64, [rbp-24]=f, [rbp-32]=f^2
+// log builtin (#1626).
+//
+// Was: m in [1,2), f = (m-1)/(m+1), and the atanh series truncated after f^6/7.
+// Two errors:
+//
+//   truncation    |f| <= 1/3, so the omitted 2*f^9/9 term is 1.1e-5
+//   CANCELLATION  x just below 1 lands at e = -1 with m ~ 2, and the result
+//                 e*ln2 + log(m) subtracts two values of magnitude 0.693 down
+//                 to ~1e-6. log(0.999999) came out as -1.3423e-5 against
+//                 -1.0000005e-6 -- thirteen times too large, and no number of
+//                 series terms recovers digits cancellation has destroyed.
+//
+// Now: branch-free centering on 1.5, then 13 terms.
+//
+//   t = bit 51 of m_bits, i.e. 1 exactly when m >= 1.5
+//   m_bits -= t << 52    decrements m's exponent field, so m in [0.75, 1.5)
+//   e      += t
+//
+// f then lies in [-1/7, 1/5] rather than [0, 1/3], u = f^2 <= 0.04, and the
+// omitted 2*f*u^13/27 term is 1e-20. Crucially x near 1 now has e = 0 and there
+// is no cancellation at all. Cody-Waite on ln2 as well, so e up to 1024 does
+// not multiply ln2's own rounding error into the answer.
+//
+// Stack: [rbp-8]=input bits  [rbp-16]=e_f64  [rbp-24]=f  [rbp-32]=u
+//        [rbp-40]=m  [rbp-48]=m-1  [rbp-56]=m+1  [rbp-64]=e  [rbp-72]=m_bits
+//        [rbp-80]=t  [rbp-88]=acc  [rbp-96]=log(m)
 fn emit_builtin_log(nc: NativeCompiler) -> NativeCompiler with Mut, Panic, Div {
     var c = nc
 
-    // Store constants in .rodata
-    // ln(2) = 0x3FE62E42FEFA39EF
-    c.rodata = data_section_add_f64(c.rodata, 0x3FE62E42FEFA39EF)
-    let ln2_off = c.rodata.last_offset
-    // 1.0 = 0x3FF0000000000000
-    c.rodata = data_section_add_f64(c.rodata, 0x3FF0000000000000)
+    c.rodata = data_section_add_f64(c.rodata, 0x3FE62E42FEFA3000)   // ln2, high 40 bits
+    let ln2_hi_off = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3D53DE6AF278ECE6)   // ln2 - ln2_hi
+    let ln2_lo_off = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FF0000000000000)   // 1.0
     let one_off = c.rodata.last_offset
-    // 2.0 = 0x4000000000000000
-    c.rodata = data_section_add_f64(c.rodata, 0x4000000000000000)
+    c.rodata = data_section_add_f64(c.rodata, 0x4000000000000000)   // 2.0
     let two_off = c.rodata.last_offset
-    // 1/3 = 0x3FD5555555555555
-    c.rodata = data_section_add_f64(c.rodata, 0x3FD5555555555555)
-    let third_off = c.rodata.last_offset
-    // 1/5 = 0x3FC999999999999A
-    c.rodata = data_section_add_f64(c.rodata, 0x3FC999999999999A)
-    let fifth_off = c.rodata.last_offset
-    // 1/7 = 0x3FC2492492492492
-    c.rodata = data_section_add_f64(c.rodata, 0x3FC2492492492492)
-    let seventh_off = c.rodata.last_offset
+
+    // 1/(2k+1) for k = 0..12, indexed by k.
+    var dc: [i64; 13] = [0; 13]
+    c.rodata = data_section_add_f64(c.rodata, 0x3FF0000000000000)   // 1/1
+    dc[0] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FD5555555555555)   // 1/3
+    dc[1] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FC999999999999A)   // 1/5
+    dc[2] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FC2492492492492)   // 1/7
+    dc[3] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FBC71C71C71C71C)   // 1/9
+    dc[4] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FB745D1745D1746)   // 1/11
+    dc[5] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FB3B13B13B13B14)   // 1/13
+    dc[6] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FB1111111111111)   // 1/15
+    dc[7] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FAE1E1E1E1E1E1E)   // 1/17
+    dc[8] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FAAF286BCA1AF28)   // 1/19
+    dc[9] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FA8618618618618)   // 1/21
+    dc[10] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FA642C8590B2164)   // 1/23
+    dc[11] = c.rodata.last_offset
+    c.rodata = data_section_add_f64(c.rodata, 0x3FA47AE147AE147B)   // 1/25
+    dc[12] = c.rodata.last_offset
 
     c.code = emit_push_rbp(c.code)
     c.code = emit_mov_rbp_rsp(c.code)
-    c.code = emit_sub_rsp_imm32(c.code, 64)
+    c.code = emit_sub_rsp_imm32(c.code, 128)
 
-    // rdi = f64 bit pattern of x
-    c.code = emit_mov_reg_reg(c.code, 0, 7)       // mov rax, rdi
-    c.code = emit_store_rax_rbp_disp32(c.code, -8)  // [rbp-8] = input bits
+    c.code = emit_mov_reg_reg(c.code, 0, 7)
+    c.code = emit_store_rax_rbp_disp32(c.code, 0 - 8)     // input bits
 
-    // Step 1: Extract biased exponent e = (bits >> 52) & 0x7FF
-    c.code = emit_mov_reg_imm(c.code, 1, 52)      // mov rcx, 52
-    // shr rax, cl: 48 D3 E8
-    var b1 = c.code
-    b1 = emit_byte(b1, 0x48)
-    b1 = emit_byte(b1, 0xD3)
-    b1 = emit_byte(b1, 0xE8)
-    c.code = b1
-    // and rax, 0x7FF: use rbx
-    c.code = emit_mov_reg_imm(c.code, 3, 0x7FF)   // mov rbx, 0x7FF
-    c.code = emit_and_rax_rbx(c.code)              // rax = biased exponent
+    // e = ((bits >> 52) & 0x7FF) - 1023
+    c.code = emit_mov_reg_imm(c.code, 1, 52)
+    var sh1 = c.code
+    sh1 = emit_byte(sh1, 0x48)
+    sh1 = emit_byte(sh1, 0xD3)
+    sh1 = emit_byte(sh1, 0xE8)                            // shr rax, cl
+    c.code = sh1
+    c.code = emit_mov_reg_imm(c.code, 3, 0x7FF)
+    c.code = emit_and_rax_rbx(c.code)
+    c.code = emit_mov_reg_imm(c.code, 3, 1023)
+    c.code = emit_sub_rax_rbx(c.code)
+    c.code = emit_store_rax_rbp_disp32(c.code, 0 - 64)    // e
 
-    // e_unbiased = e - 1023
-    c.code = emit_mov_reg_imm(c.code, 3, 1023)    // mov rbx, 1023
-    // sub rax, rbx: 48 29 D8
-    var b2 = c.code
-    b2 = emit_byte(b2, 0x48)
-    b2 = emit_byte(b2, 0x29)
-    b2 = emit_byte(b2, 0xD8)
-    c.code = b2
-    // Convert e_unbiased to f64
-    c.code = emit_cvtsi2sd_xmm0_rax(c.code)        // xmm0 = e_unbiased (f64)
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -16)  // [rbp-16] = e_f64
-
-    // Step 2: Extract mantissa m ∈ [1,2)
-    // m_bits = (bits & 0x000FFFFFFFFFFFFF) | 0x3FF0000000000000
-    c.code = emit_load_rbp_disp32_rax(c.code, -8)   // rax = input bits
+    // m_bits = (bits & mantissa_mask) | 0x3FF0000000000000  ->  m in [1, 2)
+    c.code = emit_load_rbp_disp32_rax(c.code, 0 - 8)
     c.code = emit_mov_reg_imm(c.code, 3, 0x000FFFFFFFFFFFFF)
-    c.code = emit_and_rax_rbx(c.code)              // rax = mantissa bits only
+    c.code = emit_and_rax_rbx(c.code)
     c.code = emit_mov_reg_imm(c.code, 3, 0x3FF0000000000000)
-    c.code = emit_or_rax_rbx(c.code)               // rax = m in [1,2) bits
-    c.code = emit_movq_xmm0_rax(c.code)            // xmm0 = m
+    c.code = emit_or_rax_rbx(c.code)
+    c.code = emit_store_rax_rbp_disp32(c.code, 0 - 72)    // m_bits
 
-    // Step 3: f = (m - 1) / (m + 1)
-    // Save m to [rbp-40]
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -40)  // [rbp-40] = m
-    // xmm0 = m, load 1.0 into xmm1
-    let load_one1_pos = c.code.len
+    // Branch-free centering on 1.5 -- see the header note.
+    c.code = emit_mov_reg_imm(c.code, 1, 51)
+    var sh2 = c.code
+    sh2 = emit_byte(sh2, 0x48)
+    sh2 = emit_byte(sh2, 0xD3)
+    sh2 = emit_byte(sh2, 0xE8)                            // shr rax, cl
+    c.code = sh2
+    c.code = emit_mov_reg_imm(c.code, 3, 1)
+    c.code = emit_and_rax_rbx(c.code)                     // rax = t
+    c.code = emit_store_rax_rbp_disp32(c.code, 0 - 80)
+    c.code = emit_mov_reg_imm(c.code, 1, 52)
+    c.code = emit_shl_rax_cl(c.code)                      // t << 52
+    c.code = emit_mov_reg_reg(c.code, 3, 0)
+    c.code = emit_load_rbp_disp32_rax(c.code, 0 - 72)
+    c.code = emit_sub_rax_rbx(c.code)                     // m_bits - (t << 52)
+    c.code = emit_movq_xmm0_rax(c.code)
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, 0 - 40)    // m in [0.75, 1.5)
+
+    // e_f64 = (e + t) as f64
+    c.code = emit_load_rbp_disp32_rax(c.code, 0 - 80)
+    c.code = emit_mov_reg_reg(c.code, 3, 0)
+    c.code = emit_load_rbp_disp32_rax(c.code, 0 - 64)
+    c.code = emit_add_rax_rbx(c.code)
+    c.code = emit_cvtsi2sd_xmm0_rax(c.code)
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, 0 - 16)    // e_f64
+
+    // f = (m - 1) / (m + 1)
+    c.code = emit_movsd_xmm0_rbp_disp8(c.code, 0 - 40)
+    let p_one1 = c.code.len
     c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, load_one1_pos + 4, one_off)
-    // m - 1 in xmm0
-    c.code = emit_subsd_xmm0_xmm1(c.code)         // xmm0 = m - 1
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -48)  // [rbp-48] = m - 1
-
-    // m + 1: reload m
-    c.code = emit_movsd_xmm0_rbp_disp8(c.code, -40)  // xmm0 = m
-    let load_one2_pos = c.code.len
+    c.relocs = add_rip_reloc(c.relocs, p_one1 + 4, one_off)
+    c.code = emit_subsd_xmm0_xmm1(c.code)
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, 0 - 48)    // m - 1
+    c.code = emit_movsd_xmm0_rbp_disp8(c.code, 0 - 40)
+    let p_one2 = c.code.len
     c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, load_one2_pos + 4, one_off)
-    c.code = emit_addsd_xmm0_xmm1(c.code)         // xmm0 = m + 1
+    c.relocs = add_rip_reloc(c.relocs, p_one2 + 4, one_off)
+    c.code = emit_addsd_xmm0_xmm1(c.code)
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, 0 - 56)    // m + 1
+    c.code = emit_movsd_xmm0_rbp_disp8(c.code, 0 - 48)
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, 0 - 56)
+    c.code = emit_divsd_xmm0_xmm1(c.code)
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, 0 - 24)    // f
 
-    // f = (m-1) / (m+1)
-    // xmm1 = m+1, xmm0 = m-1  (via [rbp-56]; [rbp-48] still holds m-1 from above)
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -56)  // [rbp-56] = m+1
-    c.code = emit_movsd_xmm0_rbp_disp8(c.code, -48)  // xmm0 = m-1
-    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -56)  // xmm1 = m+1
-    c.code = emit_divsd_xmm0_xmm1(c.code)          // xmm0 = f = (m-1)/(m+1)
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -24)  // [rbp-24] = f
+    // u = f*f, then Horner over 1/(2k+1) in u
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, 0 - 24)
+    c.code = emit_mulsd_xmm0_xmm1(c.code)
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, 0 - 32)    // u
+    let p_top = c.code.len
+    c.code = emit_movsd_xmm0_rip_disp32(c.code, 0)
+    c.relocs = add_rip_reloc(c.relocs, p_top + 4, dc[12])
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, 0 - 88)    // acc
+    var k: i64 = 11
+    while k >= 0 {
+        c = emit_horner_step(c, 0 - 32, 0 - 88, dc[k as usize])
+        k = k - 1
+    }
 
-    // Step 4: f^2
-    c.code = emit_movsd_xmm0_rbp_disp8(c.code, -24) // xmm0 = f
-    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -24) // xmm1 = f
-    c.code = emit_mulsd_xmm0_xmm1(c.code)          // xmm0 = f^2
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -32)  // [rbp-32] = f^2
-
-    // Step 5: Series: log(m) = 2*f*(1 + f^2/3 + f^4/5 + f^6/7)
-    // Compute f^4 = f^2 * f^2
-    c.code = emit_movsd_xmm0_rbp_disp8(c.code, -32)  // xmm0 = f^2
-    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -32)  // xmm1 = f^2
-    c.code = emit_mulsd_xmm0_xmm1(c.code)          // xmm0 = f^4
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -48)  // [rbp-48] = f^4
-
-    // Compute f^6 = f^4 * f^2
-    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -32)  // xmm1 = f^2
-    c.code = emit_mulsd_xmm0_xmm1(c.code)          // xmm0 = f^6
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -56)  // [rbp-56] = f^6
-
-    // term4 = f^6 / 7
-    let load_seventh_pos = c.code.len
+    // log(m) = 2 * f * P(u)
+    c.code = emit_movsd_xmm0_rbp_disp8(c.code, 0 - 88)
+    let p_two = c.code.len
     c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, load_seventh_pos + 4, seventh_off)
-    c.code = emit_mulsd_xmm0_xmm1(c.code)          // xmm0 = f^6 * (1/7)
+    c.relocs = add_rip_reloc(c.relocs, p_two + 4, two_off)
+    c.code = emit_mulsd_xmm0_xmm1(c.code)
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, 0 - 24)
+    c.code = emit_mulsd_xmm0_xmm1(c.code)
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, 0 - 96)    // log(m)
 
-    // + f^4 / 5
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -40)  // save partial (f^6/7) to [rbp-40]
-    c.code = emit_movsd_xmm0_rbp_disp8(c.code, -48)  // xmm0 = f^4
-    let load_fifth_pos = c.code.len
+    // result = e*ln2_hi + (e*ln2_lo + log(m))
+    c.code = emit_movsd_xmm0_rbp_disp8(c.code, 0 - 16)
+    let p_lo = c.code.len
     c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, load_fifth_pos + 4, fifth_off)
-    c.code = emit_mulsd_xmm0_xmm1(c.code)          // xmm0 = f^4 * (1/5)
-    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -40)  // xmm1 = f^6/7
-    c.code = emit_addsd_xmm0_xmm1(c.code)          // xmm0 = f^4/5 + f^6/7
-
-    // + f^2 / 3
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -40)  // save partial
-    c.code = emit_movsd_xmm0_rbp_disp8(c.code, -32)  // xmm0 = f^2
-    let load_third_pos = c.code.len
+    c.relocs = add_rip_reloc(c.relocs, p_lo + 4, ln2_lo_off)
+    c.code = emit_mulsd_xmm0_xmm1(c.code)
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, 0 - 96)
+    c.code = emit_addsd_xmm0_xmm1(c.code)
+    c.code = emit_movsd_rbp_disp8_xmm0(c.code, 0 - 96)
+    c.code = emit_movsd_xmm0_rbp_disp8(c.code, 0 - 16)
+    let p_hi = c.code.len
     c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, load_third_pos + 4, third_off)
-    c.code = emit_mulsd_xmm0_xmm1(c.code)          // xmm0 = f^2 * (1/3)
-    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -40)  // xmm1 = f^4/5 + f^6/7
-    c.code = emit_addsd_xmm0_xmm1(c.code)          // xmm0 = f^2/3 + f^4/5 + f^6/7
+    c.relocs = add_rip_reloc(c.relocs, p_hi + 4, ln2_hi_off)
+    c.code = emit_mulsd_xmm0_xmm1(c.code)
+    c.code = emit_movsd_xmm1_rbp_disp8(c.code, 0 - 96)
+    c.code = emit_addsd_xmm0_xmm1(c.code)
 
-    // + 1.0
-    let load_one3_pos = c.code.len
-    c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, load_one3_pos + 4, one_off)
-    c.code = emit_addsd_xmm0_xmm1(c.code)          // xmm0 = 1 + f^2/3 + f^4/5 + f^6/7
-
-    // * 2 * f
-    let load_two_pos = c.code.len
-    c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, load_two_pos + 4, two_off)
-    c.code = emit_mulsd_xmm0_xmm1(c.code)          // xmm0 *= 2
-    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -24)  // xmm1 = f
-    c.code = emit_mulsd_xmm0_xmm1(c.code)          // xmm0 = log(m)
-
-    // Step 6: result = e * ln(2) + log(m)
-    c.code = emit_movsd_rbp_disp8_xmm0(c.code, -40)  // [rbp-40] = log(m)
-    c.code = emit_movsd_xmm0_rbp_disp8(c.code, -16)  // xmm0 = e_f64
-    let load_ln2_pos = c.code.len
-    c.code = emit_movsd_xmm1_rip_disp32(c.code, 0)
-    c.relocs = add_rip_reloc(c.relocs, load_ln2_pos + 4, ln2_off)
-    c.code = emit_mulsd_xmm0_xmm1(c.code)          // xmm0 = e * ln(2)
-    c.code = emit_movsd_xmm1_rbp_disp8(c.code, -40)  // xmm1 = log(m)
-    c.code = emit_addsd_xmm0_xmm1(c.code)          // xmm0 = e*ln2 + log(m)
-
-    // Return as bit pattern in rax
     c.code = emit_movq_rax_xmm0(c.code)
-    c.code = emit_add_rsp_imm32(c.code, 64)
+    c.code = emit_add_rsp_imm32(c.code, 128)
     c.code = emit_pop_rbp(c.code)
     c.code = emit_ret(c.code)
     c
 }
-
 
 // Sprint 121: sin builtin — range reduction + degree-7 minimax polynomial
 // Algorithm: sin(x) ≈ x(1 - x²(1/6 - x²(1/120 - x²/5040)))


### PR DESCRIPTION
#1626. Both are builtin ids that the E219 allow-list (#1622) treats as implemented, so calls compile and run — answering with about half the precision of a double, silently.

Worst ULP distance from glibc over a 32-point grid per function, references baked in from CPython:

| | before | after |
|---|---:|---:|
| **exp** | 100 193 258 756 | **1** |
| **log** | 46 330 648 410 510 550 | 67 108 865 |

## exp — three independent errors

| | |
|---|---|
| **truncate** | `n = trunc(x/ln2)` left \|r\| < ln2 = 0.693 rather than ln2/2, so the r⁷/5040 truncation term ran to 1.5e-5 instead of 7.6e-8 — a factor of 128, for one instruction |
| **single ln2** | `n*ln2` for x = 1000 (n = 1443) rounds at ~1e-13 absolute, and that lands directly in `r`, hence **relatively** in the result |
| **degree 6** | the last stored coefficient was `1/720`; r⁷/5040 is what the measurement kept finding |

Now: round-to-nearest (\|r\| ≤ 0.3466), Cody-Waite `ln2` with 40 significant bits in the high half so `n*ln2_hi` is exact for \|n\| < 2¹³, and degree 13, whose r¹⁴/14! term is 4.1e-18 — under half an ULP. **1 ULP** across the grid including ±700, ±300 and −88.7.

## log — the series was not the problem

x just below 1 lands at e = −1 with m ≈ 2, and `e*ln2 + log(m)` subtracts two values of magnitude 0.693 down to ~1e-6:

```
log(0.999999)   gave  -1.3423e-5   against  -1.0000005e-6
```

Thirteen times too large. **No number of series terms recovers digits that cancellation has already destroyed.** The fix is branch-free centering on 1.5 using the top mantissa bit — `t = bit 51`, `m_bits -= t<<52`, `e += t` — which puts f in [−1/7, 1/5] instead of [0, 1/3] *and* gives x near 1 an exponent of 0 with no cancellation at all. Cody-Waite on `ln2` here too, so e up to 1024 does not multiply ln2's own rounding error into the answer.

## Residual, stated rather than rounded away

log is now **0–2 ULP everywhere on the grid except two points**: x = 0.99999999 (6.7e7 ULP) and x = 0.999999 (5.2e5 ULP). Both carry an absolute error of exactly **2⁻⁵³ = 1.110223e-16** — a constant, not a relative error, so it is invisible wherever \|log(x)\| is not itself tiny.

I could not root-cause it. The algorithm in double arithmetic is exact at those inputs (`2f` alone equals `log(x)` bit for bit in Python), so the 2⁻⁵³ enters somewhere in the emitted code and reading it did not find where. The Sounio-source replication that would have isolated it is unusable as an oracle because Madaros bitcasts `f64 as i64` (#983). **#1626 stays open** with this measured envelope rather than being closed on a four-orders-of-magnitude improvement.

## Shared Horner step

The previous emitters open-coded one copy of five instructions per polynomial term. That is why they stopped at degree 6 and degree 4 — the code, not the mathematics, was setting the accuracy. `emit_horner_step` makes the degree a loop bound.

## Not fixed here, said plainly

- `sin`/`cos` have the same structure and worse numbers, but theirs is dominated by argument reduction at large \|x\| — a separate problem.
- The 2ⁿ scaling in `exp` is still a raw `bits + (n << 52)`: it neither produces a denormal on underflow nor saturates to infinity on overflow.
- `data_section_add_f64` silently stops writing at 8192 bytes of `.rodata` (`(t.len + i) < 8192`). This adds 20 f64 constants — 160 bytes — and the corpus shows no fallout, but the cap has no diagnostic, so a constant-heavy program would lose constants without being told.

## Corpus — zero regressions, one program fixed

| run | failures | reported new |
|---|---:|---:|
| **control**: same tree, pre-change binary | 291 / 1707 | 17 |
| this change | 290 / 1707 | **16** |

Set difference in both directions:

- only in the control → **`mercyful_pontryagin_control.sio`**, which now goes from `MERCYFUL_PONTRYAGIN_FAIL` to `MERCYFUL_PONTRYAGIN_PASS`
- only with this change → **none**

The 16 shared entries are the `madaros_gum_fo_*` family plus `mercyful_chemo_sequencing`. That family arrived on main in a single commit (`154450258`) and was never added to the corpus baseline; a sampled one prints byte-identical output with and without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)