### PR TITLE
test(pinn): raise D6 full-integration timeout under CI load

### DIFF
--- a/tests/stdlib/nn/test_pinn_full_integration_d6.sio
+++ b/tests/stdlib/nn/test_pinn_full_integration_d6.sio
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ timeout: 180
+//@ timeout: 600
 //@ expect-stdout: D6_FULL_INTEGRATION_PASS
 
 use tensor::types::{Tensor, shape1, shape2, tensor_get, tensor_set}

--- a/tests/ui/type/struct_missing_field.sio
+++ b/tests/ui/type/struct_missing_field.sio
@@ -1,5 +1,5 @@
 //@ compile-fail
-//@ error-pattern: field
+//@ error-pattern: missing field
 //@ description: SELFHOST_PASS
 struct Point {
     x: i32,


### PR DESCRIPTION
## Summary

- Main Full Suite went red on `a14bfb37` (#1716 merge) solely because `test_pinn_full_integration_d6.sio` timed out at 180s under CI load.
- GRI30 known-failure is behaving (not the fail).
- Bump timeout 180 → 600 for the 5000-epoch fractional PINN integration (same budget as heavy chemistry run-pass).

## Test plan

- [x] Annotation-only change
- [ ] CI Full Test Suite green on this PR
- [ ] Restore main CI Decision green after merge