### PR TITLE
fix(madaros): promote tip ELF; close #1627 (sm_params effects)

### DIFF
--- a/docs/handoff/particle_madaros_exp_residuals_2026-07-26.md
+++ b/docs/handoff/particle_madaros_exp_residuals_2026-07-26.md
@@ -86,9 +86,16 @@ Native fix blocked this session by active claims on `self-hosted/native/**` and
 
 ## 6 — #1627 verify + EXP17 amp (2026-08-06)
 
-- Tip Madaros rebuild verifies #1627 fixture green; **promote deferred** (tip E035
-  on `sm_params` breaks EXP17). See `docs/research/particle_e175_1627_close_2026-08-06.md`.
+- Tip Madaros rebuild verifies #1627 fixture green.
 - EXP17 Z continuum uses `eemm_z_amplitude_nu` (shipped Madaros dual-engine OK).
+
+## 6b — #1627 promote (2026-08-06)
+
+- Root cause of promote E035: `sm_params` thin `Epistemic::measured` accessors
+  lacked `with Mut, Div, Panic`. Fixed in `sm_params.sio`.
+- Promoted tip ELF → `bin/madaros-linux-x86_64` (sha256 `f9ddba96…5189e`).
+- Gates green: #1627 shipped, E175 trilogy, EXP17/18/19.
+- Issue #1627 closable.
 
 ## 7 — EXP18 W vertex amp (2026-08-06)
 

--- a/docs/research/particle_e175_1627_close_2026-08-06.md
+++ b/docs/research/particle_e175_1627_close_2026-08-06.md
@@ -7,45 +7,46 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.particle-e175-1627-close-2026-08-06
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
 <!-- docs:status-note:end -->
 
-# Particle E175 / #1627 — verified rebuild + EXP17 amp restore (2026-08-06)
+# Particle E175 / #1627 — promote closeout (2026-08-06)
 
-## Scope
+## Scope (closed)
 
-1. Rebuild Madaros from tip (`self-hosted/check` with #1627 prefer_module /
-   visibility). Fixture: private `extern "C" { fn sqrt; }` + `complex::lib`
-   → **no E175** (`PARTICLE_E175_1627_GATE_OK`).
-2. **Do not promote** tip ELF to `bin/madaros-linux-x86_64` yet — tip rebuild
-   regresses E035 on `sm_params` (mass_z / alpha_em / …) and breaks EXP17
-   compile under the new binary. Shipped ELF remains the default.
-3. EXP17 Z continuum imports `eemm_z_amplitude_nu` (parity with EXP14); dual-engine
-   green on the shipped Madaros.
+1. Tip Madaros rebuild carries #1627 checker (`prefer_module` / visibility):
+   private `extern "C" { fn sqrt; }` + `complex::lib` → **no E175**.
+2. Promote blocker was tip `error[E035]` on `sm_params::*` thin accessors that
+   called `Epistemic::measured` (`with Mut, Div, Panic`) without declaring those
+   effects. **Fixed:** all measured accessors in
+   `stdlib/particle_physics/sm_params.sio` now declare `with Mut, Div, Panic`
+   (`v_tb` stays pure — `Epistemic::certain` only).
+3. Tip ELF promoted to `bin/madaros-linux-x86_64`
+   (sha256 `f9ddba966415fedd93a5e505f0b804b35d23332d0d858a8aa0094a45ea45189e`).
 
 ## Evidence
 
 ```bash
-# Tip ELF (local rebuild; gitignored artifacts/self-hosted/madaros):
 bash scripts/ci/build_modular_madaros.sh artifacts/self-hosted/madaros
-MADAROS_BIN=$PWD/artifacts/self-hosted/madaros \
+cp artifacts/self-hosted/madaros bin/madaros-linux-x86_64
+
+REQUIRE_SHIPPED_GREEN=1 \
   bash scripts/research/particle_e175_1627_gate.sh
 # → PARTICLE_E175_1627_GATE_OK
 
+bash scripts/research/particle_e175_amp_import_gate.sh
+# → PARTICLE_E175_TRILOGY_GATE_OK
+
 bash scripts/research/particle_exp17_zwh_ledger_gate.sh
-# → PARTICLE_EXP17_GATE_OK  (shipped Madaros)
+bash scripts/research/particle_exp18_w_vertex_amp_gate.sh
+bash scripts/research/particle_exp19_h_yukawa_amp_gate.sh
+# → all OK under shipped Madaros
 ```
-
-## Promote blocker
-
-Tip Madaros `check` of EXP17 reports many `error[E035]` in `sm_params::*`
-(ep_new path without Mut/Div/Panic on thin accessors). Separate from #1627.
-Safe promote = fix those effects (or checker) then re-run EXP13/14/17 + #1627
-gate with `REQUIRE_SHIPPED_GREEN=1`.
 
 ## Non-claims
 
-- Does not claim shipped `bin/madaros-linux-x86_64` has the #1627 checker fix.
-- Does not rewrite W/H EXP17 leaves to full vertex amplitudes.
+- Does not claim every Madaros multimodule residual is closed.
+- Does not change Epistemic::measured effect surface (still Mut/Div/Panic).

--- a/scripts/research/particle_e175_1627_gate.sh
+++ b/scripts/research/particle_e175_1627_gate.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
 # #1627 closeout gate: private extern "C" sqrt must not false-E175 complex builtins.
 #
-# Default Madaros is bin/madaros-linux-x86_64 (shipped). Tip rebuilds currently
-# regress E035 on sm_params, so this gate accepts MADAROS_BIN override for a
-# freshly built artifacts/self-hosted/madaros from:
-#   bash scripts/ci/build_modular_madaros.sh artifacts/self-hosted/madaros
-#
-# When MADAROS_BIN is unset, runs against the shipped ELF — which should FAIL
-# until a safe promote lands. Set REQUIRE_SHIPPED_GREEN=1 to demand green on
-# the committed binary (post-promote).
+# Default Madaros is bin/madaros-linux-x86_64 (shipped). As of 2026-08-06 promote
+# (sm_params Mut/Div/Panic + tip checker), the committed ELF is expected green.
+# Override with MADAROS_BIN=... for a tip rebuild. REQUIRE_SHIPPED_GREEN=1 is
+# redundant post-promote but kept for CI call sites.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
@@ -58,14 +54,9 @@ rc=$?
 set -e
 
 if grep -q 'E175' "$FIX_DIR/out.txt" "$FIX_DIR/err.txt"; then
-  if [[ "${REQUIRE_SHIPPED_GREEN:-0}" == "1" ]] || [[ "$MADAROS_BIN" == *"artifacts/self-hosted/madaros"* ]]; then
-    echo "FAIL: E175 still present (#1627 not closed in $MADAROS_BIN)" >&2
-    grep 'E175' "$FIX_DIR/out.txt" "$FIX_DIR/err.txt" | head -20 >&2
-    exit 1
-  fi
-  echo "PARTICLE_E175_1627_SHIPPED_STILL_E175"
-  echo "hint: rebuild tip Madaros and re-run with MADAROS_BIN=artifacts/self-hosted/madaros"
-  exit 0
+  echo "FAIL: E175 still present (#1627 not closed in $MADAROS_BIN)" >&2
+  grep 'E175' "$FIX_DIR/out.txt" "$FIX_DIR/err.txt" | head -20 >&2
+  exit 1
 fi
 if ! grep -qE 'verdict=0|check: OK' "$FIX_DIR/out.txt" "$FIX_DIR/err.txt"; then
   echo "FAIL: check did not pass rc=$rc" >&2

--- a/stdlib/particle_physics/sm_params.sio
+++ b/stdlib/particle_physics/sm_params.sio
@@ -18,19 +18,19 @@ use epistemic::knowledge::{Epistemic}
 /// Fine-structure constant α_EM at zero momentum.
 /// PDG 2024: α⁻¹ ≈ 137.036, α ≈ 0.0072973525693
 /// Uncertainty: ±0.0000000000011 (negligible for most QFT; we keep 1 ppb).
-pub fn alpha_em() -> Epistemic {
+pub fn alpha_em() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(0.0072973525693, 0.0000000000011)
 }
 
 /// Strong coupling α_S at M_Z.
 /// PDG 2024: α_S(M_Z) = 0.1179 ± 0.0009.
-pub fn alpha_s_mz() -> Epistemic {
+pub fn alpha_s_mz() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(0.1179, 0.0009)
 }
 
 /// Weak mixing angle sin²θ_W (MS-bar scheme at M_Z).
 /// PDG 2024: sin²θ_W = 0.23121 ± 0.00004.
-pub fn sin2_theta_w() -> Epistemic {
+pub fn sin2_theta_w() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(0.23121, 0.00004)
 }
 
@@ -80,31 +80,31 @@ pub fn coupling_gs() -> Epistemic with Mut, Div, Panic {
 
 /// Z boson mass.
 /// PDG 2024: M_Z = 91.1876 ± 0.0021 GeV.
-pub fn mass_z() -> Epistemic {
+pub fn mass_z() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(91.1876, 0.0021)
 }
 
 /// Z total width.
 /// PDG 2024 scale: Γ_Z = 2.4952 ± 0.0023 GeV (construction; used for joint GUM).
-pub fn width_z() -> Epistemic {
+pub fn width_z() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(2.4952, 0.0023)
 }
 
 /// W boson mass.
 /// PDG 2024: M_W = 80.377 ± 0.012 GeV.
-pub fn mass_w() -> Epistemic {
+pub fn mass_w() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(80.377, 0.012)
 }
 
 /// W total width.
 /// PDG 2024 scale: Γ_W = 2.085 ± 0.042 GeV (construction; used for joint GUM).
-pub fn width_w() -> Epistemic {
+pub fn width_w() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(2.085, 0.042)
 }
 
 /// Higgs boson mass.
 /// PDG 2024: M_H = 125.20 ± 0.11 GeV.
-pub fn mass_h() -> Epistemic {
+pub fn mass_h() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(125.20, 0.11)
 }
 
@@ -114,37 +114,37 @@ pub fn mass_h() -> Epistemic {
 
 /// Top quark pole mass.
 /// PDG 2024: m_t = 172.69 ± 0.30 GeV.
-pub fn mass_top() -> Epistemic {
+pub fn mass_top() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(172.69, 0.30)
 }
 
 /// Bottom quark mass (MS-bar at m_b).
 /// PDG 2024: m_b(m_b) = 4.18 ± 0.03 GeV.
-pub fn mass_bottom() -> Epistemic {
+pub fn mass_bottom() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(4.18, 0.03)
 }
 
 /// Charm quark mass (MS-bar at m_c).
 /// PDG 2024: m_c(m_c) = 1.27 ± 0.02 GeV.
-pub fn mass_charm() -> Epistemic {
+pub fn mass_charm() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(1.27, 0.02)
 }
 
 /// Strange quark mass (MS-bar at 2 GeV).
 /// PDG 2024: m_s(2 GeV) = 93.4 ± 0.8 MeV = 0.0934 ± 0.0008 GeV.
-pub fn mass_strange() -> Epistemic {
+pub fn mass_strange() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(0.0934, 0.0008)
 }
 
 /// Down quark mass (MS-bar at 2 GeV).
 /// PDG 2024: m_d(2 GeV) = 4.67 ± 0.13 MeV = 0.00467 ± 0.00013 GeV.
-pub fn mass_down() -> Epistemic {
+pub fn mass_down() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(0.00467, 0.00013)
 }
 
 /// Up quark mass (MS-bar at 2 GeV).
 /// PDG 2024: m_u(2 GeV) = 2.16 ± 0.07 MeV = 0.00216 ± 0.00007 GeV.
-pub fn mass_up() -> Epistemic {
+pub fn mass_up() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(0.00216, 0.00007)
 }
 
@@ -154,19 +154,19 @@ pub fn mass_up() -> Epistemic {
 
 /// Tau lepton mass.
 /// PDG 2024: m_τ = 1776.86 ± 0.12 MeV = 1.77686 ± 0.00012 GeV.
-pub fn mass_tau() -> Epistemic {
+pub fn mass_tau() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(1.77686, 0.00012)
 }
 
 /// Muon mass.
 /// PDG 2024: m_μ = 105.6583745 ± 0.0000024 MeV = 0.1056583745 ± 2.4e-9 GeV.
-pub fn mass_muon() -> Epistemic {
+pub fn mass_muon() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(0.1056583745, 0.0000000024)
 }
 
 /// Electron mass.
 /// PDG 2024: m_e = 0.51099895000 ± 0.00000000015 MeV = 0.00051099895 GeV.
-pub fn mass_electron() -> Epistemic {
+pub fn mass_electron() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(0.00051099895, 0.00000000000015)
 }
 
@@ -175,22 +175,22 @@ pub fn mass_electron() -> Epistemic {
 // ============================================================================
 
 /// Wolfenstein λ = sinθ_12 ≈ 0.22500 ± 0.00067.
-pub fn ckm_lambda() -> Epistemic {
+pub fn ckm_lambda() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(0.22500, 0.00067)
 }
 
 /// Wolfenstein A ≈ 0.826 ± 0.012.
-pub fn ckm_a() -> Epistemic {
+pub fn ckm_a() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(0.826, 0.012)
 }
 
 /// Wolfenstein ρ̄ ≈ 0.159 ± 0.010.
-pub fn ckm_rho_bar() -> Epistemic {
+pub fn ckm_rho_bar() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(0.159, 0.010)
 }
 
 /// Wolfenstein η̄ ≈ 0.348 ± 0.010.
-pub fn ckm_eta_bar() -> Epistemic {
+pub fn ckm_eta_bar() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(0.348, 0.010)
 }
 
@@ -204,7 +204,7 @@ pub fn v_ud() -> Epistemic with Mut, Div, Panic {
 }
 
 /// CKM matrix element |V_us| = λ.
-pub fn v_us() -> Epistemic {
+pub fn v_us() -> Epistemic with Mut, Div, Panic {
     ckm_lambda()
 }
 
@@ -224,7 +224,7 @@ pub fn v_ub() -> Epistemic with Mut, Div, Panic {
 }
 
 /// CKM matrix element |V_cd| ≈ −λ.
-pub fn v_cd() -> Epistemic {
+pub fn v_cd() -> Epistemic with Mut, Div, Panic {
     let lam = ckm_lambda()
     Epistemic::measured(0.0 - lam.val(), lam.std())
 }
@@ -276,7 +276,7 @@ pub fn v_td() -> Epistemic with Mut, Div, Panic {
 
 /// QCD scale parameter (MS-bar, N_f = 5).
 /// PDG 2024: Λ_QCD ≈ 210 ± 20 MeV = 0.210 ± 0.020 GeV.
-pub fn lambda_qcd() -> Epistemic {
+pub fn lambda_qcd() -> Epistemic with Mut, Div, Panic {
     Epistemic::measured(0.210, 0.020)
 }
 


### PR DESCRIPTION
## Summary
- Declare `with Mut, Div, Panic` on `sm_params` thin `Epistemic::measured` accessors (tip Madaros E035 promote blocker)
- Promote rebuilt tip Madaros → `bin/madaros-linux-x86_64` (sha256 `f9ddba96…`)
- #1627 shipped fixture green; E175 trilogy + EXP17/18/19 dual-engine OK

## Test plan
- [x] `REQUIRE_SHIPPED_GREEN=1 bash scripts/research/particle_e175_1627_gate.sh`
- [x] `bash scripts/research/particle_e175_amp_import_gate.sh`
- [x] EXP17 / EXP18 / EXP19 gates

Closes #1627