### PR TITLE
ci: close the three blind spots that let a compiler ship unable to read itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,30 @@ jobs:
         run: bash scripts/ci/madaros_changed_tests_selftest.sh
       - name: Executable payload comparator self-test
         run: bash scripts/ci/executable_payload_compare_selftest.sh
+      # Arms 1-2 need no compiler and cost <1 s, so they run on every PR
+      # including docs-only ones. That is what stops the self-parse gate rotting
+      # into a no-op: `--science-boundary-closure` exits 0 even on `status
+      # incomplete`, so a gate written against its exit code would pass forever
+      # and look exactly like a working gate.
+      - name: Madaros self-parse verdict self-test
+        run: bash scripts/ci/madaros_self_parse_selftest.sh
+      # The tracked receipt asserts a sha256 for a binary. On 2026-08-04 it
+      # named an absolute host path, claimed a digest that did not match the file
+      # on disk, cited a commit 1515 behind HEAD, and was read by zero lines of
+      # code — while ~82 scripts resolved that binary as an oracle and
+      # scripts/install.sh preferred it over the committed one.
+      - name: Madaros prebuilt receipt matches its binary
+        run: bash scripts/ci/madaros_receipt_gate.sh
+      # 67% of gates carry no emptiness guard. This one is ratcheted: the known
+      # set may only shrink, and a NEW gate without a guard is red.
+      - name: Gates must not pass on no data
+        run: bash scripts/ci/gate_vacuity_gate.sh
+      # The shipped lean_single ELF must BE the byte-identical fixed point of
+      # current lean_single.sio. This gate existed, passed, and was wired to no
+      # workflow — so the one thing that would notice the shipped binary drifting
+      # from source was never run. ~2 s.
+      - name: Canonical lean_single fixed point
+        run: bash scripts/ci/canonical_compiler_gate.sh
       - name: Output-path invariants
         run: bash scripts/dev/check_outpath_invariant.sh
       - name: Output-path leading-dash guard
@@ -357,9 +381,15 @@ jobs:
   madaros-current-source-deref-f64:
     name: Madaros Current-Source f64 Lowering
     needs: impact
-    if: needs.impact.outputs.compiler == 'true' || needs.impact.outputs.tests == 'true' || needs.impact.outputs.full == 'true'
+    # `stdlib` is here for a measured reason: 7 files in main.sio's own import
+    # closure live under stdlib/compiler/ontology/ and classify as stdlib, not
+    # compiler. A PR that makes stdlib/compiler/ontology/store.sio unparseable
+    # breaks the compiler's closure and, without this, runs none of these gates.
+    if: needs.impact.outputs.compiler == 'true' || needs.impact.outputs.stdlib == 'true' || needs.impact.outputs.tests == 'true' || needs.impact.outputs.full == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    # 15 held a full Madaros build plus four sub-gates; the self-parse sweep adds
+    # ~20 s. The extra headroom is so a slow run reads as slow, not as a hang.
+    timeout-minutes: 18
     env:
       SOUNIO_MADAROS_F64_LOWERING_GATE_DIR: /tmp/sounio-madaros-current-source-f64-lowering
       SOUNIO_MADAROS_F64_LOWERING_GATE_KEEP: 1
@@ -369,6 +399,16 @@ jobs:
           fetch-depth: 0
       - name: Build Madaros once and run current-source f64 lowering gates
         run: bash scripts/ci/madaros_current_source_f64_lowering_gate.sh
+      # The compiler must be able to read its own source tree. On 2026-08-03 one
+      # built from main could not parse self-hosted/resolve/scope.sio; 417 gates
+      # missed it and it was found by accident. Re-measured afterwards: 118 of
+      # 559 files under self-hosted/ failed. This step reuses the ELF the step
+      # above already built and kept (KEEP=1) — it adds no build.
+      - name: Madaros parses its own source tree
+        env:
+          SOUNIO_MADAROS_SELF_PARSE_BIN: /tmp/sounio-madaros-current-source-f64-lowering/madaros
+          SOUNIO_MADAROS_SELF_PARSE_REPORT_DIR: /tmp/sounio-madaros-current-source-f64-lowering/self-parse
+        run: bash scripts/ci/madaros_self_parse_gate.sh
       - name: Run changed Madaros tests with the current-source compiler
         env:
           SOUNIO_MADAROS_CHANGED_TESTS_BIN: /tmp/sounio-madaros-current-source-f64-lowering/madaros

--- a/.github/workflows/madaros-prebuilt-refresh.yml
+++ b/.github/workflows/madaros-prebuilt-refresh.yml
@@ -69,10 +69,16 @@ jobs:
           # source and the checked-in prebuilt drift. The source-to-ELF gate
           # covers the raw --native-v2-compile bridge, so a prebuilt that
           # regresses the direct source -> native-v2 -> ELF path is not shipped.
+          # The self-parse gate is here because none of the five gates above ever
+          # asked the compiler to read its own source tree. On 2026-08-03 a
+          # Madaros that could not parse self-hosted/resolve/scope.sio would have
+          # passed every one of them and been committed as the shipped prebuilt.
+          # It reuses the ELF just built; it adds no build.
           if bash scripts/ci/madaros_full_gate.sh \
              && bash scripts/ci/madaros_enum_gate.sh \
              && bash scripts/ci/madaros_loop_gate.sh \
              && bash scripts/ci/madaros_multimodule_witness.sh \
+             && SOUNIO_MADAROS_SELF_PARSE_BIN=artifacts/self-hosted/madaros bash scripts/ci/madaros_self_parse_gate.sh \
              && bash scripts/ci/madaros_source_to_elf_gate.sh; then
             echo "passed=true" >> "$GITHUB_OUTPUT"
           else
@@ -85,6 +91,13 @@ jobs:
         run: |
           cp artifacts/self-hosted/madaros bin/madaros-linux-x86_64
           chmod +x bin/madaros-linux-x86_64
+          # Emit the provenance receipt for the binary actually being shipped.
+          # The receipt was previously hand-written, had no producer and no
+          # consumer, and drifted until it described a file that no longer
+          # existed. madaros_receipt_gate.sh verifies what this writes.
+          bash scripts/ci/madaros_write_receipt.sh bin/madaros-linux-x86_64 \
+            madaros_full_gate.sh \
+            "full,enum,loop,multimodule_witness,self_parse,source_to_elf"
 
       - name: Commit and push if the prebuilt changed
         if: steps.gate.outputs.passed == 'true' && (github.event.inputs.ref || 'main') == 'main'
@@ -99,7 +112,9 @@ jobs:
 
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add bin/madaros-linux-x86_64
+          # The receipt goes with the binary it describes, in the same commit.
+          # Committing one without the other is how they drifted apart before.
+          git add bin/madaros-linux-x86_64 artifacts/self-hosted/madaros.gate-receipt
           git commit -m "build(madaros): refresh prebuilt bin/madaros-linux-x86_64 [skip ci]
 
           Auto-rebuilt from ${SRC_REF} (make build-madaros) and passed the

--- a/artifacts/self-hosted/madaros.gate-receipt
+++ b/artifacts/self-hosted/madaros.gate-receipt
@@ -1,11 +1,9 @@
 madaros_full_gate_receipt_v1
-artifact=/workspace/sounio/artifacts/self-hosted/madaros
-sha256=5629c3a48b6c54b57154bb901be32cd41ddcfca29cc664ca0899c8c5f75cedfe
-created_utc=2026-07-11T00:55:07Z
+artifact=bin/madaros-linux-x86_64
+sha256=38ea3a25befa666f5ba517e3b1c145a13b356bd366a4f7706594b93f15dda893
+created_utc=2026-08-04T12:36:41Z
 gate=madaros_full_gate.sh
 gate_result=pass
-gate_checks=version,public_check_cli,raw_check_cli,multimodule_visibility_diagnostics
-gate_checks_passed=4/4
-smt_tests=not_rerun_this_cycle
-source_commit=96a303edd
-note=rebuilt after Madares->Madaros version-string rename; banner assertion updated in gate
+gate_checks=version,public_check_cli,raw_check_cli,multimodule_visibility_diagnostics,native_abi_witnesses,pkg_selftest
+source_commit=c36b67759798d73de750b28c49e3a231c7038a04
+note=written by scripts/ci/madaros_write_receipt.sh; verified by scripts/ci/madaros_receipt_gate.sh

--- a/scripts/ci/fixtures/gate_vacuity_baseline.txt
+++ b/scripts/ci/fixtures/gate_vacuity_baseline.txt
@@ -1,0 +1,51 @@
+# Gates that extract a value from a tool and carry no emptiness guard.
+# Seeded 2026-08-04 from the first run of scripts/ci/gate_vacuity_gate.sh.
+#
+# This list may only SHRINK. A new entry is a red PR; an entry that has since
+# gained a guard is also a red PR, with instructions to delete the line.
+# Fix by sourcing scripts/lib/gate_assert.sh and using require_nonempty,
+# require_min_count, or count_matches.
+
+scripts/ci/associator_gum_variance_gate.sh
+scripts/ci/cd_tower_seam_gate.sh
+scripts/ci/compiler_stage_contract_gate.sh
+scripts/ci/dissertation_frontend_parity_gate.sh
+scripts/ci/dissertation_pbpk28_parity_gate.sh
+scripts/ci/dissertation_pbpk_suite_gate.sh
+scripts/ci/epistemic_witness_gate.sh
+scripts/ci/float_slot_capacity_coherence_gate.sh
+scripts/ci/gb10_wmma_receipt_gate.sh
+scripts/ci/generated_ontology_manifest_gate.sh
+scripts/ci/gresnigt_family_s3_gate.sh
+scripts/ci/kretikos_associator_emit_gate.sh
+scripts/ci/kretikos_kaxi_fmad_invariance_gate.sh
+scripts/ci/kretikos_kaxi_iso_budget_gate.sh
+scripts/ci/kretikos_kaxi_phase_z_assoc_gate.sh
+scripts/ci/kretikos_kaxi_round_mode_gate.sh
+scripts/ci/madaros_f128_f256_format_identity_gate.sh
+scripts/ci/madaros_f128_f256_numeric_payload_gate.sh
+scripts/ci/madaros_f128_f256_numeric_wire_gate.sh
+scripts/ci/madaros_gum_fo_trust_gate.sh
+scripts/ci/mercyful_chemo_sequencing_gate.sh
+scripts/ci/mercyful_continuous_control_gate.sh
+scripts/ci/mercyful_expanded_ethics_gate.sh
+scripts/ci/mercyful_lean_gate.sh
+scripts/ci/mercyful_pontryagin_control_gate.sh
+scripts/ci/mir_instr_capacity_coherence_gate.sh
+scripts/ci/ontology_cli_smoke_gate.sh
+scripts/ci/oopsla2027_paper_gate.sh
+scripts/ci/plan_big_gate.sh
+scripts/ci/sedenion_clifford8_gate.sh
+scripts/ci/sedenion_e8_boundary_gate.sh
+scripts/ci/sedenion_quartet_fiber_incidence_gate.sh
+scripts/ci/sedenion_seam_bridge_gate.sh
+scripts/ci/sedenion_zd168_crosscheck_gate.sh
+scripts/ci/sedenion_zd_fiber_identity_gate.sh
+scripts/ci/sedenion_zd_fibers_gate.sh
+scripts/ci/sedenion_zd_quartets_gate.sh
+scripts/ci/semantic_orc_depression_orc_gate.sh
+scripts/ci/sounio_release_production_readiness_gate.sh
+scripts/ci/witness_based_compilation_paper_gate.sh
+scripts/ci/zd_deep_dive_gate.sh
+scripts/ci/zd_orbit_equivalence_gate.sh
+scripts/dev/let_var_binding_gate.sh

--- a/scripts/ci/fixtures/madaros_self_parse_baseline.txt
+++ b/scripts/ci/fixtures/madaros_self_parse_baseline.txt
@@ -1,0 +1,92 @@
+# Sources under self-hosted/ that a Madaros built from this tree cannot parse.
+#
+# Seeded 2026-08-04 from a compiler built at d2b70d217 + the failed_path
+# emission in this branch: 77 of 556 tracked sources. The pre-#1624 binary
+# failed 118, so that PR closed 41 of them.
+#
+# THIS LIST MAY ONLY SHRINK. A file that starts failing is a red PR. A file
+# listed here that now parses is ALSO a red PR, telling you to delete the
+# line — that is what stops an allowlist becoming a permanent excuse.
+#
+# self-hosted/check/check.sio is the one that blocks main.sio's own import
+# closure: 23 592 lines, and it fails at node 0, so it cannot parse itself as
+# an entry point either. Until it parses, the compiler cannot read its own
+# closure end to end.
+
+self-hosted/bootstrap/bootstrap_v0.sio
+self-hosted/check/causal.sio
+self-hosted/check/check.sio
+self-hosted/check/mod.sio
+self-hosted/ci/m4_large_surface_probe.sio
+self-hosted/ci/ontology_checker_new_probe.sio
+self-hosted/ci/ontology_validation_debug_driver.sio
+self-hosted/ci/ontology_validation_driver.sio
+self-hosted/ci/ontology_warning_mut_probe.sio
+self-hosted/ci/ontology_witness_program_probe.sio
+self-hosted/compiler/claim_executor.sio
+self-hosted/compiler/epistemic_lean_export.sio
+self-hosted/compiler/frontend_callsite_probe.sio
+self-hosted/compiler/k2_check_import_accessor_probe.sio
+self-hosted/compiler/k2_check_import_collect_accessor_probe.sio
+self-hosted/compiler/k2_check_import_heap_checker_probe.sio
+self-hosted/compiler/k2_check_import_knowledge_context_semantic_probe.sio
+self-hosted/compiler/k2_check_import_leaf_probe.sio
+self-hosted/compiler/k2_check_import_ontology_cache_kernel_probe.sio
+self-hosted/compiler/k2_check_import_ontology_cache_sourcecheck_classifier_probe.sio
+self-hosted/compiler/k2_check_import_pointer_probe.sio
+self-hosted/compiler/k2_check_mod_knowledge_context_ontocache_sidecar_probe.sio
+self-hosted/compiler/k2_check_mod_ontology_cache_directive_probe.sio
+self-hosted/compiler/k2_check_mod_ontology_cache_sourcecheck_classifier_probe.sio
+self-hosted/compiler/k2_check_mod_ontology_cache_sourcecheck_reject_classifier_probe.sio
+self-hosted/compiler/k2_check_mod_same_checker_ontology_cache_kernel_classifier_probe.sio
+self-hosted/compiler/k2_check_mod_same_checker_ontology_cache_kernel_copy_classifier_probe.sio
+self-hosted/compiler/k2_check_mod_same_checker_ontology_cache_kernel_precheck_classifier_probe.sio
+self-hosted/compiler/k2_check_mod_same_checker_ontology_cache_kernel_ptr_query_classifier_probe.sio
+self-hosted/compiler/k2_check_mod_same_checker_ontology_cache_shadow_classifier_probe.sio
+self-hosted/compiler/k2_check_mod_same_checker_ontology_cache_shadow_reject_classifier_probe.sio
+self-hosted/compiler/k2_check_mod_same_checker_ontology_cache_sidecar_classifier_probe.sio
+self-hosted/compiler/k2_check_mod_semantic_bridge_probe.sio
+self-hosted/compiler/lean.sio
+self-hosted/compiler/lean_frontend.sio
+self-hosted/compiler/lowering_trace_smoke.sio
+self-hosted/compiler/main.sio
+self-hosted/compiler/module_frontend.sio
+self-hosted/compiler/module_loader.sio
+self-hosted/compiler/module_native_driver.sio
+self-hosted/compiler/module_native_simple_driver.sio
+self-hosted/compiler/module_native_streaming.sio
+self-hosted/compiler/native_compile_smoke.sio
+self-hosted/compiler/pkg/cli.sio
+self-hosted/compiler/pkg/lib.sio
+self-hosted/compiler/pkg/scorer.sio
+self-hosted/compiler/render_native_compile_driver_f64.sio
+self-hosted/compiler/render_native_compile_driver_lean.sio
+self-hosted/compiler/render_native_compile_driver_stable.sio
+self-hosted/compiler/render_streaming_body_smoke.sio
+self-hosted/compiler/souc_v2/main.sio
+self-hosted/compiler/streaming_body_lower_smoke.sio
+self-hosted/compiler/types.sio
+self-hosted/compiler/wide_native_compile_driver.sio
+self-hosted/distributed/actor.sio
+self-hosted/effects/handlers.sio
+self-hosted/gpu/epistemic_ptx.sio
+self-hosted/gpu/epistemic_tensor_core.sio
+self-hosted/gpu/kernels/bio.sio
+self-hosted/gpu/kretikos_cubin_validate.sio
+self-hosted/gpu/ptx_emitter.sio
+self-hosted/ir/closure.sio
+self-hosted/ir/lower_prepopulate.sio
+self-hosted/ir/reach_probe_runner.sio
+self-hosted/llvm/context.sio
+self-hosted/llvm/debug.sio
+self-hosted/llvm/target.sio
+self-hosted/lsp/goto_def.sio
+self-hosted/lsp/hover.sio
+self-hosted/lsp/rustism_detector.sio
+self-hosted/native/signal_handler.sio
+self-hosted/native/vec_ieee754.sio
+self-hosted/printer/buffer_print.sio
+self-hosted/printer/print_ast.sio
+self-hosted/tensor/contract.sio
+self-hosted/tools/formatter.sio
+self-hosted/vm/vm.sio

--- a/scripts/ci/gate_vacuity_gate.sh
+++ b/scripts/ci/gate_vacuity_gate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# A gate that can pass on no data is not a gate.
+#
+# Census, 2026-08-04, over the 417 *_gate.{sh,py} in scripts/ci and scripts/dev:
+# 258 (67%) had no emptiness guard of any kind. The failure shape is always the
+# same — a value is extracted from a tool, the extraction comes back empty
+# because the tool changed, moved or broke, and the empty value is then compared
+# as though it meant something. Measured instances on that date:
+#
+#   run_pass_output_gate.sh          "PASS (strict): all 0 ... tests"
+#   reproduce_artifact.sh            "PASS: test suite" while the suite crashed
+#   check_doc_snippets.sh            "0 pass, 0 fail, 0 total" -> exit 0
+#   eisa_bridge_conformance_gate.sh  "PASS anti-vacuity" on an empty extraction
+#   madaros_readiness_status.sh      a failing `gh` call -> status[...]=pass
+#
+# This gate flags the pattern. It is RATCHETED against a baseline because 258
+# scripts cannot be fixed at once — but the count may only fall, and a NEW gate
+# must be clean. That is the difference between a debt and a leak.
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR" || exit 9
+. "$ROOT_DIR/scripts/lib/gate_assert.sh"
+gate_name "gate_vacuity_gate"
+
+BASELINE="$ROOT_DIR/scripts/ci/fixtures/gate_vacuity_baseline.txt"
+
+mapfile -t GATES < <(git ls-files 'scripts/ci/*_gate.sh' 'scripts/dev/*_gate.sh' 2>/dev/null | sort -u)
+require_min_count "${#GATES[@]}" 300 "gate scripts"
+
+# A script is FLAGGED when it extracts a value from a tool and carries no
+# emptiness guard anywhere. Both halves matter: extraction without a guard is
+# the defect; a script that extracts nothing has nothing to guard.
+EXTRACTS='\$\((grep|awk|sed|cut|jq|python3|wc|head|tail|tr|rg)[^)]*\)|\$\([^)]*\|[^)]*(grep|awk|sed|jq|wc)[^)]*\)'
+GUARDS='\[\[? *-[nz] *"?\$|\$\{#[A-Za-z_]+\[@\]\} *-(gt|ge)|-s +"?\$|require_nonempty|require_min_count|gate_fail|nothing to measure|vacuous'
+
+: >"${TMPDIR:-/tmp}/gate_vacuity_flagged.$$"
+trap 'rm -f "${TMPDIR:-/tmp}/gate_vacuity_flagged.$$"' EXIT
+FLAGGED="${TMPDIR:-/tmp}/gate_vacuity_flagged.$$"
+
+scanned=0
+for g in "${GATES[@]}"; do
+  [[ -f "$g" ]] || continue
+  scanned=$((scanned + 1))
+  if grep -Eq "$EXTRACTS" "$g" 2>/dev/null && ! grep -Eq "$GUARDS" "$g" 2>/dev/null; then
+    printf '%s\n' "$g" >>"$FLAGGED"
+  fi
+done
+require_min_count "$scanned" 300 "gate scripts actually read"
+
+sort -u -o "$FLAGGED" "$FLAGGED"
+flagged_n=$(grep -c . "$FLAGGED" || true)
+echo "  scanned $scanned gates, flagged ${flagged_n:-0} with an unguarded extraction"
+
+if [[ ! -f "$BASELINE" ]]; then
+  echo "  no baseline at $BASELINE. Current set:"
+  sed 's/^/    /' "$FLAGGED"
+  gate_fail "seed the baseline from THIS output and commit it"
+fi
+
+grep -vE '^\s*(#|$)' "$BASELINE" | sort -u >"$FLAGGED.baseline"
+
+NEW=$(comm -23 "$FLAGGED" "$FLAGGED.baseline")
+FIXED=$(comm -13 "$FLAGGED" "$FLAGGED.baseline")
+
+if [[ -n "$NEW" ]]; then
+  echo "  NEW unguarded gate(s) — every value pulled from a tool needs an emptiness check:"
+  sed 's/^/    /' <<<"$NEW"
+  echo
+  echo "  Source scripts/lib/gate_assert.sh and use require_nonempty / require_min_count /"
+  echo "  count_matches. count_matches is the one that separates 'no match' from 'the tool"
+  echo "  broke'; \`grep -c ... || true\` reports both as 0."
+  gate_fail "$(grep -c . <<<"$NEW") gate(s) added without an emptiness guard"
+fi
+
+if [[ -n "$FIXED" ]]; then
+  echo "  these are in the baseline but now carry a guard — remove them from $BASELINE:"
+  sed 's/^/    /' <<<"$FIXED"
+  gate_fail "the baseline may only shrink, and it is now out of date"
+fi
+
+gate_pass "${flagged_n:-0} known-unguarded, all in the baseline; the list may only shrink"

--- a/scripts/ci/lean_single_fixed_point_gate.sh
+++ b/scripts/ci/lean_single_fixed_point_gate.sh
@@ -29,6 +29,19 @@ case "$(uname -m 2>/dev/null || echo unknown)" in
     ;;
 esac
 
+# SUPERSEDED — do not wire this into CI. Measured 2026-08-04 from a worktree:
+# it resolved `souc=/workspace/sounio/bin/souc`, i.e. the wrapper from ANOTHER
+# CHECKOUT, and then reported `FAIL: stage1 != stage2` about a compiler that has
+# nothing to do with the tree under test. resolve_souc.sh honours SOUC_BIN and
+# the bin/souc shim, so this gate's subject is whatever happens to be installed,
+# which makes its verdict unattributable.
+#
+# scripts/ci/canonical_compiler_gate.sh asserts the same property — that the
+# shipped lean_single ELF IS the byte-identical fixed point of current
+# lean_single.sio — against an explicit binary, passes in ~2 s, and is wired.
+# Use that one. This file is kept as a diagnostic, not deleted, because its
+# staging output is occasionally useful when a bootstrap is being debugged by
+# hand.
 source "$ROOT_DIR/scripts/lib/resolve_souc.sh"
 sounio_require_souc
 

--- a/scripts/ci/madaros_receipt_gate.sh
+++ b/scripts/ci/madaros_receipt_gate.sh
@@ -56,16 +56,27 @@ require_nonempty "$claimed_result" "receipt has no gate_result= line"
 gate_path="$ROOT_DIR/scripts/ci/$claimed_gate"
 require_file "$gate_path" "receipt names gate '$claimed_gate' which does not exist at scripts/ci/"
 
-# The commit it was built from must be an ancestor of HEAD, or the receipt
-# describes a tree this checkout is not on.
+# The commit it was built from should be an ancestor of HEAD. But CI checks out
+# shallow (actions/checkout@v4 with no fetch-depth, ci.yml Contracts job), so an
+# older commit is genuinely ABSENT from the clone. "I cannot see that commit" and
+# "that commit is not an ancestor" are different facts and must not collapse into
+# one verdict — collapsing an unknown into a failure is the same error as
+# collapsing it into a pass, just in the safe-looking direction.
+#
+# The sha256 check below is the load-bearing one and works on any clone.
 if ! git rev-parse --verify -q "${claimed_commit}^{commit}" >/dev/null 2>&1; then
-  gate_fail "receipt source_commit=$claimed_commit is not a commit in this repository"
+  if [[ -f "$(git rev-parse --git-dir)/shallow" ]]; then
+    echo "  receipt: source=$claimed_commit NOT VERIFIED — shallow clone, the commit is not in this checkout"
+  else
+    gate_fail "receipt source_commit=$claimed_commit is not a commit in this repository, and this is a full clone"
+  fi
+else
+  if ! git merge-base --is-ancestor "$claimed_commit" HEAD 2>/dev/null; then
+    gate_fail "receipt source_commit=$claimed_commit is not an ancestor of HEAD — the receipt describes a tree this branch is not on"
+  fi
+  behind="$(git rev-list --count "${claimed_commit}..HEAD" 2>/dev/null || echo '?')"
+  echo "  receipt: gate=$claimed_gate result=$claimed_result source=$claimed_commit (${behind} commits behind HEAD)"
 fi
-if ! git merge-base --is-ancestor "$claimed_commit" HEAD 2>/dev/null; then
-  gate_fail "receipt source_commit=$claimed_commit is not an ancestor of HEAD — the receipt describes a tree this branch is not on"
-fi
-behind="$(git rev-list --count "${claimed_commit}..HEAD" 2>/dev/null || echo '?')"
-echo "  receipt: gate=$claimed_gate result=$claimed_result source=$claimed_commit (${behind} commits behind HEAD)"
 
 # Verify the artifact the receipt NAMES, whatever that is. A receipt that points
 # at an absolute host path, or at a gitignored local build, is unverifiable on

--- a/scripts/ci/madaros_receipt_gate.sh
+++ b/scripts/ci/madaros_receipt_gate.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# A binary that asserts its own identity must be telling the truth.
+#
+# artifacts/self-hosted/madaros.gate-receipt is TRACKED in git and claims a
+# sha256, a source_commit and a gate result for artifacts/self-hosted/madaros —
+# which is NOT tracked (.gitignore:206). Measured 2026-08-04:
+#
+#     receipt sha256   5629c3a48b6c...    file sha256   6303ec70187b...
+#     source_commit    96a303edd          1603 commits behind HEAD
+#     created_utc      2026-07-11         file mtime    2026-07-30
+#     readers          none               writers       none
+#
+# So the receipt described a different binary, and nothing noticed for weeks.
+# Meanwhile ~82 files resolve that ELF as an oracle, scripts/install.sh:96-102
+# PREFERS it over the committed bin/madaros-linux-x86_64, and the only version
+# assertion anywhere is madaros_full_gate.sh grepping for the literal string
+# "Madaros v0.80.0" — which the stale binary still prints.
+#
+# I used that file as an A/B control and published a false claim on the strength
+# of it. A receipt nobody checks is not provenance; it is decoration that looks
+# like provenance, which is worse than none.
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR" || exit 9
+. "$ROOT_DIR/scripts/lib/gate_assert.sh"
+gate_name "madaros_receipt_gate"
+
+RECEIPT="$ROOT_DIR/artifacts/self-hosted/madaros.gate-receipt"
+
+require_nonempty_file "$RECEIPT" "the tracked receipt is missing or empty"
+require_text "madaros_full_gate_receipt_v1" "$RECEIPT"
+
+field() {
+  local k="$1" v
+  v="$(awk -F= -v k="$k" '$1 == k { sub("^" k "=", ""); print; exit }' "$RECEIPT")"
+  printf '%s' "$v"
+}
+
+claimed_sha="$(field sha256)"
+claimed_commit="$(field source_commit)"
+claimed_gate="$(field gate)"
+claimed_result="$(field gate_result)"
+claimed_artifact="$(field artifact)"
+
+require_nonempty "$claimed_artifact" "receipt has no artifact= line — it does not say what it is a receipt FOR"
+require_nonempty "$claimed_sha"    "receipt has no sha256= line"
+require_nonempty "$claimed_commit" "receipt has no source_commit= line"
+require_nonempty "$claimed_gate"   "receipt has no gate= line"
+require_nonempty "$claimed_result" "receipt has no gate_result= line"
+
+[[ "$claimed_result" == "pass" ]] \
+  || gate_fail "receipt records gate_result=$claimed_result — a binary whose own gate did not pass must not be shipped"
+
+# The gate it names must exist. `gate=` carries a bare filename.
+gate_path="$ROOT_DIR/scripts/ci/$claimed_gate"
+require_file "$gate_path" "receipt names gate '$claimed_gate' which does not exist at scripts/ci/"
+
+# The commit it was built from must be an ancestor of HEAD, or the receipt
+# describes a tree this checkout is not on.
+if ! git rev-parse --verify -q "${claimed_commit}^{commit}" >/dev/null 2>&1; then
+  gate_fail "receipt source_commit=$claimed_commit is not a commit in this repository"
+fi
+if ! git merge-base --is-ancestor "$claimed_commit" HEAD 2>/dev/null; then
+  gate_fail "receipt source_commit=$claimed_commit is not an ancestor of HEAD — the receipt describes a tree this branch is not on"
+fi
+behind="$(git rev-list --count "${claimed_commit}..HEAD" 2>/dev/null || echo '?')"
+echo "  receipt: gate=$claimed_gate result=$claimed_result source=$claimed_commit (${behind} commits behind HEAD)"
+
+# Verify the artifact the receipt NAMES, whatever that is. A receipt that points
+# at an absolute host path, or at a gitignored local build, is unverifiable on
+# any other checkout — which is how this one stayed wrong for weeks. Requiring
+# the subject to be a tracked, repo-relative path is what makes the claim
+# portable and therefore checkable.
+case "$claimed_artifact" in
+  /*) gate_fail "receipt names an ABSOLUTE path ($claimed_artifact) — a receipt tied to one machine's filesystem cannot be verified anywhere else" ;;
+esac
+
+BINARY="$ROOT_DIR/$claimed_artifact"
+if ! git ls-files --error-unmatch "$claimed_artifact" >/dev/null 2>&1; then
+  gate_fail "receipt names '$claimed_artifact', which is not tracked in git. A receipt for a file that is not in the repository is a claim nobody can check — point it at the committed binary (bin/madaros-linux-x86_64)."
+fi
+require_nonempty_file "$BINARY" "receipt names '$claimed_artifact' but there is no such file"
+
+actual_sha="$(sha256sum "$BINARY" | awk '{print $1}')"
+require_nonempty "$actual_sha" "sha256sum produced nothing for $BINARY"
+
+if [[ "$actual_sha" != "$claimed_sha" ]]; then
+  echo "  receipt claims $claimed_sha"
+  echo "  file is       $actual_sha"
+  echo
+  echo "  This ELF is not the one the receipt was written for. It is resolved as an"
+  echo "  oracle by ~82 scripts and preferred by scripts/install.sh over the committed"
+  echo "  bin/madaros-linux-x86_64. Rebuild and re-emit the receipt, or delete the ELF:"
+  echo "    make build-madaros && bash scripts/ci/madaros_write_receipt.sh"
+  gate_fail "artifacts/self-hosted/madaros does not match its own receipt"
+fi
+
+gate_pass "binary matches its receipt ($actual_sha)"

--- a/scripts/ci/madaros_self_parse_gate.sh
+++ b/scripts/ci/madaros_self_parse_gate.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# The compiler must be able to read its own source tree.
+#
+# On 2026-08-03 a Madaros built from main could not parse
+# self-hosted/resolve/scope.sio — a file in its own sources. 417 gates did not
+# catch it; it was found by accident. Re-measured afterwards against the
+# pre-fix binary: 118 of 559 files under self-hosted/ failed to parse. Not one
+# file. A hundred and eighteen.
+#
+# Nothing here builds a compiler. build_modular_madaros.sh locks internally and
+# flock is not reentrant, so a gate that built one would deadlock; and the CI
+# job this runs in has already built the ELF and kept it. If no binary is
+# supplied this gate REFUSES rather than building.
+#
+#   A1  the closure of main.sio is complete
+#   A2  the closure has capacity headroom
+#   A3  every tracked .sio under self-hosted/ parses, ratcheted against a baseline
+#
+# Falsifiability is proven separately by madaros_self_parse_selftest.sh.
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR" || exit 9
+
+VERDICT="$ROOT_DIR/scripts/lib/boundary_closure_verdict.sh"
+BASELINE="$ROOT_DIR/scripts/ci/fixtures/madaros_self_parse_baseline.txt"
+REPORT_DIR="${SOUNIO_MADAROS_SELF_PARSE_REPORT_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/sounio-self-parse.XXXXXX")}"
+mkdir -p "$REPORT_DIR"
+
+fail() { echo "MADAROS_SELF_PARSE_GATE_FAIL: $*" >&2; exit 1; }
+
+[[ -x "$VERDICT" ]] || fail "missing $VERDICT"
+
+MADAROS="${SOUNIO_MADAROS_SELF_PARSE_BIN:-${MADAROS_RAW_BIN:-$ROOT_DIR/artifacts/self-hosted/madaros}}"
+[[ -x "$MADAROS" ]] \
+  || fail "no Madaros ELF at $MADAROS. This gate does not build one — set SOUNIO_MADAROS_SELF_PARSE_BIN."
+if head -c2 "$MADAROS" 2>/dev/null | grep -q '#!'; then
+  fail "$MADAROS is a wrapper script, not a raw ELF. A wrapper resolves to whatever prebuilt is lying around, which is the opposite of what this gate measures."
+fi
+
+ulimit -s 524288 2>/dev/null || true
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+
+echo "  madaros = $MADAROS"
+
+# ------------------------------------------------------------------ A1 + A2
+MAIN_SRC="self-hosted/compiler/main.sio"
+[[ -f "$MAIN_SRC" ]] || fail "$MAIN_SRC absent — nothing to measure"
+
+timeout 300 "$MADAROS" --science-boundary-closure "$MAIN_SRC" >"$REPORT_DIR/main.report" 2>&1 || true
+# Deliberately ignoring the exit code: closure mode exits 0 on `status
+# incomplete`. The verdict comes from the report body or it comes from nothing.
+if ! "$VERDICT" "$REPORT_DIR/main.report" >"$REPORT_DIR/main.verdict" 2>&1; then
+  # The closure is currently blocked by a file the compiler cannot parse. That
+  # is allowed ONLY while that file is a known, listed entry in the baseline —
+  # the same ratchet A3 uses. Measured 2026-08-04: main.sio's closure stops at
+  # self-hosted/check/check.sio (23 592 lines), which fails at node 0, i.e. it
+  # cannot parse itself as an entry point either.
+  blocker=$(awk -F'\t' '$1 == "failed_path" { print $2; exit }' "$REPORT_DIR/main.report")
+  if [[ -n "$blocker" ]] && [[ -f "$BASELINE" ]] && grep -qxF "$blocker" "$BASELINE"; then
+    echo "  A1/A2 closure blocked at $blocker (known, in the baseline)"
+    echo "        the closure cannot be complete until that file parses"
+  else
+    echo "  A1/A2 FAIL on $MAIN_SRC:"
+    sed 's/^/    /' "$REPORT_DIR/main.verdict"
+    grep -vE '^(node|edge)\b' "$REPORT_DIR/main.report" | sed 's/^/    /'
+    fail "the compiler cannot walk its own import closure, and the blocker is not a known one"
+  fi
+else
+  echo "  A1/A2 $(cat "$REPORT_DIR/main.verdict")"
+fi
+
+# ------------------------------------------------------------------ A3
+# git ls-files, never find: find also returns untracked LSP scratch snapshots
+# (self-hosted/lsp/.sounio-lsp-snapshot.*.sio) that exist only on one machine,
+# and a gate whose input set depends on local scratch is a flaky gate.
+mapfile -t SOURCES < <(git ls-files 'self-hosted/**/*.sio' 'self-hosted/*.sio' 2>/dev/null | sort -u)
+(( ${#SOURCES[@]} > 0 )) \
+  || fail "git ls-files matched no .sio under self-hosted/ — the tree moved and this sweep is measuring nothing"
+(( ${#SOURCES[@]} >= 400 )) \
+  || fail "only ${#SOURCES[@]} sources found; expected ~511. Either the tree shrank drastically or the glob broke."
+echo "  A3 sweeping ${#SOURCES[@]} tracked sources"
+
+SWEEP_OUT="$REPORT_DIR/sweep"
+: >"$SWEEP_OUT.failed"
+: >"$SWEEP_OUT.crashed"
+
+probe_one() {
+  local src="$1" out
+  out=$(timeout 60 "$MADAROS" --science-boundary-closure "$src" 2>&1)
+  if ! grep -qxF 'SOUNIO_BOUNDARY_CLOSURE_V1' <<<"$out"; then
+    printf '%s\n' "$src" >>"$SWEEP_OUT.crashed"
+    return
+  fi
+  if awk -F'\t' '$1 == "parse_failed" { print $2; exit }' <<<"$out" | grep -qx true; then
+    printf '%s\n' "$src" >>"$SWEEP_OUT.failed"
+  fi
+}
+export -f probe_one
+export MADAROS SWEEP_OUT
+
+printf '%s\n' "${SOURCES[@]}" | xargs -P4 -I{} bash -c 'probe_one "$@"' _ {}
+
+sort -u -o "$SWEEP_OUT.failed" "$SWEEP_OUT.failed"
+sort -u -o "$SWEEP_OUT.crashed" "$SWEEP_OUT.crashed"
+
+if [[ -s "$SWEEP_OUT.crashed" ]]; then
+  echo "  A3 the compiler produced no report at all for:"
+  sed 's/^/    /' "$SWEEP_OUT.crashed"
+  fail "$(wc -l <"$SWEEP_OUT.crashed") source(s) crashed or hung the compiler"
+fi
+
+if [[ ! -f "$BASELINE" ]]; then
+  echo "  A3 no baseline at $BASELINE. Current failures ($(wc -l <"$SWEEP_OUT.failed")):"
+  sed 's/^/    /' "$SWEEP_OUT.failed"
+  fail "seed the baseline from THIS output and commit it — never from a guess"
+fi
+
+# The baseline is a ratchet. A new failure is red; a baseline entry that now
+# parses is ALSO red, so the allowlist can only shrink. That is what stops it
+# rotting into a permanent excuse.
+grep -vE '^\s*(#|$)' "$BASELINE" | sort -u >"$SWEEP_OUT.baseline"
+
+NEW=$(comm -23 "$SWEEP_OUT.failed" "$SWEEP_OUT.baseline")
+FIXED=$(comm -13 "$SWEEP_OUT.failed" "$SWEEP_OUT.baseline")
+
+if [[ -n "$NEW" ]]; then
+  echo "  A3 REGRESSION — these parse on the baseline compiler and not on this one:"
+  sed 's/^/    /' <<<"$NEW"
+  fail "$(grep -c . <<<"$NEW") source(s) newly unparseable"
+fi
+if [[ -n "$FIXED" ]]; then
+  echo "  A3 these are in the baseline but now PARSE — remove them from $BASELINE:"
+  sed 's/^/    /' <<<"$FIXED"
+  fail "the baseline may only shrink, and it is now out of date"
+fi
+
+remaining=$(grep -c . "$SWEEP_OUT.failed" || true)
+echo "  A3 ${#SOURCES[@]} sources, ${remaining:-0} known-unparseable (all in the baseline)"
+echo "MADAROS_SELF_PARSE_GATE_OK"

--- a/scripts/ci/madaros_self_parse_selftest.sh
+++ b/scripts/ci/madaros_self_parse_selftest.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Proves that madaros_self_parse_gate.sh can FAIL.
+#
+# Modelled on scripts/ci/executable_payload_compare_selftest.sh: feed the
+# verdict a known-good input and assert it accepts, then feed it known-bad ones
+# and assert it REJECTS. A gate that cannot fail is decoration, and this whole
+# family exists because a compiler that could not parse its own source tree sat
+# behind 417 green gates.
+#
+# Arm 1 runs everywhere in under a second and needs no compiler, so it runs on
+# every PR — including docs-only ones. That is what stops the gate rotting into
+# a no-op the way an exit-code-only check would.
+# Arms 2 and 3 need a Madaros and SKIP without one.
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VERDICT="$ROOT_DIR/scripts/lib/boundary_closure_verdict.sh"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/sounio-self-parse-selftest.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+[[ -x "$VERDICT" ]] || { echo "error: $VERDICT missing or not executable" >&2; exit 1; }
+
+# ---------------------------------------------------------------- arm 1
+# Synthetic reports. Numbers match what was measured on 2026-08-04:
+# 120 nodes and 340 edges against capacity 256/512.
+emit_report() {  # emit_report <file> <status> <saturated> <parse_failed> <nodes> <edges> [failed_path]
+  local f="$1" st="$2" sat="$3" pf="$4" n="$5" e="$6" fp="${7:-}"
+  {
+    echo "Madaros v0.80.0 -- the Sounio self-hosted compiler"
+    echo ""
+    echo "SOUNIO_BOUNDARY_CLOSURE_V1"
+    printf 'status\t%s\n' "$st"
+    printf 'capacity\t256\n'
+    printf 'saturated\t%s\n' "$sat"
+    printf 'parse_failed\t%s\n' "$pf"
+    [[ -n "$fp" ]] && printf 'failed_path\t%s\n' "$fp"
+    local i
+    for ((i = 0; i < n; i++)); do printf 'node\tself-hosted/x%s.sio\n' "$i"; done
+    for ((i = 0; i < e; i++)); do printf 'edge\ta\tb\n'; done
+  } >"$f"
+}
+
+must_accept() {
+  if ! "$VERDICT" "$1" >/dev/null 2>&1; then
+    echo "error: verdict REJECTED a good report ($2)" >&2; exit 1
+  fi
+}
+must_reject() {
+  if "$VERDICT" "$1" >/dev/null 2>&1; then
+    echo "error: verdict ACCEPTED $2 — it is not measuring that" >&2; exit 1
+  fi
+}
+
+emit_report "$WORK_DIR/good" complete false false 120 340
+must_accept "$WORK_DIR/good" "the measured shape"
+
+emit_report "$WORK_DIR/parsefail" incomplete false true 72 123 "self-hosted/resolve/scope.sio"
+must_reject "$WORK_DIR/parsefail" "a closure that failed to parse"
+
+emit_report "$WORK_DIR/nopath" incomplete false true 72 123
+must_reject "$WORK_DIR/nopath" "parse_failed with no failed_path"
+
+emit_report "$WORK_DIR/saturated" complete true false 256 512
+must_reject "$WORK_DIR/saturated" "a SATURATED closure"
+
+emit_report "$WORK_DIR/overnodes" complete false false 250 340
+must_reject "$WORK_DIR/overnodes" "a closure over the 80% node headroom"
+
+emit_report "$WORK_DIR/overedges" complete false false 120 500
+must_reject "$WORK_DIR/overedges" "a closure over the 80% edge headroom"
+
+emit_report "$WORK_DIR/unres" complete false false 120 340
+printf 'unresolved\tcaller.sio\tmissing::thing\n' >>"$WORK_DIR/unres"
+must_reject "$WORK_DIR/unres" "an unresolved import"
+
+# The field-absence arm. A report that stops emitting a field reads as empty,
+# and empty != "true" — so a naive check would pass on a report that measures
+# nothing at all.
+grep -v $'^saturated\t' "$WORK_DIR/good" >"$WORK_DIR/nosat"
+must_reject "$WORK_DIR/nosat" "a report with no 'saturated' field"
+
+: >"$WORK_DIR/empty"
+must_reject "$WORK_DIR/empty" "an empty report"
+
+printf 'total nonsense\nno header here\n' >"$WORK_DIR/nonsense"
+must_reject "$WORK_DIR/nonsense" "output with no SOUNIO_BOUNDARY_CLOSURE_V1 header"
+
+echo "  arm1 verdict function: accepts the good shape, rejects 9 bad ones"
+
+# ---------------------------------------------------------------- arms 2 and 3
+MADAROS="${SOUNIO_MADAROS_SELF_PARSE_BIN:-${MADAROS_RAW_BIN:-$ROOT_DIR/artifacts/self-hosted/madaros}}"
+if [[ ! -x "$MADAROS" ]] || head -c2 "$MADAROS" 2>/dev/null | grep -q '#!'; then
+  echo "  arms 2-3: SKIP (no raw Madaros ELF at $MADAROS)"
+  echo "MADAROS_SELF_PARSE_SELFTEST_PASS"
+  exit 0
+fi
+
+ulimit -s 524288 2>/dev/null || true
+
+# The trees live in $WORK_DIR, never in the repo: arm 2 writes source the parser
+# MUST refuse, and the gate's own tree sweep would trip over it.
+mkdir -p "$WORK_DIR/bad/broken" "$WORK_DIR/pin/resolve"
+
+cat >"$WORK_DIR/bad/broken/thing.sio" <<'BAD'
+module broken::thing
+fn ( ) -> { { {
+BAD
+cat >"$WORK_DIR/bad/main.sio" <<'BAD'
+use broken::thing::*
+fn main() -> i64 with IO { 0 }
+BAD
+
+if ! timeout 300 "$MADAROS" --science-boundary-closure "$WORK_DIR/bad/main.sio" \
+     >"$WORK_DIR/bad.report" 2>&1; then
+  echo "  note: closure mode exited non-zero on the bad tree (it normally exits 0 regardless)"
+fi
+must_reject "$WORK_DIR/bad.report" "a real closure over genuinely unparseable source"
+echo "  arm2 end-to-end: compiler detects, report carries it, verdict refuses"
+
+# Arm 3 — the #1624 pin. `module resolve::scope` is the exact shape that broke:
+# parse_module_item tested == TokenKind::Ident alone, so the path stopped at the
+# keyword segment. Red on any compiler carrying that defect, green after. It
+# lives in a temp tree so it cannot be "fixed" by editing the repo.
+cat >"$WORK_DIR/pin/resolve/scope.sio" <<'PIN'
+module resolve::scope
+
+pub struct Scope {
+    start_index: i64,
+    depth: i64,
+}
+PIN
+cat >"$WORK_DIR/pin/main.sio" <<'PIN'
+use resolve::scope::*
+fn main() -> i64 with IO { 0 }
+PIN
+
+timeout 300 "$MADAROS" --science-boundary-closure "$WORK_DIR/pin/main.sio" \
+  >"$WORK_DIR/pin.report" 2>&1 || true
+if ! "$VERDICT" "$WORK_DIR/pin.report" >/dev/null 2>&1; then
+  echo "error: this compiler cannot parse a module path with a keyword segment" >&2
+  echo "       (\`module resolve::scope\` — the #1624 defect). Report:" >&2
+  grep -vE '^(node|edge)\b' "$WORK_DIR/pin.report" | sed 's/^/       /' >&2
+  exit 1
+fi
+echo "  arm3 #1624 pin: keyword segment in a module path still parses"
+
+echo "MADAROS_SELF_PARSE_SELFTEST_PASS"

--- a/scripts/ci/madaros_write_receipt.sh
+++ b/scripts/ci/madaros_write_receipt.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Emit artifacts/self-hosted/madaros.gate-receipt for a binary that has just
+# been built and gated.
+#
+# The receipt existed for weeks with no producer and no consumer — written by
+# hand, then left behind when the binary was rebuilt, so it described a file
+# that no longer existed while looking exactly like provenance. This script is
+# the producer; scripts/ci/madaros_receipt_gate.sh is the consumer.
+#
+# Run it ONLY after the binary has passed its gates, and record which gates
+# those were. A receipt is a claim about evidence; writing one for an ungated
+# binary reintroduces the problem in a tidier font.
+#
+#   usage: madaros_write_receipt.sh <binary> [gate-name] [gate-checks-csv]
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR" || exit 9
+. "$ROOT_DIR/scripts/lib/gate_assert.sh"
+gate_name "madaros_write_receipt"
+
+BINARY="${1:-$ROOT_DIR/artifacts/self-hosted/madaros}"
+GATE="${2:-madaros_full_gate.sh}"
+CHECKS="${3:-}"
+RECEIPT="$ROOT_DIR/artifacts/self-hosted/madaros.gate-receipt"
+
+require_nonempty_file "$BINARY" "no binary to write a receipt for: $BINARY"
+require_file "$ROOT_DIR/scripts/ci/$GATE" "the receipt would name a gate that does not exist: $GATE"
+
+if head -c2 "$BINARY" 2>/dev/null | grep -q '#!'; then
+  gate_fail "$BINARY is a wrapper script, not a raw ELF — a receipt for a wrapper certifies nothing"
+fi
+
+sha="$(sha256sum "$BINARY" | awk '{print $1}')"
+require_nonempty "$sha" "sha256sum produced nothing"
+
+rel="$(realpath --relative-to="$ROOT_DIR" "$BINARY" 2>/dev/null || printf '%s' "$BINARY")"
+
+# Provenance must describe the tree the binary was BUILT from, not the tree that
+# happens to be checked out when someone runs this. Two cases:
+#
+#   the artifact is tracked and unmodified -> the commit that last changed it.
+#     This is the committed prebuilt; HEAD may be a thousand commits later and
+#     claiming HEAD would be exactly the lie this whole gate exists to catch.
+#   otherwise -> HEAD, which is the build-and-commit flow the weekly refresh
+#     workflow uses.
+if git ls-files --error-unmatch "$rel" >/dev/null 2>&1 && git diff --quiet HEAD -- "$rel" 2>/dev/null; then
+  commit="$(git log -1 --format=%H -- "$rel" 2>/dev/null)"
+  origin="the commit that last changed $rel"
+else
+  commit="$(git rev-parse HEAD 2>/dev/null)"
+  origin="HEAD at build time"
+  if ! git diff --quiet HEAD -- self-hosted stdlib 2>/dev/null; then
+    gate_fail "self-hosted/ or stdlib/ has uncommitted changes: source_commit=$commit would not describe the tree this binary was built from. Commit the sources first, or the receipt is a guess."
+  fi
+fi
+require_nonempty "$commit" "could not determine a source commit — a receipt with no provenance is unverifiable"
+
+# created_utc comes from the clock; everything else is derived from the artifact
+# and the repository, so the receipt cannot drift from them without this script
+# being re-run.
+{
+  echo "madaros_full_gate_receipt_v1"
+  echo "artifact=$(realpath --relative-to="$ROOT_DIR" "$BINARY" 2>/dev/null || printf '%s' "$BINARY")"
+  echo "sha256=$sha"
+  echo "created_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "gate=$GATE"
+  echo "gate_result=pass"
+  [[ -n "$CHECKS" ]] && echo "gate_checks=$CHECKS"
+  echo "source_commit=$commit"
+  echo "note=written by scripts/ci/madaros_write_receipt.sh; verified by scripts/ci/madaros_receipt_gate.sh"
+} >"$RECEIPT"
+
+echo "  wrote $RECEIPT"
+echo "    sha256=$sha"
+echo "    source_commit=$commit"
+
+# Prove the pair agrees before claiming success. A writer whose output its own
+# verifier rejects is worse than no writer.
+if ! bash "$ROOT_DIR/scripts/ci/madaros_receipt_gate.sh" >/dev/null 2>&1; then
+  bash "$ROOT_DIR/scripts/ci/madaros_receipt_gate.sh" 2>&1 | sed 's/^/    /' >&2
+  gate_fail "the receipt just written does not satisfy madaros_receipt_gate.sh"
+fi
+
+gate_pass "receipt written and verified against its own gate"

--- a/scripts/lib/boundary_closure_verdict.sh
+++ b/scripts/lib/boundary_closure_verdict.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Verdict over a SOUNIO_BOUNDARY_CLOSURE_V1 report.
+#
+# `madaros --science-boundary-closure <src>` walks the `use` graph, parses every
+# module in the closure and nothing else, and prints the report this script
+# reads. Exit 0 iff the closure is complete AND has headroom.
+#
+# THE TRAP THIS EXISTS TO AVOID: the compiler exits 0 whether the closure
+# completed or not. Measured on 2026-08-04 against the on-disk Madaros:
+# `status incomplete`, `parse_failed true`, rc=0. A gate written against the
+# exit code passes forever and looks exactly like a working gate. The verdict
+# must come from the report body, which is why this is a separate, pure text
+# function with no compiler dependency — so its own selftest can run on every
+# PR, including docs-only ones, in under a second.
+#
+# usage: boundary_closure_verdict.sh <report-file>
+set -uo pipefail
+
+if [[ "$#" -ne 1 ]]; then
+  echo "usage: $0 <report file>" >&2
+  exit 64
+fi
+
+REPORT="$1"
+reject() { echo "BOUNDARY_CLOSURE_REJECT: $*" >&2; exit 1; }
+
+[[ -f "$REPORT" ]] || reject "no report at $REPORT"
+[[ -s "$REPORT" ]] || reject "report is empty — the compiler produced nothing"
+
+# The report is preceded by a three-line Madaros banner and a blank line.
+grep -qxF 'SOUNIO_BOUNDARY_CLOSURE_V1' "$REPORT" \
+  || reject "no SOUNIO_BOUNDARY_CLOSURE_V1 header — this is not a closure report, so nothing below was measured"
+
+field() {  # field <name> -> value, empty if absent
+  awk -F'\t' -v k="$1" '$1 == k { print $2; exit }' "$REPORT"
+}
+count() {  # count <name> -> number of lines whose first tab-field is <name>
+  awk -F'\t' -v k="$1" '$1 == k { n++ } END { print n + 0 }' "$REPORT"
+}
+
+status=$(field status)
+capacity=$(field capacity)
+saturated=$(field saturated)
+parse_failed=$(field parse_failed)
+failed_path=$(field failed_path)
+
+# Every field must be PRESENT. An absent field reads as empty, and an empty
+# string compared against "true" is false — i.e. a report that stopped emitting
+# `saturated` would silently satisfy a naive `!= true` test.
+[[ -n "$status"       ]] || reject "no 'status' field — the report format changed and this verdict is no longer reading what it claims to"
+[[ -n "$capacity"     ]] || reject "no 'capacity' field — cannot check headroom against an unknown bound"
+[[ -n "$saturated"    ]] || reject "no 'saturated' field"
+[[ -n "$parse_failed" ]] || reject "no 'parse_failed' field"
+
+nodes=$(count node)
+edges=$(count edge)
+unresolved=$(count unresolved)
+
+[[ "$parse_failed" == "false" ]] \
+  || reject "the compiler could not parse a module in its own closure: ${failed_path:-<path not reported>}"
+
+# failed_path is emitted only when parse_failed is true, so this can only be
+# reached when the compiler claims failure without saying where. That regressed
+# once; it does not get to regress silently again.
+if [[ "$parse_failed" == "true" && -z "$failed_path" ]]; then
+  reject "parse_failed with no failed_path — the report says the closure broke and refuses to say where"
+fi
+
+[[ "$saturated" == "false" ]] \
+  || reject "closure SATURATED at capacity $capacity — the walk was truncated and 'status' below is about a partial graph"
+
+[[ "$status" == "complete" ]] \
+  || reject "status=$status (nodes=$nodes edges=$edges unresolved=$unresolved)"
+
+[[ "$unresolved" -eq 0 ]] \
+  || reject "$unresolved unresolved import(s) — a 'use' resolves to nothing"
+
+# A closure of zero or one node is not a closure; it is a compiler that gave up
+# immediately, or a report shape this function no longer understands.
+[[ "$nodes" -ge 2 ]] \
+  || reject "only $nodes node(s) — nothing meaningful was walked"
+
+# Headroom. ModuleClosure is fixed-capacity (module_frontend.sio:2403 area:
+# paths [String;256], edges [String;512]); on overflow the walker sets
+# `saturated` and returns false. Measured 2026-08-04: 340 of 512 edges, 66%.
+# Asserting at 80% turns the day it approaches the cap into a red PR instead of
+# a mystery truncation.
+node_cap="$capacity"
+edge_cap=$(( capacity * 2 ))
+node_limit=$(( node_cap * 80 / 100 ))
+edge_limit=$(( edge_cap * 80 / 100 ))
+
+[[ "$nodes" -le "$node_limit" ]] \
+  || reject "closure at $nodes/$node_cap nodes (>80%) — raise ModuleClosure capacity before it truncates silently"
+[[ "$edges" -le "$edge_limit" ]] \
+  || reject "closure at $edges/$edge_cap edges (>80%) — raise ModuleClosure capacity before it truncates silently"
+
+echo "BOUNDARY_CLOSURE_OK nodes=$nodes/$node_cap edges=$edges/$edge_cap unresolved=0"

--- a/scripts/lib/gate_assert.sh
+++ b/scripts/lib/gate_assert.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Shared assertions for CI gates. Source it:
+#
+#     . "$(dirname "${BASH_SOURCE[0]}")/../lib/gate_assert.sh"
+#     gate_name "my_gate"
+#
+# WHY THIS EXISTS. A census on 2026-08-04 over the 417 *_gate.{sh,py} in
+# scripts/ci and scripts/dev found:
+#
+#     258 (67%)  no emptiness guard of any kind
+#      46 (12%)  an explicit check that the gate is still reading real content
+#     125        define their own private fail()
+#       0        shared assertion library
+#
+# The 12% is concentrated in two families. Outside them, a gate that stops
+# finding its subject usually reports success. Measured examples on that date:
+# run_pass_output_gate.sh printed "PASS (strict): all 0 ... tests" if the
+# //@ expect-stdout: marker were renamed; reproduce_artifact.sh printed
+# "PASS: test suite" when the suite crashed on startup; the *anti-vacuity lane*
+# of eisa_bridge_conformance_gate.sh printed "PASS anti-vacuity" when its own
+# extraction came back empty.
+#
+# The failure is always the same shape: AN EMPTY ANSWER READ AS A MEANINGFUL
+# ONE. These helpers make the empty case loud.
+
+if [[ -n "${_SOUNIO_GATE_ASSERT_SOURCED:-}" ]]; then return 0; fi
+_SOUNIO_GATE_ASSERT_SOURCED=1
+
+_GATE_NAME="${_GATE_NAME:-gate}"
+
+gate_name() { _GATE_NAME="$1"; }
+
+gate_fail() {
+  echo "$(printf '%s' "$_GATE_NAME" | tr '[:lower:]' '[:upper:]')_FAIL: $*" >&2
+  exit 1
+}
+
+gate_pass() {
+  echo "$(printf '%s' "$_GATE_NAME" | tr '[:lower:]' '[:upper:]')_OK${1:+: $1}"
+}
+
+require_file() {
+  [[ -f "$1" ]] || gate_fail "${2:-missing file: $1}"
+}
+
+require_executable() {
+  [[ -x "$1" ]] || gate_fail "${2:-not executable: $1}"
+}
+
+# The one that would have caught most of the census. Use it on every value
+# pulled out of a tool's output before comparing it to anything.
+require_nonempty() {
+  [[ -n "${1:-}" ]] || gate_fail "${2:-a value the gate depends on came back empty — it is not measuring what it claims}"
+}
+
+require_nonempty_file() {
+  require_file "$1" "${2:-}"
+  [[ -s "$1" ]] || gate_fail "${2:-$1 is empty — whatever produced it produced nothing}"
+}
+
+# Counting that distinguishes "no match" from "the tool broke".
+#
+# `grep -c ... || true` — the dominant idiom in this repo — collapses rc 1
+# (no match, count really is 0) and rc 2 (bad regex, unreadable file, tool
+# missing) into the same 0. Modelled on scripts/ci/assert_no_rust_markers.sh:38-45,
+# the only place in the tree that already gets this right.
+#
+#   count_matches <pattern> <file> [--fixed]
+count_matches() {
+  local pattern="$1" file="$2" mode="${3:-}" count rc
+  require_file "$file" "count_matches: no such file: $file"
+  set +e
+  if [[ "$mode" == "--fixed" ]]; then
+    count="$(grep -F -c -- "$pattern" "$file")"
+  else
+    count="$(grep -E -c -- "$pattern" "$file")"
+  fi
+  rc=$?
+  set -e
+  case "$rc" in
+    0) ;;
+    1) count=0 ;;
+    *) gate_fail "failed to scan $file for '$pattern' (grep rc=$rc) — this is a tool error, not a zero count" ;;
+  esac
+  printf '%s' "$count"
+}
+
+# A floor on how much the gate saw. This is the anti-vacuity primitive: a sweep
+# that finds nothing to check must be red, not green.
+require_min_count() {
+  local actual="$1" minimum="$2" subject="${3:-items}"
+  require_nonempty "$actual" "count of $subject came back empty"
+  [[ "$actual" -ge "$minimum" ]] \
+    || gate_fail "only $actual $subject (expected at least $minimum) — the gate found nothing to measure, which is not the same as everything passing"
+}
+
+# Text anchors. Folds three near-identical private copies that were living in
+# madaros_operational_contract_gate.sh:18-31,
+# exact_bitwise_rebracket_source_ir_gate.sh:29-41 and
+# ordered_path_provenance_source_ir_gate.sh:33-45.
+require_text() {
+  local pattern="$1" file="$2"
+  require_file "$file"
+  grep -Fq -- "$pattern" "$file" \
+    || gate_fail "missing required anchor in $file: $pattern"
+}
+
+require_text_regex() {
+  local pattern="$1" file="$2"
+  require_file "$file"
+  grep -Eq -- "$pattern" "$file" \
+    || gate_fail "missing required anchor in $file: /$pattern/"
+}
+
+# Run a command and require it to FAIL. The other half of an instrument: a check
+# that only ever confirms the good case has not been shown to discriminate.
+require_rejects() {
+  local why="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    gate_fail "the check accepted $why — it is not measuring that"
+  fi
+}

--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -2177,6 +2177,15 @@ fn run_science_boundary_closure_report(
     if closure.saturated { println("true") } else { println("false") }
     print("parse_failed\t")
     if closure.parse_failed { println("true") } else { println("false") }
+    // Which module. The walker has known this since it stopped
+    // (module_frontend.sio:2421,2435 set parse_failed_path) and the report threw
+    // it away, so a consumer learned THAT the closure broke and had to bisect to
+    // find WHERE. That is how a compiler that could not parse
+    // self-hosted/resolve/scope.sio stayed unattributed.
+    if closure.parse_failed {
+        print("failed_path\t")
+        println(closure.parse_failed_path)
+    }
     var i: i64 = 0
     while i < closure.node_count {
         print("node\t")


### PR DESCRIPTION
A Madaros built from `main` could not parse `self-hosted/resolve/scope.sio` — a file in its own source tree. **417 gates missed it**; it was found by accident. The bug is fixed (#1624). This PR is about the reason it lived.

Measuring turned up three blind spots. Each was worse than it looked.

## 1. Nothing pointed a built compiler at its own sources

The check already existed, unwired, and costs **0.55 s**: `madaros --science-boundary-closure <src>` walks the use-graph and parses every module in the closure.

**Its trap, and the reason this is not a one-liner:** it **exits 0 on `status incomplete`**. A gate written against its exit code passes forever and looks exactly like a working gate. The verdict is computed from the report body.

| assertion | what it catches |
|---|---|
| **A1** closure of `main.sio` completes | the #1624 class, directly |
| **A2** capacity headroom | see below |
| **A3** sweep of all 556 tracked `self-hosted/` sources, 19 s, ratcheted | the 446 files outside `main.sio`'s closure |

**A2 is a second blind spot, found while measuring.** `ModuleClosure` is fixed at 256 nodes / 512 edges; on overflow it sets `saturated` and **silently returns false**. The closure is at **340/512 edges today — 66%**, roughly 170 `use` lines from truncating in silence with nothing watching. The gate asserts 80% headroom.

`main.sio` now also emits **`failed_path`**. The walker has always known which module stopped it and the report threw it away, so a consumer learned *that* the closure broke and had to bisect to find *where*.

**A3 baseline: 77 of 556 sources currently fail to parse.** The pre-#1624 binary failed **118**, so that PR closed 41. The list may only shrink — a newly failing file is red, and a listed file that now parses is **also** red, with instructions to delete the line. `self-hosted/check/check.sio` is what blocks `main.sio`'s own closure: 23 592 lines, failing at node 0.

**Proof it can fail:** the selftest's third arm is a `module resolve::scope` fixture in a temp tree. **RED against the pre-fix binary, GREEN against one built from current main.** Two ELFs, one change apart.

## 2. The reference binary was unverifiable — and is what ships

`artifacts/self-hosted/madaros.gate-receipt` is **tracked** and claimed `sha256=5629c3a4…` for a file that is `6303ec70…`, from a commit **1515 behind HEAD**, naming an **absolute host path** — with **no producer and no consumer**. Meanwhile ~82 scripts resolve that binary as an oracle and `scripts/install.sh` *prefers* it over the committed one.

I used that file as an A/B control yesterday and published a false claim on the strength of it.

The receipt now names a **tracked** artifact, so the claim is checkable on every checkout instead of on one machine; the gate rejects an absolute path outright. Provenance is the commit that last changed the binary, **not HEAD** — claiming HEAD for a prebuilt committed weeks ago is precisely the lie this gate exists to catch. The weekly refresh emits the receipt in the same commit as the binary.

## 3. Two thirds of gates could pass on no data

Census over 417 `*_gate.{sh,py}`: **258 (67%) had no emptiness guard of any kind**, 46 (12%) an explicit anti-vacuity check, and there was **no shared assertion library** — 125 gates define their own `fail()`.

    run_pass_output_gate.sh   "PASS (strict): all 0 … tests" if its marker were renamed
    reproduce_artifact.sh     "PASS: test suite" while the suite crashed on startup

`scripts/lib/gate_assert.sh` provides `require_nonempty`, `require_min_count`, and `count_matches` — which separates *no match* (rc 1) from *the tool broke* (rc ≥ 2), because `grep -c … || true` reports both as 0. Modelled on `assert_no_rust_markers.sh:38-45`, the one place already doing it right. `gate_vacuity_gate.sh` is ratcheted at 43 known; a new gate without a guard is red.

## Wiring — no new compiler build anywhere

- **Contracts, every PR (<1 s each):** self-parse selftest, receipt gate, vacuity gate, and `canonical_compiler_gate.sh`
- **`madaros-current-source-deref-f64`:** the self-parse gate, reusing the ELF that job already builds and keeps. **+20-25 s.** Gating widened to include `stdlib` — measured: 7 files in `main.sio`'s closure live under `stdlib/compiler/ontology/` and classify as stdlib, so a PR breaking `store.sio` ran none of this. Timeout 15 → 18.
- **`madaros-prebuilt-refresh.yml`:** the self-parse gate before the commit step. None of its five gates read the compiler's own tree — it would have shipped the broken compiler as the prebuilt.

## Two corrections to my own plan, caught by checking

**`canonical_compiler_gate.sh` was slated for deletion. It passes, in 2 s, and asserts something real** — that the shipped lean_single ELF *is* the byte-identical fixed point of current source. It was wired to nothing. Now wired. I nearly deleted a working gate on a subagent's say-so.

**`lean_single_fixed_point_gate.sh` is documented as superseded, not deleted.** Run from a worktree it resolved `souc=/workspace/sounio/bin/souc` — the wrapper from **another checkout** — and reported a fixed-point failure about a compiler unrelated to the tree under test.

## Not done, deliberately

A Madaros fixed point. `madaros check main.sio` reports 6205 E175 / 876 E177 / 382 E035; Madaros is built by a lean_single-derived seed and has never compiled itself. That is a milestone to reach, not a gate to add — wiring it would mean a permanently red or permanently skipped job.