### PR TITLE
fix(ir): DCE was blind to two register-operand classes (#1682)

### DIFF
--- a/self-hosted/ir/opt_cleanup.sio
+++ b/self-hosted/ir/opt_cleanup.sio
@@ -9302,6 +9302,43 @@ fn ocp_mfi_dce_once(module: &! IrModule, fi: i64) -> i64 with Mut, Div, Panic {
         if s2 >= 0 && s2 < 256 {
             used[s2 as usize] = true
         }
+        // #1682: NOT EVERY REGISTER USE LIVES IN src1/src2. This scan assumed it
+        // did, and two operand classes were invisible to it.
+        //
+        // IrIndexSet's THIRD operand -- the value being stored -- is parked in
+        // `imm_i64` (see ir_index_set), because IrInstr has only two source
+        // slots. An IMMEDIATE field holding a REGISTER is exactly what a liveness
+        // scan will not look at. `var a: [i64; 4] = [7; 4]` lowers to a fill loop
+        // whose only use of the 7 is that field, so the load_imm defining it was
+        // deleted as dead and the array was filled with garbage.
+        //
+        // ocp_rebracket_source_use_count already counted this operand. Two
+        // use-scanners disagreed, and the one that deletes was the wrong one.
+        if (*module).functions[fi as usize].instrs[i as usize].op == IrOpcode::IrIndexSet {
+            let v = (*module).functions[fi as usize].instrs[i as usize].imm_i64
+            if v >= 0 && v < 256 {
+                used[v as usize] = true
+            }
+        }
+        // Call arguments beyond the first two. ir_reg_list_first_two mirrors args
+        // 0 and 1 into src1/src2, so a two-argument call was already covered by
+        // accident; the THIRD argument onwards was not. Walking the chain needs no
+        // allocation -- same read-only shape mf_arebox_extract_at uses.
+        var arg_cur = (*module).functions[fi as usize].instrs[i as usize].call_args
+        var guard: i64 = 0
+        while guard < 64 {
+            match arg_cur {
+                Some(node) => {
+                    let h = (*node).head
+                    if h >= 0 && h < 256 {
+                        used[h as usize] = true
+                    }
+                    arg_cur = (*node).tail
+                    guard = guard + 1
+                }
+                _ => { guard = 64 }
+            }
+        }
         i = i + 1
     }
     var removed: i64 = 0

--- a/tests/run-pass/index_set_value_survives_dce.sio
+++ b/tests/run-pass/index_set_value_survives_dce.sio
@@ -1,0 +1,44 @@
+//@ run-pass
+//@ expect-stdout: a1=5 a2=9 b0=1 b3=4
+//
+// #1682: -O deleted the register holding the VALUE of an indexed store.
+//
+// IrIndexSet has three register operands -- base, index, value -- but IrInstr
+// has only src1/src2, so ir_index_set parks the value in `imm_i64`. An immediate
+// slot holding a register is exactly what a liveness scan does not look at, and
+// ocp_mfi_dce_once scanned src1/src2 only. The load_imm defining the stored
+// value was therefore removed as dead.
+//
+// Before the fix, under -O: a1=0 a2=0 b0=0 b3=0.
+//
+// Deliberately uses a ZERO-fill initialiser. A non-zero fill (`[7; 4]`) lowers
+// to a fill loop, and that loop hangs under -O on account of a SEPARATE, still
+// open defect (#1667, propagation across block boundaries) -- so a test written
+// that way would time out rather than fail, and would be testing two things at
+// once. Zero fill emits no loop, which isolates this defect exactly.
+//
+// Only meaningful WITH -O; without it the pass does not run and this passes
+// vacuously.
+//
+// Refs #1682, #1667
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    var a: [i64; 4] = [0; 4]
+    a[1 as usize] = 5
+    a[2 as usize] = 9
+    print("a1=")
+    print_int(a[1 as usize])
+    print(" a2=")
+    print_int(a[2 as usize])
+
+    var b: [i64; 4] = [0; 4]
+    var v: i64 = 1
+    b[0 as usize] = v
+    b[3 as usize] = v + 3
+    print(" b0=")
+    print_int(b[0 as usize])
+    print(" b3=")
+    print_int(b[3 as usize])
+    print("\n")
+    0
+}


### PR DESCRIPTION
`ocp_mfi_dce_once` marked a register used only if it appeared in `src1` or `src2`. Two kinds of register use are not stored there.

## The defect

**`IrIndexSet`'s third operand — the value being stored — lives in `imm_i64`**, because `IrInstr` has only two source slots:

```sounio
pub fn ir_index_set(base_reg: i64, idx_reg: i64, src_reg: i64) -> IrInstr {
    ...
    src1: base_reg,
    src2: idx_reg,
    imm_i64: src_reg,      // a REGISTER, in an IMMEDIATE slot
```

An immediate field holding a register is exactly what a liveness scan will not look at. So the `load_imm` defining a stored value was deleted as dead:

```sounio
var a: [i64; 4] = [0; 4]
a[1] = 5
print_int(a[1])          // 5 without -O, 0 with -O
```

**Call arguments beyond the first two** are the second class. `ir_reg_list_first_two` mirrors args 0 and 1 into `src1`/`src2`, so a two-argument call was covered *by accident*; the third argument onwards was invisible. Walking the chain needs no allocation — the same read-only shape `mf_arebox_extract_at` already uses.

## The tree already disagreed with itself

`ocp_rebracket_source_use_count` counts `src1`, `src2` **and** `IrIndexSet.imm_i64`. Two use-scanners had different ideas of what a use is, and **the one that was wrong is the one that deletes.**

## Evidence

```
stock main    -O:  a1=0 a2=0 b0=0 b3=0
this PR       -O:  a1=5 a2=9 b0=1 b3=4
```

`tests/run-pass/index_set_value_survives_dce.sio` pins it.

The test deliberately uses a **zero-fill** initialiser. A non-zero fill (`[7; 4]`) lowers to a fill loop, and that loop **hangs** under `-O` because of #1667 — separate and still open — so a test written that way would time out rather than fail, and would be testing two defects at once.

## No regression

- Madaros builds at the **6-error `origin/main` baseline**
- `--self-test` output **byte-identical** to stock main (20 OK / 7 FAIL)
- the **2948-test suite**: pass count identical at 377, and the FAIL set identical once the newly added test is excluded
- the new test passes under the suite's own CI configuration (1/1)

## Scope — what this does NOT fix

This does **not** make the five-line array-fill program terminate on `main`:

```sounio
var a: [i64; 4] = [7; 4]
print_int(a[0])          // still hangs under -O after this PR
```

That hang is **#1667** — the four propagation peels carry their table across block boundaries with no invalidation — which is demonstrable on its own with a loop containing no arrays at all (`origin/main` rc=124; a tree with #1667 fixed prints the right answer).

**#1682 alone is a wrong answer. #1667 is what turns it into a hang.** Both are open on `main`; this PR closes one of them.

Refs #1682, #1667

🤖 Generated with [Claude Code](https://claude.com/claude-code)