### PR TITLE
docs(triage): record the #1531 outcome and correct two wrong numbers

### DIFF
--- a/docs/research/compiler_issue_triage_2026-08-10.md
+++ b/docs/research/compiler_issue_triage_2026-08-10.md
@@ -63,7 +63,7 @@ the compiler built from the tree could no longer typecheck its own entry point (
 **Corrected in place:** #1667 (title symptom fixed, comment-1 shape still fails) and #852
 (does not terminate, rather than exiting in seconds).
 
-**#1531 is held**: the 108-test delta is a repository-scale decision, not a triage one.
+**#1531 landed** after its delta was measured correctly (16 failures under CI's compiler, not the 108 first reported here) and each one dispositioned — see below.
 
 The two systemic findings explain the backlog's shape better than any individual bug does: type
 errors in the compiler do not stop a build, and wrong answers at rc=0 do not fail a test.
@@ -561,6 +561,54 @@ The `if` is present — `split` simply stopped being able to case on this `ite` 
 4.33.0. No case analysis is needed: `Nat.add_zero` reduces the guard to exactly `hv`, so
 `exact if_pos hv` closes it. Verified under **both** toolchains, and under 4.33.0 a full
 `lake build` completes (215 jobs).
+
+
+
+## #1531 landed, and the numbers in this report were wrong twice
+
+The harness fix is merged. The suite now evaluates its `//@ expect-stdout:` and
+`//@ error-pattern:` annotations for the first time, with pre-existing debt recorded in
+`tests/vacuous_expect_baseline.txt` rather than left invisible.
+
+### Correcting this document's own measurements
+
+Two numbers reported earlier here were measured against the wrong subject:
+
+- **"108 tests go red"** — measured by applying a hand-written regex fix and running the suite
+  against a from-source **Madaros**.
+- **"Fail: 542"** — same mistake, with #1531's own harness.
+
+`.github/workflows/ci.yml` runs the suite with `SOUNIO_TEST_SOUC_BIN=/tmp/souc-stage2` and
+`--format junit`. **stage2 and Madaros do not emit the same diagnostics**, so neither number
+predicted CI. The true figures, from the CI job itself:
+
+| | |
+|---|---|
+| Pass | **1545** |
+| Fail | **16** (beyond the author's 36-entry baseline) |
+| Known failures | 137 |
+| Vacuous baseline tolerated | 35 of 36 |
+| Total | 2956 |
+
+A shrink of the baseline from 36 to 8 was also attempted and **reverted**: it was derived from
+the Madaros run, and CI immediately failed on entries it had removed. The lesson is the one this
+report already makes about the ratchet, in a second costume — *which binary produced the
+measurement is part of the measurement.*
+
+### What arming the assertions actually exposed
+
+Of the 16 CI failures, all were run again under Madaros to tell a feature gap from a defect:
+
+- **14 `madaros_gum_fo_*` fail under BOTH engines**, and `madaros_gum_fo_knowledge_ops`
+  segfaults. Their `MADAROS_GUM_FO_*_PASS` markers had never been evaluated, so an entire
+  feature's regression family read green while the feature did not work. They are named
+  `madaros_*` yet carry no `//@ requires: madaros` — and adding one would be false, since
+  Madaros fails them too. Filed as **#1706**.
+- **2 are a real engine divergence**: `ontology_property_weakening` and `gum_correlated` pass
+  under Madaros and fail under stage2.
+
+That is the concrete payoff of #444: not a projection, but fourteen tests that asserted a
+feature works when it does not, plus one that crashes.
 
 
 ## Ranking

--- a/docs/research/compiler_issue_triage_2026-08-10.md
+++ b/docs/research/compiler_issue_triage_2026-08-10.md
@@ -611,6 +611,59 @@ That is the concrete payoff of #444: not a projection, but fourteen tests that a
 feature works when it does not, plus one that crashes.
 
 
+
+## Following the thread to its end: #1706 defect 1, fixed
+
+Arming the assertions (#1531) exposed 14 `madaros_gum_fo_*` tests asserting a PASS marker
+neither engine produces (#1706). Investigating *why* found two independent defects, not one.
+
+**Defect 1 — variance was never tracked per struct field.** It was keyed by local NAME and by
+base REG only, so `let a = A { x: k.value }` followed by `variance_of(a.x)` had nowhere to look
+and emitted a silent `0.0`. **One hop was enough**; this was not a deep-nesting corner case. The
+compiler's own trace (`SOUNIO_LOWER_LIVE_TRACE=1`, printing `fo_xfer_miss name=…`) was what
+separated this from the transfer-table story.
+
+Fixed and merged as **#1711** (`9c6a04d865`):
+
+| expression | before | after |
+|---|---|---|
+| `a.x` (one hop) | `0.000000` | **`0.090000`** |
+| `d.c.b.a.x` (four hops) | `0.000000` | **`0.090000`** |
+| `d.v0` | `0.000000` | **`4.000000`** |
+| `pk2.cl0` (aggregate alias) | `0.000000` | **`0.090000`** |
+
+152 lines, insertions only. No new tables — `Lowerer` is passed by value and already carries
+`[i64; 4096]` plus two `[i64; 1024]` inline, so a field slot encodes `(base_reg, field_idx)` into
+two disjoint key bands of the existing base-reg table.
+
+**Defect 2 — the FO transfer classifier's coverage — remains open.** `fo_classify_expr_transfer`
+accepts only identity, `lit*x`, `a+b`, `a*b`, and a bare forwarded call; `ExprIf` bodies, calls
+nested inside a binary, and >2-param bodies fall through unregistered. So `v_call` and `v_meth`
+still read zero, all 14 entries stay in `tests/vacuous_expect_baseline.txt`, and #1706 stays open.
+
+### Two method notes worth keeping
+
+**A regression test must be proven to discriminate.** `gum_fo_field_chain_variance.sio` was run
+against unmodified `main` (FAIL) *and* the fix (OK) before being committed. In a report whose
+subject is assertions that never ran, shipping a test that passes either way would have been
+self-defeating.
+
+**`//@ requires: madaros` is truthful here and would be a lie on the other 14.** This fix lives
+in `self-hosted/ir/lower.sio`, which only Madaros runs — Madaros passes, stage2 does not, so the
+annotation states a real engine boundary. On the `madaros_gum_fo_*` family the same annotation
+would be false, because Madaros fails those too.
+
+### The suite is flaky, and that is now visible
+
+`main` fails roughly one run in four, on a *different* test each time
+(`global_scalar_init_still_works`, `observe_io_boundary`) — always `missing stdout` or
+`missing error`. A re-run of an unchanged commit went from red to 10/10 green, which is what
+identified it as flakiness rather than regression.
+
+Those are precisely the assertions #1531 armed. The instability is not new; the ability to see it
+is. Whoever picks this up should expect to re-run before believing a single red.
+
+
 ## Ranking
 
 Silent-wrong ranks above crash, because a crash announces itself.


### PR DESCRIPTION
Closes out the triage report (#1698) now that #1531 has landed, and corrects two figures in it that were measured wrong.

## The corrections

The report claimed **"108 tests go red"** and later **"Fail: 542"**. Both were measured by running the suite against a from-source **Madaros**. `.github/workflows/ci.yml` runs it with `SOUNIO_TEST_SOUC_BIN=/tmp/souc-stage2` and `--format junit`, and the two compilers do not emit the same diagnostics — so neither number predicted CI.

Real figures, from the CI job: **Pass 1545, Fail 16, known-failures 137, vacuous baseline tolerated 35/36, total 2956.**

A shrink of `tests/vacuous_expect_baseline.txt` from 36 to 8 was attempted on the same wrong basis and **reverted** — CI failed immediately on entries it had removed. Same lesson the report already draws about the fixed-point ratchet, in a second costume: which binary produced the measurement is part of the measurement.

## What arming the assertions actually found

All 16 CI failures were then run under Madaros too, to separate a feature gap from a defect:

- **14 `madaros_gum_fo_*` fail under both engines**, and `madaros_gum_fo_knowledge_ops` segfaults. Their `MADAROS_GUM_FO_*_PASS` markers had never been evaluated, so an entire feature's regression family read green while the feature did not work. Named `madaros_*`, yet no `//@ requires: madaros` — and adding one would be false, since Madaros fails them too. Filed as **#1706**.
- **2 are a genuine engine divergence**: `ontology_property_weakening` and `gum_correlated` pass under Madaros, fail under stage2.

That is #444's payoff made concrete: not a projection, but fourteen tests asserting a feature works when it does not, plus one that crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)