### PR TITLE
test(chemistry): split GRI30 full coverage — tables green on stage2

### DIFF
--- a/tests/stdlib/chemistry/test_gri30_full.sio
+++ b/tests/stdlib/chemistry/test_gri30_full.sio
@@ -1,21 +1,17 @@
 //@ run-pass
-//@ timeout: 600
-//@ known-failure: stage2 Full Suite SEGV (exit 139) on full GRI30 workspace path; measured green under current-source Madaros in PR validation
+//@ timeout: 120
 // tests/stdlib/chemistry/test_gri30_full.sio
 //
-// FULL GRI-Mech 3.0 mechanism (53 species, 325 reactions): modified-Arrhenius
-// rates, three-body efficiencies, Troe + Lindemann falloff, 16 irreversible
-// reactions, NASA-7 thermochemistry with reverse rates from detailed balance
-// (k_rev = k_fwd / Kc). Deterministic checkpoints are pinned to Cantera 3.2.0;
-// the in-repo Python replicas are not reference oracles. The 200-step UQ smoke
-// exercises the same persistent workspace as the deterministic reactor.
+// Stage2-safe coverage of the full GRI30 tables (stoich / rates / thermo).
+// The RK4 + sensitivity paths construct a ~1.1 MiB G30FWorkspace; under
+// stage2 lean_single that stack allocation SIGSEGVs (exit 139). Those paths
+// live in test_gri30_full_sim.sio as a documented known-failure until the
+// workspace is moved off-stack.
 use chemistry::gri30_full::*
 fn main() -> i32 with IO, Mut, Div, Panic {
     if !test_g30f_stoich_tables() { print("FAIL g30f_stoich_tables\n"); return 1 }
     if !test_g30f_rates() { print("FAIL g30f_rates\n"); return 2 }
     if !test_g30f_thermo() { print("FAIL g30f_thermo\n"); return 3 }
-    if !test_g30f_sim() { print("FAIL g30f_sim\n"); return 4 }
-    if !test_g30f_epistemic_smoke() { print("FAIL g30f_epistemic_smoke\n"); return 5 }
-    print("GRI30 FULL PASS\n")
+    print("GRI30 FULL TABLES PASS\n")
     0
 }

--- a/tests/stdlib/chemistry/test_gri30_full_sim.sio
+++ b/tests/stdlib/chemistry/test_gri30_full_sim.sio
@@ -1,0 +1,16 @@
+//@ run-pass
+//@ timeout: 600
+//@ known-failure: stage2 lean_single SIGSEGV (exit 139) constructing ~1.1 MiB G30FWorkspace on the call stack in simulate_gri30_full / simulate_gri30_full_epistemic; tables path is covered by test_gri30_full.sio
+// tests/stdlib/chemistry/test_gri30_full_sim.sio
+//
+// Full-mechanism RK4 isothermal integration + forward-sensitivity UQ smoke.
+// Green under current-source Madaros with sufficient stack / native-v2 frames;
+// stage2 stack-constructs the workspace and dies. Off-stack workspace is the
+// durable fix (tracked with this known-failure).
+use chemistry::gri30_full::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    if !test_g30f_sim() { print("FAIL g30f_sim\n"); return 1 }
+    if !test_g30f_epistemic_smoke() { print("FAIL g30f_epistemic_smoke\n"); return 2 }
+    print("GRI30 FULL SIM PASS\n")
+    0
+}


### PR DESCRIPTION
## Summary

- Root cause of stage2 `test_gri30_full` exit 139: stack construction of `G30FWorkspace` (~1.1 MiB) inside `simulate_gri30_full` / `simulate_gri30_full_epistemic`.
- Measured under lean_single: **stoich / rates / thermo PASS**; **sim / epistemic SEGV**.
- Split coverage:
  - `test_gri30_full.sio` — tables only (hard green)
  - `test_gri30_full_sim.sio` — RK4 + UQ smoke (`//@ known-failure` with the stack-size diagnosis)
- Removes the blanket known-failure from the tables path so CI still enforces table correctness.

Off-stack workspace (module-level / heap) remains the durable fix; global struct-literal init hit a separate lean_single typecheck gap in this pass.

## Test plan

- [x] lean_single: tables probe PASS
- [x] lean_single: sim probe exit 139 (known-failure)
- [ ] CI Full Test Suite green