### PR TITLE
ci(madaros): the changed-tests gate under-provisions the stack, not the compiler (unblocks main)

### DIFF
--- a/scripts/ci/madaros_changed_tests_gate.sh
+++ b/scripts/ci/madaros_changed_tests_gate.sh
@@ -59,9 +59,26 @@ fi
 # current Madaros multi-module lower+codegen: measured 2026-07-20, 65536 KiB
 # completes lower (final_fn_count 225) but fails to emit the ELF (wrapper then
 # reports "run exited 1" / typecheck: failed); >= ~120000 KiB writes and runs
-# DUAL_GUM_KNOWLEDGE_OK. Default 131072 leaves headroom on GHA Linux runners
-# (hard limit unlimited).
-stack_kb="${SOUNIO_MADAROS_CHANGED_TESTS_STACK_KB:-131072}"
+# DUAL_GUM_KNOWLEDGE_OK.
+#
+# 131072 was calibrated on THAT witness alone, and "leaves headroom" did not
+# hold. This gate runs tests through `$SOUC_BIN run <file>`
+# (scripts/dev/run_sio_test_suite_v1.sh:153), which executes the program on top
+# of the compiler's own frame rather than in a fresh process, so it needs
+# materially more stack than `compile` + exec. Measured 2026-08-09 on a
+# current-source Madaros, six tests, unanimous:
+#
+#   131072 KiB -> SIGSEGV (rc 139)   524288 KiB -> rc 0
+#     gpu_kernel_lane_loop            epistemic_var_accumulator_slots
+#     _diag_sobol                     approx_basic
+#     arima_levinson_ar2              array_elem_field_store
+#
+# CI surfaced this as `run timed out after 30s` while the same binary faults in
+# under a second locally, so it read as slowness and hid a crash.
+# madaros_imported_call_arity_13_gate.sh already recorded the same lesson
+# ("262144 KiB passes; 131072 fails. Default 512 MiB for headroom"); 524288 is
+# what 16 other gates in scripts/ci already use.
+stack_kb="${SOUNIO_MADAROS_CHANGED_TESTS_STACK_KB:-524288}"
 [[ "$stack_kb" =~ ^[1-9][0-9]*$ && ${#stack_kb} -le 9 ]] \
   || fail "invalid_stack_kb"
 


### PR DESCRIPTION
`main` is red on `Madaros Current-Source f64 Lowering` → `Run changed Madaros tests`. It is the gate, not the compiler.

## What it is

The gate runs each test as `$SOUC_BIN run <file>` (`scripts/dev/run_sio_test_suite_v1.sh:153`), which executes the program **on top of the compiler's own frame** rather than in a fresh process. That needs materially more stack than `compile` + exec. The gate's default soft stack was `131072` KiB — below the line.

Measured on a current-source Madaros whose `sha256` is **byte-identical** to the binary CI reports in the failing job (`43994b3a8d4de76a2fdb5daeec971e8345468a824ebef62447a974bb2f0ba091`), so this is the same instrument, not a lookalike. Unanimous, six for six:

| test | 131072 KiB | 524288 KiB |
|---|---|---|
| `gpu_kernel_lane_loop` | SIGSEGV (139) | 0 |
| `epistemic_var_accumulator_slots` | SIGSEGV (139) | 0 |
| `_diag_sobol` | SIGSEGV (139) | 0 |
| `approx_basic` | SIGSEGV (139) | 0 |
| `arima_levinson_ar2` | SIGSEGV (139) | 0 |
| `array_elem_field_store` | SIGSEGV (139) | 0 |

And through the gate's **own harness**, on exactly the six tests CI selected:

```
131072 KiB   Pass: 4  Fail: 2   <- epistemic_var_accumulator_slots, gpu_kernel_lane_loop
524288 KiB   Pass: 6  Fail: 0
```

## Not a regression from #1650 / #1672

A Madaros built from `be4e96d211` — `main` before both merges, `sha256 96557d8c9779d6f2…` — fails **identically** at 131072. What changed was only *exposure*: `madaros_changed_tests_gate.sh` selected 0 tests on those PR runs and 6 on the merge push, so these ran for the first time in a while.

## Why 524288 and not a guess

`madaros_imported_call_arity_13_gate.sh` already recorded the identical lesson — *"262144 KiB passes; 131072 fails. Default 512 MiB for headroom"* — and **16 other gates** under `scripts/ci` already use `524288`. This aligns the outlier rather than inventing a number.

The old value was calibrated on **one** witness (the gum+knowledge dual-module case, 2026-07-20) and the comment's claim that it "leaves headroom" did not survive contact with the `run` path. The comment now carries the counter-measurement instead of the assertion.

## The part worth not losing

CI reported this as **`run timed out after 30s`** while the same binary faults in under a second locally. A crash presenting as a timeout reads as slowness — which is how it sat unnoticed. Worth fixing in the runner separately.

## Deliberately not addressed here

`run` needing ~4× the stack of `compile` + exec is a real property of that path, not something every gate default should have to know independently. Kept in the #1690 discussion rather than silently closed.

Closes #1690
