### PR TITLE
[compiler] Classify thin-link rc=12 as f64-cmp-in-bool-struct-fields

### DIFF
--- a/docs/compiler/KNOWN_LIMITATIONS.md
+++ b/docs/compiler/KNOWN_LIMITATIONS.md
@@ -460,6 +460,7 @@ Madaros native-v2 (shepherd-merge 2026-08-05 onto `origin/main`):
 | **full `math::qd128` / `qd_mul`** | **green** (closed 2026-08-04) | `qd_nine_*` take `[f64;9]`; gates `madaros_qd128_mul_native_v2_gate.sh`, `qd128_import_native_v2_smoke.sio` |
 | **compact zero-provenance** (sedenion + local f64 kinds) | **green** (closed 2026-08-05) | `tests/run-pass/zero_provenance_native_v2_smoke.sio` (~41 fn); gate `scripts/ci/madaros_zero_provenance_native_v2_gate.sh`. Does **not** import `eisa::core_v2`. |
 | **combined zero-provenance (sedenion+eisa::core_v2)** | **fail-closed / waived-E3** (2026-08-05) | ~5 modules / ~111 fn → thin-link `rc=12`. Probe + gate: `tests/known_failures/zero_provenance_native_v2_probe.sio`, `madaros_zero_provenance_failclosed_gate.sh`. BLK: `docs/handoff/BLK-20260805-p0b-zero-provenance.md` |
+| **≥2 f64 comparisons in `bool` struct fields** | **fail-closed** (classified 2026-08-05) | Minimal CU `Pair { a: 2.0 > 0.0, b: 3.0 > 0.0 }` → thin-link `rc=12` (~3 fn). Precomp locals green. **Not** an IR fn-count ceiling (pad-to-49 still emits). Probe/gate: `thinlink_bool_cmp_field_probe.sio`, `madaros_thinlink_bool_cmp_field_gate.sh`. BLK: `docs/handoff/BLK-20260805-thinlink-ir-threshold.md` |
 | `zero_event` stdlib probe (Madaros native) | green | `tests/known_failures/zero_event_stdlib_native_v2_probe.sio` prints `ZERO_EVENT_STDLIB PASS` under stock Madaros |
 
 Constructor privacy was closed by running the same visibility preflight used
@@ -474,12 +475,14 @@ bash scripts/ci/madaros_qd128_core_native_v2_gate.sh
 bash scripts/ci/madaros_qd128_mul_native_v2_gate.sh
 bash scripts/ci/madaros_zero_provenance_native_v2_gate.sh
 bash scripts/ci/madaros_zero_provenance_failclosed_gate.sh
+bash scripts/ci/madaros_thinlink_bool_cmp_field_gate.sh
 bash scripts/ci/zero_event_native_v2_matrix.sh
 bash scripts/ci/zero_event_gate.sh
 ```
 
 Do not claim `eisa::core_v2`+sedenion combined import Madaros-green; the compact
-smoke is a distinct, smaller CU.
+smoke is a distinct, smaller CU. Do not cite a raw `final_fn_count` ceiling for
+the fat `ZeroWitness` fail — prefer the bool-cmp-in-field classification.
 
 ## Reporting Issues
 

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1298
-- Repo-backed topics: 1148
+- Total governed topics: 1299
+- Repo-backed topics: 1149
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 387
-- Authority count `repo_only`: 723
+- Authority count `repo_only`: 724
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 740 topics
+- A2: 741 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 36 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -418,6 +418,10 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.guide.sounio-style-guide | repo_only | docs/guide/SOUNIO_STYLE_GUIDE.md | - | A5 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.guide.tutorial | repo_only | docs/guide/tutorial.md | - | A5 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.apple-selfhost-release-gate-sigsegv-2026-07-10 | repo_only | docs/handoff/apple_selfhost_release_gate_sigsegv_2026-07-10.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.blk-20260804-p0a-d3-validation-e019 | repo_only | docs/handoff/BLK-20260804-p0a-d3-validation-e019.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.blk-20260804-p0b-qd128-native-v2 | repo_only | docs/handoff/BLK-20260804-p0b-qd128-native-v2.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.blk-20260805-p0b-zero-provenance | repo_only | docs/handoff/BLK-20260805-p0b-zero-provenance.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.blk-20260805-thinlink-ir-threshold | repo_only | docs/handoff/BLK-20260805-thinlink-ir-threshold.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.butterfly-handoff | repo_only | docs/handoff/butterfly-handoff.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.c2-heap-columnar-dataframe-codex-dispatch-2026-07-18 | repo_only | docs/handoff/c2_heap_columnar_dataframe_codex_dispatch_2026-07-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.c3-group-select-radix-codex-dispatch-2026-07-21 | repo_only | docs/handoff/c3_group_select_radix_codex_dispatch_2026-07-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -9184,6 +9184,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.handoff.blk-20260805-thinlink-ir-threshold",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/BLK-20260805-thinlink-ir-threshold.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.handoff.butterfly-handoff",
       "collection": "repo",
       "repo_doc_path": "docs/handoff/butterfly-handoff.md",

--- a/docs/handoff/BLK-20260805-p0b-zero-provenance.md
+++ b/docs/handoff/BLK-20260805-p0b-zero-provenance.md
@@ -55,3 +55,10 @@ does **not** import `eisa::core_v2` and must not be cited as closing this BLK.
 This BLK remains open as the **eisa::core_v2 + sedenion** combined-import
 thin-link residual until Madaros emits that larger CU (`~111` fn) without
 `rc=12`.
+
+**Related shape residual (not this BLK):** a fat local `ZeroWitness` helper
+form near ~49 fn was previously read as an IR-count ceiling. Isolation shows
+that is a misattribution — Madaros fails on ≥2 **f64 comparisons in bool
+struct fields** even at `final_fn_count` 3. See
+`docs/handoff/BLK-20260805-thinlink-ir-threshold.md` and
+`scripts/ci/madaros_thinlink_bool_cmp_field_gate.sh`.

--- a/docs/handoff/BLK-20260805-thinlink-ir-threshold.md
+++ b/docs/handoff/BLK-20260805-thinlink-ir-threshold.md
@@ -1,0 +1,63 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.blk-20260805-thinlink-ir-threshold
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.blk-20260805-thinlink-ir-threshold
+-->
+
+# Blocker: BLK-20260805-thinlink-ir-threshold
+
+```text
+Blocker-ID: BLK-20260805-thinlink-ir-threshold
+Status: classified (2026-08-05) — shape residual, not fn-count ceiling
+Severity: B2
+Class: compiler-native / thin-link / struct-field-lowering
+Owner: cursor--p0-thinlink-threshold-20260805
+Lane: p0-thinlink-threshold-20260805
+Worktree: /tmp/sounio-thinlink-threshold-20260805
+Branch: research/thinlink-ir-threshold-20260805
+Root-Cause: Stock Madaros native emit fails closed (thin-link rc=12, no
+  segfault) when a struct literal initializes **two or more** `bool` fields
+  from **f64 comparison expressions** in field position
+  (`Pair { a: 2.0 > 0.0, b: 3.0 > 0.0 }`). Same CU with comparisons prebound
+  to locals is green. lean_single oracle PASS. IR `final_fn_count` is **not**
+  the discriminator: pad-to-49 i64 helpers on the compact zero-provenance
+  smoke still emit; this 3-fn probe fails.
+Acceptance-Gate: scripts/ci/madaros_thinlink_bool_cmp_field_gate.sh
+Evidence-Level: E3
+LLM-Offload: not-required (compiler residual classification; no new math claim)
+Residual: compiler fix for f64-cmp → bool field init under native emit
+Next-Action: compiler lane may reopen; stdlib/tests should prefer precomp
+  locals for multi-bool struct literals until fixed. Do not cite “~41 fn
+  ceiling” as the zero-provenance thin-link cause.
+```
+
+## Evidence ladder (2026-08-05, main @ 4fd0c48985)
+
+| Case | Outcome |
+|---|---|
+| `Pair { a: 2.0 > 0.0, b: 3.0 > 0.0 }` | Madaros `rc=12`; lean_single PASS |
+| Same with `let a = 2.0 > 0.0; let b = …; Pair { a: a, b: b }` | Madaros PASS |
+| Single `Wrap { flag: 2.0 > 0.0 }` | Madaros PASS |
+| Two **i64** comparisons in bool fields | Madaros PASS |
+| Two f64 `==` in bool fields | Madaros `rc=12` |
+| Compact zero-provenance + 8 pad fns (`final_fn_count` 49) | Madaros PASS |
+| Fat `ZeroWitness` with `sed_norm_sq(…) > 0.0` in bool fields | Madaros `rc=12` (same shape family) |
+
+```bash
+bash scripts/ci/madaros_thinlink_bool_cmp_field_gate.sh
+./bin/souc run tests/known_failures/thinlink_bool_cmp_field_probe.sio
+# expect: Failed to write native binary … rc=12
+SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run tests/known_failures/thinlink_bool_cmp_field_probe.sio
+# expect: BOOL_CMP_FIELD PASS
+```
+
+## Relation to BLK-20260805-p0b-zero-provenance
+
+The combined `eisa::core_v2`+sedenion probe (~111 fn) remains a **separate**
+multi-module scale residual. The earlier “41→49 fn” reading of the fat
+sedenion+`ZeroWitness` witness was a **misattribution**: that CU failed because
+it embedded live f64 comparisons into bool struct fields, not because it
+crossed an IR function-count ceiling.

--- a/scripts/ci/madaros_thinlink_bool_cmp_field_gate.sh
+++ b/scripts/ci/madaros_thinlink_bool_cmp_field_gate.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Classifies Madaros thin-link rc=12 on ≥2 f64 comparisons in bool struct fields,
+# with lean_single oracle green and precomp smoke green.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
+SOUC="${SOUC:-$ROOT/bin/souc}"
+PROBE="tests/known_failures/thinlink_bool_cmp_field_probe.sio"
+SMOKE="tests/run-pass/thinlink_bool_cmp_field_precomp_smoke.sio"
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+
+echo "== madaros_thinlink_bool_cmp_field_gate =="
+
+unset SOUNIO_SOUC_ENGINE || true
+set +e
+"$SOUC" run "$PROBE" >"$OUT/madaros_probe.log" 2>&1
+MRC=$?
+set -e
+if [[ "$MRC" -eq 0 ]]; then
+  echo "FAIL: Madaros unexpectedly succeeded on cmp-in-field probe; promote needs a green gate"
+  cat "$OUT/madaros_probe.log" || true
+  exit 1
+fi
+grep -Fq 'Failed to write native binary' "$OUT/madaros_probe.log" || {
+  echo "FAIL: missing fail-closed native emit marker"
+  cat "$OUT/madaros_probe.log" || true
+  exit 1
+}
+if grep -Fq 'Segmentation fault' "$OUT/madaros_probe.log"; then
+  echo "FAIL: segfault (not an allowed fail-closed mode)"
+  cat "$OUT/madaros_probe.log" || true
+  exit 1
+fi
+if grep -Fq 'BOOL_CMP_FIELD PASS' "$OUT/madaros_probe.log"; then
+  echo "FAIL: Madaros printed PASS while rc!=0"
+  cat "$OUT/madaros_probe.log" || true
+  exit 1
+fi
+
+export SOUNIO_SOUC_ENGINE=lean_single
+set +e
+"$SOUC" run "$PROBE" >"$OUT/lean_probe.log" 2>&1
+LRC=$?
+set -e
+unset SOUNIO_SOUC_ENGINE || true
+[[ "$LRC" -eq 0 ]] || {
+  echo "FAIL: lean_single oracle rc=$LRC"
+  cat "$OUT/lean_probe.log" || true
+  exit 1
+}
+grep -Fq 'BOOL_CMP_FIELD PASS' "$OUT/lean_probe.log" || {
+  echo "FAIL: lean_single missing BOOL_CMP_FIELD PASS"
+  cat "$OUT/lean_probe.log" || true
+  exit 1
+}
+
+set +e
+"$SOUC" run "$SMOKE" >"$OUT/smoke.log" 2>&1
+SRC=$?
+set -e
+[[ "$SRC" -eq 0 ]] || {
+  echo "FAIL: precomp smoke rc=$SRC"
+  cat "$OUT/smoke.log" || true
+  exit 1
+}
+grep -Fq 'BOOL_CMP_FIELD_PRECOMP PASS' "$OUT/smoke.log" || {
+  echo "FAIL: precomp smoke missing sentinel"
+  cat "$OUT/smoke.log" || true
+  exit 1
+}
+if grep -Fq 'Segmentation fault' "$OUT/smoke.log"; then
+  echo "FAIL: precomp smoke segfault"
+  cat "$OUT/smoke.log" || true
+  exit 1
+fi
+
+echo "MADAROS_THINLINK_BOOL_CMP_FIELD_GATE_OK"

--- a/scripts/ci/zero_event_native_v2_matrix.sh
+++ b/scripts/ci/zero_event_native_v2_matrix.sh
@@ -89,6 +89,18 @@ require_marker combined 'Failed to write native binary'
 reject_marker combined 'Segmentation fault'
 reject_marker combined 'ZERO_PROVENANCE PASS'
 
+# Bool-cmp-in-struct-field shape residual (not an IR fn-count ceiling)
+run_capture bool_cmp_precomp tests/run-pass/thinlink_bool_cmp_field_precomp_smoke.sio
+require_rc bool_cmp_precomp 0
+require_marker bool_cmp_precomp 'BOOL_CMP_FIELD_PRECOMP PASS'
+reject_marker bool_cmp_precomp 'Segmentation fault'
+
+run_capture bool_cmp_probe tests/known_failures/thinlink_bool_cmp_field_probe.sio
+require_rc bool_cmp_probe 1
+require_marker bool_cmp_probe 'Failed to write native binary'
+reject_marker bool_cmp_probe 'Segmentation fault'
+reject_marker bool_cmp_probe 'BOOL_CMP_FIELD PASS'
+
 # Receipt stdlib probe is green on stock Madaros (main already closed this surface)
 run_capture receipt tests/known_failures/zero_event_stdlib_native_v2_probe.sio
 require_rc receipt 0
@@ -96,4 +108,4 @@ require_marker receipt 'Compilation successful!'
 require_marker receipt 'ZERO_EVENT_STDLIB PASS'
 reject_marker receipt 'Segmentation fault'
 
-echo '[zero-native-matrix] PASS: dd64+sedenion+qd128(+core,+mul)+zp_compact+receipt green; eisa+sedenion combined fail-closed'
+echo '[zero-native-matrix] PASS: dd64+sedenion+qd128(+core,+mul)+zp_compact+bool_cmp_precomp+receipt green; eisa+sedenion combined + bool_cmp_probe fail-closed'

--- a/tests/known_failures/thinlink_bool_cmp_field_probe.sio
+++ b/tests/known_failures/thinlink_bool_cmp_field_probe.sio
@@ -1,0 +1,20 @@
+//! Known Madaros native-v2 failure (classified 2026-08-05): thin-link rc=12 when
+//! a struct literal initializes **two or more** `bool` fields from **f64
+//! comparison expressions** (`>`, `==`, …) in field position.
+//!
+//! Not an IR `final_fn_count` ceiling: pad-to-49 with plain i64 helpers still
+//! emits; this 3-fn CU fails. Precomputing the bools into locals first is green
+//! (`tests/run-pass/thinlink_bool_cmp_field_precomp_smoke.sio`). lean_single
+//! oracle PASS. Gate: `scripts/ci/madaros_thinlink_bool_cmp_field_gate.sh`.
+//! BLK: `docs/handoff/BLK-20260805-thinlink-ir-threshold.md`
+
+struct Pair { a: bool, b: bool }
+
+fn main() -> i32 with IO, Div, Panic {
+    let p = Pair { a: 2.0 > 0.0, b: 3.0 > 0.0 }
+    if p.a && p.b {
+        println("BOOL_CMP_FIELD PASS")
+        return 0
+    }
+    1
+}

--- a/tests/run-pass/thinlink_bool_cmp_field_precomp_smoke.sio
+++ b/tests/run-pass/thinlink_bool_cmp_field_precomp_smoke.sio
@@ -1,0 +1,19 @@
+//@ run-pass
+//@ expect-stdout: BOOL_CMP_FIELD_PRECOMP PASS
+
+//! Green control for the bool-cmp-in-struct-field thin-link residual:
+//! same `Pair` shape as the known_failures probe, but f64 comparisons are
+//! bound to locals before the struct literal.
+
+struct Pair { a: bool, b: bool }
+
+fn main() -> i32 with IO, Div, Panic {
+    let a = 2.0 > 0.0
+    let b = 3.0 > 0.0
+    let p = Pair { a: a, b: b }
+    if p.a && p.b {
+        println("BOOL_CMP_FIELD_PRECOMP PASS")
+        return 0
+    }
+    1
+}


### PR DESCRIPTION
## Summary
- Isolate the Madaros thin-link `rc=12` residual to **≥2 f64 comparison expressions in `bool` struct fields** (`Pair { a: 2.0 > 0.0, b: 3.0 > 0.0 }`), not an IR `final_fn_count` ceiling.
- Add fail-closed probe + precomp green smoke + gate; wire into `zero_event_native_v2_matrix.sh`.
- Correct BLK/KNOWN_LIMITATIONS: fat `ZeroWitness` fail was the same shape family; pad-to-49 still emits.

## Test plan
- [x] `bash scripts/ci/madaros_thinlink_bool_cmp_field_gate.sh`
- [x] `bash scripts/ci/zero_event_native_v2_matrix.sh`
- [ ] CI Decision green