### PR TITLE
fix(particle): close Madaros E175 on EXP13 amp import

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1303
-- Repo-backed topics: 1153
+- Total governed topics: 1304
+- Repo-backed topics: 1154
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 391
+- Authority count `historical`: 392
 - Authority count `repo_only`: 724
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 32 topics
 - A5: 36 topics
-- A6: 425 topics
+- A6: 426 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -916,6 +916,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.octonion-pbpk | historical | docs/research/octonion_pbpk.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.octonion-validation-report | historical | docs/research/OCTONION_VALIDATION_REPORT.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.onn-benchmark-analysis | historical | docs/research/ONN_BENCHMARK_ANALYSIS.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.particle-e175-amp-import-2026-08-05 | historical | docs/research/particle_e175_amp_import_2026-08-05.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-exp10-approx-algebra-2026-07-26 | historical | docs/research/particle_exp10_approx_algebra_2026-07-26.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-exp11-scheme-approx-product-2026-07-26 | historical | docs/research/particle_exp11_scheme_approx_product_2026-07-26.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-exp123-vertical-2026-07-25 | historical | docs/research/particle_exp123_vertical_2026-07-25.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -20339,6 +20339,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.particle-e175-amp-import-2026-08-05",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/particle_e175_amp_import_2026-08-05.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.particle-exp10-approx-algebra-2026-07-26",
       "collection": "repo",
       "repo_doc_path": "docs/research/particle_exp10_approx_algebra_2026-07-26.md",

--- a/docs/handoff/particle_madaros_exp_residuals_2026-07-26.md
+++ b/docs/handoff/particle_madaros_exp_residuals_2026-07-26.md
@@ -37,7 +37,7 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.partic
 | `ep_gate` field-if | stdlib `ep_i64_ge` (still needs native fix) |
 | `pb_is_credible` / `ck_is_credible` | same call-arg pattern |
 | Thin EXP10 physics vertical | remains (IR size) |
-| Vertex/amplitude on full EXP123 | **partial close** EXP13 — `eemm_z_amplitude_nu` Madaros-safe via ep_square on vertex f64 (raw f64*f64 of imported negatives was 0) |
+| Vertex/amplitude on full EXP123 | **closed** EXP13 dual-engine (2026-08-05) — drop private `extern "C" sqrt/sinh/cosh` in `lorentz`/`vertex` (false E175 vs `complex` builtins); see `docs/research/particle_e175_amp_import_2026-08-05.md` |
 
 
 Compiler residual: i64 field-if mis-branch in imported native codegen.

--- a/docs/research/particle_e175_amp_import_2026-08-05.md
+++ b/docs/research/particle_e175_amp_import_2026-08-05.md
@@ -1,0 +1,80 @@
+<!-- docs:meta
+topic_id: repo.docs.research.particle-e175-amp-import-2026-08-05
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.particle-e175-amp-import-2026-08-05
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# Particle E175 — Madaros import of `eemm_z_amplitude_nu` (2026-08-05)
+
+## Claim
+
+Under default Madaros, `examples/particle_physics/exp13_amplitude_honesty.sio`
+(which imports `particle_physics::nonunitary_amp::eemm_z_amplitude_nu`) type-checks
+and runs with `PARTICLE_EXP13_OK`, matching lean_single.
+
+## Symptom (pre-fix)
+
+```text
+SOUNIO_SOUC_ENGINE=madaros ./bin/souc check examples/particle_physics/exp13_amplitude_honesty.sio
+→ many error[E175] function is private in its defining module
+```
+
+Bisect:
+
+| Program | Madaros `check` |
+|---|---|
+| `lorentz` alone | OK |
+| `complex::lib` alone | OK |
+| `complex` + `lorentz` | **E175** |
+| `spinor` (pulls both) | **E175** |
+| full EXP13 | **E175** |
+
+lean_single accepted the same sources throughout.
+
+## Root cause
+
+`stdlib/particle_physics/lorentz.sio` (and `vertex.sio`) declared
+
+```sio
+extern "C" {
+    fn sqrt(x: f64) -> f64;
+    // lorentz also: sinh, cosh
+}
+```
+
+Those bindings are **private** fn sigs in the multimodule table. Madaros
+`fn_sig_table_find_prefer_module` prefers same-module, else any **non-private**,
+else the first free-fn match. `complex::lib` calls builtin `sqrt` / `sinh` /
+`cosh` with no local definition, so lookup fell through to lorentz/vertex's
+private extern stubs → false E175.
+
+Same class as the gum+knowledge helper-name collision (#1245), but the colliding
+names were **private extern builtins**, not `chk`/`near`. Related: #1622 (extern
+stubs return 0 under native — builtins need no declaration).
+
+## Fix
+
+1. Drop the private `extern "C"` blocks in `lorentz.sio` and `vertex.sio`.
+2. Call builtins (`sqrt`, `sinh`, `cosh`) directly — no declaration.
+3. In `spinor.sio`, import `metric_eta` from `lorentz` instead of a local private
+   duplicate (hygiene; not the E175 trigger once externs were removed).
+
+No change to Madaros checker sources (claimed elsewhere); no formula change.
+
+## Evidence
+
+```bash
+bash scripts/research/particle_e175_amp_import_gate.sh
+# → PARTICLE_E175_AMP_IMPORT_GATE_OK
+# also: PARTICLE_EXP13_GATE_OK (lean_single + madaros)
+```
+
+Minimal witness after fix: complex + lorentz `check: OK` under Madaros.

--- a/docs/research/particle_exp14_amp_to_xsec_2026-08-05.md
+++ b/docs/research/particle_exp14_amp_to_xsec_2026-08-05.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.particle-exp14-amp-to-xsec-2026-08-05
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/docs/research/particle_exp15_w_amp_to_xsec_2026-08-05.md
+++ b/docs/research/particle_exp15_w_amp_to_xsec_2026-08-05.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.particle-exp15-w-amp-to-xsec-2026-08-05
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/docs/research/particle_exp16_h_amp_to_xsec_2026-08-05.md
+++ b/docs/research/particle_exp16_h_amp_to_xsec_2026-08-05.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.particle-exp16-h-amp-to-xsec-2026-08-05
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/scripts/research/particle_e175_amp_import_gate.sh
+++ b/scripts/research/particle_e175_amp_import_gate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# E175 residual closeout: complex+lorentz must check under Madaros, and EXP13
+# dual-engine green. Lives under scripts/research/ (scripts/ci/ may be claimed).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
+
+WITNESS="$(mktemp /tmp/particle_e175_witness.XXXXXX.sio)"
+trap 'rm -f "$WITNESS"' EXIT
+cat >"$WITNESS" <<'EOF'
+use complex::lib::{complex_new, complex_mul}
+use particle_physics::lorentz::{lorentz_new, metric_eta, rapidity}
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let z = complex_mul(complex_new(1.0, 2.0), complex_new(3.0, 4.0))
+    let p = lorentz_new(100.0, 0.0, 0.0, 50.0)
+    print_f64(rapidity(p) + metric_eta(0, 0) + z.re)
+    print("\n")
+    0
+}
+EOF
+
+echo "== E175 witness: complex+lorentz Madaros check =="
+set +e
+SOUNIO_SOUC_ENGINE=madaros ./bin/souc check "$WITNESS" >/tmp/particle_e175_witness_out.txt 2>/tmp/particle_e175_witness_err.txt
+rc=$?
+set -e
+if ! grep -q 'check: OK' /tmp/particle_e175_witness_out.txt && ! grep -q 'verdict=0' /tmp/particle_e175_witness_err.txt; then
+  # Madaros prints verdict on stderr in some paths; accept either stream.
+  if ! grep -qE 'verdict=0|check: OK' /tmp/particle_e175_witness_out.txt /tmp/particle_e175_witness_err.txt; then
+    echo "complex+lorentz Madaros check failed rc=$rc" >&2
+    tail -40 /tmp/particle_e175_witness_err.txt >&2
+    exit 1
+  fi
+fi
+if grep -q 'E175' /tmp/particle_e175_witness_out.txt /tmp/particle_e175_witness_err.txt; then
+  echo "E175 still present on complex+lorentz witness" >&2
+  grep 'E175' /tmp/particle_e175_witness_out.txt /tmp/particle_e175_witness_err.txt >&2
+  exit 1
+fi
+
+echo "== EXP13 dual-engine (canonical CI gate) =="
+if [[ -x "$ROOT/scripts/ci/particle_exp13_amplitude_honesty_gate.sh" ]]; then
+  bash "$ROOT/scripts/ci/particle_exp13_amplitude_honesty_gate.sh"
+else
+  echo "missing scripts/ci/particle_exp13_amplitude_honesty_gate.sh" >&2
+  exit 1
+fi
+
+echo "PARTICLE_E175_AMP_IMPORT_GATE_OK"

--- a/stdlib/particle_physics/lorentz.sio
+++ b/stdlib/particle_physics/lorentz.sio
@@ -9,11 +9,10 @@
 
 module particle_physics::lorentz
 
-extern "C" {
-    fn sqrt(x: f64) -> f64;
-    fn sinh(x: f64) -> f64;
-    fn cosh(x: f64) -> f64;
-}
+// #1622 / E175: do not declare private extern "C" sqrt/sinh/cosh here.
+// Madaros multimodule registers those as private fn sigs; any sibling module
+// that calls the builtin (e.g. complex::lib) then resolves to this private
+// stub and false-fails E175. Builtins need no declaration.
 
 // ============================================================================
 // LORENTZ VECTOR

--- a/stdlib/particle_physics/spinor.sio
+++ b/stdlib/particle_physics/spinor.sio
@@ -18,7 +18,7 @@ use complex::lib::{Complex, complex_new, complex_zero, complex_one, complex_i,
                    complex_add, complex_sub, complex_mul, complex_scale, complex_neg,
                    complex_conj, complex_eq, complex_is_zero}
 
-use particle_physics::lorentz::{LorentzVector, lorentz_new}
+use particle_physics::lorentz::{LorentzVector, lorentz_new, metric_eta}
 
 // ============================================================================
 // DIRAC MATRIX TYPE (4×4 complex, stored as separate real/imag flat arrays)
@@ -366,12 +366,5 @@ fn levi_civita_4(i: i64, j: i64, k: i64, l: i64) -> f64 {
     }
 }
 
-// ============================================================================
-// METRIC HELPER (imported from lorentz)
-// ============================================================================
-
-fn metric_eta(mu: i64, nu: i64) -> f64 {
-    if mu != nu { return 0.0 }
-    if mu == 0 { return 1.0 }
-    return -1.0
-}
+// metric_eta: use particle_physics::lorentz::metric_eta (imported above).
+// Local private duplicate removed — prefer the single pub definition in lorentz.

--- a/stdlib/particle_physics/vertex.sio
+++ b/stdlib/particle_physics/vertex.sio
@@ -19,9 +19,7 @@ use epistemic::knowledge::{Epistemic}
 use complex::lib::{Complex, complex_new, complex_zero, complex_one, complex_i,
                    complex_scale, complex_mul}
 
-extern "C" {
-    fn sqrt(x: f64) -> f64;
-}
+// #1622 / E175: builtin sqrt needs no private extern (see lorentz.sio).
 
 // ============================================================================
 // QED VERTEX


### PR DESCRIPTION
## Summary
- Drop private `extern "C" sqrt/sinh/cosh` in `lorentz`/`vertex` that shadowed builtins when `complex` was co-loaded (false Madaros E175).
- Import `metric_eta` from `lorentz` in `spinor` (remove local duplicate); dual-engine EXP13 green again.
- Research note + `scripts/research/particle_e175_amp_import_gate.sh` witness.

## Test plan
- [x] `bash scripts/research/particle_e175_amp_import_gate.sh` → `PARTICLE_E175_AMP_IMPORT_GATE_OK`
- [x] Madaros + lean_single: `PARTICLE_EXP13_OK`
- [x] Minimal witness: complex + lorentz Madaros `check: OK`