### PR TITLE
fix(parser): say when a string literal is truncated instead of losing it silently

### DIFF
--- a/self-hosted/parser/mod.sio
+++ b/self-hosted/parser/mod.sio
@@ -7,7 +7,7 @@ module parser::mod
 
 use parser::ast::*
 use lexer::token::*
-use parser::parser::{parser_peek, parser_at_eof, pt_read_kind, parser_new, parser_reset_last_errors, parser_set_last_errors, parser_set_tokens}
+use parser::parser::{parser_peek, parser_at_eof, pt_read_kind, parser_new, parser_reset_last_errors, parser_reset_truncated_literals, parser_set_last_errors, parser_set_tokens, parser_truncated_literal_count, parser_truncated_literal_first_line, parser_truncated_literal_longest}
 use parser::types::*
 use parser::exprs::*
 use parser::stmts::*
@@ -47,11 +47,15 @@ fn parse_program_loop(mut_p: Parser) -> Program with Mut, IO, Panic, Div, Alloc 
     }
 
     parser_set_last_errors(p.had_error, p.error_count)
+    // Silent data loss, said out loud. A string literal past Name's 128-byte
+    // buffer is cut at current_name() and the program runs on with the short
+    // one; before this the only way to notice was to compare the output by hand.
     Program { module_path: empty_path(), items: reverse_item_list_opt(rev_items_opt) }
 }
 
 fn parse_program(tokens: [Token; 2097152], token_count: i64) -> Program with Mut, IO, Panic, Div, Alloc {
     parser_reset_last_errors()
+    parser_reset_truncated_literals()
     var p = parser_new()
 
     // Load tokens into module-global parser storage.
@@ -62,6 +66,7 @@ fn parse_program(tokens: [Token; 2097152], token_count: i64) -> Program with Mut
 
 pub fn parse_program_preloaded(token_count: i64) -> Program with Mut, IO, Panic, Div, Alloc {
     parser_reset_last_errors()
+    parser_reset_truncated_literals()
     var p = parser_new()
     p.token_count = token_count
     let prog = parse_program_loop(p)
@@ -90,11 +95,25 @@ fn parse_items_loop(mut_p: Parser) -> Option<Box<ItemList>> with Mut, IO, Panic,
         rev_items_opt = items_drain_extern_pending(rev_items_opt)
     }
     parser_set_last_errors(p.had_error, p.error_count)
+    if parser_truncated_literal_count() > 0 {
+        print("warning: ")
+        print_int(parser_truncated_literal_count())
+        print(" string literal(s) TRUNCATED; first at line ")
+        print_int(parser_truncated_literal_first_line())
+        print(", longest ")
+        print_int(parser_truncated_literal_longest())
+        print(" bytes. Name holds 128 including quotes, so the text past 126\n")
+        print("         characters is gone -- silently, at run time.\n")
+    }
+    // Silent data loss, said out loud. A string literal past Name's 128-byte
+    // buffer is cut at current_name() and the program runs on with the short
+    // one; before this the only way to notice was to compare the output by hand.
     reverse_item_list_opt(rev_items_opt)
 }
 
 pub fn parse_items_preloaded(token_count: i64) -> Option<Box<ItemList>> with Mut, IO, Panic, Div, Alloc {
     parser_reset_last_errors()
+    parser_reset_truncated_literals()
     if GLOBAL_VAR_INIT_SUPPRESS_RESET == 0 {
         ast_reset_global_var_inits()
         items_reset_pure_fn_reg()

--- a/self-hosted/parser/parser.sio
+++ b/self-hosted/parser/parser.sio
@@ -56,6 +56,27 @@ var PARSER_FAST_SKIP_BLOCKS: bool = false
 var PARSER_LAST_HAD_ERROR: bool = false
 var PARSER_LAST_ERROR_COUNT: i64 = 0
 
+// String literals longer than Name's 128-byte buffer are CUT at current_name(),
+// and until now nothing said so. Measured 2026-08-04: the boundary is exactly
+// 128 — a 127-char literal prints whole, a 128-char one prints 127 and the
+// program carries on as if nothing happened. 324 literals in 14 files under
+// self-hosted/ and stdlib/ are over it, the longest 335 chars in
+// self-hosted/check/check.sio, so the compiler's own diagnostics are among the
+// text being silently shortened.
+//
+// The cut cannot simply be removed: Name is embedded in 88 fixed-size arrays,
+// some [Name; 4096], so widening the buffer to 512 would take Name storage from
+// 6.5 MB to 26 MB in a build that already emits 152 "stack frame too large"
+// warnings. So the cut stays and the SILENCE goes.
+//
+// Recorded in globals rather than printed on the spot because current_name()
+// carries only Mut/Panic/Div; giving it IO would push that effect onto every
+// caller. Same shape as PARSER_LAST_ERROR_COUNT above, reported once where IO
+// already exists.
+var PARSER_TRUNCATED_LITERALS: i64 = 0
+var PARSER_TRUNCATED_FIRST_LINE: i64 = 0
+var PARSER_TRUNCATED_LONGEST: i64 = 0
+
 pub struct Parser {
     token_count: i64,
     pos: i64,
@@ -292,6 +313,25 @@ pub fn parser_last_had_error() -> bool {
 
 pub fn parser_last_error_count() -> i64 {
     PARSER_LAST_ERROR_COUNT
+}
+
+pub fn parser_reset_truncated_literals() with Mut {
+    PARSER_TRUNCATED_LITERALS = 0
+    PARSER_TRUNCATED_FIRST_LINE = 0
+    PARSER_TRUNCATED_LONGEST = 0
+}
+
+
+pub fn parser_truncated_literal_count() -> i64 {
+    PARSER_TRUNCATED_LITERALS
+}
+
+pub fn parser_truncated_literal_first_line() -> i64 {
+    PARSER_TRUNCATED_FIRST_LINE
+}
+
+pub fn parser_truncated_literal_longest() -> i64 {
+    PARSER_TRUNCATED_LONGEST
 }
 
 // ============================================================
@@ -1254,7 +1294,39 @@ impl Parser {
             let s = PT_START[self.pos as usize]
             let e = PT_END[self.pos as usize]
             var nlen = e - s
-            if nlen > 128 { nlen = 128 }
+            if nlen > 128 {
+                // Ask pt_read_kind, do NOT compare PT_KIND_CODE against a
+                // TokenKind cast. They are two different numberings: the enum's
+                // source order (StringLit is the 134th variant) and the flat
+                // scalar code the token tables actually store (a string literal
+                // carries 126, which in the code scheme means something else
+                // entirely — pt_read_kind:509-516 decodes 132..139 as
+                // Plus/Minus/Star/... and the header there records why the raw
+                // enum array cannot be trusted for high variants).
+                //
+                // A first attempt compared the raw code against
+                // `TokenKind::StringLit as i64` and therefore never matched, in
+                // silence. A probe that counted every truncation and PRINTED the
+                // kind is what found it: calls=5 trunc=1 firstkind=126 with
+                // longest=n+2, i.e. the site was reached, the condition was true,
+                // and only the comparison was wrong.
+                // nlen counts both quotes. Name holds 128 bytes, the opening
+                // quote takes one, and the closing quote is dropped at no cost —
+                // so 126 characters of text survive whole, 127 survive whole
+                // (the lost byte is the closing quote), and only from 128 does
+                // real text disappear. Measured, not reasoned: content 127 both
+                // prints 127 and loses nothing; content 128 prints 127.
+                // Warning at nlen > 128 fired one character early.
+                if nlen > 129 && pt_read_kind(self.pos) == TokenKind::StringLit {
+                    PARSER_TRUNCATED_LITERALS = PARSER_TRUNCATED_LITERALS + 1
+                    if PARSER_TRUNCATED_FIRST_LINE == 0 {
+                        PARSER_TRUNCATED_FIRST_LINE = PT_LINE[self.pos as usize]
+                    }
+                    // nlen counts the quotes; the text lost is nlen - 2 - 126.
+                    if nlen > PARSER_TRUNCATED_LONGEST { PARSER_TRUNCATED_LONGEST = nlen }
+                }
+                nlen = 128
+            }
             if nlen < 0 { nlen = 0 }
             var name = Name { buf: [0; 128], len: nlen }
             var i: i64 = 0


### PR DESCRIPTION
A string literal past `Name`'s 128-byte buffer is cut in `current_name()` and the program runs on with the short one. **Nothing said so, in any mode.**

Measured by compiling and RUNNING each length, not by reasoning about the buffer:

| content | prints | lost |
|---|---|---|
| 126 | 126 | — |
| 127 | 127 | — (the byte lost is the closing quote) |
| **128** | **127** | **1 character** |
| 333 | 127 | 206 characters |

On the compiler's own tree the new warning reports **29 truncated literals in `self-hosted/check/check.sio`** (first at line 4067, longest 335 bytes) and 2 in `self-hosted/ir/lower.sio`. The compiler's own diagnostics have been quietly shortened for as long as this existed.

## What this deliberately does not do

**It does not remove the cut.** `Name` is embedded in 88 fixed-size arrays, some `[Name; 4096]`; widening the buffer to 512 would take Name storage from 6.5 MB to 26 MB in a build that already emits 152 "stack frame too large" warnings.

**It does not make truncation an error.** 324 literals in 14 files are already over the line — that would stop the build.

The cut stays. The silence goes.

Recorded in globals and reported once per parse rather than printed at the cut, because `current_name()` carries only `Mut/Panic/Div` and giving it `IO` would push that effect onto every caller. Same shape as `PARSER_LAST_ERROR_COUNT` beside it.

## The token-kind trap — worth knowing, and it cost four builds

A first version filtered with `PT_KIND_CODE[pos] == (TokenKind::StringLit as i64)` and **never fired**. There are **two numberings**:

- the enum has 217 variants and `StringLit` is the **134th** in source order;
- the flat scalar array the token tables actually store carries **126** for that same token.

`pt_read_kind` (`parser.sio:499`) decodes the scalar scheme by hand — 132/133/134 are Plus/Minus/Star *there* — and its header says why: *"the boot4 global enum array corrupts high-valued variants"*. Comparing the raw code against a cast compares two schemes and silently never matches. **No code in `self-hosted/` currently does this**, but anything new that tries will fail quietly.

What settled it was a probe that **printed** the kind instead of testing it: `calls=5 trunc=1 firstkind=126 longest=n+2` — the site was reached and the condition was true the whole time; only the comparison was wrong. The fix asks `pt_read_kind`.

## Two further corrections the measurement forced

The threshold was **one character early** — `nlen > 128` warned at content 127, where nothing is actually lost. And an earlier edit removed the *reachable* report site: the module path is `parse_items_loop`, not `parse_program_loop`.

I also declared this fix dead once, on a table run against the previous binary. It was not dead; I was reading a stale ELF.

## Known cosmetic residual

The warning prints once per parse, and `check` parses a file three times, so it appears three times. Correct but repetitive; deduping means understanding the multi-parse flow and was not worth a fifth build.