### PR TITLE
fix(lean): pin the toolchain — `stable` moved to v4.33.0 and broke main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,6 +566,11 @@ jobs:
           path: |
             ~/.elan
             formal/lean4/.lake
+          # Keyed on the toolchain FILE, which is only meaningful now that the
+          # file names a version. While it read `leanprover/lean4:stable` the
+          # hash never changed even as `stable` advanced, so the cache pinned
+          # the toolchain in place and hid the drift until an eviction. Do not
+          # put a moving ref back in that file without changing this key too.
           key: lean-${{ runner.os }}-${{ hashFiles('formal/lean4/lean-toolchain') }}
           restore-keys: lean-${{ runner.os }}-
       - name: Install elan (Lean toolchain manager)

--- a/formal/lean4/lean-toolchain
+++ b/formal/lean4/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:stable
+leanprover/lean4:v4.32.2


### PR DESCRIPTION
`main` is red on **Lean Proofs** since 2026-08-10T08:42, and nothing in `formal/` changed to cause it. `SounioEpistemic.lean` has not been touched since **2026-02-21**, and the merge straddling the transition (#1490) contains **no `formal/` file at all**.

The dependency moved instead of the code.

```
formal/lean4/lean-toolchain  =  leanprover/lean4:stable
```

Measured from the CI logs:

| run | date | lean | Lean Proofs |
|---|---|---|---|
| 31312511396 | 2026-08-09 | **v4.32.2** | success |
| 31375613638 | 2026-08-10 | **v4.33.0** | failure |

A real behaviour change, not a flake:

```
SounioEpistemic.lean:272:56: Tactic `split` failed: Could not split an
`if` or `match` expression in the goal
⊢ (if prior.confidence + 0 ≤ bound then prior.confidence + 0 else bound)
    = prior.confidence
```

Pinned to **v4.32.2**, the last version main was measured green on. The repo's other two toolchains were already pinned (`v4.30.0-rc2`, `v4.29.0-rc2`); `formal/lean4` — the one CI builds — was the outlier.

## Why it surfaced as a cliff, not as drift

The elan cache key is `hashFiles('formal/lean4/lean-toolchain')`, and that file's **contents** were the literal string `leanprover/lean4:stable` — a hash that never changes no matter where `stable` points. The key held the old toolchain in place and masked the upgrade entirely. The day the cache missed, CI installed v4.33.0 and every proof depending on the old `split` behaviour failed at once. A comment now records this, since keying on the file is only sound while the file names a version.

## Deliberately not addressed

v4.33.0 also emits new `unusedVariables` / `unusedSimpArgs` linter warnings across these files, and `SounioGradedModal.lean` + `EpistemicEffects.lean` carry `sorry`s the build already tolerates. Moving to a newer Lean is real work; this restores the measured-good state so main is green while that gets scheduled.