### PR TITLE
fix(parser): `effect` and `handler` are names too — self-parse baseline 17 → 10

### DIFF
--- a/scripts/ci/fixtures/madaros_self_parse_baseline.txt
+++ b/scripts/ci/fixtures/madaros_self_parse_baseline.txt
@@ -1,32 +1,36 @@
 # Sources under self-hosted/ that a Madaros built from this tree cannot parse.
 #
-# Regenerated 2026-08-04 on the branch that adds Level/Scope/Is/Study to
-# tk_is_contextual_ident and routes at_expr_start through it: 77 -> 17.
+# 2026-08-04: 17 -> 10. Adding Effect and Handler to tk_is_contextual_ident closed
+# seven, all the same defect as `study` before them: an ordinary parameter named
+# after a keyword --
+#     fn has_effect(a: &TypeArena, type_id: i64, effect: string)
+#     fn sigh_set_action(table: &! SighTable, sig: i64, disp: i64, handler: i64)
 #
-# The 60 that dropped out were all the same defect: a keyword used as an
-# ordinary identifier. self-hosted/check/check.sio was the one blocking
-# main.sio's own import closure, at line 13951 --
-#     let study = studies.entries[(studies.count - 1) as usize]
-# where `study` lexes as TokenKind::Study and has its own branch in the item
-# dispatcher, so as a variable name it was not an identifier at all.
+# The ten that remain are NOT one class, and each was reduced with the compiler
+# as oracle rather than guessed:
+#   * two are invalid source, not compiler gaps --
+#       ci/ontology_validation_driver.sio:3  `use parser::parser:{...}` (one colon)
+#       compiler/souc_v2/main.sio:4          `use self-hosted::...` (hyphen); that
+#                                            file is built by textual concatenation
+#                                            and was never meant to be parsed
+#   * two are syntax the language does not accept, now named --
+#       gpu/kretikos_cubin_validate.sio:26   typed literal suffix `[0u8; 64]`
+#       vm/vm.sio:1125                       `else <expr>` without braces
+#   * the rest have no established cause yet. gpu/ptx_emitter.sio fails only as a
+#     whole file, not on any prefix. lsp/rustism_detector.sio was suspected of the
+#     octal escape "\033" -- probed, and the escape parses fine, so that guess was
+#     wrong and no replacement has been measured.
 #
-# THIS LIST MAY ONLY SHRINK. A file that starts failing is a red PR; a listed
-# file that now parses is ALSO a red PR, telling you to delete the line.
+# THIS LIST MAY ONLY SHRINK. A file that starts failing is a red PR; a listed file
+# that now parses is ALSO a red PR, telling you to delete the line.
 
-self-hosted/check/causal.sio
 self-hosted/ci/ontology_validation_driver.sio
 self-hosted/compiler/pkg/lib.sio
 self-hosted/compiler/souc_v2/main.sio
-self-hosted/compiler/types.sio
-self-hosted/distributed/actor.sio
-self-hosted/effects/handlers.sio
 self-hosted/gpu/epistemic_ptx.sio
 self-hosted/gpu/epistemic_tensor_core.sio
-self-hosted/gpu/kernels/bio.sio
 self-hosted/gpu/kretikos_cubin_validate.sio
 self-hosted/gpu/ptx_emitter.sio
-self-hosted/lsp/hover.sio
 self-hosted/lsp/rustism_detector.sio
-self-hosted/native/signal_handler.sio
 self-hosted/native/vec_ieee754.sio
 self-hosted/vm/vm.sio

--- a/self-hosted/lexer/token.sio
+++ b/self-hosted/lexer/token.sio
@@ -642,6 +642,17 @@ fn tk_is_punctuation(kind: TokenKind) -> bool {
 // Centralised here so the next contextual keyword is added in one place.
 pub fn tk_is_contextual_ident(kind: TokenKind) -> bool {
     match kind {
+        // `effect` and `handler` join for the same reason `study` and `scope`
+        // did, and the evidence is the same shape: a sweep of every source under
+        // self-hosted/ found 6 files the compiler could not read, each stopping
+        // on an ordinary parameter named after a keyword —
+        //     fn has_effect(a: &TypeArena, type_id: i64, effect: string)
+        //     fn sigh_set_action(table: &! SighTable, ..., handler: i64)
+        // Effect does have an item branch (items.sio:1146) and Handler has none;
+        // neither is reachable from expression position, because items are parsed
+        // only at top level.
+        TokenKind::Effect => true,
+        TokenKind::Handler => true,
         TokenKind::PolicyLower => true,
         TokenKind::AcquisitionPolicyLower => true,
         TokenKind::RecoursePolicyLower => true,


### PR DESCRIPTION
A sweep of all 556 tracked sources under `self-hosted/` found seven the compiler could not read, for one reason: **an ordinary parameter named after a keyword.**

    self-hosted/compiler/types.sio:823
        fn has_effect(a: &TypeArena, type_id: i64, effect: string) -> bool
    self-hosted/native/signal_handler.sio:292
        fn sigh_set_action(table: &! SighTable, sig: i64, disp: i64, handler: i64)

Same defect as `study` in #1611 and `scope` in #1624, with different words. Each culprit was **reduced by prefix-bisect over complete top-level items with the compiler as oracle**, not guessed from reading.

## The control, not the argument

`Effect` does have an item branch (`items.sio:1146`); `Handler` has none. Neither is reachable from expression position because items are parsed only at top level — but rather than assert that, a file carrying **both** a real `effect Logger { fn log(msg: string) }` item **and** a parameter named `effect` was compiled. It parses.

## Measured, two ELFs one change apart, all 556 sources

| | |
|---|---|
| baseline | **17 → 10** (7 closed) |
| newly broken | **0** |
| `main.sio` closure | `status=complete`, `parse_failed=false`, `saturated=false` |

Closed: `check/causal.sio`, `compiler/types.sio`, `distributed/actor.sio`, `effects/handlers.sio`, `gpu/kernels/bio.sio`, `lsp/hover.sio`, `native/signal_handler.sio`.

## The ten that remain are not one class, and the baseline now says what each is

Rather than leave a bare list, the header records the reduction for each:

**Two are invalid source, not compiler gaps.** `ci/ontology_validation_driver.sio:3` writes `use parser::parser:{...}` with a **single colon**. `compiler/souc_v2/main.sio:4` writes `use self-hosted::...` with a **hyphen** — and that file's own comment says it is assembled by textual concatenation, i.e. it was never meant to be parsed as a module. The compiler is right to refuse both.

**Two are syntax the language does not accept**, now named and confirmed by minimal probe: a typed literal suffix `[0u8; 64]` (`gpu/kretikos_cubin_validate.sio:26`) and `else <expr>` without braces (`vm/vm.sio:1125`). Those are language decisions, not obvious fixes.

**The rest have no established cause.** `gpu/ptx_emitter.sio` fails only as a whole file — no prefix of it fails. And one guess of mine was **refuted**: I suspected the octal escape `"\033"` in `lsp/rustism_detector.sio`, probed it, and the escape parses fine. Nothing has replaced that hypothesis, and the header says so rather than inventing one.

The list may only shrink — a file that starts failing is red, and a listed file that now parses is also red, telling you to delete the line.