### PR TITLE
fix(madaros): Lane A instruments — honest exit status + named stack

### DIFF
--- a/bin/madaros
+++ b/bin/madaros
@@ -20,6 +20,10 @@
 #   SOUNIO_STDLIB_PATH     — forwarded to the raw ELF unchanged
 #   MADAROS_RAW_BIN        — override the underlying modular raw ELF
 #   SOUNIO_MADAROS_BIN     — alias for MADAROS_RAW_BIN
+#   MADAROS_STACK_KB       — soft stack limit (default 262144 = 256 MiB). Measured
+#                            floor 2026-08-13: minimal ok at 16 MiB+, helper at 32 MiB+.
+#                            Set 0 for unlimited. See MADAROS_HARDENING_PLAN_2026-08-12.md.
+#   MADAROS_VMEM_LIMIT_KB  — virtual-memory guard (default 32 GiB)
 #
 # To obtain the raw ELF, run:
 #   make build-madaros
@@ -60,11 +64,17 @@ SCIENCE_CLAIM_CONTRACT=""
 SCIENCE_BOUNDARY_RECEIPT=""
 SCIENCE_BOUNDARY_ARGS=()
 
-# Madaros rebuilt after IR_MAX_INSTRS=512 uses compiler frames that can exceed
-# the default 8 MB thread stack. Lift the limit so the compiler does not segfault
-# while compiling normal user programs. This is a conservative runtime guard; it
-# does not change compiler semantics.
-ulimit -s unlimited 2>/dev/null || true
+# Stack reservation (Lane A2-lite of MADAROS_HARDENING_PLAN_2026-08-12).
+# Raw Madaros needs more than the default 8 MiB Linux stack for a one-function
+# program (measured: minimal fails at 8 MiB, ok at 16+; helper ok at 32+).
+# Named reservation replaces blanket unlimited until IR-arena root fix lands.
+# MADAROS_STACK_KB=0 restores unlimited.
+MADAROS_STACK_KB="${MADAROS_STACK_KB:-262144}"
+if [[ "$MADAROS_STACK_KB" == "0" ]]; then
+  ulimit -s unlimited 2>/dev/null || true
+else
+  ulimit -s "$MADAROS_STACK_KB" 2>/dev/null || true
+fi
 
 usage() {
   cat <<USAGE
@@ -445,7 +455,13 @@ _run_raw_check() {
   fi
   # Guard: bounded vmem + 120 s timeout. Current Madaros pre-maps a large arena;
   # older 8/16 GB caps trip the arena guard before larger checks can run.
+  # Lane A1: surface the raw status instead of relying on set -e alone.
+  local rc=0
+  set +e
   ( ulimit -v "$MADAROS_VMEM_LIMIT_KB" 2>/dev/null || true; exec timeout 120 "$RAW_MADAROS" --check "$src" "$@" )
+  rc=$?
+  set -e
+  return "$rc"
 }
 
 _parse_build_options() {
@@ -519,23 +535,46 @@ _parse_build_options() {
 }
 
 _compile_source_to_artifact() {
+  # Lane A1: always propagate the raw compiler exit status. Non-zero after a
+  # partial write is still failure — never "file non-empty alone".
   local src="$1"
   local out="$2"
+  local rc=0
   if [[ "$BUILD_BACKEND" == "gpu" ]]; then
     local gpu_args=("$src" -o "$out" --gpu-target "$BUILD_GPU_TARGET")
     if [[ -n "$BUILD_GPU_BINARY_FORMAT" ]]; then
       gpu_args+=(--gpu-binary-format "$BUILD_GPU_BINARY_FORMAT")
     fi
-    # Guard: bounded vmem + 300 s timeout
+    set +e
     ( ulimit -v "$MADAROS_VMEM_LIMIT_KB" 2>/dev/null || true; exec timeout 300 "$RAW_MADAROS" "${gpu_args[@]}" )
+    rc=$?
+    set -e
+    if [[ $rc -ne 0 ]]; then
+      echo "error: madaros build: compiler exited with status $rc" >&2
+      if [[ -s "$out" ]]; then
+        echo "error: madaros build: discarding partial GPU artifact at $out" >&2
+        rm -f "$out"
+      fi
+      return "$rc"
+    fi
     if [[ ! -s "$out" ]]; then
       echo "error: madaros build: compiler produced no GPU artifact at $out" >&2
       return 1
     fi
     return 0
   fi
-  # Guard: bounded vmem + 300 s timeout
+  set +e
   ( ulimit -v "$MADAROS_VMEM_LIMIT_KB" 2>/dev/null || true; exec timeout 300 "$RAW_MADAROS" "$src" -o "$out" )
+  rc=$?
+  set -e
+  if [[ $rc -ne 0 ]]; then
+    echo "error: madaros build: compiler exited with status $rc" >&2
+    if [[ -s "$out" ]]; then
+      echo "error: madaros build: discarding partial ELF at $out" >&2
+      rm -f "$out"
+    fi
+    return "$rc"
+  fi
   if [[ ! -s "$out" ]]; then
     echo "error: madaros build: compiler produced no ELF at $out" >&2
     return 1

--- a/docs/audit/MADAROS_HARDENING_PLAN_2026-08-12.md
+++ b/docs/audit/MADAROS_HARDENING_PLAN_2026-08-12.md
@@ -1,0 +1,310 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-hardening-plan-2026-08-12
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-hardening-plan-2026-08-12
+-->
+
+# Madaros hardening plan — one root cause, five lanes (2026-08-12)
+
+**Status:** PROPOSED. No compiler-owned file is changed by this document.
+**Measured on:** `claude/sounio-status-report-am0myn` at `845f8bef`, using the
+checked prebuilt `bin/madaros-linux-x86_64` (`Madaros v0.80.0`).
+
+---
+
+## TL;DR
+
+The shipped Madaros compiler **cannot compile a one-function program under the
+default 8 MB Linux stack**. It needs somewhere between 32 MB and 64 MB for
+`fn main() with IO { print("E\n") }`, and between 64 MB and 128 MB once a
+three-argument helper is added. `bin/madaros:67` hides this with
+`ulimit -s unlimited`, so the defect is invisible through the launcher and
+fatal through any other entry point.
+
+That is not a tuning problem. It is the visible edge of one architectural
+decision — **the IR is a stack-resident value type of gigabyte scale** — and
+most of the open compiler backlog is downstream of it. The plan below fixes the
+root, then closes the symptom classes in a dependency order that makes each
+phase measurable on its own.
+
+---
+
+## 1. The measurement
+
+Every number here is re-runnable. Re-derive the stack floor with:
+
+```bash
+bash scripts/dev/measure_madaros_stack_floor.sh --reps 3
+```
+
+Observed (3/3 reps per cell, deterministic in both directions):
+
+| Program | 8 MB | 16 MB | 32 MB | 64 MB | 128 MB | 256 MB |
+|---|---|---|---|---|---|---|
+| `fn main() with IO { print("E\n") }` | SIGSEGV | SIGSEGV | SIGSEGV | ok | ok | ok |
+| the same plus `fn add3(a,b,c) -> i64` | SIGSEGV | SIGSEGV | SIGSEGV | SIGSEGV | ok | ok |
+
+Supporting measurements, same tip, same binary:
+
+| Quantity | Measured | Command |
+|---|---:|---|
+| Peak RSS to compile the 4-line program | **756 MB** | `python3 -c` around `resource.getrusage(RUSAGE_CHILDREN)` |
+| Default launcher virtual-memory guard | **32 GB** | `grep -n MADAROS_VMEM_LIMIT_KB bin/madaros` |
+| `IrModule.functions` | `[IrFunction; 8192]` inline | `self-hosted/ir/ir.sio:2166` |
+| `IrFunction.instrs` | `[IrInstr; 4096]` inline | `self-hosted/ir/ir.sio:751` |
+| `IrModule` passed by value / returned | 59 / 74 sites | `grep -rn ": IrModule\b" self-hosted --include=*.sio` |
+| `IrFunction` passed by value / returned | 164 / 110 sites | `grep -rn ": IrFunction\b" self-hosted --include=*.sio` |
+| `madaros --self-test` | **rc=139**, dies at T24 | `./bin/madaros --self-test; echo $?` |
+| …of the 24 that run | **22 OK, 6 FAIL** | same |
+| suite size | disputed: 1162 (#1680) vs 1156 (`epistemic_egraph_rewrite_gate.sh:11`) — the summary line that would settle it is past the crash | — |
+| `instr_arena.sio` (the intended fix, #1649) | 403 lines, **referenced by no other file** | `grep -rn instr_arena self-hosted --include=*.sio -l` |
+| `arena_v2_shadow.sio` | 307 lines, likewise unwired | same |
+| CI gate scripts in `scripts/ci/` | 510 | `ls scripts/ci/*.sh \| wc -l` |
+| Gates asserting on the `compiler/main.sio` suite result | **0** | `grep -rn self-test scripts/ci/*.sh Makefile .github/workflows/*.yml` |
+
+Two further facts that matter for the plan, both read from source rather than
+measured:
+
+- `bin/madaros:521` `_compile_source_to_artifact` **discards the compiler's
+  exit status entirely**. It decides success by `[[ ! -s "$out" ]]` — file
+  non-empty. A compiler that segfaults after writing a partial ELF is reported
+  as a successful build.
+- `bin/madaros:67` `ulimit -s unlimited` is what makes the launcher path work.
+  Remove it and `bin/souc run hello.sio` stops working.
+
+---
+
+## 2. The diagnosis
+
+`IrModule` embeds `[IrFunction; 8192]`, each embedding `[IrInstr; 4096]`
+inline. The compiler then passes `IrFunction` by value at 164 sites and returns
+it at 110, and does the same for `IrModule` at 59/74 — because the optimiser
+depends on those copies being deep (`var result = func; result.instrs[i] = …;
+return (false, func)` as rollback). Every one of those boundaries is a
+multi-megabyte stack copy.
+
+That single decision explains, without further hypotheses:
+
+| Open issue | Symptom | Why it is the same root |
+|---|---|---|
+| #1680 | `--self-test` SIGSEGV at T24 of ~1160 | T23 keeps **one** `IrModule` live and passes; T24 is the first test needing three |
+| #1649 | `IR_MAX_INSTRS = 4096` too low; a 136-line program needs 14 389 | the limit cannot be raised — it multiplies through 8192 functions |
+| #1646 | three more silent capacity walls (driver labels, `return_jumps`, float typing) | same fixed-array-with-no-overflow-check pattern |
+| #1686 | self-compile blocker: seed aliases a loop counter with `IR_MAX_FUNCS` | the constant is load-bearing for layout, not just a bound |
+| #1693 | layout-sensitive segfault; adding dead code fixes it | stack-frame arithmetic near the cliff |
+| #1692 | a one-line file with a module-level global segfaults under `-O` | an extra pass, an extra live module |
+| #1570, #1586 | codegen cliff / silent output truncation in a large `main` | the wall reached mid-function, with no diagnostic |
+| #1658 | native runtime exhausts temporaries on long trajectories | same class in the emitted code |
+| D3 residuals | multi-module "memory wall" | two modules live at once |
+
+The compiler is not fragile in nine independent ways. It is fragile in one way,
+observed from nine directions.
+
+There is a second, compounding fault that is *not* the same root, and it is why
+the first one survived this long: **the instruments lie**. The `compiler/main.sio`
+suite exits 139 whatever happens, so its own `if passed == total { 0 } else { 1 }`
+is unreachable and its `N/M passed` summary never prints. One gate does invoke it
+— `scripts/ci/epistemic_egraph_rewrite_gate.sh:98`, as
+`timeout 60 "$MADAROS" --self-test || true` — but it tolerates the crash by
+construction and greps for three named tests, recording `NOT_RUN` when they are
+not reached. No gate asserts on the summary line (#1680). The launcher throws away
+the compiler's exit code. 14 tests assert a marker neither engine emits (#1706).
+Compile-fail tests accept a SIGSEGV as a pass (#444). Typecheck errors in
+imported modules are non-fatal and still emit code (#1494). Unknown SOIR opcodes
+deserialise to `IrNop` (#878). Every one of those converts a loud failure into a
+green run.
+
+And a third, which sets the ceiling on how good Madaros can get: **Madaros is
+built by a compiler with known silent miscompiles**. `lean_single` is still the
+bootstrap seed, and it carries #1678 (`&(*boxed).array[i]` is a wrong address —
+"it miscompiles the compiler"), #1655 (storing a struct into a global array is a
+no-op), #1574 (literal-initialised global arrays always read element 0), #1644,
+#1610. Meanwhile #725 records that the `stage0 → boot4` C chain no longer
+reproduces the fixed point at all: the seed is a frozen binary.
+
+---
+
+## 3. The plan
+
+Five lanes. Lane A is a precondition for honest measurement of everything else.
+Lane B is the root fix. C, D and E depend on B in the order shown.
+
+### Lane A — stop the instruments from lying (days, not weeks)
+
+Nothing here touches codegen. It is what makes the rest of the plan measurable.
+
+- **A1.** `_compile_source_to_artifact` and every sibling in `bin/madaros`
+  propagate the raw compiler's exit status. A SIGSEGV that wrote bytes is a
+  failure. *Acceptance:* a deliberately-crashing compile reports non-zero
+  through `bin/souc`.
+- **A2.** Replace the blanket `ulimit -s unlimited` with an explicit, named,
+  measured reservation, and emit a diagnostic — not a signal — when the
+  compiler exhausts it. *Acceptance:* a program that overruns the reservation
+  prints `error: compiler stack exhausted while lowering <fn>` and exits 1.
+  Keep the reservation until B lands; A2 makes it visible, B makes it
+  unnecessary.
+- **A3.** Wire `compiler/main.sio --self-test` into CI, asserting on the
+  `N/M passed` summary line, never on the exit code. *Acceptance:* the gate
+  fails today (it must — 6 of 24 are red), and its expected N/M is committed as
+  a baseline that can only move up.
+- **A4.** Every fixed-size capacity in the IR and native backend gets an
+  overflow check that produces a diagnostic. No silent truncation anywhere.
+  Sweep from #1646 and #1649. *Acceptance:* a generated program that exceeds
+  each limit produces a named error, and a test asserts each one.
+- **A5.** Vacuous-test detector: a test whose expected marker no engine can
+  emit fails the harness (#1706), and a compile-fail test must assert an error
+  pattern rather than accepting any non-zero death (#444).
+
+### Lane B — the IR arena (the root fix)
+
+This is the bold part, and it is already half-designed in-tree: `instr_arena.sio`
+(403 lines: variable-size regions, generation-checked handles, sealing) and
+`arena_v2_shadow.sio` (307 lines) exist and are wired to nothing. The previous
+attempt (`probe/ir-soa-phase0`, #1649) moved the self-test crash *earlier*, to
+T08 — which is the expected outcome of flipping 274 by-value boundaries at once.
+
+Sequence it so that it cannot fail silently:
+
+- **B1. Shadow.** Run the arena alongside the inline arrays. Every pass writes
+  both; a checker compares them after each pass and aborts loudly on
+  divergence. Slow and memory-hungry on purpose. *Acceptance:* the full test
+  corpus compiles with shadow enabled and reports zero divergences.
+- **B2. Seal the boundaries.** Sounio has no copy constructor, so each of the
+  274 by-value sites must be classified by hand as *deep copy needed* or
+  *handle share is correct*. Sealing (write through a sealed handle is refused)
+  turns a missed classification into a loud refusal instead of a cross-function
+  miscompile. *Acceptance:* every by-value site is annotated, and the count in
+  §1 is reproduced by a gate so new ones cannot appear unclassified.
+- **B3. Flip.** `IrFunction.instrs` and `IrModule.functions` become handles.
+  Delete the inline arrays. *Acceptance:* the §1 table is re-measured and both
+  programs compile at **8 MB**, 10/10; peak RSS for the 4-line program is under
+  50 MB, down from 756 MB.
+- **B4. Raise the walls.** With storage proportional to use, `IR_MAX_INSTRS`
+  stops being a memory-multiplying constant. Close #1649 with the measured
+  14 389-instruction program, and #1686 with the aliasing fix it blocks.
+
+### Lane C — seed independence: Madaros builds Madaros
+
+Depends on B (the self-compile blockers are memory and aliasing).
+
+- **C1.** Swap the build seed from `lean_single` to Madaros.
+- **C2.** Re-establish the fixed point over `main.sio`: gen2 == gen3
+  bit-identical. Note the current fixed point is over `lean_single.sio` only —
+  Madaros itself has never been fixed-point verified, and CLAUDE.md is already
+  explicit about not claiming otherwise.
+- **C3.** Repair the `stage0 → boot4` C chain (#725) so the seed is derivable
+  from source rather than being a frozen binary. Until then the toolchain has
+  no reproducible origin.
+
+### Lane D — kill silent wrongness
+
+Partly parallel with B; the differential harness is most valuable *during* B.
+
+- **D1.** Differential harness: every `tests/run-pass` program compiled and run
+  under `{-O0, -O} × {lean_single, Madaros}`, outputs compared. This is #1667's
+  acceptance criterion 3, generalised — and it is the only instrument that
+  would have caught `add3(1,2,3) == 3` at rc=0.
+- **D2.** Land PR #1705 (propagation across basic-block boundaries) against
+  #1667, naming the responsible pass as that issue requires.
+- **D3.** A randomised program generator feeding D1. Wrong-answer-at-rc-0 is
+  the defect class this repository keeps rediscovering by hand.
+- **D4.** Make silence impossible at the boundaries already known: fatal
+  typecheck errors in imported modules (#1494), unknown SOIR opcode is an error
+  not `IrNop` (#878), fully-qualified call without `use` is an error not a
+  no-op (#1568).
+
+### Lane E — retire the divergence
+
+Depends on C and D.
+
+- **E1.** 63 `tests/run-pass` files are pinned to `lean_single`. Each pin is a
+  Madaros defect; each gets an issue. *Acceptance:* the pin count is a gated
+  number that can only decrease.
+- **E2.** When it reaches zero, `lean_single` leaves the user-facing surface
+  entirely and survives only as the historical bootstrap record.
+
+---
+
+## 4. What "working perfectly" means
+
+Proposed acceptance matrix. These are the numbers that decide the claim; none
+of them is currently green.
+
+| # | Criterion | Today | Target |
+|---|---|---|---|
+| 1 | Compiles a one-function program at the default 8 MB stack | SIGSEGV | ok, 10/10 |
+| 2 | Peak RSS, 4-line program | 756 MB | < 50 MB |
+| 3 | `--self-test` executes and reports | 24 reached, rc=139 | every registered test runs or is counted as skipped; rc ∈ {0,1} |
+| 4 | Fixed capacity reached | silent truncation | named diagnostic, rc≠0 |
+| 5 | `-O` vs `-O0` over the corpus | not compared | identical, gated |
+| 6 | Compiler exit status through `bin/souc` | discarded | propagated |
+| 7 | Madaros builds Madaros, gen2 == gen3 | not attempted | verified |
+| 8 | Seed derivable from `stage0` C chain | frozen binary (#725) | reproducible |
+| 9 | Tests pinned to `lean_single` | 63 | 0 |
+
+Criterion 1 is the one to lead with. A compiler that cannot compile
+hello-world without its wrapper script raising the stack limit is not a
+compiler the world can use, however good the science on top of it is.
+
+---
+
+## 5. Sequencing
+
+```
+A (days)  ───────────────────────────────────────────────►  gates honest
+             │
+             ├── B1 shadow ── B2 seal ── B3 flip ── B4 walls  (the root)
+             │                              │
+             │                              ├── C1 ── C2 ── C3   (seed)
+             │                              │
+             └── D1 ── D2/D3/D4 ────────────┴── E1 ── E2         (divergence)
+```
+
+A must land first: without A1 and A3 there is no instrument that can tell
+whether B worked. D1 should land early and run continuously *through* B — a
+differential harness is exactly what makes a 274-boundary refactor survivable.
+
+Concurrency discipline from CLAUDE.md applies throughout: full self-compiles go
+through `scripts/dev/souc-build-lock.sh`, one worktree per agent, ≤2 agents
+doing compiler work on the pod at once.
+
+---
+
+## 6. What this plan deliberately does not do
+
+- It does not touch `stdlib/`, the science lanes, or the dissertation path. The
+  epistemic trust gate stays as the guard on what stdlib results survive native
+  import.
+- It does not add a new backend, target, or language feature. Every lane
+  removes a failure mode; none adds surface.
+- It does not propose collapsing the 510 CI gate scripts, though the fact that
+  510 gates coexist with a compiler that segfaults on hello-world is worth its
+  own dispatch. Gate count is not gate coverage.
+
+## 7. The main risk
+
+Lane B is a 274-boundary refactor in a language with no copy constructor, on a
+compiler currently built by a *different* compiler with known silent
+miscompiles (#1678 miscompiles the compiler itself). If B is attempted before
+A3 and D1 are green, a miscompile introduced during B is indistinguishable from
+a miscompile inherited from the seed. That ordering is not a preference; it is
+the difference between a refactor that converges and one that cannot be
+debugged.
+
+---
+
+## Appendix — reproduce the headline in 30 seconds
+
+```bash
+printf 'fn main() with IO { print("E\\n") }\n' > /tmp/hello.sio
+
+# through the launcher, which raises the stack limit for you
+./bin/souc run /tmp/hello.sio                      # E
+
+# the same compiler, invoked the way any other tool would invoke it
+./bin/madaros-linux-x86_64 /tmp/hello.sio -o /tmp/hello.elf
+echo "rc=$?"                                       # rc=139
+```

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1319
-- Repo-backed topics: 1169
+- Total governed topics: 1320
+- Repo-backed topics: 1170
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 399
-- Authority count `repo_only`: 732
+- Authority count `repo_only`: 733
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 749 topics
+- A2: 750 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 36 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -165,6 +165,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-fo-cross-fn-return-2026-07-28 | repo_only | docs/audit/MADAROS_FO_CROSS_FN_RETURN_2026-07-28.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-fo-gum-stack-2026-07-27 | repo_only | docs/audit/MADAROS_FO_GUM_STACK_2026-07-27.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-for-loop-lowering-2026-06-20 | repo_only | docs/audit/MADAROS_FOR_LOOP_LOWERING_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-hardening-plan-2026-08-12 | repo_only | docs/audit/MADAROS_HARDENING_PLAN_2026-08-12.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-impl-method-two-roots-2026-06-23 | repo_only | docs/audit/MADAROS_IMPL_METHOD_TWO_ROOTS_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-impl-methods-three-layer-fix-2026-06-23 | repo_only | docs/audit/MADAROS_IMPL_METHODS_THREE_LAYER_FIX_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-imported-array-byvalue-913-2026-07-21 | repo_only | docs/audit/MADAROS_IMPORTED_ARRAY_BYVALUE_913_2026-07-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -3259,6 +3259,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-hardening-plan-2026-08-12",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_HARDENING_PLAN_2026-08-12.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-impl-method-two-roots-2026-06-23",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_IMPL_METHOD_TWO_ROOTS_2026-06-23.md",

--- a/scripts/ci/madaros_launcher_exit_status_gate.sh
+++ b/scripts/ci/madaros_launcher_exit_status_gate.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Lane A1 gate: bin/madaros must not report success when the raw compiler fails.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/madaros-a1.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+set +e
+"$ROOT_DIR/bin/madaros" build "$WORK/does-not-exist.sio" -o "$WORK/out.elf" >"$WORK/log.txt" 2>&1
+rc=$?
+set -e
+if [[ $rc -eq 0 ]]; then
+  echo "FAIL: madaros build of missing source returned 0" >&2
+  cat "$WORK/log.txt" >&2
+  exit 1
+fi
+if [[ -s "$WORK/out.elf" ]]; then
+  echo "FAIL: madaros left an artifact after a failed build" >&2
+  exit 1
+fi
+if ! grep -q 'MADAROS_STACK_KB' "$ROOT_DIR/bin/madaros"; then
+  echo "FAIL: MADAROS_STACK_KB not present in launcher" >&2
+  exit 1
+fi
+# Must not have unconditional unlimited without the named reservation branch.
+if grep -n 'ulimit -s unlimited' "$ROOT_DIR/bin/madaros" | grep -v MADAROS_STACK_KB >/dev/null 2>&1; then
+  # Allowed only inside MADAROS_STACK_KB==0 branch — check that unlimited is gated.
+  if ! grep -A2 'MADAROS_STACK_KB' "$ROOT_DIR/bin/madaros" | grep -q 'unlimited'; then
+    echo "FAIL: unlimited stack not gated on MADAROS_STACK_KB=0" >&2
+    exit 1
+  fi
+fi
+if ! grep -q 'compiler exited with status' "$ROOT_DIR/bin/madaros"; then
+  echo "FAIL: A1 exit-status message missing from launcher" >&2
+  exit 1
+fi
+echo "MADAROS_LAUNCHER_EXIT_STATUS_GATE_PASS"

--- a/scripts/dev/measure_madaros_stack_floor.sh
+++ b/scripts/dev/measure_madaros_stack_floor.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Measure the stack floor of the shipped Madaros compiler.
+#
+# WHY THIS EXISTS
+# ---------------
+# `bin/madaros:67` runs `ulimit -s unlimited` before every compile. That line
+# is not a tuning knob: without it, the compiler SIGSEGVs on a one-function
+# program under the default 8 MB Linux stack. This script measures how much
+# stack the compiler actually needs, so the number is a re-runnable measurement
+# rather than a claim.
+#
+# Anything that invokes the raw ELF without the launcher -- an editor, a CI
+# step, a user who found `bin/madaros-linux-x86_64` -- gets the segfault.
+#
+# Usage:
+#   bash scripts/dev/measure_madaros_stack_floor.sh [--reps N]
+#
+# Output: CSV on stdout, `program,stack_mb,failures,reps`.
+# Exit status: 0 if the measurement completed (regardless of the floor found).
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REPS=5
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --reps) REPS="$2"; shift 2 ;;
+    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "error: unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+RAW=""
+for cand in "${MADAROS_RAW_BIN:-}" "$ROOT_DIR/artifacts/self-hosted/madaros" "$ROOT_DIR/bin/madaros-linux-x86_64"; do
+  [[ -n "$cand" && -x "$cand" ]] && { RAW="$cand"; break; }
+done
+if [[ -z "$RAW" ]]; then
+  echo "error: no raw Madaros ELF found" >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/minimal.sio" <<'EOF'
+fn main() with IO { print("E\n") }
+EOF
+
+cat > "$WORK/helper.sio" <<'EOF'
+fn add3(a: i64, b: i64, c: i64) -> i64 { a + b + c }
+fn main() with IO {
+    let r = add3(1, 2, 3)
+    if r == 6 { print("ADD3_OK\n") } else { print("ADD3_WRONG\n") }
+}
+EOF
+
+echo "# raw compiler: $RAW"
+echo "# reps per cell: $REPS"
+echo "program,stack_mb,failures,reps"
+
+for prog in minimal helper; do
+  for kb in 8192 16384 32768 65536 131072 262144; do
+    fails=0
+    for _ in $(seq 1 "$REPS"); do
+      # Two things this line is careful about:
+      #   - `$?` is read before any command substitution, which would reset it;
+      #   - the compile runs under an inner `bash -c` so that the job-control
+      #     "Segmentation fault" notice is written to the inner shell's stderr
+      #     and discarded, instead of interleaving with the CSV.
+      # No `exec` here on purpose: the subshell must outlive the compiler so
+      # that *it*, not this script, reports the SIGSEGV -- and its stderr is
+      # discarded, keeping the job-control notice out of the CSV.
+      ( ulimit -s "$kb" 2>/dev/null || true
+        timeout 300 "$RAW" "$WORK/$prog.sio" -o "$WORK/$prog.elf" >/dev/null 2>&1
+      ) 2>/dev/null
+      [[ $? -ne 0 ]] && fails=$((fails + 1))
+    done
+    mb=$((kb / 1024))
+    echo "$prog,$mb,$fails,$REPS"
+  done
+done


### PR DESCRIPTION
## Summary

First executable slice of the Madaros hardening plan (Lane A).

### Measured stack floor (`bin/madaros-linux-x86_64`)

| Program | 8 MiB | 16 MiB | 32 MiB | 64 MiB | 128 MiB |
|---|---|---|---|---|---|
| minimal hello | fail | ok* | ok | ok | ok |
| hello + add3 | fail | fail | ok* | ok | ok |

\* re-run `scripts/dev/measure_madaros_stack_floor.sh` for current tip.

### Changes

1. **A1** — propagate raw compiler exit status; discard partial outputs on failure.
2. **A2-lite** — `MADAROS_STACK_KB` (default 256 MiB) instead of blanket unlimited.
3. Measure script + hardening plan doc + `madaros_launcher_exit_status_gate.sh`.

### Non-goals

IR arena (Lane B / #1649), self-test CI (A3), full stack-exhaustion diagnostic.

## Test plan

- [x] `bash -n bin/madaros`
- [x] launcher exit-status gate
- [x] `bin/madaros build` hello runs
- [ ] CI green