### PR TITLE
ci: per-peel kill switch for the -O cleanup pipeline (OCP_SKIP_MASK)

### DIFF
--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -7,7 +7,7 @@ use parser::ast::{AstPath, empty_path, Item, ItemKind, ItemList, Name, ParamList
 use parser::mod::{count_items}
 use parser::parser::{parser_last_error_count, parser_reset_last_errors}
 use ir::ir::*
-use ir::opt_cleanup::{OcpCleanupModuleReceipt, opt_cleanup_module_inplace}
+use ir::opt_cleanup::{OcpCleanupModuleReceipt, opt_cleanup_module_inplace, OCP_SKIP_MASK}
 use io::env::{read_env}
 use io::trace::{io_trace_i64_string}
 use check::mod::{check_items_verdict_boot4, check_items_verdict_boot4_with_ontocache_sidecar, check_modules_verdict_boot4, check_program_epistemic_into, check_program_with_artifacts, checker_to_ir_epistemic_into, checker_apply_ir_metadata, checker_apply_ir_ontology_parameter_links_from_items}
@@ -6138,11 +6138,33 @@ fn module_frontend_merge_imported_into_box(
     true
 }
 
+// Load the per-peel kill switch once, here: this compile entry already carries
+// IO, and the peels it gates do not. One env var per peel rather than an integer
+// mask, so the peel's name appears in the command line that reproduced a bug.
+fn module_frontend_load_ocp_skip_mask() with IO, Mut, Panic, Div {
+    var m: i64 = 0
+    if str_eq(read_env("SOUNIO_OCP_SKIP_DEDUP_IMM"), "1")       { m = m + 1 }
+    if str_eq(read_env("SOUNIO_OCP_SKIP_CONST_FOLD"), "1")      { m = m + 2 }
+    if str_eq(read_env("SOUNIO_OCP_SKIP_COPY_PROP"), "1")       { m = m + 4 }
+    if str_eq(read_env("SOUNIO_OCP_SKIP_DSE"), "1")             { m = m + 8 }
+    if str_eq(read_env("SOUNIO_OCP_SKIP_REDUNDANT_JUMP"), "1")  { m = m + 16 }
+    if str_eq(read_env("SOUNIO_OCP_SKIP_JUMP_TO_RETURN"), "1")  { m = m + 32 }
+    if str_eq(read_env("SOUNIO_OCP_SKIP_DEAD_AFTER_JUMP"), "1") { m = m + 64 }
+    if str_eq(read_env("SOUNIO_OCP_SKIP_DEAD_LABEL"), "1")      { m = m + 128 }
+    if str_eq(read_env("SOUNIO_OCP_SKIP_CSE"), "1")             { m = m + 256 }
+    if str_eq(read_env("SOUNIO_OCP_SKIP_DCE_LOOP"), "1")        { m = m + 512 }
+    if str_eq(read_env("SOUNIO_OCP_SKIP_SCCP"), "1")            { m = m + 1024 }
+    if str_eq(read_env("SOUNIO_OCP_SKIP_DCE_FINAL"), "1")       { m = m + 2048 }
+    if str_eq(read_env("SOUNIO_OCP_SKIP_COMPACT_NOPS"), "1")    { m = m + 4096 }
+    OCP_SKIP_MASK = m
+}
+
 pub fn module_frontend_compile_imported_to_file(
     main_path: string,
     output_path: string,
     optimize: bool,
 ) -> i32 with IO, Mut, Div, Panic, Alloc {
+    module_frontend_load_ocp_skip_mask()
     parser_reset_last_errors()
     // One reset + suppress for the full multi-mod load/typecheck/lower window so
     // imported module f64 constants (e.g. stats::densities::DE_LN_SQRT_2PI) remain

--- a/self-hosted/ir/opt_cleanup.sio
+++ b/self-hosted/ir/opt_cleanup.sio
@@ -9690,32 +9690,54 @@ fn ocp_mfi_compact_nops(module: &! IrModule, fi: i64) with Mut, Div, Panic {
 }
 
 // Safe multi-module function cleanup via module+fi field access only.
+// Per-peel kill switch for the in-place -O pipeline. Bit set = peel SKIPPED.
+// Default 0, so with no environment set this file behaves exactly as before.
+//
+// WHY THIS EXISTS. Bisecting "which peel produced this bad IR" previously cost a
+// full ~15-minute Madaros rebuild per hypothesis, because the only way to remove
+// a peel was to edit this list and recompile. With the switch it is one build
+// and N runs. It paid for itself the first time it was used: it showed that
+// skipping ALL peels is not a valid control, because skipping compaction leaves
+// every nop in the stream and is independently fatal -- an experiment that had
+// already produced one wrong conclusion before the switch made it visible.
+//
+// A global rather than read_env at each site: the peels carry Mut/Div/Panic and
+// no IO, and widening them would cascade the effect to every caller. The value
+// is loaded once from the compile entry, which already has IO.
+pub var OCP_SKIP_MASK: i64 = 0
+
+fn ocp_skip(bit: i64) -> bool with Div {
+    (OCP_SKIP_MASK / bit) % 2 == 1
+}
+
 fn opt_cleanup_function_mfi(module: &! IrModule, fi: i64) with Mut, Div, Panic {
     let ic = (*module).functions[fi as usize].instr_count
     if ic <= 0 {
         return
     }
-    ocp_mfi_dedup_imm(module, fi)
-    ocp_mfi_const_fold(module, fi)
-    ocp_mfi_copy_prop(module, fi)
-    ocp_mfi_dse(module, fi)
-    ocp_mfi_redundant_jump(module, fi)
-    ocp_mfi_jump_to_return(module, fi)
-    ocp_mfi_dead_after_jump(module, fi)
-    ocp_mfi_dead_label(module, fi)
-    ocp_mfi_cse(module, fi)
-    var iter: i64 = 0
-    while iter < 8 {
-        let removed = ocp_mfi_dce_once(module, fi)
-        if removed == 0 {
-            iter = 8
+    if !ocp_skip(1)    { ocp_mfi_dedup_imm(module, fi) }
+    if !ocp_skip(2)    { ocp_mfi_const_fold(module, fi) }
+    if !ocp_skip(4)    { ocp_mfi_copy_prop(module, fi) }
+    if !ocp_skip(8)    { ocp_mfi_dse(module, fi) }
+    if !ocp_skip(16)   { ocp_mfi_redundant_jump(module, fi) }
+    if !ocp_skip(32)   { ocp_mfi_jump_to_return(module, fi) }
+    if !ocp_skip(64)   { ocp_mfi_dead_after_jump(module, fi) }
+    if !ocp_skip(128)  { ocp_mfi_dead_label(module, fi) }
+    if !ocp_skip(256)  { ocp_mfi_cse(module, fi) }
+    if !ocp_skip(512) {
+        var iter: i64 = 0
+        while iter < 8 {
+            let removed = ocp_mfi_dce_once(module, fi)
+            if removed == 0 {
+                iter = 8
+            }
+            iter = iter + 1
         }
-        iter = iter + 1
     }
     // SCCP-lite + compact: previously deferred (by-value path only).
-    ocp_mfi_sccp(module, fi)
-    let _ = ocp_mfi_dce_once(module, fi)
-    ocp_mfi_compact_nops(module, fi)
+    if !ocp_skip(1024) { ocp_mfi_sccp(module, fi) }
+    if !ocp_skip(2048) { let _ = ocp_mfi_dce_once(module, fi) }
+    if !ocp_skip(4096) { ocp_mfi_compact_nops(module, fi) }
 }
 
 // Run safe field-wise cleanup on every function without copying IrModule or


### PR DESCRIPTION
A diagnostic, not a behaviour change. **Default 0 — with no environment variable set, `opt_cleanup_function_mfi` behaves exactly as before.**

## Why

Bisecting *"which peel produced this bad IR"* costs a full **~15-minute Madaros rebuild per hypothesis**, because the only way to remove a peel is to edit the list and recompile. With this, it is one build and N runs.

It paid for itself the first time it was used, and not in the way I expected. I had run "skip every peel" as a control and concluded the crash under investigation was not in any peel. **That control was invalid** — skipping compaction leaves every nop in the stream and is independently fatal, so the crash it showed was a different one. The switch is what made that visible; without it I would have shipped the wrong conclusion.

## Shape

One environment variable per peel rather than an integer mask, so the peel's name appears in the command line that reproduced a bug:

```
SOUNIO_OCP_SKIP_DEDUP_IMM   _CONST_FOLD   _COPY_PROP   _DSE
_REDUNDANT_JUMP   _JUMP_TO_RETURN   _DEAD_AFTER_JUMP   _DEAD_LABEL
_CSE   _DCE_LOOP   _SCCP   _DCE_FINAL   _COMPACT_NOPS
```

Loaded once from `module_frontend_compile_imported_to_file`, which already carries `IO`. The peels themselves carry `Mut/Div/Panic` only, and widening them would cascade the effect to every caller — the failure mode that desynchronised the checker earlier in this lane, so the global is deliberate.

## Verified — including that it actually does something

| | rc | emitted ELF md5 |
|---|---|---|
| mask unset | 0 | `fe46635eb26a` |
| `SOUNIO_OCP_SKIP_DCE_LOOP=1` | 0 | `6c6b7b01719b` |

Different output, so the switch demonstrably takes effect rather than being silently ignored. I checked that **before** relying on it — a diagnostic you have not proven responsive is worse than none, which is the same lesson as a receipt nobody verifies.

- Builds at the current `origin/main` **2-error baseline**.
- `--self-test` unchanged at 22 OK / 6 FAIL.
- No call-site or signature changes outside the two files.

## Context

Came out of the investigation in #1693 (a layout-sensitive segfault in the same pipeline) and #1669 / PR #1687. Useful independently of how those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)