### PR TITLE
fix(resolve): module exports move out of ModuleEntry into a flat pool — two silent caps (refs #1689)

### DIFF
--- a/self-hosted/compiler/module_loader.sio
+++ b/self-hosted/compiler/module_loader.sio
@@ -13,7 +13,7 @@ use parser::ast::{AstPath, empty_path, ImportItemList, ItemKind, ItemList, Name,
 use ir::ir::{ir_empty_epistemic_section, ir_empty_function, ir_empty_module, ir_empty_name, ir_empty_validated_patch_stats, IrAlgebraTable, IrEpistemicSection, IrFunction, IrInstr, IrLowerResult, IR_MAX_EPI_ACQUISITION_PLANS, IR_MAX_EPI_ACQUISITION_POLICIES, IR_MAX_EPI_ACQUISITION_REASON_WITNESSES, IR_MAX_EPI_ALTERNATIVE_CANDIDATES, IR_MAX_EPI_ALTERNATIVE_FRONTIERS, IR_MAX_EPI_ALTERNATIVE_POLICIES, IR_MAX_EPI_ALTERNATIVE_REASON_WITNESSES, IR_MAX_EPI_ALTERNATIVE_SETS, IR_MAX_EPI_AUDITS, IR_MAX_EPI_CONTESTS, IR_MAX_EPI_CONTEST_WITNESSES, IR_MAX_EPI_COUNTEREXAMPLES, IR_MAX_EPI_DECISION_CERTIFICATES, IR_MAX_EPI_DECISION_POLICIES, IR_MAX_EPI_DEFERRAL_POLICIES, IR_MAX_EPI_DEFERRED_CERTIFICATES, IR_MAX_EPI_DEFERRED_REASON_WITNESSES, IR_MAX_EPI_MECHANISTIC_REPORTS, IR_MAX_EPI_MODEL_FAMILIES, IR_MAX_EPI_MONITORING_POLICIES, IR_MAX_EPI_OBSERVED_TRANSITIONS, IR_MAX_EPI_POLICIES, IR_MAX_EPI_POSTERIOR_WEIGHTS, IR_MAX_EPI_RECOURSE_PLANS, IR_MAX_EPI_RECOURSE_POLICIES, IR_MAX_EPI_RECOURSE_REASON_WITNESSES, IR_MAX_EPI_ROBUST_PROOFS, IR_MAX_EPI_ROLLBACK_CERTIFICATES, IR_MAX_EPI_TRANSITION_PLANS, IR_MAX_EPI_TRANSITION_POLICIES, IR_MAX_EPI_TRANSITION_PROTOCOLS, IR_MAX_EPI_TRANSITION_REASON_WITNESSES, IR_MAX_EPI_TRANSITION_STEPS, IR_MAX_EPI_VALIDATED_MANIFESTS, IR_MAX_EPI_VALIDATIONS, IR_MAX_FUNCS, IR_MAX_STRINGS, IrModule, ir_name_eq, IrOpcode, IrProfCounterInfo, IR_STRATEGY_STANDARD, make_name}
 use check::mod::{check_program_epistemic_into, check_program_with_artifacts, checker_apply_ir_metadata, checker_to_ir_epistemic_into}
 use resolve::mod::{resolve_modules, ResolveBatchResult}
-use resolve::imports::{collect_module_exports, ModuleEntry, ModuleRegistry, module_registry_find, module_registry_new, module_registry_put}
+use resolve::imports::{collect_module_exports, ModuleEntry, ModuleRegistry, module_registry_find, module_registry_new, module_registry_put, module_registry_report_overflow, modreg_export_kind_at, modreg_export_name_at}
 use resolve::symbol::{SymbolKind}
 use parser::mod::{parse_program_preloaded, count_items}
 use lexer::mod::{sourcefile_load, sourcefile_parse_program_loaded, sourcefile_status_ok}
@@ -2458,9 +2458,12 @@ fn thin_collect_selective_imports(
 fn thin_collect_glob_imports_from_entry(map: ThinImportMap, module_idx: i64, entry: ModuleEntry) -> ThinImportMap with Mut, Panic, Div {
     var out = map
     var i: i64 = 0
-    while i < entry.export_count && i < 1024 {
-        if entry.exports[i as usize].kind == SymbolKind::SymFunction {
-            out = thin_import_map_add(out, entry.exports[i as usize].name, module_idx, entry.exports[i as usize].name)
+    while i < entry.export_count {
+        // #1689: pool-backed exports; the old `&& i < 1024` was a silent cap.
+        let at = entry.export_base + i
+        if modreg_export_kind_at(at) == SymbolKind::SymFunction {
+            let nm = modreg_export_name_at(at)
+            out = thin_import_map_add(out, nm, module_idx, nm)
         }
         i = i + 1
     }
@@ -2542,6 +2545,9 @@ fn thin_load_module_graph(main_path: string) -> ThinModuleGraph with IO, Mut, Pa
         graph.nodes[pi as usize].source_hash = thin_hash_file(graph.nodes[pi as usize].file_path)
         pi = pi + 1
     }
+    // #1689: ASK. The overflow flag was written and never read, so a dropped
+    // module surfaced as E137 on innocent call sites.
+    let _ovf = module_registry_report_overflow(graph.registry)
     println("[thinlink] graph:registry_ready")
 
     graph

--- a/self-hosted/resolve/imports.sio
+++ b/self-hosted/resolve/imports.sio
@@ -53,16 +53,106 @@ pub struct ModuleExport {
     kind: SymbolKind,
 }
 
+// ============================================================
+// Export pool (#1689)
+// ============================================================
+// Exports used to live INLINE in every ModuleEntry as `[ModuleExport; 1024]`.
+// ModuleExport embeds a Name (`[i8;128]` + len), so an entry was ~144 KB and a
+// 64-entry ModuleRegistry ~9 MB -- passed BY VALUE, since module_registry_put
+// takes the registry and returns it. That is why the module cap was 64, and 64
+// is below what real programs need: self-hosted/compiler/main.sio has 76 `use`
+// declarations, so imports #65..#76 were dropped and every symbol they export
+// reported E137 at the CALL SITE, blaming code that was correct.
+//
+// The 1024 was a second silent cap in the same struct: stdlib/theorem/portfolio.sio
+// declares 2160 pub items, so exports past 1024 were dropped too.
+//
+// Both caps are now affordable because the payload moved out of the entry into a
+// flat pool, leaving ModuleEntry at ~168 bytes. Same shape resolve/modules.sio
+// already uses for MgModuleGraph (a shared exports array plus per-entry base and
+// count), and the same shape ir.sio uses for IR_A_*.
+//
+// PARALLEL FLAT ARRAYS, NOT AN ARRAY OF STRUCTS. The bootstrap seed drops struct
+// stores into global ARRAYS silently -- a global `[ModuleExport; N]` would accept
+// the write, return zeros, and look exactly like a module that exports nothing.
+// i8/i64 arrays round-trip correctly.
+//
+// All-zero is the correct initial state: count 0, and this compiler BSS-zeroes
+// `var` initialisers.
+pub let MODREG_POOL_MAX: i64 = 65536
+pub let MODREG_MAX_MODULES: i64 = 512
+
+var MODREG_EXP_NAME_BUF: [i8; 8388608] = [0; 8388608]
+var MODREG_EXP_NAME_LEN: [i64; 65536] = [0; 65536]
+var MODREG_EXP_KIND: [i64; 65536] = [0; 65536]
+var MODREG_POOL_COUNT: i64 = 0
+var MODREG_POOL_DROPPED: i64 = 0
+
+// The pool is MONOTONIC and deliberately never reset. Resetting on
+// module_registry_new() would look tidier and be wrong: Resolver::new() also
+// calls it, so a reset there would invalidate the base/count of a registry that
+// is already populated and live.
+pub fn modreg_pool_count() -> i64 { MODREG_POOL_COUNT }
+pub fn modreg_pool_dropped() -> i64 { MODREG_POOL_DROPPED }
+
+fn modreg_pool_push(name: Name, kind: SymbolKind) with Mut, Panic, Div {
+    if name_is_empty(name) { return }
+    if MODREG_POOL_COUNT >= MODREG_POOL_MAX {
+        MODREG_POOL_DROPPED = MODREG_POOL_DROPPED + 1
+        return
+    }
+    let at = MODREG_POOL_COUNT
+    var i: i64 = 0
+    while i < name.len && i < 128 {
+        MODREG_EXP_NAME_BUF[(at * 128 + i) as usize] = name.buf[i as usize]
+        i = i + 1
+    }
+    MODREG_EXP_NAME_LEN[at as usize] = name.len
+    MODREG_EXP_KIND[at as usize] = kind as i64
+    MODREG_POOL_COUNT = at + 1
+}
+
+pub fn modreg_export_name_at(at: i64) -> Name with Mut, Panic, Div {
+    var out = Name { buf: [0; 128], len: 0 }
+    if at < 0 || at >= MODREG_POOL_COUNT { return out }
+    let n = MODREG_EXP_NAME_LEN[at as usize]
+    var i: i64 = 0
+    while i < n && i < 128 {
+        out.buf[i as usize] = MODREG_EXP_NAME_BUF[(at * 128 + i) as usize]
+        i = i + 1
+    }
+    out.len = n
+    out
+}
+
+pub fn modreg_export_kind_at(at: i64) -> SymbolKind with Mut, Panic, Div {
+    if at < 0 || at >= MODREG_POOL_COUNT { return SymbolKind::SymVariable }
+    MODREG_EXP_KIND[at as usize] as SymbolKind
+}
+
+// Byte compare against the pool without materialising a Name.
+fn modreg_export_name_eq_at(at: i64, name: Name) -> bool with Mut, Panic, Div {
+    if at < 0 || at >= MODREG_POOL_COUNT { return false }
+    if MODREG_EXP_NAME_LEN[at as usize] != name.len { return false }
+    var i: i64 = 0
+    while i < name.len && i < 128 {
+        if MODREG_EXP_NAME_BUF[(at * 128 + i) as usize] != name.buf[i as usize] { return false }
+        i = i + 1
+    }
+    true
+}
+
 pub struct ModuleEntry {
     path: AstPath,
-    exports: [ModuleExport; 1024],
+    export_base: i64,
     export_count: i64,
 }
 
 pub struct ModuleRegistry {
-    modules: [ModuleEntry; 64],
+    modules: [ModuleEntry; 512],
     count: i64,
     overflow: bool,
+    dropped: i64,
 }
 
 fn empty_module_export() -> ModuleExport {
@@ -72,17 +162,46 @@ fn empty_module_export() -> ModuleExport {
 fn empty_module_entry() -> ModuleEntry {
     ModuleEntry {
         path: empty_path(),
-        exports: [empty_module_export(); 1024],
+        export_base: 0,
         export_count: 0,
     }
 }
 
 pub fn module_registry_new() -> ModuleRegistry {
     ModuleRegistry {
-        modules: [empty_module_entry(); 64],
+        modules: [empty_module_entry(); 512],
         count: 0,
         overflow: false,
+        dropped: 0,
     }
+}
+
+// #1689: the overflow flag used to be WRITTEN HERE AND READ NOWHERE, which is
+// what made the failure silent. Callers must ask. Reporting is split out because
+// module_registry_put has no IO effect and giving it one would cascade.
+pub fn module_registry_report_overflow(reg: ModuleRegistry) -> bool with IO, Mut, Panic, Div {
+    // print_int, not io_trace_i64_string: this module imports only parser::ast,
+    // and pulling in the io helper for a diagnostic would add a dependency edge
+    // from the resolver to it.
+    var bad = false
+    if reg.overflow {
+        print("error: module registry overflow: ")
+        print_int(reg.dropped)
+        print(" module(s) dropped past MODREG_MAX_MODULES = ")
+        print_int(MODREG_MAX_MODULES)
+        print("\n")
+        print("  note: symbols exported by a dropped module resolve as undeclared at the CALL SITE, so the reported errors name innocent code\n")
+        bad = true
+    }
+    if modreg_pool_dropped() > 0 {
+        print("error: module export pool overflow: ")
+        print_int(modreg_pool_dropped())
+        print(" export(s) dropped past MODREG_POOL_MAX = ")
+        print_int(MODREG_POOL_MAX)
+        print("\n")
+        bad = true
+    }
+    bad
 }
 
 // StringList equality (byte-by-byte + structural)
@@ -122,7 +241,7 @@ pub fn module_registry_find(reg: ModuleRegistry, path: AstPath) -> i64 with Mut,
 pub fn module_registry_put(
     reg: ModuleRegistry,
     path: AstPath,
-    exports: [ModuleExport; 1024],
+    export_base: i64,
     export_count: i64
 ) -> ModuleRegistry with Mut, Panic, Div, Alloc {
     var r = reg
@@ -130,29 +249,32 @@ pub fn module_registry_put(
     if idx >= 0 {
         r.modules[idx as usize] = ModuleEntry {
             path: path,
-            exports: exports,
+            export_base: export_base,
             export_count: export_count,
         }
         return r
     }
 
-    if r.count < 64 {
+    if r.count < MODREG_MAX_MODULES {
         r.modules[r.count as usize] = ModuleEntry {
             path: path,
-            exports: exports,
+            export_base: export_base,
             export_count: export_count,
         }
         r.count = r.count + 1
     } else {
+        // Counted, not just flagged: "how many" is the difference between a cap
+        // that is one short and a cap that is an order out.
         r.overflow = true
+        r.dropped = r.dropped + 1
     }
     r
 }
 
 pub fn module_entry_contains(entry: ModuleEntry, name: Name) -> bool with Mut, Panic, Div {
     var i: i64 = 0
-    while i < entry.export_count && i < 1024 {
-        if name_eq(entry.exports[i as usize].name, name) {
+    while i < entry.export_count {
+        if modreg_export_name_eq_at(entry.export_base + i, name) {
             return true
         }
         i = i + 1
@@ -160,152 +282,121 @@ pub fn module_entry_contains(entry: ModuleEntry, name: Name) -> bool with Mut, P
     false
 }
 
-fn exports_empty() -> [ModuleExport; 1024] {
-    [empty_module_export(); 1024]
+// Absolute pool index of an entry's k-th export, for callers that iterate.
+pub fn module_entry_export_at(entry: ModuleEntry, k: i64) -> i64 {
+    entry.export_base + k
 }
 
-fn exports_push(
-    exports: [ModuleExport; 1024],
-    count: i64,
-    name: Name,
-    kind: SymbolKind
-) -> ([ModuleExport; 1024], i64) with Mut, Panic, Div {
-    var ex = exports
-    var c = count
-    if c < 1024 && !name_is_empty(name) {
-        ex[c as usize] = ModuleExport { name: name, kind: kind }
-        c = c + 1
-    }
-    (ex, c)
+pub fn collect_module_exports(items: Option<Box<ItemList>>) -> (i64, i64) with Mut, Panic, Div, Alloc {
+    let base = modreg_pool_count()
+    collect_module_exports_loop(items)
+    (base, modreg_pool_count() - base)
 }
 
-pub fn collect_module_exports(items: Option<Box<ItemList>>) -> ([ModuleExport; 1024], i64) with Mut, Panic, Div, Alloc {
-    collect_module_exports_loop(items, exports_empty(), 0)
-}
-
-fn collect_module_exports_loop(
-    items: Option<Box<ItemList>>,
-    exports: [ModuleExport; 1024],
-    count: i64
-) -> ([ModuleExport; 1024], i64) with Mut, Panic, Div, Alloc {
+fn collect_module_exports_loop(items: Option<Box<ItemList>>) with Mut, Panic, Div, Alloc {
     match items {
-        None => (exports, count)
+        None => {}
         Some(list) => {
-            let item = (*list).head
-            let pair = collect_module_exports_item(item, exports, count)
-            collect_module_exports_loop((*list).tail, pair.0, pair.1)
+            collect_module_exports_item((*list).head)
+            collect_module_exports_loop((*list).tail)
         }
     }
 }
 
-fn collect_module_exports_item(
-    item: Item,
-    exports: [ModuleExport; 1024],
-    count: i64
-) -> ([ModuleExport; 1024], i64) with Mut, Panic, Div, Alloc {
+fn collect_module_exports_item(item: Item) with Mut, Panic, Div, Alloc {
     // For now: export pub top-level items, and for pub enums also export variant names
     match item.kind {
         ItemKind::ItemFn => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymFunction) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymFunction) }
         }
         ItemKind::ItemStruct => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymStruct) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymStruct) }
         }
         ItemKind::ItemEnum => {
             if visibility_to_bool(item.visibility) {
-                let pair = exports_push(exports, count, item.name, SymbolKind::SymEnum)
-                collect_module_exports_variants(item.enum_def, pair.0, pair.1)
-            } else {
-                (exports, count)
+                modreg_pool_push(item.name, SymbolKind::SymEnum)
+                collect_module_exports_variants(item.enum_def)
             }
         }
         ItemKind::ItemTypeAlias => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymTypeAlias) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymTypeAlias) }
         }
         ItemKind::ItemModels => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymTypeAlias) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymTypeAlias) }
         }
         ItemKind::ItemPolicy => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymPolicy) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymPolicy) }
         }
         ItemKind::ItemAcquisitionPolicy => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymAcquisitionPolicy) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymAcquisitionPolicy) }
         }
         ItemKind::ItemRecoursePolicy => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymRecoursePolicy) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymRecoursePolicy) }
         }
         ItemKind::ItemTransitionPolicy => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymTransitionPolicy) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymTransitionPolicy) }
         }
         ItemKind::ItemTransitionProtocol => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymTransitionProtocol) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymTransitionProtocol) }
         }
         ItemKind::ItemMonitoringPolicy => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymMonitoringPolicy) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymMonitoringPolicy) }
         }
         ItemKind::ItemAlternativePolicy => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymAlternativePolicy) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymAlternativePolicy) }
         }
         ItemKind::ItemAlternativeFrontier => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymAlternativeFrontier) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymAlternativeFrontier) }
         }
         ItemKind::ItemDecisionPolicy => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymDecisionPolicy) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymDecisionPolicy) }
         }
         ItemKind::ItemDeferralPolicy => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymDeferralPolicy) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymDeferralPolicy) }
         }
         ItemKind::ItemValidation => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymPolicy) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymPolicy) }
         }
         ItemKind::ItemAudit => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymAudit) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymAudit) }
         }
         ItemKind::ItemEffect => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymEffect) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymEffect) }
         }
         ItemKind::ItemSession => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymTypeAlias) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymTypeAlias) }
         }
         ItemKind::ItemTrait => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymTypeAlias) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymTypeAlias) }
         }
         ItemKind::ItemAlgebra => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymTypeAlias) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymTypeAlias) }
         }
         ItemKind::ItemStudy => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymTypeAlias) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymTypeAlias) }
         }
         ItemKind::ItemOntology => {
-            if visibility_to_bool(item.visibility) { exports_push(exports, count, item.name, SymbolKind::SymTypeAlias) } else { (exports, count) }
+            if visibility_to_bool(item.visibility) { modreg_pool_push(item.name, SymbolKind::SymTypeAlias) }
         }
-        ItemKind::ItemImpl => (exports, count)
-        ItemKind::ItemUse => (exports, count)
-        ItemKind::ItemUnit => (exports, count)
+        ItemKind::ItemImpl => {}
+        ItemKind::ItemUse => {}
+        ItemKind::ItemUnit => {}
     }
 }
 
-fn collect_module_exports_variants(
-    opt: Option<Box<EnumDef>>,
-    exports: [ModuleExport; 1024],
-    count: i64
-) -> ([ModuleExport; 1024], i64) with Mut, Panic, Div, Alloc {
+fn collect_module_exports_variants(opt: Option<Box<EnumDef>>) with Mut, Panic, Div, Alloc {
     match opt {
-        None => (exports, count)
-        Some(ed) => collect_module_exports_variant_list((*ed).variants, exports, count)
+        None => {}
+        Some(ed) => collect_module_exports_variant_list((*ed).variants)
     }
 }
 
-fn collect_module_exports_variant_list(
-    opt: Option<Box<VariantDefList>>,
-    exports: [ModuleExport; 1024],
-    count: i64
-) -> ([ModuleExport; 1024], i64) with Mut, Panic, Div, Alloc {
+fn collect_module_exports_variant_list(opt: Option<Box<VariantDefList>>) with Mut, Panic, Div, Alloc {
     match opt {
-        None => (exports, count)
+        None => {}
         Some(list) => {
-            let pair = exports_push(exports, count, (*list).head.name, SymbolKind::SymEnumVariant)
-            collect_module_exports_variant_list((*list).tail, pair.0, pair.1)
+            modreg_pool_push((*list).head.name, SymbolKind::SymEnumVariant)
+            collect_module_exports_variant_list((*list).tail)
         }
     }
 }

--- a/self-hosted/resolve/mod.sio
+++ b/self-hosted/resolve/mod.sio
@@ -141,6 +141,9 @@ pub fn resolve_modules(programs: [Program; 256], count: i64) -> ResolveBatchResu
         reg = module_registry_put(reg, prog.module_path, pair.0, pair.1)
         i = i + 1
     }
+    // #1689: ASK whether anything was dropped. Silence here is what turned a
+    // capacity limit into 80 spurious E137 in main.sio.
+    let _ovf = module_registry_report_overflow(reg)
 
     // Resolve each module using the shared export registry
     var results: [ResolveResult; 256] = [empty_resolve_result(); 256]

--- a/self-hosted/resolve/resolve.sio
+++ b/self-hosted/resolve/resolve.sio
@@ -505,8 +505,10 @@ impl Resolver {
         // Glob import (`use foo::*`): import all exports.
         if is_glob {
             var i: i64 = 0
-            while i < entry.export_count && i < 1024 {
-                r = r.define(entry.exports[i as usize].name, SymbolKind::SymImported, span)
+            while i < entry.export_count {
+                // #1689: exports live in the shared pool now, not inline in the
+                // entry. The old `&& i < 1024` bound was also a silent cap.
+                r = r.define(modreg_export_name_at(entry.export_base + i), SymbolKind::SymImported, span)
                 i = i + 1
             }
             return r


### PR DESCRIPTION
Two silent caps in one struct, and the reason they were small.

`ModuleEntry` embedded `exports: [ModuleExport; 1024]` and `ModuleExport` embeds a `Name` (`[i8;128]`+len), so an entry was **~144 KB** and a 64-entry `ModuleRegistry` **~9 MB passed BY VALUE** (`module_registry_put` takes it and returns it). That is *why* the module cap was 64.

| cap | what happened past it |
|---|---|
| modules > 64 | `r.overflow = true` — **written here and read nowhere** |
| exports > 1024 | dropped with **no channel at all**; `stdlib/theorem/portfolio.sio` declares **2160** pub items |

Payload now lives in a flat pool, so `ModuleEntry` is ~168 B and the registry ~86 KB at 512 entries — the ~100× reduction is what makes the cap affordable. Same shape `resolve/modules.sio` already uses for `MgModuleGraph`, and `ir.sio` for `IR_A_*`.

**Parallel flat arrays, not a global array of structs** — the seed drops struct stores into global arrays silently, so a global `[ModuleExport; N]` would accept the write, read back zeros, and look exactly like a module that exports nothing.

The pool is monotonic and deliberately **never reset**: resetting in `module_registry_new()` would look tidier and be wrong, since `Resolver::new()` calls it too and would invalidate the base/count of a live populated registry.

`module_registry_report_overflow` is new and **both call sites now ask**. Separate from `put` because `put` has no `IO` effect and giving it one cascades. It prints counts, not a flag — "one short" and "an order out" need different responses.

Knock-on win: removes a 144 KB by-value copy **per item** from the recursive `collect_module_exports_loop`, which threaded the whole array through every item — ~288 MB of bump-allocated garbage for a 2000-item module, against an allocator that never reclaims.

## Measured against origin/main baselines, not against zero

| file | this branch | baseline |
|---|---|---|
| `resolve/imports.sio` | 0 | 0 |
| `resolve/resolve.sio` | 4 | 4 |
| `resolve/mod.sio` | 4 | 4 |
| `compiler/module_loader.sio` | 180 | 180 |

## What this does NOT fix

`main.sio` still reports the same **80 E137**. This registry is not on the `souc check` path — `grep resolve::imports` over `module_frontend.sio` and `check.sio` finds nothing. #1689's filed root cause was mine and it was wrong; corrected in that issue, along with the positional experiment that does pin the real behaviour and the two other decoy copies of this cap.

Refs #1689