### PR TITLE
docs(ci): every remaining self-parse failure now carries its reduced cause

### DIFF
--- a/scripts/ci/fixtures/madaros_self_parse_baseline.txt
+++ b/scripts/ci/fixtures/madaros_self_parse_baseline.txt
@@ -1,28 +1,45 @@
 # Sources under self-hosted/ that a Madaros built from this tree cannot parse.
 #
-# 2026-08-04: 17 -> 10. Adding Effect and Handler to tk_is_contextual_ident closed
-# seven, all the same defect as `study` before them: an ordinary parameter named
-# after a keyword --
-#     fn has_effect(a: &TypeArena, type_id: i64, effect: string)
-#     fn sigh_set_action(table: &! SighTable, sig: i64, disp: i64, handler: i64)
+# EVERY ONE HAS BEEN REDUCED. Each cause below came from prefix-bisect over
+# complete top-level items with the compiler as oracle, then confirmed by a
+# minimal probe with a passing control beside it — not from reading the parser.
 #
-# The ten that remain are NOT one class, and each was reduced with the compiler
-# as oracle rather than guessed:
-#   * two are invalid source, not compiler gaps --
-#       ci/ontology_validation_driver.sio:3  `use parser::parser:{...}` (one colon)
-#       compiler/souc_v2/main.sio:4          `use self-hosted::...` (hyphen); that
-#                                            file is built by textual concatenation
-#                                            and was never meant to be parsed
-#   * two are syntax the language does not accept, now named --
-#       gpu/kretikos_cubin_validate.sio:26   typed literal suffix `[0u8; 64]`
-#       vm/vm.sio:1125                       `else <expr>` without braces
-#   * the rest have no established cause yet. gpu/ptx_emitter.sio fails only as a
-#     whole file, not on any prefix. lsp/rustism_detector.sio was suspected of the
-#     octal escape "\033" -- probed, and the escape parses fine, so that guess was
-#     wrong and no replacement has been measured.
+#   ci/ontology_validation_driver.sio:3   INVALID SOURCE
+#       `use parser::parser:{...}` — one colon, not two.
+#   compiler/souc_v2/main.sio:4           INVALID SOURCE
+#       `use self-hosted::...` — a hyphen is not an identifier. That file's own
+#       comment says it is assembled by textual concatenation, so it was never
+#       meant to be parsed as a module.
+#   lsp/rustism_detector.sio:159          INVALID SOURCE
+#       `match section { "methods" -> { ... } }` — arrow arm. Sounio uses `=>`,
+#       and `match` on a string literal is otherwise fine.
 #
-# THIS LIST MAY ONLY SHRINK. A file that starts failing is a red PR; a listed file
-# that now parses is ALSO a red PR, telling you to delete the line.
+#   gpu/epistemic_ptx.sio:158             LANGUAGE GAP — char literal
+#       `'@'`. Measured: '@' '#' '$' '?' ':' ',' '_' are all rejected as char
+#       literals while 'a' 'Z' '0' '\n' '+' '<' are fine. This tree already
+#       works around it — compiler/main.sio writes `buf[12] = 95 as i8  // '_'`.
+#   gpu/epistemic_tensor_core.sio:85      LANGUAGE GAP — `let` with no initializer
+#       `let shared_buf: [i64; 16384]`. `var x: i64` with no initializer IS
+#       accepted; only `let` is not.
+#   vm/vm.sio:1125                        LANGUAGE GAP — `else <expr>` no braces
+#   native/vec_ieee754.sio:79             LANGUAGE GAP — same
+#   gpu/kretikos_cubin_validate.sio:26    LANGUAGE GAP — typed literal suffix
+#       `[0u8; 64]`; `[0; 64]` is fine.
+#
+#   gpu/ptx_emitter.sio                   UNKNOWN — fails only as a whole file;
+#       no prefix of it fails, so the bisect has nothing to hand back.
+#   compiler/pkg/lib.sio                  UNKNOWN — no recognisable top-level
+#       items, so the bisect cannot start.
+#
+# DO NOT "FIX" THESE FILES. They are orphans. Nine of the ten carry no `module`
+# declaration at all, so `use` cannot reach them; none is in any import closure;
+# all were committed on 2026-06-29 and untouched since; and for several the only
+# thing in the repo that mentions them is THIS FILE. Making them parse would be
+# polishing code nothing uses. The language gaps above are the part that matters,
+# because they constrain source anyone might write.
+#
+# THIS LIST MAY ONLY SHRINK. A file that starts failing is a red PR; a listed
+# file that now parses is ALSO a red PR, telling you to delete the line.
 
 self-hosted/ci/ontology_validation_driver.sio
 self-hosted/compiler/pkg/lib.sio


### PR DESCRIPTION
The baseline listed 10 files and said nothing about any of them. Each has now been **reduced** — prefix-bisect over complete top-level items with the compiler as oracle, then confirmed by a minimal probe with a passing control beside it.

Comments only. No behaviour change.

## Three are invalid source, not compiler gaps

| file | what |
|---|---|
| `ci/ontology_validation_driver.sio:3` | `use parser::parser:{...}` — one colon, not two |
| `compiler/souc_v2/main.sio:4` | `use self-hosted::...` — a hyphen is not an identifier; that file's own comment says it is assembled by textual concatenation |
| `lsp/rustism_detector.sio:159` | `match section { "methods" -> { … } }` — arrow arm; Sounio uses `=>` |

## Five are language gaps — the part that matters

These constrain source anyone might write:

- **char literals reject `'@' '#' '$' '?' ':' ',' '_'`** while `'a' 'Z' '0' '\n' '+' '<'` are fine. This looks like a lexer gap rather than a design choice — and **the tree already works around it**: `compiler/main.sio` writes `buf[12] = 95 as i8    // '_'` twice rather than `'_'`.
- **`let x: T` with no initializer is rejected; `var x: T` with no initializer is ACCEPTED.** An asymmetry nothing documents. Probably deliberate, but the error says nothing about it.
- `else <expr>` without braces — two files.
- typed literal suffix `[0u8; 64]`; `[0; 64]` is fine.

## Two remain unknown, and are labelled as such

`gpu/ptx_emitter.sio` fails only as a **whole file** — no prefix of it fails, so the bisect has nothing to hand back. `compiler/pkg/lib.sio` has no recognisable top-level items, so the bisect cannot start. Neither gets a guessed cause.

## Why NOT to fix these files

The header says this too, because it is the conclusion most likely to be re-derived at cost. **They are orphans.** Nine of the ten carry no `module` declaration at all, so `use` cannot reach them; none is in any import closure; all were committed 2026-06-29 and untouched since; and for several the only thing in the whole repo that mentions them is this baseline file itself.

Making them parse would be polishing code nothing uses. The classification is the deliverable.