### PR TITLE
fix(lean): make bayesianUpdate_zero_evidence toolchain-independent

### DIFF
--- a/formal/lean4/SounioEpistemic.lean
+++ b/formal/lean4/SounioEpistemic.lean
@@ -269,7 +269,14 @@ theorem bayesianUpdate_bounded (prior evidence : Knowledge) (bound : Nat) :
 theorem bayesianUpdate_zero_evidence (prior : Knowledge) (bound : Nat)
     (hv : prior.confidence ≤ bound) :
     (bayesianUpdate prior (measure 0) bound).confidence = prior.confidence := by
-  simp only [bayesianUpdate, measure, Confidence] at *; split <;> omega
+  -- `split` cannot case on this `ite` under Lean 4.33; it can under the pinned
+  -- 4.32.2. That difference is what took `main` red when `leanprover/lean4:stable`
+  -- moved (fixed by pinning, 7cd35ba73c). No case analysis is needed either way:
+  -- `measure 0` contributes zero confidence, so `Nat.add_zero` reduces the guard to
+  -- exactly `hv` and `if_pos` takes the then-branch. Verified to compile under BOTH
+  -- 4.32.2 and 4.33.0, so the pin can be moved forward without reopening this.
+  simp only [bayesianUpdate, measure, Confidence, Nat.add_zero]
+  exact if_pos hv
 
 theorem bayesianUpdate_provenance_sum (k e₁ e₂ : Knowledge) (bound : Nat) :
     (bayesianUpdate (bayesianUpdate k e₁ bound) e₂ bound).provenance =


### PR DESCRIPTION
Follow-up to #1701 / `7cd35ba73c`, which took `main` green again by pinning `lean-toolchain` back to `v4.32.2` after `leanprover/lean4:stable` moved to `v4.33.0`. **This PR leaves that pin exactly as it is** and removes the underlying fragility, so the pin can be moved forward later without reopening the same failure.

## The actual failure

```
SounioEpistemic.lean:272:56: error: Tactic `split` failed:
  Could not split an `if` or `match` expression in the goal
```

The goal at that point does contain an `if` — I traced it:

```
hv : prior.confidence ≤ bound
⊢ (if prior.confidence + 0 ≤ bound then prior.confidence + 0 else bound) = prior.confidence
```

So it is not that simp ate the `if`; `split` simply stopped being able to case on this `ite` between 4.32.2 and 4.33.0.

## The change

No case analysis is needed at all. `measure 0` contributes zero confidence, so `Nat.add_zero` reduces the guard to exactly the hypothesis `hv`, and `if_pos` takes the then-branch:

```lean
simp only [bayesianUpdate, measure, Confidence, Nat.add_zero]
exact if_pos hv
```

## Verification

- compiles under **v4.32.2** (the current pin) — `SounioEffects`, `SounioLinear`, `SounioEpistemic` all rc=0
- compiles under **v4.33.0** — and there a full `lake build` of the project completes: **215 jobs, "Build completed successfully"**

That second line is the useful one: with this single proof fixed, nothing else in the project blocks a bump to 4.33.0.

Found while triaging the open-issue backlog (#1698), where `Lean Proofs` was the one red job on `main` and had to be separated from the compiler work before anything could be judged green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)