### PR TITLE
test(ui): harden division-by-zero error-patterns

### DIFF
--- a/tests/ui/type/division_by_zero_const_expr.sio
+++ b/tests/ui/type/division_by_zero_const_expr.sio
@@ -1,5 +1,5 @@
 //@ compile-fail
-//@ error-pattern: zero
+//@ error-pattern: division by zero
 //@ description: SELFHOST_PASS: passes via self-hosted JIT checker (E056 const-folded div-by-zero)
 fn main() {
     let x = 10 / (2 - 2)

--- a/tests/ui/type/division_by_zero_const_ident.sio
+++ b/tests/ui/type/division_by_zero_const_ident.sio
@@ -1,6 +1,6 @@
 //@ compile-fail
 //@ ignore
-//@ error-pattern: zero
+//@ error-pattern: division by zero
 //@ description: SELFHOST_PASS: passes via self-hosted JIT checker (E056 const-tracked div-by-zero)
 fn main() {
     let z = 0


### PR DESCRIPTION
## Summary

- After #1723 merge, main Full Suite failed on `division_by_zero_const_expr.sio` missing short pattern `zero` (harness null-byte noise — same class as #1722’s `struct_missing_field`).
- Match full diagnostic: `division by zero`.
- Also harden the ignored ident twin for when it is de-ignored.

## Test plan

- [x] Local lean_single emits `error: division by zero`
- [ ] CI Full Suite green