### PR TITLE
feat(trust): C1 Madaros imported Epistemic Var preserve

### DIFF
--- a/artifacts/compiler/madaros_imported_ep_var_preserve_receipt.v1.json
+++ b/artifacts/compiler/madaros_imported_ep_var_preserve_receipt.v1.json
@@ -1,0 +1,9 @@
+{
+  "schema": "madaros.imported_ep_var_preserve.v1",
+  "classification": "TRUSTWORTHY",
+  "ep_var_mb_scale18": 900000000000000,
+  "ep_var_amp_scale18": 1354,
+  "engines": ["lean_single", "madaros"],
+  "fixture": "tests/epistemic_trust/imported_ep_var_preserve.sio",
+  "note": "bit-identical scaled Var; EXP print_f64 0.000000 was display rounding of ~1e-15 not corruption"
+}

--- a/docs/audit/EPISTEMIC_TRUST_MAP_2026-07-14.md
+++ b/docs/audit/EPISTEMIC_TRUST_MAP_2026-07-14.md
@@ -9,7 +9,7 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.epistemi
 
 # Epistemic trust map — which stdlib/epistemic results a real program can trust today
 
-**Date:** 2026-07-14 (Wave10 k95 closeout 2026-07-21)
+**Date:** 2026-07-14 (Wave10 k95 closeout 2026-07-21; **C1 imported ep-var preserve 2026-08-06**)
 **Toolchain:** `./bin/souc` → Madaros v0.80.0 (default **native** engine)
 **Scope:** core uncertainty primitives (GUM, uncertainty propagation, Knowledge<T>,
 correlation/covariance, imprecise probability). Bounded, not exhaustive.
@@ -55,6 +55,7 @@ A result is usable under native import iff **both** hold:
 | `propagate` (delta-method + MC) | product `6`/`0.25`; `exp_delta(1,σ²=0.01)` → `e` / `e²·0.01`; MC identity mean≈`1` var≈`0.01`; MC square E[X²]≈`4.01` var≈`0.16` | **2026-07-20 multi-module green** for free-function `Epistemic` + `exp_delta`/`product`/`ln`/`sin`/`cos_delta` and value-style LCG MC kernels (`monte_carlo_identity`, `monte_carlo_square`). Gate: `scripts/madaros_propagate_native_gate.sh` + Section A `PROPAGATE_TRUST_OK`. Caveats (pre-Wave6-C): literal `exp`/`cos` SEGV — **fixed** (empty-stub builtins only); remaining: exclusive-ref xoshiro inside imported bodies untrustworthy (MC uses Knuth LCG+CLT); generic `monte_carlo(x,f,n)` fn-ptr still fragile. |
 | `algebra::associator_field` | non-Fano ‖α‖²=`4`, g2=`2`, aug var=`4.25`; pentagon (e1,e2,e4,e1) var=`0.96` | **2026-07-20 multi-module green** after #1274 oct_mul lo/hi split + pub API surface (`assoc_field_*`, `pentagon_*`, `af_*`). Gate: `scripts/madaros_associator_field_native_gate.sh`. L0: `associator_field_octonion` + `associator_field_pentagon`. |
 | `algebra::octonion` (`oct_mul`, `oct_associator`, …) | e1·e2→e3; non-Fano ‖[e1,e2,e4]‖²=`4` | **2026-07-20** lo/hi frame split. Gate: `scripts/madaros_algebra_octonion_import_gate.sh`. |
+| `particle_physics::nonunitary_amp` + `sm_params::mass_bottom` | imported `Epistemic` **variance** bit-identical Madaros≡lean_single (scaled i64×1e18): `mass_bottom` → `900000000000000` (=0.0009×1e18); `h_bb_yukawa_amplitude_nu` amp → `1354` (~1.354e-15×1e18) | **C1 2026-08-06** — EXP `print_f64` `0.000000` was display rounding of ~1e-15, not Var corruption. Gate: `scripts/ci/madaros_imported_ep_var_preserve_gate.sh`. Audit: `docs/audit/MADAROS_IMPORTED_EP_VAR_PRESERVE_2026-08-06.md`. |
 
 Heuristic: **self-contained modules (no stdlib `use` deps) import cleanly and
 return correct numbers** under default Madaros. Method-call form on `Epistemic`
@@ -124,8 +125,10 @@ Historical failures reduce to filed compiler dispatches (status as of Wave10):
 ## Living boundary
 
 `scripts/epistemic_trust_gate.sh` gates the trustworthy set (Section A), including
-finite-dof gum k95 (`witness_gum_k95` → `2776`). Section B (k95 trip-wire) is
-**retired**. Update this map when a residual Section C / fragile form graduates.
+finite-dof gum k95 (`witness_gum_k95` → `2776`) and **C1 imported ep-var preserve**
+(`madaros_imported_ep_var_preserve_gate.sh` — Madaros≡lean_single scaled Var).
+Section B (k95 trip-wire) is **retired**. Update this map when a residual
+Section C / fragile form graduates.
 
 ## AI disclosure
 

--- a/docs/audit/MADAROS_IMPORTED_EP_VAR_PRESERVE_2026-08-06.md
+++ b/docs/audit/MADAROS_IMPORTED_EP_VAR_PRESERVE_2026-08-06.md
@@ -1,0 +1,51 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-imported-ep-var-preserve-2026-08-06
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-imported-ep-var-preserve-2026-08-06
+-->
+
+
+# Madaros C1 — imported Epistemic variance preservation (2026-08-06)
+
+## Claim
+
+Under default Madaros native multimodule import, Epistemic **variance** returned
+from `sm_params::mass_bottom` and from `nonunitary_amp::h_bb_yukawa_amplitude_nu`
+(H pole) is **bit-identical** (scaled i64 ×1e18) to lean_single.
+
+Classification: **TRUSTWORTHY** (trust map row + Section A gate).
+
+## Measurement (shipped Madaros, 2026-08-06)
+
+| Quantity | scale18 i64 | Meaning |
+|---|---:|---|
+| `ep_variance(mass_bottom())` | `900000000000000` | PDG σ=0.03 → var=0.0009 |
+| `ep_variance(h_bb…amp_sq)` at pole | `1354` | ≈1.354×10⁻¹⁵ |
+
+Both engines print the same integers. Fixture sentinel:
+`MADAROS_IMPORTED_EP_VAR_PRESERVE_OK`.
+
+## Non-finding (important)
+
+Particle EXP18/19 sometimes printed `AMP_VAR 0.000000` under Madaros while
+lean_single showed `~1e-15`. That was **`print_f64` display rounding**, not
+loss of GUM variance on the imported path. The preserve gate reads variance via
+`ep_variance` + integer scale, avoiding #862/`print_f64`.
+
+## Reproduce
+
+```bash
+export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+bash scripts/ci/madaros_imported_ep_var_preserve_gate.sh
+# expect: MADAROS_IMPORTED_EP_VAR_PRESERVE_GATE_OK
+```
+
+Receipt: `artifacts/compiler/madaros_imported_ep_var_preserve_receipt.v1.json`
+
+## Related
+
+- Trust map: `docs/audit/EPISTEMIC_TRUST_MAP_2026-07-14.md`
+- Parent gate: `scripts/epistemic_trust_gate.sh` (Section A hooks this gate)

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1308
-- Repo-backed topics: 1158
+- Total governed topics: 1309
+- Repo-backed topics: 1159
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 396
-- Authority count `repo_only`: 724
+- Authority count `repo_only`: 725
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 741 topics
+- A2: 742 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 36 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -165,6 +165,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-impl-method-two-roots-2026-06-23 | repo_only | docs/audit/MADAROS_IMPL_METHOD_TWO_ROOTS_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-impl-methods-three-layer-fix-2026-06-23 | repo_only | docs/audit/MADAROS_IMPL_METHODS_THREE_LAYER_FIX_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-imported-array-byvalue-913-2026-07-21 | repo_only | docs/audit/MADAROS_IMPORTED_ARRAY_BYVALUE_913_2026-07-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-imported-ep-var-preserve-2026-08-06 | repo_only | docs/audit/MADAROS_IMPORTED_EP_VAR_PRESERVE_2026-08-06.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-imported-f64-bss-arith-2026-07-22 | repo_only | docs/audit/MADAROS_IMPORTED_F64_BSS_ARITH_2026-07-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-imported-f64-mul-2026-07-26 | repo_only | docs/audit/MADAROS_IMPORTED_F64_MUL_2026-07-26.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-imported-module-f64-cast-bitcast-2026-07-14 | repo_only | docs/audit/MADAROS_IMPORTED_MODULE_F64_CAST_BITCAST_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -3259,6 +3259,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-imported-ep-var-preserve-2026-08-06",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_IMPORTED_EP_VAR_PRESERVE_2026-08-06.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-imported-f64-bss-arith-2026-07-22",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_IMPORTED_F64_BSS_ARITH_2026-07-22.md",

--- a/scripts/ci/madaros_imported_ep_var_preserve_gate.sh
+++ b/scripts/ci/madaros_imported_ep_var_preserve_gate.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# C1 — Madaros imported Epistemic variance preservation (fail-closed).
+#
+# Fixture: tests/epistemic_trust/imported_ep_var_preserve.sio
+# Compares lean_single vs Madaros on scaled i64 Var reports for:
+#   - mass_bottom() Epistemic variance (PDG σ=0.03 → var=9e-4)
+#   - h_bb_yukawa_amplitude_nu amp_sq variance at H pole
+#
+# Requires bit-identical scaled integers across engines (trust axis).
+# Madaros retry×3 for intermittent native SEGV under load.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
+
+SRC=tests/epistemic_trust/imported_ep_var_preserve.sio
+OUT_DIR="$(mktemp -d /tmp/ep_var_preserve.XXXXXX)"
+trap 'rm -rf "$OUT_DIR"' EXIT
+
+extract_field() {
+  local file="$1" key="$2"
+  awk -v k="$key" '$1 == k { print $2; exit }' "$file"
+}
+
+run_eng() {
+  local eng="$1" out="$2" err="$3"
+  local attempts=1
+  if [ "$eng" = madaros ]; then
+    attempts=3
+  fi
+  local try=1
+  while [ "$try" -le "$attempts" ]; do
+    echo "== imported ep-var engine=$eng try=$try =="
+    set +e
+    SOUNIO_SOUC_ENGINE="$eng" ./bin/souc run "$SRC" >"$out" 2>"$err"
+    local rc=$?
+    set -e
+    if grep -q 'MADAROS_IMPORTED_EP_VAR_PRESERVE_OK' "$out"; then
+      return 0
+    fi
+    if [ "$try" -eq "$attempts" ]; then
+      echo "engine=$eng failed rc=$rc" >&2
+      tail -40 "$err" >&2
+      grep -E 'EP_|PRESERVE_' "$out" >&2 || true
+      exit 1
+    fi
+    echo "engine=$eng soft-fail rc=$rc; retrying" >&2
+    try=$((try + 1))
+    sleep 1
+  done
+}
+
+run_eng lean_single "$OUT_DIR/lean_out.txt" "$OUT_DIR/lean_err.txt"
+run_eng madaros "$OUT_DIR/mad_out.txt" "$OUT_DIR/mad_err.txt"
+
+# Strip compiler banners: keep only EP_/PRESERVE_ lines
+grep -E '^(EP_|MADAROS_IMPORTED_EP_VAR_PRESERVE_)' "$OUT_DIR/lean_out.txt" >"$OUT_DIR/lean_keys.txt"
+grep -E '^(EP_|MADAROS_IMPORTED_EP_VAR_PRESERVE_)' "$OUT_DIR/mad_out.txt" >"$OUT_DIR/mad_keys.txt"
+
+lean_mb=$(extract_field "$OUT_DIR/lean_keys.txt" EP_VAR_MB_SCALE18)
+lean_amp=$(extract_field "$OUT_DIR/lean_keys.txt" EP_VAR_AMP_SCALE18)
+mad_mb=$(extract_field "$OUT_DIR/mad_keys.txt" EP_VAR_MB_SCALE18)
+mad_amp=$(extract_field "$OUT_DIR/mad_keys.txt" EP_VAR_AMP_SCALE18)
+
+if [[ -z "$lean_mb" || -z "$lean_amp" || -z "$mad_mb" || -z "$mad_amp" ]]; then
+  echo "FAIL: missing scaled Var fields" >&2
+  cat "$OUT_DIR/lean_keys.txt" "$OUT_DIR/mad_keys.txt" >&2
+  exit 1
+fi
+
+if [[ "$lean_mb" != "$mad_mb" || "$lean_amp" != "$mad_amp" ]]; then
+  echo "FAIL: Madaros/lean Var mismatch (CORRUPTED)" >&2
+  echo "  lean mb=$lean_mb amp=$lean_amp" >&2
+  echo "  mad  mb=$mad_mb amp=$mad_amp" >&2
+  exit 1
+fi
+
+# PDG m_b σ=0.03 → var=0.0009 → *1e18 = 900_000_000_000_000
+if [[ "$lean_mb" != "900000000000000" ]]; then
+  echo "FAIL: mass_bottom var scale18 expected 900000000000000 got $lean_mb" >&2
+  exit 1
+fi
+
+# Amp var ~1.354e-15 → scale18 ≈ 1354 (measured lean+Madaros 2026-08-06)
+if [[ "$lean_amp" -lt 1000 || "$lean_amp" -gt 2000 ]]; then
+  echo "FAIL: amp var scale18 out of expected band [1000,2000] got $lean_amp" >&2
+  exit 1
+fi
+
+RECEIPT_DIR=artifacts/compiler
+mkdir -p "$RECEIPT_DIR"
+RECEIPT="$RECEIPT_DIR/madaros_imported_ep_var_preserve_receipt.v1.json"
+cat >"$RECEIPT" <<EOF
+{
+  "schema": "madaros.imported_ep_var_preserve.v1",
+  "classification": "TRUSTWORTHY",
+  "ep_var_mb_scale18": $lean_mb,
+  "ep_var_amp_scale18": $lean_amp,
+  "engines": ["lean_single", "madaros"],
+  "fixture": "$SRC",
+  "note": "bit-identical scaled Var; EXP print_f64 0.000000 was display rounding of ~1e-15 not corruption"
+}
+EOF
+
+echo "MADAROS_IMPORTED_EP_VAR_PRESERVE_GATE_OK"
+echo "receipt=$RECEIPT"
+echo "mb_scale18=$lean_mb amp_scale18=$lean_amp"

--- a/scripts/epistemic_trust_gate.sh
+++ b/scripts/epistemic_trust_gate.sh
@@ -41,6 +41,16 @@ runproof "product_nonassoc: fano/nonfano" tests/epistemic_trust/product_nonassoc
 # Full propagate delta-method + value-style LCG MC (2026-07-20): exp/product + MC kernels.
 runproof "propagate: exp/product/MC" tests/epistemic_trust/propagate_trust.sio PROPAGATE_TRUST_OK
 
+# C1 (2026-08-06): imported Epistemic Var preserve under particle amp graph.
+# Dual-engine parity (lean_single ≡ Madaros scaled i64). Fail-closed.
+echo "== imported ep-var preserve (Madaros ≡ lean_single) =="
+if bash scripts/ci/madaros_imported_ep_var_preserve_gate.sh; then
+  echo "PASS: MADAROS_IMPORTED_EP_VAR_PRESERVE_GATE_OK"
+else
+  echo "FAIL: imported ep-var preserve gate"
+  fail=1
+fi
+
 # Finite-dof coverage factor (promoted from retired Section B trip-wire).
 # Expect k95*1000 = 2776 = t95(4) on Type-A-dominant budget (NOT 1960).
 echo "== gum k95 coverage factor (gating: expect 2776 = t95(4)) =="

--- a/tests/epistemic_trust/imported_ep_var_preserve.sio
+++ b/tests/epistemic_trust/imported_ep_var_preserve.sio
@@ -1,0 +1,66 @@
+// tests/epistemic_trust/imported_ep_var_preserve.sio
+//
+// C1 — Madaros imported Epistemic variance preservation (dual-engine).
+//
+// Imports particle_physics::nonunitary_amp and reports Var via scaled i64
+// (avoid print_f64 / #862). Scale = 1e18 (fits i64 for mb var ~9e-4 and
+// amp var ~1e-15).
+//
+// Gate: scripts/ci/madaros_imported_ep_var_preserve_gate.sh
+
+use particle_physics::sm_params::{mass_h, mass_bottom}
+use particle_physics::nonunitary_amp::{h_bb_yukawa_amplitude_nu}
+use epistemic::knowledge::{ep_val, ep_variance}
+
+fn scale18(v: f64) -> i64 with Div, Panic {
+    let s = v * 1000000000000000000.0
+    s as i64
+}
+
+fn main() -> i32 with IO, NonUnitary, Mut, Div, Panic {
+    let mh = mass_h().val()
+    let s_pole = mh * mh
+    let gh = 0.00407
+
+    let mb = mass_bottom()
+    let mb_var = ep_variance(&mb)
+    let mb_vi = scale18(mb_var)
+
+    let nu = h_bb_yukawa_amplitude_nu(s_pole, gh)
+    let amp = ep_val(&nu.amp_sq)
+    let amp_var = ep_variance(&nu.amp_sq)
+    let amp_vi = scale18(amp_var)
+    let amp_i = (amp * 1000000000000.0) as i64
+
+    print("EP_VAR_MB_SCALE18 ")
+    print_int(mb_vi)
+    print("\n")
+    print("EP_VAR_AMP_SCALE18 ")
+    print_int(amp_vi)
+    print("\n")
+    print("EP_AMP_SCALE12 ")
+    print_int(amp_i)
+    print("\n")
+
+    // PDG m_b σ=0.03 → var=0.0009 → *1e18 = 900_000_000_000_000
+    // Allow ±1% band for float noise.
+    let mb_ok = mb_vi > 890000000000000 && mb_vi < 910000000000000
+    // Amp GUM var at pole is tiny (~1e-15); require strictly positive scaled.
+    let amp_ok = amp_vi > 0
+    let amp_val_ok = amp_i > 0 && amp_i < 10000000
+
+    if mb_ok && amp_ok && amp_val_ok {
+        print("MADAROS_IMPORTED_EP_VAR_PRESERVE_OK\n")
+        0
+    } else {
+        print("MADAROS_IMPORTED_EP_VAR_PRESERVE_FAIL\n")
+        print("EP_VAR_DIAG mb_ok=")
+        print_int(if mb_ok { 1 } else { 0 })
+        print(" amp_ok=")
+        print_int(if amp_ok { 1 } else { 0 })
+        print(" amp_val_ok=")
+        print_int(if amp_val_ok { 1 } else { 0 })
+        print("\n")
+        1
+    }
+}


### PR DESCRIPTION
## Summary
- Dual-engine fail-closed gate: Madaros ≡ lean_single on imported `Epistemic` variance (`mass_bottom` + `h_bb_yukawa_amplitude_nu`)
- Classification **TRUSTWORTHY** — EXP `print_f64` `0.000000` was rounding of ~1e-15, not Var loss
- Trust map + Section A hook in `epistemic_trust_gate.sh`

## Test plan
- [x] `bash scripts/ci/madaros_imported_ep_var_preserve_gate.sh` → `MADAROS_IMPORTED_EP_VAR_PRESERVE_GATE_OK`
- [x] `bash scripts/epistemic_trust_gate.sh` → `EPISTEMIC_TRUST_GATE_OK`