### PR TITLE
fix(lean): move the toolchain pin forward to v4.33.0

### DIFF
--- a/formal/lean4/lean-toolchain
+++ b/formal/lean4/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.32.2
+leanprover/lean4:v4.33.0


### PR DESCRIPTION
Retires the emergency pin from #1701, which held `formal/lean4/lean-toolchain` at **v4.32.2** after `leanprover/lean4:stable` moved to **v4.33.0** and `split` stopped being able to case on the `ite` in `bayesianUpdate_zero_evidence`.

**#1703 removed the fragility rather than working around it.** The proof now reduces the guard with `Nat.add_zero` and takes the then-branch with `if_pos`, needing no case analysis at all, and its comment records that it compiles under **both** 4.32.2 and 4.33.0. That is what turns moving the pin into a one-line change instead of a gamble.

## Still pinned, deliberately

The obvious reading of "the pin is no longer needed" is to put `leanprover/lean4:stable` back. That is exactly the configuration that took `main` red this morning:

- a **moving reference** means the next Lean release can break the build with **no commit to this repository**
- #1703 fixed **one** proof; v4.33.0 also introduced new `unusedVariables` / `unusedSimpArgs` linter output across these files, so the surface that could become an error next time is not empty

Naming a version keeps the failure attached to a commit that changes it.

It also keeps the cache honest. The elan cache key is `hashFiles('formal/lean4/lean-toolchain')` — while that file read `stable`, its hash never moved even as the toolchain did, so the cache pinned the build in place and hid the drift until an eviction turned it into a cliff. A file that names a version is what that key was always assuming.

The repo's other two toolchains (`formal/` v4.30.0-rc2, `formal/omega_mathlib/` v4.29.0-rc2) remain pinned and are untouched.

If you do want the fully-unpinned `stable`, it is one line from here — this PR is the version that keeps main's failures attributable.