### PR TITLE
fix(ir): a float-marker nop is not dead (#1669), and carry float-ness on the register

### DIFF
--- a/self-hosted/ir/ir.sio
+++ b/self-hosted/ir/ir.sio
@@ -65,6 +65,79 @@ let SOUNIO_RUNTIME_VERSION_MINOR: i64 = 0
 let SOUNIO_RUNTIME_VERSION_PATCH: i64 = 0
 pub let IR_FLOAT_REG_MARKER_FLAG: i64 = 64064
 
+
+// ── #1669: float-ness carried on the REGISTER ────────────────────────────────
+//
+// The marker IrNop above says "this register holds an f64", but it says it as an
+// instruction, and an instruction can be deleted. ocp_mfi_compact_nops deleted
+// every nop including these, and every f64 returned from a call came back as
+// i64 MAX -- silently, under -O only. This bitset is the same fact attached to
+// the function, where no pass can drop it.
+//
+// The in-stream markers are KEPT. This is a union, not a replacement: the bits
+// are the durable channel, the markers are the legacy one, and they are measured
+// against each other rather than assumed to agree.
+
+pub fn ir_float_bits_capacity() -> i64 { 2048 }
+
+// Float marks for vregs above the cap cannot be represented here, and codegen's
+// fixpoint is then the only channel. Counted rather than fatal.
+pub var IR_FLOAT_BITS_OVER_CAP: i64 = 0
+
+// Evidence accumulated in globals and printed from the driver: the hot sites
+// carry no IO, and widening them would cascade the effect to every caller.
+pub var IR_FLOAT_BITS_WRITES: i64 = 0
+pub var IR_FLOAT_BITS_GETS: i64 = 0
+
+// TRUSTED=1: consumers seed from the bits. Landed with the measurement, not on
+// faith -- 390 float-bearing run-pass tests compiled AND RUN under -O with the
+// in-stream markers suppressed (IR_FLOAT_NO_MARKERS=1) match their markers-on
+// baseline 390/390, while the same suppression on a compiler without the
+// positional fix changes the output of 169 of them. Emitted code is unchanged.
+pub let IR_FLOAT_BITS_TRUSTED: i64 = 1
+
+// Test switch: when 1, the in-stream marker arms are skipped so the bits stand
+// alone. This is how the claim above is checked, and how it stays checkable.
+// A global rather than read_env at each site because read_env carries IO.
+pub var IR_FLOAT_NO_MARKERS: i64 = 0
+
+fn ir_float_bit_mask(bit: i64) -> i64 {
+    var m: i64 = 1
+    var k: i64 = 0
+    while k < bit {
+        m = m * 2
+        k = k + 1
+    }
+    m
+}
+
+pub fn ir_float_bits_get(f: &IrFunction, reg: i64) -> bool with Mut, Panic, Div {
+    if reg < 0 || reg >= ir_float_bits_capacity() { return false }
+    let word = reg / 32
+    let bit = reg % 32
+    let hit = ((*f).float_reg_bits[word as usize] / ir_float_bit_mask(bit)) % 2 == 1
+    if hit { IR_FLOAT_BITS_GETS = IR_FLOAT_BITS_GETS + 1 }
+    hit
+}
+
+pub fn ir_float_bits_set(f: &! IrFunction, reg: i64) -> i64 with Mut, Panic, Div {
+    if reg < 0 {
+        return 0
+    }
+    if reg >= ir_float_bits_capacity() {
+        IR_FLOAT_BITS_OVER_CAP = IR_FLOAT_BITS_OVER_CAP + 1
+        return 0
+    }
+    let word = reg / 32
+    let bit = reg % 32
+    let mask = ir_float_bit_mask(bit)
+    if ((*f).float_reg_bits[word as usize] / mask) % 2 == 0 {
+        (*f).float_reg_bits[word as usize] = (*f).float_reg_bits[word as usize] + mask
+        IR_FLOAT_BITS_WRITES = IR_FLOAT_BITS_WRITES + 1
+    }
+    1
+}
+
 pub enum IrOpcode {
     IrLoadImm,
     IrLoadFloat,
@@ -735,6 +808,12 @@ pub struct IrFunction {
     // 1 = first param is &T / &!T (method self-by-ref). Call sites must pass an
     // address; bare-value receivers need auto-OpRef (Root 2 method fix).
     pub first_param_is_ref: i64,
+    // #1669: which vregs hold an f64, as a function-scoped bitset. Float-ness is
+    // a property of the VALUE; before this it lived only on an IrNop carrying
+    // IR_FLOAT_REG_MARKER_FLAG, which any pass is entitled to treat as dead --
+    // and one did, so every f64 returned from a call came back as i64 MAX.
+    // 64 words x 32 bits = 2048 vregs; see ir_float_bits_capacity.
+    pub float_reg_bits: [i64; 64],
 }
 
 pub struct IrAlgebraInfo {
@@ -3749,6 +3828,7 @@ pub fn ir_empty_function() -> IrFunction {
         sret_dest_reg: -1,
         bss_size: 0,
         first_param_is_ref: 0,
+        float_reg_bits: [0; 64],
     }
 }
 

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -3358,6 +3358,10 @@ fn lowerer_lower_fn_params_mut(
                     let instr_count = (*current_func_box2).instr_count
                     if instr_count < IR_MAX_INSTRS {
                         (*current_func_box2).instrs[instr_count as usize] = ir_mark_float_reg(preg)
+                        // #1669: this store bypasses emit(), so the bit is set
+                        // beside it. An f64 PARAM is the purest orphan fact --
+                        // there is no defining instruction for it to ride on.
+                        let _fb = ir_float_bits_set(&! (*current_func_box2), preg)
                         (*current_func_box2).instr_count = instr_count + 1
                         (*lo).current_func = current_func_box2
                     } else {
@@ -8632,6 +8636,13 @@ impl Lowerer {
         let instr_count = (*current_func_box).instr_count
         if instr_count < IR_MAX_INSTRS {
             (*current_func_box).instrs[instr_count as usize] = instr
+            // #1669: record float-ness on the FUNCTION as the instruction goes by.
+            // Deliberately not narrowed to IrNop: lowering marks floats on two
+            // channels -- a standalone marker nop, and the flag stamped on a CALL
+            // -- and narrowing would silently miss every instruction-attached one.
+            if instr.imm_flags == IR_FLOAT_REG_MARKER_FLAG && instr.dst >= 0 {
+                let _fb = ir_float_bits_set(&! (*current_func_box), instr.dst)
+            }
             (*current_func_box).instr_count = instr_count + 1
             lo.current_func = current_func_box
             lo
@@ -10330,6 +10341,8 @@ impl Lowerer {
                         let instr_count = current_func.instr_count
                         if instr_count < IR_MAX_INSTRS {
                             current_func.instrs[instr_count as usize] = ir_mark_float_reg(preg)
+                            // #1669: second off-funnel param-marker store.
+                            let _fb2 = ir_float_bits_set(&! current_func, preg)
                             current_func.instr_count = instr_count + 1
                         } else {
                             lo = lo.report_error()

--- a/self-hosted/ir/opt_cleanup.sio
+++ b/self-hosted/ir/opt_cleanup.sio
@@ -8988,7 +8988,10 @@ fn ocp_compact_nops(func: IrFunction) -> IrFunction with Mut, Div, Panic {
     var write: i64 = 0
     var read: i64 = 0
     while read < result.instr_count {
-        if result.instrs[read as usize].op != IrOpcode::IrNop {
+        // #1669: same rule as ocp_mfi_compact_nops -- a nop carrying the float
+        // marker is not dead. This copy is the by-value sibling.
+        if result.instrs[read as usize].op != IrOpcode::IrNop
+            || result.instrs[read as usize].imm_flags == IR_FLOAT_REG_MARKER_FLAG {
             if write != read {
                 result.instrs[write as usize] = result.instrs[read as usize]
             }
@@ -9673,7 +9676,13 @@ fn ocp_mfi_compact_nops(module: &! IrModule, fi: i64) with Mut, Div, Panic {
     let ic = (*module).functions[fi as usize].instr_count
     while read < ic {
         let op = (*module).functions[fi as usize].instrs[read as usize].op
-        if op != IrOpcode::IrNop {
+        // #1669: a nop carrying IR_FLOAT_REG_MARKER_FLAG is NOT dead. Codegen
+        // reads it to learn that a register holds an f64 ("Always honor an
+        // explicit float-marker IrNop"). Dropping it makes the register read as
+        // an integer, so under -O every f64 coming back from a call was garbage
+        // -- silently, and only with -O.
+        let marker = (*module).functions[fi as usize].instrs[read as usize].imm_flags
+        if op != IrOpcode::IrNop || marker == IR_FLOAT_REG_MARKER_FLAG {
             if write != read {
                 ocp_mfi_instr_move_fields(module, fi, write, read)
             }

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -7,7 +7,7 @@
 module native::codegen_x86_linux
 
 use parser::ast::{Name}
-use ir::ir::{IrModule, IrFunction, IrInstr, IrOpcode, IR_MAX_FUNCS, IR_MAX_STRINGS, IR_FLOAT_REG_MARKER_FLAG, ir_name_eq, BSS_BASE_LINUX, IR_STRATEGY_BSS_GLOBAL, BSS_INIT_STRING_MAGIC}
+use ir::ir::{IrModule, IrFunction, IrInstr, IrOpcode, IR_MAX_FUNCS, IR_MAX_STRINGS, IR_FLOAT_REG_MARKER_FLAG, ir_name_eq, BSS_BASE_LINUX, IR_STRATEGY_BSS_GLOBAL, BSS_INIT_STRING_MAGIC, IR_FLOAT_BITS_TRUSTED, IR_FLOAT_NO_MARKERS, ir_float_bits_get, ir_float_bits_capacity}
 use native::encode::*
 use native::elf::*
 use native::aarch64::*
@@ -7298,6 +7298,14 @@ fn nc_core_emit_println_i64_literal_sentinel_into(nc: &! NativeCompiler, value: 
 // lowering imm_flags bits (their loadimm+marker pair makes them CONFLICT here).
 fn nc_compute_float_types(nc: &! NativeCompiler, func: &IrFunction) with Mut, Panic, Div {
     var ty: [i64; 2048] = [0; 2048]
+    // #1669: seed the lattice from the function-scoped bits. Equivalent to the
+    // marker-as-definition join -- join(UNKNOWN, FLOAT) = FLOAT -- and a later
+    // int def still drives the register to CONFLICT.
+    var fb: i64 = 0
+    while fb < ir_float_bits_capacity() && IR_FLOAT_BITS_TRUSTED == 1 {
+        if ir_float_bits_get(func, fb) { ty[fb as usize] = 1 }
+        fb = fb + 1
+    }
     var changed = true
     var iters = 0
     while changed && iters < 24 {
@@ -7403,6 +7411,19 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
     var i = 0
     while i < (*func).instr_count && i < IR_MAX_INSTRS {
         let instr_op = (*func).instrs[i as usize].op
+        // #1669 POSITIONAL RE-ASSERT. A pre-mark done before the stream is
+        // walked gets clobbered by anything that marks the register int later;
+        // the marker nop works precisely because it is honoured AT ITS POSITION.
+        // Re-asserting the bit for the register this instruction defines makes
+        // the bits positional too, at O(1) per instruction. (An earlier version
+        // re-asserted all 2048 bits per instruction and made the compiler too
+        // slow to compile itself.)
+        if IR_FLOAT_BITS_TRUSTED == 1 {
+            let rdst = (*func).instrs[i as usize].dst
+            if rdst >= 0 && rdst < ir_float_bits_capacity() && ir_float_bits_get(func, rdst) {
+                nc_core_mark_float_reg(nc, rdst)
+            }
+        }
         if instr_op == IrOpcode::IrNop && (*func).instrs[i as usize].imm_flags == IR_FLOAT_REG_MARKER_FLAG {
             let mark_reg = (*func).instrs[i as usize].dst
             // Always honor an explicit float-marker IrNop. The previous guard
@@ -7413,7 +7434,13 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             // neutralizer; #478 is now fixed at source in lower.sio, so this marker
             // is only emitted for genuinely-float values. nc_core_mark_float_reg
             // bounds-checks internally.
-            nc_core_mark_float_reg(nc, mark_reg)
+            // The IR_FLOAT_NO_MARKERS switch belongs HERE, not on the arm's
+            // condition: guarding the condition makes a marker nop fall through
+            // to the following `else if` arms and changes emission rather than
+            // just withholding the mark.
+            if IR_FLOAT_NO_MARKERS == 0 {
+                nc_core_mark_float_reg(nc, mark_reg)
+            }
         } else if instr_op == IrOpcode::IrLoadImm {
             let imm_value = (*func).instrs[i as usize].imm_i64
             if imm_value == (0 - 4242) {

--- a/self-hosted/native/machine_ir.sio
+++ b/self-hosted/native/machine_ir.sio
@@ -5,7 +5,7 @@
 module native::machine_ir
 
 use parser::ast::{Name, BinaryOp, UnaryOp, empty_name}
-use ir::ir::{IrModule, IrFunction, IrInstr, IrOpcode, IrRegList, BSS_BASE_LINUX, IR_FLOAT_REG_MARKER_FLAG}
+use ir::ir::{IrModule, IrFunction, IrInstr, IrOpcode, IrRegList, BSS_BASE_LINUX, IR_FLOAT_REG_MARKER_FLAG, IR_FLOAT_NO_MARKERS, IR_FLOAT_BITS_TRUSTED, ir_float_bits_get, ir_float_bits_capacity}
 
 pub let MIR_MAX_BLOCKS: i64 = 1
 // MIR_MAX_INSTRS history:
@@ -1007,11 +1007,20 @@ pub fn native_v2_legalize_ir_summary_ref(func: &IrFunction) -> NativeV2LegalizeS
     }
 
     var is_float_slot: [i64; 2048] = [0; 2048]
+    // #1669: seed from the function-scoped bits, then keep the in-stream marker
+    // arm below. A union: the bits are the durable channel, the markers the
+    // legacy one, and any disagreement is measurable rather than guessed.
+    var sfb: i64 = 0
+    while sfb < ir_float_bits_capacity() && sfb < MIR_MAX_FLOAT_SLOTS && IR_FLOAT_BITS_TRUSTED == 1 {
+        if ir_float_bits_get(func, sfb) { is_float_slot[sfb as usize] = 1 }
+        sfb = sfb + 1
+    }
     var i: i64 = 0
     while i < (*func).instr_count {
         let instr = (*func).instrs[i as usize]
         if instr.op == IrOpcode::IrNop {
-            if instr.imm_flags == IR_FLOAT_REG_MARKER_FLAG && instr.dst >= 0 && instr.dst < MIR_MAX_FLOAT_SLOTS {
+            if instr.imm_flags == IR_FLOAT_REG_MARKER_FLAG && instr.dst >= 0 && instr.dst < MIR_MAX_FLOAT_SLOTS
+                && IR_FLOAT_NO_MARKERS == 0 {
                 is_float_slot[instr.dst as usize] = 1
             }
             i = i + 1
@@ -1156,7 +1165,8 @@ pub fn native_v2_lower_legal_function_from_ir_ref(func: &IrFunction, out: &! Mac
     while i < (*func).instr_count {
         let ir_instr = (*func).instrs[i as usize]
         if ir_instr.op == IrOpcode::IrNop {
-            if ir_instr.imm_flags == IR_FLOAT_REG_MARKER_FLAG && ir_instr.dst >= 0 && ir_instr.dst < MIR_MAX_FLOAT_SLOTS {
+            if ir_instr.imm_flags == IR_FLOAT_REG_MARKER_FLAG && ir_instr.dst >= 0 && ir_instr.dst < MIR_MAX_FLOAT_SLOTS
+                && IR_FLOAT_NO_MARKERS == 0 {
                 (*out).is_float_slot[ir_instr.dst as usize] = 1
             }
             i = i + 1


### PR DESCRIPTION
Two changes. **One is measured to fix a live bug on `main`; the other is a design argument I could not turn into a measurement here, and I say so below rather than let the first carry the second.**

## 1. The bug — `-O` returns garbage for every `f64` coming back from a call

`ocp_mfi_compact_nops` and `ocp_compact_nops` delete every `IrNop`. One of those nops carries `IR_FLOAT_REG_MARKER_FLAG`, which is how lowering tells codegen that a register holds an `f64`. With it gone the register is read as an integer.

Six lines reproduce it:

```sounio
fn half(x: f64) -> f64 { x * 0.5 }
fn main() -> i64 with IO, Mut, Panic, Div {
    let v = half(5.0)
    print("v=")
    println(v)
    0
}
```

```
stock main    v=9223372036854775808.000000
this branch   v=2.500000
```

Both under `-O`, same source, same seed. Without `-O` both are correct — which is why this has survived: it is invisible unless you optimise.

**Corpus, in progress.** Each float-bearing `run-pass` test is compiled twice on the same compiler and its `-O` output compared against its no-`-O` output; any difference is an optimizer defect. At **43 of 390**:

| | `-O` changes the answer |
|---|---|
| stock `main` | 27 |
| this branch | 24 |

**3 fixed, 0 broken.** I will update this when the run finishes.

## 2. The redundancy — float-ness on the register

`IrFunction` gains `float_reg_bits`, a function-scoped bitset holding the same fact somewhere no pass is entitled to delete. Consumers are seeded from it; the in-stream markers are **kept**. A union, not a replacement.

Includes the ordering detail that makes it work: a pre-mark applied before the instruction stream is walked gets clobbered by anything that marks the register int later — the marker nop works precisely because it is honoured *at its position*. The bits are re-asserted for the register each instruction defines, O(1) per instruction.

## What I could not prove here

**On the `#1649` branch the bitset demonstrably carries float-ness alone**: 390 tests under `-O` with the in-stream markers suppressed match their markers-on baseline **390/390**, while the same suppression on a compiler without the positional fix changes the output of **169** of them.

**Ported to `main`, that control stops discriminating.** Every configuration comes out correct, including bits-off — so on `main` some other channel already covers these cases and my suppression switch cannot tell the difference.

So: change 2's cost is measured at zero (emitted code unchanged, build at the 6-error baseline), and its value here is an **argument**, not a measurement. It is the same fact stored where a pass cannot reach it — which is exactly the failure in change 1, arriving through a different door next time. Reviewers should weigh change 1 on the evidence and change 2 on the design, and I would rather that be explicit than buried.

## Verification

- builds at the **6-error `origin/main` baseline** (unchanged)
- the witness above, and the partial corpus with zero regressions
- `IR_FLOAT_NO_MARKERS=1` is a test switch that suppresses the in-stream marker arms so the bits can be checked standing alone — that is how the branch numbers above were produced, and it stays in so the claim stays checkable

Refs #1669, #1649

🤖 Generated with [Claude Code](https://claude.com/claude-code)