### PR TITLE
fix(madaros): Lane B peel — vestigial CodeBuffer + trampoline by-ref

### DIFF
--- a/docs/audit/MADAROS_HARDENING_PLAN_2026-08-12.md
+++ b/docs/audit/MADAROS_HARDENING_PLAN_2026-08-12.md
@@ -28,13 +28,26 @@ checked-in `bin/madaros-linux-x86_64` can lag (still reports 4096 until rebuilt/
 **64 MiB** stack (fails at 8/16/32). `IrModule.functions: [IrFunction; 8192]` remains
 inline (~11 MiB) and codegen still has multi-10 MiB frames.
 
-**B-nc peel (in flight, branch `fix/lane-b-nc-codebuffer-peel-20260813`):**
+**B-nc peel (branch `fix/lane-b-nc-codebuffer-peel-20260813`, rebuilt):**
 - `CodeBuffer.bytes` shrunk 262144 → 64 (vestigial; payload is `NC_BIG_CODE`)
 - `trampoline_offset` takes `&NativeCompiler` (was by-value full NC)
 - by-value `emit_entry_trampoline` is a thin wrapper over `_into`; `wide_driver` calls into
 
-Next peel after remeasure: functions table as arena handles (B3-functions) and residual
-by-value `NativeCompiler` on `emit_builtin_*` / `persist_builtin_emit_into`.
+**Measured on current-source peel binary** (`artifacts/self-hosted/madaros-peel3`):
+
+| Metric | pre-peel | post-peel |
+|---|---:|---:|
+| ELF frames ≥1 MiB | 926 | 613 |
+| max `sub rsp` frame | 128.07 MiB | **54.32 MiB** |
+| hello stack floor | 64 MiB | **64 MiB** (unchanged) |
+| helper (+add3) floor | 128 MiB | **128 MiB** (unchanged) |
+
+The vestigial CodeBuffer tax is gone from the binary, but the hello path still
+hits a ≥32 MiB live frame (largest remaining is ~54 MiB). Next peel:
+functions table as arena handles (B3-functions) and residual by-value
+`NativeCompiler` on `emit_builtin_*` / `persist_builtin_emit_into`, plus
+`MachineModule`/`MachineFunction` arena (still ~1.3 MiB per function of
+inline MIR).
 
 Re-measure: `MADAROS_RAW_BIN=artifacts/self-hosted/madaros bash scripts/dev/measure_madaros_stack_floor.sh`
 

--- a/docs/audit/MADAROS_HARDENING_PLAN_2026-08-12.md
+++ b/docs/audit/MADAROS_HARDENING_PLAN_2026-08-12.md
@@ -26,8 +26,15 @@ checked-in `bin/madaros-linux-x86_64` can lag (still reports 4096 until rebuilt/
 
 **Lane B residual (stack floor):** with current-source Madaros, minimal hello still needs
 **64 MiB** stack (fails at 8/16/32). `IrModule.functions: [IrFunction; 8192]` remains
-inline (~11 MiB) and codegen still has multi-10 MiB frames. Next peel: functions table
-as arena handles + shrink by-value `IrFunction`/`IrModule` copies (B3-functions).
+inline (~11 MiB) and codegen still has multi-10 MiB frames.
+
+**B-nc peel (in flight, branch `fix/lane-b-nc-codebuffer-peel-20260813`):**
+- `CodeBuffer.bytes` shrunk 262144 → 64 (vestigial; payload is `NC_BIG_CODE`)
+- `trampoline_offset` takes `&NativeCompiler` (was by-value full NC)
+- by-value `emit_entry_trampoline` is a thin wrapper over `_into`; `wide_driver` calls into
+
+Next peel after remeasure: functions table as arena handles (B3-functions) and residual
+by-value `NativeCompiler` on `emit_builtin_*` / `persist_builtin_emit_into`.
 
 Re-measure: `MADAROS_RAW_BIN=artifacts/self-hosted/madaros bash scripts/dev/measure_madaros_stack_floor.sh`
 

--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -1200,11 +1200,16 @@ fn compiler_bytes_contains(bytes: [i8; 65536], size: i64, needle: string) -> boo
     false
 }
 
-fn compiler_bytes_contains_seq_i64(bytes: [i8; 262144], size: i64, seq: [i64; 32], seq_len: i64) -> bool with Mut, Panic, Div {
+fn compiler_bytes_contains_seq_i64(size: i64, seq: [i64; 32], seq_len: i64) -> bool with Mut, Panic, Div {
+    // Payload is NC_BIG_CODE (CodeBuffer.bytes is a 64-byte vestigial stub).
     if seq_len <= 0 {
         return true
     }
     if size < seq_len {
+        return false
+    }
+    let cap = nc_code_capacity_bytes()
+    if size > cap {
         return false
     }
 
@@ -1213,7 +1218,7 @@ fn compiler_bytes_contains_seq_i64(bytes: [i8; 262144], size: i64, seq: [i64; 32
         var j: i64 = 0
         var matched = true
         while j < seq_len {
-            if bytes[(i + j) as usize] != (seq[j as usize] as i8) {
+            if NC_BIG_CODE[(i + j) as usize] != (seq[j as usize] as i8) {
                 matched = false
                 break
             }
@@ -5992,9 +5997,9 @@ fn compiler_main_test_prof_counter_inc_encoding() -> bool with Mut, Panic, Div, 
     lower_instr(&!nc, instr)
     // INC QWORD PTR [RIP+disp32]: 48 FF 05 <4 bytes disp32> = 7 bytes total
     if nc.code.len != 7 { return false }
-    if nc.code.bytes[0] != 0x48 as i8 { return false }
-    if nc.code.bytes[1] != 0xFF as i8 { return false }
-    if nc.code.bytes[2] != 0x05 as i8 { return false }
+    if NC_BIG_CODE[0] != 0x48 as i8 { return false }
+    if NC_BIG_CODE[1] != 0xFF as i8 { return false }
+    if NC_BIG_CODE[2] != 0x05 as i8 { return false }
     true
 }
 
@@ -6031,7 +6036,7 @@ fn compiler_main_test_prof_dump_emitted() -> bool with Mut, Panic, Div {
     // Verify: code was emitted (prologue + at least one syscall + epilogue)
     if nc.code.len <= before_len { return false }
     // Verify: function ends with ret (0xC3)
-    if nc.code.bytes[(nc.code.len - 1) as usize] != 0xC3 as i8 { return false }
+    if NC_BIG_CODE[(nc.code.len - 1) as usize] != 0xC3 as i8 { return false }
     true
 }
 
@@ -8258,7 +8263,7 @@ fn compiler_main_test_native_v2_alloc_slow_path_trap() -> bool with Mut, Panic, 
     seq[13] = 0x00
     seq[14] = 0x0F
     seq[15] = 0x05
-    compiler_bytes_contains_seq_i64(nc.code.bytes, nc.code.len, seq, 16)
+    compiler_bytes_contains_seq_i64(nc.code.len, seq, 16)
 }
 
 fn compiler_main_test_native_v2_runtime_context_handles() -> bool {

--- a/self-hosted/native/codegen.sio
+++ b/self-hosted/native/codegen.sio
@@ -4840,7 +4840,7 @@ fn emit_entry_trampoline_split_into(nc: &! NativeCompiler, main_fn_index: i64) w
     emit_entry_trampoline_call_exit_into(nc, main_fn_index)
 }
 
-fn emit_entry_trampoline_into(nc: &! NativeCompiler, main_fn_index: i64) with Mut, Panic, Div {
+pub fn emit_entry_trampoline_into(nc: &! NativeCompiler, main_fn_index: i64) with Mut, Panic, Div {
     (*nc).entry_offset = (*nc).code.len
 
     (*nc).code = emit_mov_r14_rsp((*nc).code)
@@ -4931,120 +4931,11 @@ fn emit_entry_trampoline_into(nc: &! NativeCompiler, main_fn_index: i64) with Mu
 }
 
 fn emit_entry_trampoline(nc: NativeCompiler, main_fn_index: i64) -> NativeCompiler with Mut, Panic, Div {
+    // Thin by-value wrapper over the into path. Kept for legacy callers
+    // (wide_driver); new code should call emit_entry_trampoline_into directly so the
+    // NativeCompiler never leaves the caller's stack slot.
     var c = nc
-
-    // Record trampoline offset (this is the ELF entry point)
-    c.entry_offset = c.code.len
-
-    // M4: Save original stack pointer for argc/argv access BEFORE mmap
-    // At _start, [rsp] = argc, [rsp+8] = argv[0], [rsp+16] = argv[1], ...
-    c.code = emit_mov_r14_rsp(c.code)             // mov r14, rsp (save original rsp)
-
-    // mmap anonymous heap: sys_mmap(NULL, 512MB, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0)
-    // 512MB is sufficient for full self-hosted compiler runs with large IR data structures
-    c.code = emit_mov_rax_imm(c.code, 9)           // sys_mmap = 9
-    c.code = emit_mov_rdi_imm(c.code, 0)           // addr = NULL
-    c.code = emit_mov_reg_imm(c.code, 6, 536870912) // len = 512MB
-    c.code = emit_mov_reg_imm(c.code, 2, 3)       // prot = PROT_READ|PROT_WRITE
-    // syscall ABI uses: rdi, rsi, rdx, r10, r8, r9 (NOT rcx for arg4)
-    c.code = emit_mov_r10_imm32(c.code, 34)       // r10 = flags = MAP_PRIVATE|MAP_ANONYMOUS (0x22)
-    c.code = emit_mov_r8_imm32(c.code, -1)        // r8 = fd = -1
-    c.code = emit_mov_r9_imm32(c.code, 0)         // r9 = offset = 0
-    c.code = emit_syscall(c.code)
-
-    // Publish the RuntimeContext pointer into the .data slot.
-    let ctx_slot_disp = c.code.len + 3
-    c.code = emit_mov_rip_disp32_rax(c.code, 0)
-    c.relocs = add_data_section_reloc(c.relocs, ctx_slot_disp, c.runtime_context_slot_offset)
-
-    // Managed handle table lives immediately after the fixed-size RuntimeContext.
-    c.code = emit_mov_reg_imm(c.code, 1, runtime_context_size())
-    c.code = emit_add_reg_reg(c.code, 0, 1)
-    c = emit_store_rax_runtime_context_field(c, runtime_context_field_handle_table_base())
-    c = emit_store_runtime_context_imm(c, runtime_context_field_handle_count(), 0)
-    c = emit_store_runtime_context_imm(c, runtime_context_field_handle_capacity(), native_v2_handle_table_capacity_default())
-    c = emit_store_runtime_context_imm(c, runtime_context_field_pin_registry(), 0)
-    c = emit_store_runtime_context_imm(c, runtime_context_field_pin_count(), 0)
-    c = emit_store_runtime_context_imm(c, runtime_context_field_collector_epoch(), 0)
-    c = emit_store_runtime_context_imm(c, runtime_context_field_last_gc_stats(), 0)
-
-    // Heap allocation starts after the RuntimeContext and fixed-capacity handle table.
-    c = emit_load_runtime_context_field_rax(c, runtime_context_field_handle_table_base())
-    c.code = emit_mov_reg_imm(c.code, 1, native_v2_handle_table_bytes())
-    c.code = emit_add_reg_reg(c.code, 0, 1)
-    c = emit_store_rax_runtime_context_field(c, runtime_context_field_heap_base())
-    c = emit_store_rax_runtime_context_field(c, runtime_context_field_heap_cursor())
-
-    // heap_limit = heap_base + (mmap_size - runtime_context_size - handle_table_bytes)
-    c = emit_load_runtime_context_field_rax(c, runtime_context_field_heap_base())
-    c.code = emit_mov_reg_imm(c.code, 1, 536870912 - runtime_context_size() - native_v2_handle_table_bytes())
-    c.code = emit_add_reg_reg(c.code, 0, 1)
-    c = emit_store_rax_runtime_context_field(c, runtime_context_field_heap_limit())
-
-    // M4: Store argc and argv in RuntimeContext memory.
-    c.code = emit_mov_rax_mem_r14(c.code)          // rax = [r14] = argc
-    c = emit_store_rax_runtime_context_field(c, runtime_context_field_argc())
-    c.code = emit_lea_rax_r14_disp8(c.code, 8)    // rax = r14 + 8 = argv pointer
-    c = emit_store_rax_runtime_context_field(c, runtime_context_field_argv_ptr())
-    c = emit_store_runtime_context_imm(c, runtime_context_field_stdout_fd(), 1)
-    c = emit_store_runtime_context_imm(c, runtime_context_field_stderr_fd(), 2)
-
-    // AVX10.2-aware capability guard: abort (exit 200) if CPU lacks any vector support.
-    // emit_avx10_detect probes leaf 7.1 EDX[19] for AVX10, falls back to leaf 7.0
-    // EBX[16] for legacy AVX-512F CPUs.  Sets r15 = VL capability mask:
-    //   bit0=128-bit, bit1=256-bit, bit2=512-bit.
-    // Returns rax = 1 if any vector support detected, 0 otherwise.
-    c.code = emit_avx10_detect(c.code)
-    c.code = emit_test_rax_rax(c.code)
-    let avx_jnz = c.code.len
-    c.code = emit_jnz_rel32(c.code)           // JNZ past the no-vector abort block
-    c.code = emit_mov_rdi_imm(c.code, 200)    // exit code 200 = no vector support
-    c.code = emit_mov_rax_imm(c.code, 60)     // sys_exit
-    c.code = emit_syscall(c.code)
-    let avx_ok = c.code.len
-    c.code = patch_u32_le(c.code, avx_jnz + 2, avx_ok - (avx_jnz + 6))
-    c.code = emit_mov_rax_preg(c.code, 15)
-    c = emit_store_rax_runtime_context_field(c, runtime_context_field_simd_capability_mask())
-    if c.descriptor_data_offset >= 0 {
-        c = emit_store_runtime_context_data_ptr(c, runtime_context_field_descriptor_table(), c.descriptor_data_offset)
-    }
-    c = emit_store_runtime_context_imm(c, runtime_context_field_descriptor_count(), c.descriptor_count)
-    if c.gc_state_data_offset >= 0 {
-        c = emit_store_runtime_context_data_ptr(c, runtime_context_field_gc_state(), c.gc_state_data_offset)
-    }
-    if c.stack_map_data_offset >= 0 {
-        c = emit_store_runtime_context_data_ptr(c, runtime_context_field_stack_maps(), c.stack_map_data_offset)
-    }
-    if c.deopt_state_data_offset >= 0 {
-        c = emit_store_runtime_context_data_ptr(c, runtime_context_field_deopt_state(), c.deopt_state_data_offset)
-    }
-
-    // call main (placeholder, will be relocated)
-    let call_pos = c.code.len
-    c.code = emit_call_rel32_placeholder(c.code)
-    c.relocs = add_call_reloc(c.relocs, call_pos + 1, main_fn_index)
-
-    // mov rdi, rax (exit code = main's return value)
-    c.code = emit_mov_rdi_rax(c.code)
-
-    // Sprint 46: call __prof_dump if counters exist (preserves rdi = exit code)
-    if c.prof_counter_count > 0 {
-        c.code = emit_push_rdi(c.code)       // save exit code
-        let dump_call_pos = c.code.len
-        c.code = emit_call_rel32_placeholder(c.code)
-        c.relocs = add_call_reloc(c.relocs, dump_call_pos + 1, c.prof_dump_fn_index)
-        c.code = emit_pop_rdi(c.code)        // restore exit code
-    }
-
-    // mov rax, 60 (sys_exit)
-    c.code = emit_mov_rax_imm(c.code, 60)
-
-    // syscall
-    c.code = emit_syscall(c.code)
-
-    // ud2 (should never reach here)
-    c.code = emit_ud2(c.code)
-
+    emit_entry_trampoline_into(&! c, main_fn_index)
     c
 }
 
@@ -5301,8 +5192,8 @@ fn emit_entry_trampoline_macos_x86(nc: NativeCompiler, main_fn_index: i64) -> Na
 }
 
 // Get the entry trampoline offset (recorded during emit_entry_trampoline)
-fn trampoline_offset(nc: NativeCompiler) -> i64 {
-    nc.entry_offset
+fn trampoline_offset(nc: &NativeCompiler) -> i64 {
+    (*nc).entry_offset
 }
 
 // ============================================================================
@@ -5766,7 +5657,7 @@ fn compile_to_elf_v2(module: &IrModule, base_addr: i64) -> NativeCompileResult w
         final_data.len = runtime_context_global_slot_size()
         nc.data = final_data
     }
-    let entry = trampoline_offset(nc)
+    let entry = trampoline_offset(&nc)
     var bss_total: i64 = 0
     var bsi: i64 = 0
     while bsi < (*module).fn_count {
@@ -6199,7 +6090,7 @@ pub fn compile_native(module: &IrModule, target_spec: NativeTargetSpec) -> Nativ
 fn compile_to_elf(module: &IrModule, base_addr: i64) -> Elf64Binary with Mut, Panic, Div, Alloc {
     var nc = compiler_new()
     nc = compile_module(nc, module)
-    let entry = trampoline_offset(nc)
+    let entry = trampoline_offset(&nc)
     var final_data = nc.data
     let min_data_len = nc.prof_counter_data_base + (nc.prof_counter_count * 8)
     if final_data.len < min_data_len {
@@ -6210,7 +6101,7 @@ fn compile_to_elf(module: &IrModule, base_addr: i64) -> Elf64Binary with Mut, Pa
 }
 
 pub fn finalize_compiled_elf(nc: NativeCompiler, base_addr: i64) -> Elf64Binary with Mut, Panic, Div, Alloc {
-    let entry = trampoline_offset(nc)
+    let entry = trampoline_offset(&nc)
     var final_data = nc.data
     let min_data_len = nc.prof_counter_data_base + (nc.prof_counter_count * 8)
     if final_data.len < min_data_len {

--- a/self-hosted/native/codegen.sio
+++ b/self-hosted/native/codegen.sio
@@ -5588,7 +5588,8 @@ fn compile_to_macho_arm64_preview(module: &IrModule, target_spec: NativeTargetSp
     var w = macho_writer_new_arm64()
     w.strtab = macho_strtab_init()
     w = macho_add_section(w, macho_make_text_section(text_vmaddr, c.code.len, text_offset))
-    let macho = macho_assemble_executable(w, c.code.bytes, c.code.len, [0; 131072], 0, text_offset + c.entry_offset)
+    let code_blob = nc_code_copy_to_262144(c.code.len)
+    let macho = macho_assemble_executable(w, code_blob, c.code.len, [0; 131072], 0, text_offset + c.entry_offset)
     native_compile_result_ok_narrow(macho.buf, macho.buf_len, FORMAT_MACHO64())
 }
 
@@ -5693,7 +5694,8 @@ fn compile_to_macho_x86_64(module: &IrModule, target_spec: NativeTargetSpec) -> 
     var w = macho_writer_new()
     w.strtab = macho_strtab_init()
     w = macho_add_section(w, macho_make_text_section(text_vmaddr, nc.code.len, text_offset))
-    let macho = macho_assemble_executable(w, nc.code.bytes, nc.code.len, [0; 131072], 0, text_offset + nc.entry_offset)
+    let code_blob = nc_code_copy_to_262144(nc.code.len)
+    let macho = macho_assemble_executable(w, code_blob, nc.code.len, [0; 131072], 0, text_offset + nc.entry_offset)
     native_compile_result_ok_narrow(macho.buf, macho.buf_len, FORMAT_MACHO64())
 }
 
@@ -5808,7 +5810,8 @@ fn compile_to_pe_x86_64(module: &IrModule, target_spec: NativeTargetSpec) -> Nat
     w = pe_set_data_directory(w, PE_DIR_IMPORT, idata_rva + idt_offset, 40)
     w = pe_set_data_directory(w, PE_DIR_IAT, idata_rva + iat_offset, PE_IAT_SIZE())
 
-    w = pe_build_executable(w, nc.code.bytes, nc.code.len)
+    let pe_code = nc_code_copy_to_65536(nc.code.len)
+    w = pe_build_executable(w, pe_code, nc.code.len)
 
     // Phase 6: Emit .idata section
     while w.buf_len < idata_raw_offset {
@@ -5959,7 +5962,8 @@ fn compile_to_pe_aarch64_preview(module: &IrModule, target_spec: NativeTargetSpe
     w = pe_set_data_directory(w, PE_DIR_IMPORT, idata_rva + idt_offset, 40)
     w = pe_set_data_directory(w, PE_DIR_IAT, idata_rva + iat_offset, 24)
 
-    w = pe_build_executable(w, out.code.bytes, out.code.len)
+    let pe_code = nc_code_copy_to_65536(out.code.len)
+    w = pe_build_executable(w, pe_code, out.code.len)
 
     // Emit .idata section
     while w.buf_len < idata_raw_offset {

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -9885,7 +9885,7 @@ fn emit_entry_trampoline_with_global_inits_into(nc: &! NativeCompiler, module: &
     emit_entry_trampoline_call_exit_into(nc, main_fn_index)
 }
 
-fn emit_entry_trampoline_into(nc: &! NativeCompiler, main_fn_index: i64) with Mut, Panic, Div {
+pub fn emit_entry_trampoline_into(nc: &! NativeCompiler, main_fn_index: i64) with Mut, Panic, Div {
     (*nc).entry_offset = (*nc).code.len
 
     (*nc).code = emit_mov_r14_rsp((*nc).code)
@@ -9977,121 +9977,11 @@ fn emit_entry_trampoline_into(nc: &! NativeCompiler, main_fn_index: i64) with Mu
 }
 
 fn emit_entry_trampoline(nc: NativeCompiler, main_fn_index: i64) -> NativeCompiler with Mut, Panic, Div {
+    // Thin by-value wrapper over the into path. Kept for legacy callers
+    // (wide_driver); new code should call emit_entry_trampoline_into directly so the
+    // NativeCompiler never leaves the caller's stack slot.
     var c = nc
-
-    // Record trampoline offset (this is the ELF entry point)
-    c.entry_offset = c.code.len
-
-    // M4: Save original stack pointer for argc/argv access BEFORE mmap
-    // At _start, [rsp] = argc, [rsp+8] = argv[0], [rsp+16] = argv[1], ...
-    c.code = emit_mov_r14_rsp(c.code)             // mov r14, rsp (save original rsp)
-
-    // mmap anonymous heap: sys_mmap(NULL, 512MB, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0)
-    // 512MB is sufficient for full self-hosted compiler runs with large IR data structures
-    c.code = emit_mov_rax_imm(c.code, 9)           // sys_mmap = 9
-    c.code = emit_mov_rdi_imm(c.code, 0)           // addr = NULL
-    c.code = emit_mov_reg_imm(c.code, 6, 2147483648) // len = 512MB
-    c.code = emit_mov_reg_imm(c.code, 2, 3)       // prot = PROT_READ|PROT_WRITE
-    // syscall ABI uses: rdi, rsi, rdx, r10, r8, r9 (NOT rcx for arg4)
-    c.code = emit_mov_r10_imm32(c.code, 34)       // r10 = flags = MAP_PRIVATE|MAP_ANONYMOUS (0x22)
-    c.code = emit_mov_r8_imm32(c.code, -1)        // r8 = fd = -1
-    c.code = emit_mov_r9_imm32(c.code, 0)         // r9 = offset = 0
-    c.code = emit_syscall(c.code)
-
-    // Publish the RuntimeContext pointer into the .data slot.
-    let ctx_slot_disp = c.code.len + 3
-    c.code = emit_mov_rip_disp32_rax(c.code, 0)
-    c.relocs = add_data_section_reloc(c.relocs, ctx_slot_disp, c.runtime_context_slot_offset)
-
-    // Managed handle table lives immediately after the fixed-size RuntimeContext.
-    c.code = emit_mov_reg_imm(c.code, 1, runtime_context_size())
-    c.code = emit_add_reg_reg(c.code, 0, 1)
-    c = emit_store_rax_runtime_context_field(c, runtime_context_field_handle_table_base())
-    c = emit_store_runtime_context_imm(c, runtime_context_field_handle_count(), 0)
-    c = emit_store_runtime_context_imm(c, runtime_context_field_handle_capacity(), native_v2_handle_table_capacity_default())
-    c = emit_store_runtime_context_imm(c, runtime_context_field_pin_registry(), 0)
-    c = emit_store_runtime_context_imm(c, runtime_context_field_pin_count(), 0)
-    c = emit_store_runtime_context_imm(c, runtime_context_field_collector_epoch(), 0)
-    c = emit_store_runtime_context_imm(c, runtime_context_field_last_gc_stats(), 0)
-
-    // Heap allocation starts after the RuntimeContext and fixed-capacity handle table.
-    c = emit_load_runtime_context_field_rax(c, runtime_context_field_handle_table_base())
-    c.code = emit_mov_reg_imm(c.code, 1, native_v2_handle_table_bytes())
-    c.code = emit_add_reg_reg(c.code, 0, 1)
-    c = emit_store_rax_runtime_context_field(c, runtime_context_field_heap_base())
-    c = emit_store_rax_runtime_context_field(c, runtime_context_field_heap_cursor())
-
-    // heap_limit = heap_base + (mmap_size - runtime_context_size - handle_table_bytes)
-    c = emit_load_runtime_context_field_rax(c, runtime_context_field_heap_base())
-    c.code = emit_mov_reg_imm(c.code, 1, 2147483648 - runtime_context_size() - native_v2_handle_table_bytes())
-    c.code = emit_add_reg_reg(c.code, 0, 1)
-    c = emit_store_rax_runtime_context_field(c, runtime_context_field_heap_limit())
-
-    // M4: Store argc and argv in RuntimeContext memory.
-    c.code = emit_mov_rax_mem_r14(c.code)          // rax = [r14] = argc
-    c.code = emit_sub_rax_imm8(c.code, 1)          // hide argv[0] from Sounio programs
-    c = emit_store_rax_runtime_context_field(c, runtime_context_field_argc())
-    c.code = emit_lea_rax_r14_disp8(c.code, 16)   // rax = r14 + 16 = argv[1] pointer
-    c = emit_store_rax_runtime_context_field(c, runtime_context_field_argv_ptr())
-    c = emit_store_runtime_context_imm(c, runtime_context_field_stdout_fd(), 1)
-    c = emit_store_runtime_context_imm(c, runtime_context_field_stderr_fd(), 2)
-
-    // AVX10.2-aware capability guard: abort (exit 200) if CPU lacks any vector support.
-    // emit_avx10_detect probes leaf 7.1 EDX[19] for AVX10, falls back to leaf 7.0
-    // EBX[16] for legacy AVX-512F CPUs.  Sets r15 = VL capability mask:
-    //   bit0=128-bit, bit1=256-bit, bit2=512-bit.
-    // Returns rax = 1 if any vector support detected, 0 otherwise.
-    c.code = emit_avx10_detect(c.code)
-    c.code = emit_test_rax_rax(c.code)
-    let avx_jnz = c.code.len
-    c.code = emit_jnz_rel32(c.code)           // JNZ past the no-vector abort block
-    c.code = emit_mov_rdi_imm(c.code, 200)    // exit code 200 = no vector support
-    c.code = emit_mov_rax_imm(c.code, 60)     // sys_exit
-    c.code = emit_syscall(c.code)
-    let avx_ok = c.code.len
-    c.code = patch_u32_le(c.code, avx_jnz + 2, avx_ok - (avx_jnz + 6))
-    c.code = emit_mov_rax_preg(c.code, 15)
-    c = emit_store_rax_runtime_context_field(c, runtime_context_field_simd_capability_mask())
-    if c.descriptor_data_offset >= 0 {
-        c = emit_store_runtime_context_data_ptr(c, runtime_context_field_descriptor_table(), c.descriptor_data_offset)
-    }
-    c = emit_store_runtime_context_imm(c, runtime_context_field_descriptor_count(), c.descriptor_count)
-    if c.gc_state_data_offset >= 0 {
-        c = emit_store_runtime_context_data_ptr(c, runtime_context_field_gc_state(), c.gc_state_data_offset)
-    }
-    if c.stack_map_data_offset >= 0 {
-        c = emit_store_runtime_context_data_ptr(c, runtime_context_field_stack_maps(), c.stack_map_data_offset)
-    }
-    if c.deopt_state_data_offset >= 0 {
-        c = emit_store_runtime_context_data_ptr(c, runtime_context_field_deopt_state(), c.deopt_state_data_offset)
-    }
-
-    // call main (placeholder, will be relocated)
-    let call_pos = c.code.len
-    c.code = emit_call_rel32_placeholder(c.code)
-    c.relocs = add_call_reloc(c.relocs, call_pos + 1, main_fn_index)
-
-    // mov rdi, rax (exit code = main's return value)
-    c.code = emit_mov_rdi_rax(c.code)
-
-    // Sprint 46: call __prof_dump if counters exist (preserves rdi = exit code)
-    if c.prof_counter_count > 0 {
-        c.code = emit_push_rdi(c.code)       // save exit code
-        let dump_call_pos = c.code.len
-        c.code = emit_call_rel32_placeholder(c.code)
-        c.relocs = add_call_reloc(c.relocs, dump_call_pos + 1, c.prof_dump_fn_index)
-        c.code = emit_pop_rdi(c.code)        // restore exit code
-    }
-
-    // mov rax, 60 (sys_exit)
-    c.code = emit_mov_rax_imm(c.code, 60)
-
-    // syscall
-    c.code = emit_syscall(c.code)
-
-    // ud2 (should never reach here)
-    c.code = emit_ud2(c.code)
-
+    emit_entry_trampoline_into(&! c, main_fn_index)
     c
 }
 
@@ -10349,8 +10239,8 @@ fn emit_entry_trampoline_macos_x86(nc: NativeCompiler, main_fn_index: i64) -> Na
 }
 
 // Get the entry trampoline offset (recorded during emit_entry_trampoline)
-fn trampoline_offset(nc: NativeCompiler) -> i64 {
-    nc.entry_offset
+fn trampoline_offset(nc: &NativeCompiler) -> i64 {
+    (*nc).entry_offset
 }
 
 // ============================================================================
@@ -10726,7 +10616,7 @@ fn compile_to_elf_v2(module: &IrModule, base_addr: i64) -> NativeCompileResult w
         final_data.len = runtime_context_global_slot_size()
         nc.data = final_data
     }
-    let entry = trampoline_offset(nc)
+    let entry = trampoline_offset(&nc)
     let bss_total = (*module).bss_total_size
     nc.bss_total_size = bss_total
     let elf = finalize_elf64(nc.code, nc.rodata, final_data, entry, base_addr, nc.symbols, nc.fn_offsets, nc.fn_count, bss_total, BSS_BASE_LINUX)
@@ -11093,7 +10983,7 @@ pub fn compile_native_v2_preview_to_file(module: &IrModule, target_spec: NativeT
     let patched_eff_rodata_len = if nc.flat_rodata_len > 0 { nc.flat_rodata_len } else { nc.rodata.len }
     let patched_data_file_offset = align_page(patched_rodata_file_offset + patched_eff_rodata_len)
     apply_relocations_into(&! nc, patched_rodata_file_offset, patched_data_file_offset)
-    let entry = trampoline_offset(nc)
+    let entry = trampoline_offset(&nc)
     nc.bss_total_size = (*module).bss_total_size
     if nc.bss_total_size < 8 { nc.bss_total_size = 8 }
     // Machine code exceeded the 2MB NC_BIG_CODE buffer. nc_emit_byte drops
@@ -11528,7 +11418,7 @@ pub fn compile_native_x86_linux_to_file(module: &IrModule, output_path: string) 
 fn compile_to_elf(module: &IrModule, base_addr: i64) -> Elf64Binary with Mut, Panic, Div, Alloc {
     var nc = compiler_new()
     nc = compile_module(nc, module)
-    let entry = trampoline_offset(nc)
+    let entry = trampoline_offset(&nc)
     var final_data = nc.data
     let min_data_len = nc.prof_counter_data_base + (nc.prof_counter_count * 8)
     if final_data.len < min_data_len {
@@ -11539,7 +11429,7 @@ fn compile_to_elf(module: &IrModule, base_addr: i64) -> Elf64Binary with Mut, Pa
 }
 
 pub fn finalize_compiled_elf(nc: NativeCompiler, base_addr: i64) -> Elf64Binary with Mut, Panic, Div, Alloc {
-    let entry = trampoline_offset(nc)
+    let entry = trampoline_offset(&nc)
     var final_data = nc.data
     let min_data_len = nc.prof_counter_data_base + (nc.prof_counter_count * 8)
     if final_data.len < min_data_len {

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -11046,7 +11046,8 @@ fn compile_to_macho_arm64_preview(module: &IrModule, target_spec: NativeTargetSp
     w.strtab = macho_strtab_init()
     w = macho_add_section(w, macho_make_text_section(text_vmaddr, c.code.len, text_offset))
     var empty_data: [i8; 131072] = [0; 131072]
-    let macho = macho_assemble_executable(w, c.code.bytes, c.code.len, empty_data, 0, text_offset + c.entry_offset)
+    let code_blob = nc_code_copy_to_262144(c.code.len)
+    let macho = macho_assemble_executable(w, code_blob, c.code.len, empty_data, 0, text_offset + c.entry_offset)
     native_compile_result_ok_narrow(macho.buf, macho.buf_len, FORMAT_MACHO64())
 }
 

--- a/self-hosted/native/encode.sio
+++ b/self-hosted/native/encode.sio
@@ -39,6 +39,34 @@ pub var NC_BIG_CODE: [i8; 8388608] = [0; 8388608]
 // scripts/ci/native_capacity_tiers_gate.sh.
 pub fn nc_code_capacity_bytes() -> i64 { 8388608 }
 
+// Materialise NC_BIG_CODE into fixed arrays expected by legacy macho/pe assemblers
+// that still take by-value `[i8; N]`. Linux ELF writers read NC_BIG_CODE directly.
+pub fn nc_code_copy_to_262144(code_len: i64) -> [i8; 262144] with Mut, Panic, Div {
+    var out: [i8; 262144] = [0; 262144]
+    var i: i64 = 0
+    let n = if code_len < 262144 { code_len } else { 262144 }
+    let cap = nc_code_capacity_bytes()
+    let lim = if n < cap { n } else { cap }
+    while i < lim {
+        out[i as usize] = NC_BIG_CODE[i as usize]
+        i = i + 1
+    }
+    out
+}
+
+pub fn nc_code_copy_to_65536(code_len: i64) -> [i8; 65536] with Mut, Panic, Div {
+    var out: [i8; 65536] = [0; 65536]
+    var i: i64 = 0
+    let n = if code_len < 65536 { code_len } else { 65536 }
+    let cap = nc_code_capacity_bytes()
+    let lim = if n < cap { n } else { cap }
+    while i < lim {
+        out[i as usize] = NC_BIG_CODE[i as usize]
+        i = i + 1
+    }
+    out
+}
+
 pub fn code_buffer_new() -> CodeBuffer {
     var out: CodeBuffer
     out.len = 0

--- a/self-hosted/native/encode.sio
+++ b/self-hosted/native/encode.sio
@@ -5,8 +5,15 @@
 
 module native::encode
 
+// Lane B residual (2026-08-13): `.bytes` is vestigial on the Linux native_v2 path.
+// Real machine code lives in NC_BIG_CODE; `.len` is the only live field threaded
+// through by-value emit_* and by-ref nc_emit_*. Keeping a multi-256 KiB array here
+// forced every `var out = buf` / `nc: NativeCompiler` copy to pay ~256 KiB per
+// stack frame (and nested emit_u64 → emit_u32 → emit_byte chains stacked several).
+// The 64-byte stub preserves a non-empty array type for the few macho/pe readers
+// that still mention `.bytes`; those paths must read NC_BIG_CODE for payload.
 pub struct CodeBuffer {
-    pub bytes: [i8; 262144],
+    pub bytes: [i8; 64],
     pub len: i64,
 }
 
@@ -16,12 +23,11 @@ pub struct CodeBuffer {
 // module-global BSS array holds the emitted code so NativeCompiler stays small on
 // the stack, while `.len` (a scalar, threaded through BOTH the by-ref nc_emit_byte
 // path and the by-value emit_byte path) stays the authoritative length. Both emit
-// paths write NC_BIG_CODE[.len]; the struct .bytes field is now vestigial for the
-// Linux path (kept only for the macho/pe by-value readers). Because .len is threaded
-// consistently, the by-value builtin emitters (which emit into a copy of nc) append
-// to the same global at the shared offset, so no persist/call-site changes are
-// needed. Accessed INLINE only — never via a returning helper (miscompiles under
-// the seed). NOT used by the aarch64/suite scratch-buffer paths (those keep .bytes).
+// paths write NC_BIG_CODE[.len]; the struct .bytes field is now a 64-byte stub (see
+// struct comment). Because .len is threaded consistently, the by-value builtin
+// emitters (which emit into a copy of nc) append to the same global at the shared
+// offset, so no persist/call-site changes are needed. Accessed INLINE only —
+// never via a returning helper (miscompiles under the seed).
 pub var NC_BIG_CODE: [i8; 8388608] = [0; 8388608]
 
 // Single source of truth for the NC_BIG_CODE bound. The DECLARATION above must
@@ -68,10 +74,11 @@ pub fn wide_emit_byte(buf: WideCodeBuffer, b: i64) -> WideCodeBuffer with Mut, P
 }
 
 pub fn wide_copy_from_code_buffer(dst: WideCodeBuffer, src: CodeBuffer) -> WideCodeBuffer with Mut, Panic, Div {
+    // Payload is in NC_BIG_CODE keyed by src.len — not the vestigial src.bytes stub.
     var out = dst
     var i: i64 = 0
-    while i < src.len && out.len < 262144 {
-        out.bytes[out.len as usize] = src.bytes[i as usize]
+    while i < src.len && out.len < 262144 && i < nc_code_capacity_bytes() {
+        out.bytes[out.len as usize] = NC_BIG_CODE[i as usize]
         out.len = out.len + 1
         i = i + 1
     }

--- a/self-hosted/native/wide_driver.sio
+++ b/self-hosted/native/wide_driver.sio
@@ -295,7 +295,7 @@ fn wide_compile_and_emit(module: &IrModule, output_path: string) -> WideCompileR
         // Compile entry trampoline in a final mini-batch
         var nc_tramp = compiler_new()
         compile_module_streaming_begin_into(&!nc_tramp, module)
-        nc_tramp = emit_entry_trampoline(nc_tramp, main_idx)
+        emit_entry_trampoline_into(&!nc_tramp, main_idx)
 
         let tramp_code_base = wide_code.len
         let entry_offset = nc_tramp.entry_offset + tramp_code_base


### PR DESCRIPTION
## Summary

Lane B residual peel after #1726 (instr arena / #1649). Shrinks the vestigial
`CodeBuffer.bytes` that was still embedded by value in every `NativeCompiler`
and every by-value `emit_*` chain, and routes the remaining by-value trampoline
call sites through the existing `_into` path.

### Changes

- `CodeBuffer.bytes`: 262144 → **64** (payload is `NC_BIG_CODE`; `.len` is authoritative)
- `wide_copy_from_code_buffer` / macho-pe bridges / self-tests read `NC_BIG_CODE`
- `trampoline_offset(nc: &NativeCompiler)` (was by-value full NC)
- by-value `emit_entry_trampoline` is a thin wrapper over `emit_entry_trampoline_into`
- `wide_driver` calls into directly

### Measured (current-source rebuild)

| Metric | pre-peel | post-peel |
|---|---:|---:|
| ELF frames ≥1 MiB | 926 | 613 |
| max `sub rsp` frame | 128.07 MiB | **54.32 MiB** |
| hello stack floor | 64 MiB | 64 MiB (unchanged) |
| helper (+add3) floor | 128 MiB | 128 MiB (unchanged) |

Honest status: the binary's largest frames dropped hard, but the **hello live
path** still needs 64 MiB (something ≥32 MiB is still on the stack). Next peel
is B3-functions / residual by-value NC builtins / MachineFunction arena.

### Non-goals

- Shipping a new `bin/madaros-linux-x86_64` blob
- Dropping the hello stack floor to 8 MiB (not achieved yet)

## Test plan

- [x] Current-source Madaros rebuild typechecks + emits ELF
- [x] Compiles `fn main() with IO { print("E\n") }`
- [x] Stack floor re-measured (`measure_madaros_stack_floor.sh`)
- [ ] CI green