### PR TITLE
fix(madaros): close #1649 for IR arena — promote knowledge_octonion

### DIFF
--- a/docs/audit/MADAROS_HARDENING_PLAN_2026-08-12.md
+++ b/docs/audit/MADAROS_HARDENING_PLAN_2026-08-12.md
@@ -15,6 +15,23 @@ checked prebuilt `bin/madaros-linux-x86_64` (`Madaros v0.80.0`).
 
 ---
 
+## Status update 2026-08-13
+
+**Lane A:** landed on `main` via #1725 (honest exit status + `MADAROS_STACK_KB` + measure script).
+
+**Lane B — instruction storage (B3-instrs):** DONE in source. `IrFunction.region: IrInstrRegion`
+and `IR_MAX_INSTRS = 16384` are on `main`. A current-source Madaros rebuild compiles and
+runs `tests/run-pass/knowledge_octonion_structure.sio` (14 389 IR ops) to `PASS`. The
+checked-in `bin/madaros-linux-x86_64` can lag (still reports 4096 until rebuilt/shipped).
+
+**Lane B residual (stack floor):** with current-source Madaros, minimal hello still needs
+**64 MiB** stack (fails at 8/16/32). `IrModule.functions: [IrFunction; 8192]` remains
+inline (~11 MiB) and codegen still has multi-10 MiB frames. Next peel: functions table
+as arena handles + shrink by-value `IrFunction`/`IrModule` copies (B3-functions).
+
+Re-measure: `MADAROS_RAW_BIN=artifacts/self-hosted/madaros bash scripts/dev/measure_madaros_stack_floor.sh`
+
+
 ## TL;DR
 
 The shipped Madaros compiler **cannot compile a one-function program under the

--- a/tests/madaros_corpus_baseline.txt
+++ b/tests/madaros_corpus_baseline.txt
@@ -132,7 +132,6 @@ knightian_syntax.sio compile
 knowledge_acknowledge.sio compile
 knowledge_array.sio compile
 knowledge_octonion_inner.sio compile
-knowledge_octonion_structure.sio compile
 knowledge_require_confidence.sio compile
 knowledge_unwrap.sio compile
 knowledge_value_with_epistemic.sio compile


### PR DESCRIPTION
## Summary

Lane B instruction storage is **already on main** (`IrFunction.region`, `IR_MAX_INSTRS=16384`). What was missing was a **current-source Madaros rebuild** of the checked prebuilt, which still said 4096.

### Evidence (this PR branch)

```text
MADAROS_RAW_BIN=artifacts/self-hosted/madaros  # rebuilt via build_modular_madaros.sh
./bin/madaros run tests/run-pass/knowledge_octonion_structure.sio
# … composition err = 0.000000
# PASS
```

Stack floor of the **new** binary (still not 8 MiB — next peel):

| Program | 8 | 16 | 32 | 64 | 128 |
|---|---|---|---|---|---|
| minimal | fail | fail | fail | ok | ok |
| +add3 | fail | fail | fail | fail | ok |

`IrModule.functions: [IrFunction; 8192]` remains inline (~11 MiB) and is the residual stack cost after instrs left the struct.

### Changes

- Promote `knowledge_octonion_structure.sio` off Madaros compile baseline (**Fixes #1649** for the capacity wall).
- Status note in `MADAROS_HARDENING_PLAN_2026-08-12.md` (B-instrs done; B-functions next).

### Non-goals

- Shipping a new `bin/madaros-linux-x86_64` blob in this PR (operators rebuild via `make build-madaros` / CI current-source).
- Functions-array arena (next Lane B peel).

## Test plan

- [x] Current-source Madaros: knowledge_octonion_structure PASS
- [x] Stack floor re-measured
- [ ] CI green