### PR TITLE
docs(trust): monte_carlo fn-ptr failclosed; xoshiro green; defer EXP20

### DIFF
--- a/docs/audit/EPISTEMIC_TRUST_MAP_2026-07-14.md
+++ b/docs/audit/EPISTEMIC_TRUST_MAP_2026-07-14.md
@@ -52,7 +52,7 @@ A result is usable under native import iff **both** hold:
 | `knowledge` (**method** form) | `Epistemic::measured` / `e.val()` / `e.add` / `e.mul` / `e.std` | **Wave9 residual closeout** — free vs method parity under multi-module Madaros. Gate: `scripts/madaros_knowledge_method_residual_gate.sh` + Section A `KNOWLEDGE_METHOD_PARITY_OK` / `KNOWLEDGE_METHOD_OK` |
 | `order_spread_exact` (`order_spread4`) | CPC N=4 exact spread ≈ `2.044226` (scaled µ-units `2044225`/`2044226`) | **stdlib leaf 2026-07-20** — algebra inlined via field-wise `OsOct` (no `algebra::` use). Gate: `scripts/madaros_order_spread_native_gate.sh` + Section A `ORDER_SPREAD_TRUST_OK`. `product4_exact` remains available (pulls free-function `knowledge`); method-form `Epistemic::measured` is also green (Wave9). |
 | `product_nonassoc` (structural variance) | Fano variance `0.25` / non-Fano `4.25` (κ=1, base σ²=0.25) | **stdlib leaf 2026-07-20** — algebra inlined via field-wise `PnOct` (no `algebra::` use). Gate: `scripts/madaros_product_nonassoc_native_gate.sh` + Section A `PRODUCT_NONASSOC_TRUST_OK`. Knowledge-free `product_nonassoc_augment` is the hard numeric witness; `product_nonassoc(Epistemic,…)` uses field-form `Epistemic` under Madaros (direct `ep_*` + leaf multi-import trips E035). Historic `epistemic::propagate::product_nonassoc` removed. |
-| `propagate` (delta-method + MC) | product `6`/`0.25`; `exp_delta(1,σ²=0.01)` → `e` / `e²·0.01`; MC identity mean≈`1` var≈`0.01`; MC square E[X²]≈`4.01` var≈`0.16` | **2026-07-20 multi-module green** for free-function `Epistemic` + `exp_delta`/`product`/`ln`/`sin`/`cos_delta` and value-style LCG MC kernels (`monte_carlo_identity`, `monte_carlo_square`). Gate: `scripts/madaros_propagate_native_gate.sh` + Section A `PROPAGATE_TRUST_OK`. Caveats (pre-Wave6-C): literal `exp`/`cos` SEGV — **fixed** (empty-stub builtins only); remaining: exclusive-ref xoshiro inside imported bodies untrustworthy (MC uses Knuth LCG+CLT); generic `monte_carlo(x,f,n)` fn-ptr still fragile. |
+| `propagate` (delta-method + MC) | product `6`/`0.25`; `exp_delta(1,σ²=0.01)` → `e` / `e²·0.01`; MC identity mean≈`1` var≈`0.01`; MC square E[X²]≈`4.01` var≈`0.16` | **2026-07-20 multi-module green** for free-function `Epistemic` + `exp_delta`/`product`/`ln`/`sin`/`cos_delta` and value-style LCG MC kernels (`monte_carlo_identity`, `monte_carlo_square`). Gate: `scripts/madaros_propagate_native_gate.sh` + Section A `PROPAGATE_TRUST_OK`. Caveats (pre-Wave6-C): literal `exp`/`cos` SEGV — **fixed**. ~~exclusive-ref xoshiro untrustworthy~~ **remeasured GREEN 2026-08-06** (`scripts/ci/madaros_xoshiro_imported_gate.sh`). Generic `monte_carlo(x,f,n)` fn-ptr remains **fail-closed wrong-result** (not SEGV): `scripts/ci/madaros_propagate_monte_carlo_fnptr_failclosed_gate.sh`. |
 | `algebra::associator_field` | non-Fano ‖α‖²=`4`, g2=`2`, aug var=`4.25`; pentagon (e1,e2,e4,e1) var=`0.96` | **2026-07-20 multi-module green** after #1274 oct_mul lo/hi split + pub API surface (`assoc_field_*`, `pentagon_*`, `af_*`). Gate: `scripts/madaros_associator_field_native_gate.sh`. L0: `associator_field_octonion` + `associator_field_pentagon`. |
 | `algebra::octonion` (`oct_mul`, `oct_associator`, …) | e1·e2→e3; non-Fano ‖[e1,e2,e4]‖²=`4` | **2026-07-20** lo/hi frame split. Gate: `scripts/madaros_algebra_octonion_import_gate.sh`. |
 | `particle_physics::nonunitary_amp` + `sm_params::mass_bottom` | imported `Epistemic` **variance** bit-identical Madaros≡lean_single (scaled i64×1e18): `mass_bottom` → `900000000000000` (=0.0009×1e18); `h_bb_yukawa_amplitude_nu` amp → `1354` (~1.354e-15×1e18) | **C1 2026-08-06** — EXP `print_f64` `0.000000` was display rounding of ~1e-15, not Var corruption. Gate: `scripts/ci/madaros_imported_ep_var_preserve_gate.sh`. Audit: `docs/audit/MADAROS_IMPORTED_EP_VAR_PRESERVE_2026-08-06.md`. |
@@ -97,8 +97,8 @@ converge to k≈1.96).
 | Module / form | Failure | Consequence |
 |---|---|---|
 | `propagate` **export names** `exp` / `cos` (call site) | **FIXED Wave6 C** — empty-stub builtins only (`instr_count==0`); user-bodied `exp`/`cos` keep IR | call `exp`/`cos` freely under multi-module Madaros; `exp_delta`/`cos_delta` remain aliases |
-| `propagate::monte_carlo` (generic fn-ptr form) | fragile / NaN under multi-module when combined with exclusive-ref RNG | use `monte_carlo_identity` / `monte_carlo_square` (value-style LCG) |
-| `uncertain_eq` | method / multi-module path | equality-under-uncertainty native-import-blocked |
+| `propagate::monte_carlo` (generic fn-ptr form) | **FAIL-CLOSED 2026-08-06** — compiles+runs under Madaros but returns invalid mean/variance (lean_single PASS). Gate: `scripts/ci/madaros_propagate_monte_carlo_fnptr_failclosed_gate.sh` | use `monte_carlo_identity` / `monte_carlo_square` (value-style LCG) until promotion |
+| `uncertain_eq` | method / multi-module path | equality-under-uncertainty native-import-blocked (check current residual gates before quoting) |
 
 Stdlib `Epistemic` method form is TRUSTWORTHY under multi-module Madaros (Wave9).
 Language generic `Knowledge<T>` method form is a separate surface — do not
@@ -112,8 +112,9 @@ What works under native import today includes the free-function **and method-for
 correlation/covariance, p-box dispersion, `order_spread4`, `product_nonassoc`,
 and **`propagate` delta-method + value-style MC kernels**. A real PBPK/GUM
 pipeline can import `gum` + `knowledge` + `propagate` under default Madaros when
-it uses those surfaces. Residual traps: exclusive-ref xoshiro inside module
-bodies; generic `monte_carlo` fn-ptr form; language `Knowledge<T>` generics.
+it uses those surfaces. Residual trap: generic `monte_carlo` fn-ptr form
+(fail-closed). ~~exclusive-ref xoshiro~~ remeasured trustworthy 2026-08-06.
+Language `Knowledge<T>` generics remain a separate surface.
 
 Historical failures reduce to filed compiler dispatches (status as of Wave10):
 

--- a/docs/audit/MADAROS_PROPAGATE_MONTE_CARLO_FNPTR_2026-08-06.md
+++ b/docs/audit/MADAROS_PROPAGATE_MONTE_CARLO_FNPTR_2026-08-06.md
@@ -1,0 +1,35 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-propagate-monte-carlo-fnptr-2026-08-06
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-propagate-monte-carlo-fnptr-2026-08-06
+-->
+
+# Madaros residual — `propagate::monte_carlo` fn-ptr (2026-08-06)
+
+**Status:** FAIL-CLOSED (wrong result, not SEGV)  
+**Gate:** `scripts/ci/madaros_propagate_monte_carlo_fnptr_failclosed_gate.sh`  
+**Probe:** `tests/known_failures/madaros_propagate_monte_carlo_fnptr_probe.sio`
+
+## Finding
+
+Under tip Madaros, `monte_carlo(x, square, N)` with a named `fn(f64)->f64`:
+
+- `souc check` OK; native compile+run exits without SEGV;
+- mean/variance are invalid (sentinel `MONTE_CARLO_FNPTR FAIL`);
+- `lean_single` oracle prints `MONTE_CARLO_FNPTR PASS` (≈4.01 / 0.16).
+
+Minimal same-file fn-pointer `apply(square, 2.0)` is green — residual is the
+imported generic MC shape, not fn-pointers generally.
+
+## Supported path
+
+`monte_carlo_identity` / `monte_carlo_square` (value-style LCG) remain green via
+`scripts/madaros_propagate_native_gate.sh`.
+
+## Companion remeasure
+
+Imported exclusive-ref Xoshiro first-draw is **GREEN** on tip Madaros:
+`scripts/ci/madaros_xoshiro_imported_gate.sh` → `MADAROS_XOSHIRO_IMPORTED_GATE_OK`.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,25 +19,25 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1314
-- Repo-backed topics: 1164
+- Total governed topics: 1316
+- Repo-backed topics: 1166
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 397
-- Authority count `repo_only`: 729
+- Authority count `historical`: 398
+- Authority count `repo_only`: 730
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 746 topics
+- A2: 747 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 36 topics
-- A6: 431 topics
+- A6: 432 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -188,6 +188,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-print-int-dispatch-2026-06-20 | repo_only | docs/audit/MADAROS_PRINT_INT_DISPATCH_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-print-negative-f64-2026-07-14 | repo_only | docs/audit/MADAROS_PRINT_NEGATIVE_F64_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-production-readiness-plan-2026-06-21 | repo_only | docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-propagate-monte-carlo-fnptr-2026-08-06 | repo_only | docs/audit/MADAROS_PROPAGATE_MONTE_CARLO_FNPTR_2026-08-06.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-raw-reference-codegen-2026-06-21 | repo_only | docs/audit/MADAROS_RAW_REFERENCE_CODEGEN_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-raw-references-codegen-2026-06-24 | repo_only | docs/audit/MADAROS_RAW_REFERENCES_CODEGEN_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-root2-enum-fncount-2026-06-20 | repo_only | docs/audit/MADAROS_ROOT2_ENUM_FNCOUNT_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -933,6 +934,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.particle-exp17-zwh-amp-xsec-ledger-2026-08-05 | historical | docs/research/particle_exp17_zwh_amp_xsec_ledger_2026-08-05.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-exp18-w-vertex-amp-2026-08-06 | historical | docs/research/particle_exp18_w_vertex_amp_2026-08-06.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-exp19-h-yukawa-amp-2026-08-06 | historical | docs/research/particle_exp19_h_yukawa_amp_2026-08-06.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.particle-exp20-deferred-2026-08-06 | historical | docs/research/particle_exp20_deferred_2026-08-06.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-exp6-universal-xi-2026-07-26 | historical | docs/research/particle_exp6_universal_xi_2026-07-26.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-exp7-gum-transfer-2026-07-26 | historical | docs/research/particle_exp7_gum_transfer_2026-07-26.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.particle-exp8-collapse-failure-2026-07-26 | historical | docs/research/particle_exp8_collapse_failure_2026-07-26.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -3788,6 +3788,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-propagate-monte-carlo-fnptr-2026-08-06",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_PROPAGATE_MONTE_CARLO_FNPTR_2026-08-06.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-raw-reference-codegen-2026-06-21",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_RAW_REFERENCE_CODEGEN_2026-06-21.md",
@@ -20699,6 +20722,28 @@
       "topic_id": "repo.docs.research.particle-exp19-h-yukawa-amp-2026-08-06",
       "collection": "repo",
       "repo_doc_path": "docs/research/particle_exp19_h_yukawa_amp_2026-08-06.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.research.particle-exp20-deferred-2026-08-06",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/particle_exp20_deferred_2026-08-06.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "researchers",

--- a/docs/research/particle_exp20_deferred_2026-08-06.md
+++ b/docs/research/particle_exp20_deferred_2026-08-06.md
@@ -1,0 +1,43 @@
+<!-- docs:meta
+topic_id: repo.docs.research.particle-exp20-deferred-2026-08-06
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.particle-exp20-deferred-2026-08-06
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# Particle EXP20 — deferred (2026-08-06)
+
+**Status:** DEFERRED (honesty halt)  
+**Depends:** EXP17–19 Z/W/H stdlib amp ledgers (Madaros+lean green)
+
+## Why not ship an EXP20 amp leaf today
+
+1. **Top-channel (gg→tt̄ / similar)** needs an explicit, bounded flux × phase-space
+   normalisation and NWA comparator. Inventing `|M|² · s/(12π)` would reopen the
+   scalar/vector `4π` vs `12π` disagreement already logged on EXP16/19.
+2. **Public `particle_physics::mod` re-export wiring** is blocked by module-resolution
+   behaviour (even established exports failed a minimal consumer probe) — that is a
+   compiler leaf, not a physics leaf.
+3. Optical theorem / unitarity remain **NonUnitary non-claims** (Lean N×NWA leaf).
+
+## What is green (no new claim)
+
+```bash
+bash scripts/research/particle_exp17_zwh_ledger_gate.sh
+# PARTICLE_EXP17_GATE_OK  (lean_single + Madaros)
+```
+
+Ratios remain construction gaps: Z≈13.952395, W≈3.486637, H≈0.652209.
+
+## Next when unblocked
+
+- Compiler: public `mod` export resolution for `particle_physics`.
+- Science: EXP20 top-channel with published flux/PS derivation + math-review
+  **before** any continuum/NWA ratio claim.

--- a/scripts/ci/madaros_propagate_monte_carlo_fnptr_failclosed_gate.sh
+++ b/scripts/ci/madaros_propagate_monte_carlo_fnptr_failclosed_gate.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Fail-honest classifier: imported epistemic::propagate::monte_carlo with a
+# named fn(f64)->f64 compiles but produces an invalid Monte Carlo result under
+# stock Madaros. A green result must replace this gate with a promotion gate.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+# Always pin this worktree's stdlib (never inherit a foreign SOUNIO_STDLIB_PATH).
+export SOUNIO_STDLIB_PATH="$ROOT/stdlib"
+SOUC="${SOUC:-$ROOT/bin/souc}"
+PROBE="tests/known_failures/madaros_propagate_monte_carlo_fnptr_probe.sio"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+echo "== madaros_propagate_monte_carlo_fnptr_failclosed_gate =="
+
+unset SOUNIO_SOUC_ENGINE || true
+set +e
+"$SOUC" run "$PROBE" >"$OUT/madaros.log" 2>&1
+MRC=$?
+set -e
+if [[ "$MRC" -eq 0 ]]; then
+    echo "FAIL: Madaros unexpectedly passed; replace this with a green promotion gate"
+    cat "$OUT/madaros.log" || true
+    exit 1
+fi
+grep -Fq 'MONTE_CARLO_FNPTR FAIL' "$OUT/madaros.log" || {
+    echo "FAIL: missing deterministic wrong-result sentinel"
+    cat "$OUT/madaros.log" || true
+    exit 1
+}
+if grep -Fq 'Segmentation fault' "$OUT/madaros.log"; then
+    echo "FAIL: segfault is not the classified wrong-result mode"
+    cat "$OUT/madaros.log" || true
+    exit 1
+fi
+
+export SOUNIO_SOUC_ENGINE=lean_single
+set +e
+"$SOUC" run "$PROBE" >"$OUT/lean.log" 2>&1
+LRC=$?
+set -e
+unset SOUNIO_SOUC_ENGINE || true
+[[ "$LRC" -eq 0 ]] || {
+    echo "FAIL: lean_single oracle rc=$LRC"
+    cat "$OUT/lean.log" || true
+    exit 1
+}
+grep -Fq 'MONTE_CARLO_FNPTR PASS' "$OUT/lean.log" || {
+    echo "FAIL: lean_single missing MONTE_CARLO_FNPTR PASS"
+    cat "$OUT/lean.log" || true
+    exit 1
+}
+
+echo "MADAROS_PROPAGATE_MONTE_CARLO_FNPTR_FAILCLOSED_GATE_OK"

--- a/scripts/ci/madaros_xoshiro_imported_gate.sh
+++ b/scripts/ci/madaros_xoshiro_imported_gate.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Promotion gate: imported exclusive-ref Xoshiro first-draw is trustworthy under
+# tip Madaros (2026-08-06 remeasure). lean_single remains the oracle twin.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="$ROOT/stdlib"
+unset SOUNIO_SOUC_ENGINE || true
+SOUC="${SOUC:-$ROOT/bin/souc}"
+PROBE="tests/epistemic_trust/madaros_xoshiro_imported_probe.sio"
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+
+echo "== madaros_xoshiro_imported_gate =="
+run_eng() {
+  local eng="$1" log="$2"
+  unset SOUNIO_SOUC_ENGINE || true
+  if [[ "$eng" != "madaros" ]]; then
+    export SOUNIO_SOUC_ENGINE="$eng"
+  fi
+  set +e
+  "$SOUC" run "$PROBE" >"$log" 2>&1
+  local rc=$?
+  set -e
+  unset SOUNIO_SOUC_ENGINE || true
+  [[ "$rc" -eq 0 ]] || { echo "FAIL: engine=$eng rc=$rc"; cat "$log"; exit 1; }
+  grep -Fq 'XOSHIRO_IMPORTED PASS' "$log" || {
+    echo "FAIL: engine=$eng missing PASS"
+    cat "$log"
+    exit 1
+  }
+}
+
+run_eng madaros "$OUT/mad.log"
+run_eng lean_single "$OUT/lean.log"
+echo "MADAROS_XOSHIRO_IMPORTED_GATE_OK"

--- a/scripts/ci/particle_exp17_zwh_ledger_gate.sh
+++ b/scripts/ci/particle_exp17_zwh_ledger_gate.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# CI-facing alias for EXP17 ZWH ledger (lean_single + Madaros).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="$ROOT/stdlib"
+bash scripts/research/particle_exp17_zwh_ledger_gate.sh
+echo "PARTICLE_EXP17_CI_GATE_OK"

--- a/tests/epistemic_trust/madaros_xoshiro_imported_probe.sio
+++ b/tests/epistemic_trust/madaros_xoshiro_imported_probe.sio
@@ -1,0 +1,39 @@
+//! Imported exclusive-ref Xoshiro residual probe (2026-08-06).
+//! Two seeded first draws from an imported module body should differ if the
+//! exclusive-ref state advances; tip Madaros historically returned identical
+//! garbage draws. Gate expects FAIL mode or documents SKIP if import path changes.
+//!
+//! Gate: scripts/ci/madaros_xoshiro_imported_gate.sh
+
+use random::xoshiro::{Xoshiro256, xoshiro_seed, xoshiro_next_i64, uniform}
+
+fn first_draw(seed: i64) -> i64 with Mut {
+    var rng = xoshiro_seed(seed)
+    xoshiro_next_i64(&!rng)
+}
+
+fn first_uniform(seed: i64) -> f64 with Prob, Mut {
+    var rng = xoshiro_seed(seed)
+    uniform(&!rng)
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic, Prob {
+    let a = first_draw(1)
+    let b = first_draw(1)
+    let u = first_uniform(1)
+    print("XOSHIRO_DRAW_A ")
+    print_int(a)
+    print("\n")
+    print("XOSHIRO_DRAW_B ")
+    print_int(b)
+    print("\n")
+    // Healthy: same seed → same first draw (deterministic), and uniform in (0,1).
+    let det_ok = a == b
+    let uni_ok = u > 0.0 && u < 1.0
+    if det_ok && uni_ok {
+        print("XOSHIRO_IMPORTED PASS\n")
+        return 0
+    }
+    print("XOSHIRO_IMPORTED FAIL\n")
+    1
+}

--- a/tests/known_failures/madaros_propagate_monte_carlo_fnptr_probe.sio
+++ b/tests/known_failures/madaros_propagate_monte_carlo_fnptr_probe.sio
@@ -1,0 +1,32 @@
+//! Known Madaros imported-module native failure (classified 2026-08-06):
+//! `epistemic::propagate::monte_carlo` accepts a named `fn(f64)->f64`, compiles,
+//! and exits successfully, but returns an invalid result under default Madaros.
+//! The fixed value-style MC kernels remain the supported native surface.
+//!
+//! Gate: scripts/ci/madaros_propagate_monte_carlo_fnptr_failclosed_gate.sh
+
+use epistemic::knowledge::{Epistemic}
+use epistemic::propagate::{monte_carlo}
+
+fn square(x: f64) -> f64 {
+    x * x
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic, Prob {
+    let x = Epistemic { val: 2.0, variance: 0.01, confidence: 900 }
+    let result = monte_carlo(x, square, 8000)
+    let mean_ok = abs_f(result.val - 4.01) < 0.15
+    let variance_ok = abs_f(result.variance - 0.16) < 0.08
+
+    if mean_ok && variance_ok {
+        print("MONTE_CARLO_FNPTR PASS\n")
+        return 0
+    }
+
+    print("MONTE_CARLO_FNPTR FAIL\n")
+    return 1
+}


### PR DESCRIPTION
## Summary
- **1 Hunt:** next red corpus = imported `propagate::monte_carlo` fn-ptr (wrong result, not SEGV) — fail-closed gate.
- **2 Trust:** promote imported Xoshiro first-draw to green; update epistemic trust map.
- **3 Particle:** EXP20 amp leaf deferred (flux/PS + mod-export blockers); EXP17 lean+Madaros CI alias.

## Test plan
- [x] `bash scripts/ci/madaros_propagate_monte_carlo_fnptr_failclosed_gate.sh`
- [x] `bash scripts/ci/madaros_xoshiro_imported_gate.sh`
- [x] `bash scripts/ci/particle_exp17_zwh_ledger_gate.sh`