### PR TITLE
fix(parser): decimal float literals are now correctly rounded

### DIFF
--- a/self-hosted/parser/parser.sio
+++ b/self-hosted/parser/parser.sio
@@ -984,6 +984,194 @@ pub fn parser_advance(p_in: Parser) -> Parser with Mut, Panic, Div {
     p
 }
 
+// ---------------------------------------------------------------------------
+// Correctly-rounded decimal -> binary64, slow path (#1626).
+//
+// The fast paths below are exact only while the significand fits 53 bits and
+// |dexp| <= 22. Outside that window they cost one to two roundings, which left
+// four of 91 realistic literals one ULP out: two with 17 significant digits,
+// 1.602176634e-19, and 1e+300. Getting those right needs the exact quotient,
+// which needs integers wider than i64 -- so this is Clinger's AlgorithmM on a
+// small bignum.
+//
+// Base 2^31 limbs so that limb*10 + carry stays far inside i64. 64 limbs is
+// 1984 bits, against 1329 for 10^400, which is the clamp applied to dexp.
+//
+// Module-level rather than local arrays on purpose: boot4 corrupts
+// struct-by-value and large local aggregates, and the rest of this file
+// already uses the scalar-globals idiom for the same reason.
+var PFL_N: [i64; 64] = [0; 64]
+var PFL_NL: i64 = 0
+var PFL_D: [i64; 64] = [0; 64]
+var PFL_DL: i64 = 0
+
+fn pfl_set(is_num: bool, v: i64) with Mut, Panic, Div {
+    var i: i64 = 0
+    while i < 64 {
+        if is_num { PFL_N[i as usize] = 0 } else { PFL_D[i as usize] = 0 }
+        i = i + 1
+    }
+    var x = v
+    var n: i64 = 0
+    while x > 0 {
+        if is_num { PFL_N[n as usize] = x % 2147483648 } else { PFL_D[n as usize] = x % 2147483648 }
+        x = x / 2147483648
+        n = n + 1
+    }
+    if is_num { PFL_NL = n } else { PFL_DL = n }
+}
+
+fn pfl_mul_small(is_num: bool, m: i64) with Mut, Panic, Div {
+    var len = if is_num { PFL_NL } else { PFL_DL }
+    var carry: i64 = 0
+    var i: i64 = 0
+    while i < len {
+        let cur = if is_num { PFL_N[i as usize] } else { PFL_D[i as usize] }
+        let prod = cur * m + carry
+        if is_num { PFL_N[i as usize] = prod % 2147483648 } else { PFL_D[i as usize] = prod % 2147483648 }
+        carry = prod / 2147483648
+        i = i + 1
+    }
+    while carry > 0 && len < 64 {
+        if is_num { PFL_N[len as usize] = carry % 2147483648 } else { PFL_D[len as usize] = carry % 2147483648 }
+        carry = carry / 2147483648
+        len = len + 1
+    }
+    if is_num { PFL_NL = len } else { PFL_DL = len }
+}
+
+fn pfl_bits(is_num: bool) -> i64 with Mut, Panic, Div {
+    let len = if is_num { PFL_NL } else { PFL_DL }
+    if len == 0 { return 0 }
+    let top = if is_num { PFL_N[(len - 1) as usize] } else { PFL_D[(len - 1) as usize] }
+    var b: i64 = 0
+    var t = top
+    while t > 0 { b = b + 1  t = t / 2 }
+    (len - 1) * 31 + b
+}
+
+fn pfl_cmp() -> i64 with Mut, Panic, Div {
+    if PFL_NL != PFL_DL {
+        if PFL_NL > PFL_DL { return 1 }
+        return 0 - 1
+    }
+    var i = PFL_NL - 1
+    while i >= 0 {
+        let a = PFL_N[i as usize]
+        let b = PFL_D[i as usize]
+        if a != b {
+            if a > b { return 1 }
+            return 0 - 1
+        }
+        i = i - 1
+    }
+    0
+}
+
+// PFL_N -= PFL_D, assuming PFL_N >= PFL_D
+fn pfl_sub() with Mut, Panic, Div {
+    var borrow: i64 = 0
+    var i: i64 = 0
+    while i < PFL_NL {
+        var d = PFL_N[i as usize] - borrow
+        if i < PFL_DL { d = d - PFL_D[i as usize] }
+        if d < 0 { d = d + 2147483648  borrow = 1 } else { borrow = 0 }
+        PFL_N[i as usize] = d
+        i = i + 1
+    }
+    while PFL_NL > 0 && PFL_N[(PFL_NL - 1) as usize] == 0 { PFL_NL = PFL_NL - 1 }
+}
+
+fn pfl_shl(is_num: bool, k: i64) with Mut, Panic, Div {
+    var j: i64 = 0
+    while j < k {
+        pfl_mul_small(is_num, 2)
+        j = j + 1
+    }
+}
+
+fn pfl_is_zero(is_num: bool) -> bool with Mut, Panic, Div {
+    if is_num { return PFL_NL == 0 }
+    PFL_DL == 0
+}
+
+// Multiply x by 2^k exactly, in two halves so a large negative k does not
+// underflow an intermediate on the way to a representable result.
+fn pfl_scale2(x: f64, k: i64) -> f64 with Mut, Panic, Div {
+    var v = x
+    var a = k / 2
+    var b = k - a
+    var n = a
+    while n > 0 { v = v * 2.0  n = n - 1 }
+    while n < 0 { v = v / 2.0  n = n + 1 }
+    n = b
+    while n > 0 { v = v * 2.0  n = n - 1 }
+    while n < 0 { v = v / 2.0  n = n + 1 }
+    v
+}
+
+// sig * 10^dexp, correctly rounded. Only called when the exact fast paths
+// cannot answer.
+fn pfl_slow(sig: i64, dexp: i64) -> f64 with Mut, Panic, Div {
+    pfl_set(true, sig)
+    pfl_set(false, 1)
+    var k: i64 = 0
+    if dexp > 0 {
+        while k < dexp { pfl_mul_small(true, 10)  k = k + 1 }
+    } else {
+        while k < 0 - dexp { pfl_mul_small(false, 10)  k = k + 1 }
+    }
+
+    // Normalise to 1 <= N/D < 2, tracking the binary exponent.
+    var e: i64 = 0
+    let diff = pfl_bits(true) - pfl_bits(false)
+    if diff > 0 { pfl_shl(false, diff)  e = e + diff }
+    if diff < 0 { pfl_shl(true, 0 - diff)  e = e + diff }
+    if pfl_cmp() < 0 { pfl_shl(true, 1)  e = e - 1 }
+
+    // How many significand bits this exponent can actually hold. 53 when the
+    // result is normal; fewer in the subnormal range, where binary64 loses
+    // precision gradually. Extracting 53 and then scaling down would round
+    // twice -- which is what left 610e-315 (6.1e-313, subnormal) one ULP out
+    // while every normal value was already exact.
+    var want: i64 = 53
+    if e < 0 - 1022 { want = e + 1075 }
+    if want < 1 { return 0.0 }
+    if want > 53 { want = 53 }
+
+    var q: i64 = 1
+    pfl_sub()
+    var i: i64 = 1
+    while i < want {
+        pfl_shl(true, 1)
+        q = q * 2
+        if pfl_cmp() >= 0 { pfl_sub()  q = q + 1 }
+        i = i + 1
+    }
+
+    // Round to nearest, ties to even.
+    pfl_shl(true, 1)
+    var round_up = false
+    if pfl_cmp() >= 0 {
+        pfl_sub()
+        if !pfl_is_zero(true) { round_up = true }
+        else { if q % 2 == 1 { round_up = true } }
+    }
+    if round_up { q = q + 1 }
+
+    // A carry out of the top bit renormalises; the extra bit comes for free
+    // from the exponent.
+    var qmax: i64 = 1
+    var z: i64 = 0
+    while z < want { qmax = qmax * 2  z = z + 1 }
+    if q >= qmax { q = q / 2  e = e + 1 }
+
+    // Every intermediate on the way down is representable because the target
+    // is, so the halving chain in pfl_scale2 is exact rather than repeatedly
+    // rounding.
+    pfl_scale2(q as f64, e - (want - 1))
+}
+
 // Exact powers of ten, built by multiplication rather than written out:
 // lean_single, which compiles this file, parses 10^19 as a NEGATIVE number, so
 // a literal table arrives poisoned. 10^k is exactly representable for k <= 22
@@ -1096,12 +1284,15 @@ fn parser_parse_float_token(start: i64, end: i64) -> f64 with Mut, Panic, Div {
     if dexp > 400 { dexp = 400 }
     if dexp < 0 - 400 { dexp = 0 - 400 }
 
-    // Correctly rounded window: one exact scale, one rounding.
-    if dexp >= 0 && dexp <= 22 {
-        return sf * parser_pow10_exact(dexp)
-    }
-    if dexp < 0 && dexp >= 0 - 22 {
-        return sf / parser_pow10_exact(0 - dexp)
+    // Correctly rounded window: significand exact in f64 AND an exact power of
+    // ten, so the single operation below is the only rounding.
+    if sig <= 9007199254740992 {
+        if dexp >= 0 && dexp <= 22 {
+            return sf * parser_pow10_exact(dexp)
+        }
+        if dexp < 0 && dexp >= 0 - 22 {
+            return sf / parser_pow10_exact(0 - dexp)
+        }
     }
 
     // Extended: walk the exponent DOWN into the exact window by growing the
@@ -1126,25 +1317,11 @@ fn parser_parse_float_token(start: i64, end: i64) -> f64 with Mut, Panic, Div {
         }
     }
 
-    // Fallback: 10^22 at a time. Not correctly rounded, but ~14 roundings for
-    // 1e300 instead of ~300.
-    var v = sf
-    var e3 = dexp
-    while e3 >= 22 {
-        v = v * parser_pow10_exact(22)
-        e3 = e3 - 22
-    }
-    while e3 <= 0 - 22 {
-        v = v / parser_pow10_exact(22)
-        e3 = e3 + 22
-    }
-    if e3 > 0 {
-        v = v * parser_pow10_exact(e3)
-    }
-    if e3 < 0 {
-        v = v / parser_pow10_exact(0 - e3)
-    }
-    v
+    // Everything the exact windows cannot answer goes to the bignum path, which
+    // is correctly rounded by construction. It replaces a chunked 10^22 scaling
+    // that cost one rounding per chunk and left 1e300 and 1.602176634e-19 an ULP
+    // out.
+    pfl_slow(sig, dexp)
 }
 
 pub fn parser_peek_ahead(p: Parser, offset: i64) -> TokenKind with Mut, Panic, Div {

--- a/tests/run-pass/float_literal_correctly_rounded.sio
+++ b/tests/run-pass/float_literal_correctly_rounded.sio
@@ -1,0 +1,56 @@
+//@ run-pass
+//@ requires: madaros
+//@ expect-stdout: float_literal_correctly_rounded: PASS
+// requires: madaros because lean_single carries its OWN copy of the decimal
+// conversion, inside lean_single.sio, still the pre-#1626 one -- it gets five
+// of these ten wrong. The suite's stage2 binary is built by lean_single, so
+// without this guard the test is a false red. Porting the bignum path there is
+// a separate change: it needs its own seed re-derivation. Filed as follow-up.
+// #1626: decimal -> binary64 must be correctly rounded, not merely close.
+//
+// The original conversion accumulated `frac = frac * 0.1`, and 0.1 is not
+// representable, so every digit compounded a rounding: 32 of 91 realistic
+// literals were wrong. Exact fast paths took that to 4, and the bignum slow
+// path takes it to 0 -- measured at 0 wrong across 920 random literals
+// spanning 1e-320 to 1e300, against 359 wrong on the pre-fix compiler.
+//
+// Every literal below is one that a shortcut got wrong at some point in that
+// sequence. Keep them: each one is a different failure mode, and they are
+// cheap insurance against the next person reaching for a shortcut.
+//
+//   0.99999999            one ULP high; this is what made log look like it
+//                         had a 2^-53 residual, since ulp(1.0)/1.0 IS 2^-53
+//   944.6810951079374     16 significant digits -- trimming the significand
+//                         to 2^53 threw away a digit it actually carries
+//   118.06577825496211    17 digits; f64 accumulation stops at 2^53
+//   1.602176634e-19       |exponent| > 22, outside the exact power-of-ten window
+//   1e300 / 1e-300        chunked scaling cost one rounding per chunk
+//   610e-315              SUBNORMAL: extracting 53 bits and scaling down
+//                         rounds twice, because binary64 loses precision
+//                         gradually below 2^-1022
+//
+// Compared against bit patterns from CPython. Kept short on purpose: a file
+// with ~150 such comparisons hits a separate Madaros miscompile and reports
+// false failures, which cost a measurement pass to notice.
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var bad: i64 = 0
+    if f64_to_bits(0.99999999) != 4607182418709945415 { bad = bad + 1 }
+    if f64_to_bits(944.6810951079374) != 4651520718607872116 { bad = bad + 1 }
+    if f64_to_bits(118.06577825496211) != 4638008557483030122 { bad = bad + 1 }
+    if f64_to_bits(0.9999999999999999) != 4607182418800017407 { bad = bad + 1 }
+    if f64_to_bits(1.602176634e-19) != 4325607224011134547 { bad = bad + 1 }
+    if f64_to_bits(1e300) != 9094988921128908188 { bad = bad + 1 }
+    if f64_to_bits(1e-300) != 118622047889322841 { bad = bad + 1 }
+    if f64_to_bits(610e-315) != 123465374517 { bad = bad + 1 }
+    if f64_to_bits(6.02214076e23) != 4962933279127225623 { bad = bad + 1 }
+    if f64_to_bits(3.141592653589793) != 4614256656552045848 { bad = bad + 1 }
+    if bad != 0 {
+        print("float_literal_correctly_rounded: FAIL ")
+        print_int(bad)
+        print("\n")
+        return 1
+    }
+    print("float_literal_correctly_rounded: PASS\n")
+    0
+}


### PR DESCRIPTION
#1626, the last four. Exact fast paths got the count from 32 wrong per 91 to 4; those four needed the **exact quotient**, which needs integers wider than i64. This is Clinger's AlgorithmM on a small bignum, reached only when the fast paths cannot answer exactly.

| literals wrong | 91-case suite | 920 random literals |
|---|---:|---:|
| before #1626 | 32 | — |
| before this PR | 4 | **359** |
| after | **0** | **0** |

The 920 span 1e-320 to 1e300 with 1-to-19-digit significands. **359 → 0** is the honest headline; the 91-case suite had stopped discriminating.

## How it works

Three tiers, cheapest first:

1. **significand < 2⁵³ and `|dexp| ≤ 22`** — one exact multiply or divide by an exactly representable power of ten. One rounding, hence correctly rounded (Clinger 1990).
2. **`dexp > 22`** — walk the exponent down into that window by growing the significand; every step exact.
3. **everything else** — bignum. Base 2³¹ limbs, 64 of them (1984 bits against 1329 for 10⁴⁰⁰). Normalise N/D to [1,2), extract the significand bit by bit, round to nearest with ties to even.

Cost: **+30 ms on a file of 40 literals that all take tier 3** (282 → 312 ms). Real sources rarely have one.

Module-level scratch arrays rather than locals: boot4 corrupts large local aggregates, and this file already uses the scalar-globals idiom for the same reason.

## Subnormals

Tier 3 first extracted 53 bits and scaled down, which rounds **twice** below 2⁻¹⁰²² where binary64 loses precision gradually — `610e-315` was the one literal in 920 still wrong. It now extracts exactly `e + 1075` bits when the result is subnormal, so the halving chain that applies the exponent is exact rather than repeatedly rounding.

## Two measurement traps worth recording

A generated harness of ~150 comparisons reports **~15% false failures** — `got` prints *equal* to `want` while `!=` fires. Isolated, the same comparison is correct. That is a separate Madaros miscompile at scale, and it nearly had me "fix" a parser that was already right. Batches of 40 are clean; the regression test is deliberately ten lines for this reason.

I also mis-transcribed the bit pattern for `610e-315` into the test and briefly read the failure as a bug in the fix.

## Not fixed here, stated plainly

**lean_single carries its own copy of this conversion**, still the pre-#1626 one; it gets five of the regression test's ten literals wrong. The suite's stage2 binary is built by lean_single, so the test carries `//@ requires: madaros`. Porting the bignum there needs its own seed re-derivation and is a separate change.

## Verified

- `log` 1 ULP, `exp` 1 ULP
- ontology validation gate **rc=0**
- corpus **293/1707**; the only difference against a control built from `main` is this commit's own regression test — failing there, passing here

🤖 Generated with [Claude Code](https://claude.com/claude-code)