### PR TITLE
fix(ir): track variance per struct field, not just per local (#1706)

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -7435,7 +7435,78 @@ impl Lowerer {
             lo.variance_value_regs[idx as usize] = variance_reg
             lo.variance_base_reg_count = idx + 1
         }
+        // #1706 NOTE: past this wall a variance binding is silently DROPPED and the
+        // later lookup returns -1, which variance_of turns into a 0.0 -- the exact
+        // shape of defect that let a whole test family read green. Field slots (two
+        // keys per struct field) raise the pressure here.
+        //
+        // A diagnostic print belongs here, but this helper is declared
+        // `with Mut, Panic, Div` while print/lower_live_diag_enabled need IO, and
+        // widening the effect signature of a helper this widely called broke the
+        // self-compile ratchet with 2x error[E035]. Documented rather than fixed by
+        // effect-widening; no program is known to reach the wall.
         lo
+    }
+
+    // #1706 defect 1: variance was tracked per LOCAL NAME and per BASE REG only, so
+    // `variance_of(a.x)` on `let a = A { x: k.value }` read 0.0 -- a zero that means
+    // "not tracked" is indistinguishable from a true zero, which is how an entire
+    // test family stayed green (see tests/vacuous_expect_baseline.txt).
+    //
+    // Rather than add another pair of [i64; 1024] arrays to Lowerer -- which is
+    // passed BY VALUE, so every field costs a copy on each of the thousands of
+    // threadings per function -- a field slot reuses the existing base-reg table by
+    // encoding (base_reg, field_idx) into one key. NC_MAX_VREGS is 2048
+    // (native/frame.sio), and the encoding leaves the whole non-negative reg range
+    // untouched: real base regs stay < 2^20, so no encoded key can ever collide with
+    // a plain reg key.
+    fn variance_field_key(self, base_reg: i64, field_idx: i64) -> i64 with Div {
+        if base_reg < 0 || field_idx < 0 || base_reg >= 1048576 || field_idx >= 1024 {
+            return -1
+        }
+        1048576 + base_reg * 1024 + field_idx
+    }
+
+    fn bind_variance_for_field(self, base_reg: i64, field_idx: i64, variance_reg: i64) -> Lowerer with Mut, Panic, Div {
+        let key = self.variance_field_key(base_reg, field_idx)
+        if key < 0 {
+            return self
+        }
+        self.bind_variance_for_base_reg(key, variance_reg)
+    }
+
+    fn lookup_variance_for_field(self, base_reg: i64, field_idx: i64) -> i64 with Mut, Panic, Div {
+        let key = self.variance_field_key(base_reg, field_idx)
+        if key < 0 {
+            return -1
+        }
+        self.lookup_variance_for_base_reg(key)
+    }
+
+    // The reg holding a STRUCT-valued field, so a chain can hop: for `c.a.x`, the
+    // `.a` step needs the inner aggregate's base reg to then look up `.x` on it.
+    // Second key band, disjoint from both plain regs and the field-variance band.
+    fn variance_field_base_key(self, base_reg: i64, field_idx: i64) -> i64 with Div {
+        if base_reg < 0 || field_idx < 0 || base_reg >= 1048576 || field_idx >= 1024 {
+            return -1
+        }
+        1073741824 + base_reg * 1024 + field_idx
+    }
+
+    fn bind_variance_for_field_base(self, base_reg: i64, field_idx: i64, inner_reg: i64) -> Lowerer with Mut, Panic, Div {
+        let key = self.variance_field_base_key(base_reg, field_idx)
+        if key < 0 {
+            return self
+        }
+        self.bind_variance_for_base_reg(key, inner_reg)
+    }
+
+    fn lookup_variance_for_field_base(self, base_reg: i64, field_idx: i64) -> i64 with Mut, Panic, Div {
+        let key = self.variance_field_base_key(base_reg, field_idx)
+        if key < 0 {
+            return -1
+        }
+        self.lookup_variance_for_base_reg(key)
     }
 
     fn lookup_variance_for_base_reg(self, base_reg: i64) -> i64 with Mut, Panic, Div {
@@ -8808,6 +8879,31 @@ impl Lowerer {
         (lo, dst)
     }
 
+    // Resolve the aggregate reg that a field access is rooted at, hopping through
+    // struct-valued fields recorded by bind_variance_for_field_base. `a.x` roots at
+    // the local `a`; `c.a.x` roots at `c`, then hops `.a`. Depth-capped so a
+    // pathological chain terminates rather than recursing without bound.
+    fn variance_field_chain_base(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        match (*e).left {
+            Some(base_expr) => {
+                if (*base_expr).kind == ExprKind::ExprIdent {
+                    return (self, self.lookup_local((*base_expr).name))
+                }
+                if (*base_expr).kind == ExprKind::ExprFieldAccess {
+                    let inner = self.variance_field_chain_base(&(*base_expr))
+                    var lo = inner.0
+                    if inner.1 < 0 {
+                        return (lo, -1)
+                    }
+                    let idx = lo.field_idx_from_name_simple((*base_expr).name)
+                    return (lo, lo.lookup_variance_for_field_base(inner.1, idx))
+                }
+                (self, -1)
+            }
+            _ => (self, -1),
+        }
+    }
+
     fn lower_expr_variance_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
         if (*e).kind == ExprKind::ExprCall {
             match (*e).left {
@@ -8884,6 +8980,20 @@ impl Lowerer {
                         }
                     }
                     _ => {}
+                }
+            }
+            // #1706: any other field access -- `a.x`, `c.a.x`, arbitrary depth --
+            // resolves through the field slots recorded when the struct literal was
+            // lowered. Before this, every one of these fell to the `-1` below and
+            // variance_of read a silent 0.0.
+            let fbase = self.variance_field_chain_base(e)
+            if fbase.1 >= 0 {
+                var lo_f = fbase.0
+                let idx = lo_f.field_idx_from_name_simple((*e).name)
+                let fv = lo_f.lookup_variance_for_field(fbase.1, idx)
+                if fv >= 0 {
+                    lo_f = lo_f.so_clear_expr_hess().fo_seed_from_variance(fv)
+                    return (lo_f, fv)
                 }
             }
             return (self.fo_clear_expr_sens().so_clear_expr_hess(), -1)
@@ -12216,6 +12326,34 @@ impl Lowerer {
             lo = lo.bind_local_closure_fn_id(s.name, lo.pending_closure_fn_id)
             lo.pending_closure_fn_id = -1
         }
+        // #1706: `let pk2 = pk` on an aggregate gives pk2 its own reg, so the field
+        // slots recorded under pk's reg are invisible through pk2. Copy the mapping
+        // across for the fields actually recorded. This is a VALUE copy of the
+        // uncertainty mapping, matching the value semantics of the assignment (see
+        // #1487): a later rebind of one does not retroactively change the other.
+        match s.expr {
+            Some(rhs_alias) => {
+                if (*rhs_alias).kind == ExprKind::ExprIdent {
+                    let src_reg = lo.lookup_local((*rhs_alias).name)
+                    let dst_reg = lo.lookup_local(s.name)
+                    if src_reg >= 0 && dst_reg >= 0 && src_reg != dst_reg {
+                        var fi: i64 = 0
+                        while fi < 64 {
+                            let sv = lo.lookup_variance_for_field(src_reg, fi)
+                            if sv >= 0 {
+                                lo = lo.bind_variance_for_field(dst_reg, fi, sv)
+                            }
+                            let sb = lo.lookup_variance_for_field_base(src_reg, fi)
+                            if sb >= 0 {
+                                lo = lo.bind_variance_for_field_base(dst_reg, fi, sb)
+                            }
+                            fi = fi + 1
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
         if lo.pending_variance_reg >= 0 {
             lo = lo.bind_local_variance_reg(s.name, lo.pending_variance_reg)
             lo.pending_variance_reg = -1
@@ -13182,6 +13320,20 @@ impl Lowerer {
                     lo = pair.0
                     let vreg = pair.1
                     lo = lo.emit(ir_field_set(base_reg, named_field_idx, vreg, (*list).head.name))
+                    // #1706: record this field's uncertainty so `variance_of(a.x)` can
+                    // find it later. The initialiser expression is the only place the
+                    // provenance is still visible -- after the field_set the value is
+                    // just bytes in an aggregate. Nested literals recurse naturally,
+                    // because lowering the inner literal runs this same loop against
+                    // the inner base reg.
+                    let fv = lo.lower_expr_variance_ref(&(*list).head.value)
+                    lo = fv.0
+                    if fv.1 >= 0 {
+                        lo = lo.bind_variance_for_field(base_reg, named_field_idx, fv.1)
+                    }
+                    // A struct-valued field carries its own field slots; remember the
+                    // inner base so a chain (`c.a.x`) can hop through it.
+                    lo = lo.bind_variance_for_field_base(base_reg, named_field_idx, vreg)
                     current = &(*list).tail
                     field_idx = field_idx + 1
                 }

--- a/tests/run-pass/gum_fo_field_chain_variance.sio
+++ b/tests/run-pass/gum_fo_field_chain_variance.sio
@@ -1,0 +1,37 @@
+//@ run-pass
+//@ expect-stdout: GUM_FO_FIELD_CHAIN_OK
+
+// #1706 defect 1: variance_of on a STRUCT FIELD read a silent 0.0, because variance
+// was tracked per local name and per base reg only -- never per field. One hop was
+// enough to lose it, so this is the minimal witness, not a deep-nesting corner case.
+//
+// Before: direct=0.09 (correct), one_hop=0.00, two_hop=0.00
+// After:  all three 0.09
+
+struct A { x: f64 }
+struct C { a: A }
+fn main() with IO, Mut, Div, Epistemic {
+    let kx: Knowledge<f64> = measure(5.0, uncertainty: 0.3)
+    let x = kx.value
+    let a = A { x: x }
+    let c = C { a: A { x: x } }
+    let v_direct = variance_of(x)
+    let v_one = variance_of(a.x)
+    let v_two = variance_of(c.a.x)
+    print("direct="); print_f64(v_direct); print("\n")
+    print("one_hop="); print_f64(v_one); print("\n")
+    print("two_hop="); print_f64(v_two); print("\n")
+    // 0.3^2 = 0.09 on every path; a field hop must not lose the uncertainty.
+    if abs_f(v_direct - 0.09) < 1.0e-9
+        && abs_f(v_one - 0.09) < 1.0e-9
+        && abs_f(v_two - 0.09) < 1.0e-9 {
+        print("GUM_FO_FIELD_CHAIN_OK\n")
+    } else {
+        print("GUM_FO_FIELD_CHAIN_FAIL\n")
+    }
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { return 0.0 - x }
+    return x
+}

--- a/tests/run-pass/gum_fo_field_chain_variance.sio
+++ b/tests/run-pass/gum_fo_field_chain_variance.sio
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ requires: madaros
 //@ expect-stdout: GUM_FO_FIELD_CHAIN_OK
 
 // #1706 defect 1: variance_of on a STRUCT FIELD read a silent 0.0, because variance
@@ -7,6 +8,12 @@
 //
 // Before: direct=0.09 (correct), one_hop=0.00, two_hop=0.00
 // After:  all three 0.09
+//
+// `requires: madaros` because the fix lives in self-hosted/ir/lower.sio, which only
+// the Madaros engine runs; souc-stage2 (what CI's Full Test Suite uses) still reads
+// 0.00 for the field hops. Unlike the madaros_gum_fo_* family -- where the same
+// annotation would be FALSE, since Madaros fails those too -- here it states a real
+// engine boundary.
 
 struct A { x: f64 }
 struct C { a: A }


### PR DESCRIPTION
`variance_of` on a struct field read a silent **0.0**. Variance was keyed by local NAME and by base REG only — never per field — so `let a = A { x: k.value }` followed by `variance_of(a.x)` had nowhere to look. **One hop was enough to lose it**; this is not a deep-nesting corner case.

A zero that means "not tracked" is indistinguishable from a true zero. That is how an entire test family read green until #1531 armed the assertions.

## Measured, before → after

From-source Madaros:

| expression | before | after |
|---|---|---|
| `a.x` (one hop) | `0.000000` | **`0.090000`** |
| `c.a.x` (two hops) | `0.000000` | **`0.090000`** |
| `d.c.b.a.x` (four hops) | `0.000000` | **`0.090000`** |
| `d.v0` | `0.000000` | **`4.000000`** |
| `pk.cl0 + pk.v0` | `0.000000` | **`4.090000`** |
| `pk2.cl0` (aggregate alias) | `0.000000` | **`0.090000`** |

## Design: no new tables

`Lowerer` is passed **by value** and already carries `[i64; 4096]` plus two `[i64; 1024]` inline — every added field costs a copy on each of the thousands of threadings per function. So a field slot encodes `(base_reg, field_idx)` into two disjoint key bands of the **existing** base-reg table: one for the field's variance, one for the inner aggregate's reg (which is what makes chains hop). `NC_MAX_VREGS` is 2048 (`native/frame.sio`), so bands at 2²⁰ and 2³⁰ cannot collide with a real reg, and both encoders guard their range.

`let pk2 = pk` **copies** the field mapping rather than sharing it, matching the value semantics #1487/#1501 just established for aggregates.

The diff is **152 lines, insertions only** — no existing line changed.

## Verification

- **The new test discriminates**: `GUM_FO_FIELD_CHAIN_FAIL` on unmodified `main`, `GUM_FO_FIELD_CHAIN_OK` with this change. Given what this thread is about, a test that passes either way would be worthless.
- **Fixed-point ratchet**: `MADAROS_FIXED_POINT_OK`, `rc=0 errors=0`.
- **`madaros_full_gate`**: green.
- **A/B over every `gum`/`epistemic`/`variance`/`knowledge` test**: `pass=25 fail=18` on **both** unmodified `main` and this tree — no regression, and any delta would have been attributable.

## Scope

This is **defect 1 of #1706 only**. Call- and method-derived variance (`v_call`, `v_meth`) is defect 2 — a coverage gap in the FO transfer classifier — and remains open. The 14 `madaros_gum_fo_*` entries therefore **stay** in `tests/vacuous_expect_baseline.txt`; they each exercise both defects in one file.

One hazard is **documented in place rather than fixed**: past 1024 entries the shared variance table drops bindings silently. A diagnostic there needs `IO`, and widening the effect signature of that widely-called helper broke the ratchet with `2x error[E035]`, which is a worse trade than a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)