### PR TITLE
stdlib: fix insertion-sort break (index-0 corruption) em prob/conformal e medical/survival

### DIFF
--- a/stdlib/darwin_pbpk/test_sort_fix.sio
+++ b/stdlib/darwin_pbpk/test_sort_fix.sio
@@ -1,0 +1,49 @@
+//@ run-pass
+//@ expect-stdout: PASS
+// test_sort_fix.sio — valida a correção do insertion sort (stdlib prob/conformal
+// + medical/survival): o padrão `else { j = -1 }` escrevia a key em scores[0]
+// quando nenhum shift era necessário (corrompia índice 0; com entrada já
+// ordenada, todo o resto). A correção usa flag de parada preservando j.
+fn sort_fix(v: [f64; 6], n: i64) -> [f64; 6] with Mut, Panic {
+    var out = v
+    var i = 1
+    while i < n {
+        let key = out[i]
+        var j = i - 1
+        var stop = false
+        while j >= 0 && !stop {
+            if out[j] > key {
+                out[j + 1] = out[j]
+                j = j - 1
+            } else {
+                stop = true
+            }
+        }
+        out[j + 1] = key
+        i = i + 1
+    }
+    return out
+}
+fn main() -> i64 with Mut, Div, IO, Panic {
+    var ok: i64 = 1
+    // A) caso do mini-teste que falhava: [0.5,0.2,0.9,0.1,0.7,0.3]
+    let a = sort_fix([0.5, 0.2, 0.9, 0.1, 0.7, 0.3], 6)
+    let ea: [f64; 6] = [0.1, 0.2, 0.3, 0.5, 0.7, 0.9]
+    var k = 0
+    while k < 6 {
+        if a[k] != ea[k] { ok = 0 println("  G FAIL A") }
+        k = k + 1
+    }
+    // B) entrada já ordenada (o caso que corrompia o índice 0 silenciosamente)
+    let b = sort_fix([0.1, 0.2, 0.3, 0.4, 0.5, 0.6], 6)
+    if b[0] != 0.1 { ok = 0 println("  G FAIL B idx0") }
+    // C) ordem reversa
+    let c = sort_fix([0.6, 0.5, 0.4, 0.3, 0.2, 0.1], 6)
+    if c[0] != 0.1 || c[5] != 0.6 { ok = 0 println("  G FAIL C") }
+    // D) duplicatas
+    let d = sort_fix([0.3, 0.3, 0.1, 0.1, 0.2, 0.2], 6)
+    if d[0] != 0.1 || d[2] != 0.2 || d[5] != 0.3 { ok = 0 println("  G FAIL D") }
+    if ok == 1 { println("PASS") return 0 }
+    println("FAIL")
+    return 1
+}

--- a/stdlib/medical/survival.sio
+++ b/stdlib/medical/survival.sio
@@ -155,7 +155,8 @@ fn surv_sort_by_time(data: &!SurvivalData) with Mut, Div, Panic {
         while c < 16 { key_cov[c] = data.events[i].covariates[c]; c = c + 1 }
 
         var j = i - 1
-        while j >= 0 {
+        var stop = false
+        while j >= 0 && !stop {
             if data.events[j].time > key_time {
                 data.events[j + 1].time = data.events[j].time
                 data.events[j + 1].observed = data.events[j].observed
@@ -166,7 +167,7 @@ fn surv_sort_by_time(data: &!SurvivalData) with Mut, Div, Panic {
                 }
                 j = j - 1
             } else {
-                j = -1  // break
+                stop = true  // break, preserving j (else j+1 slot is wrong)
             }
         }
         data.events[j + 1].time = key_time

--- a/stdlib/prob/conformal.sio
+++ b/stdlib/prob/conformal.sio
@@ -90,12 +90,13 @@ fn conformal_sort_scores(cal: &!ConformalCalibration) with Mut, Div, Panic {
     while i < cal.n_scores {
         let key = cal.scores[i]
         var j = i - 1
-        while j >= 0 {
+        var stop = false
+        while j >= 0 && !stop {
             if cal.scores[j] > key {
                 cal.scores[j + 1] = cal.scores[j]
                 j = j - 1
             } else {
-                j = -1  // break
+                stop = true  // break, preserving j (else j+1 slot is wrong)
             }
         }
         cal.scores[j + 1] = key


### PR DESCRIPTION
## English

The insertion-sort pattern shared by `prob/conformal.sio` (`conformal_sort_scores`) and `medical/survival.sio` (event sort) broke the inner loop with `else { j = -1 }` and then wrote the key at `[j+1]` — **index 0** — whenever the current element needed no shift. For partially-ascending input this silently corrupts slot 0 and drops the smallest element; downstream that means **wrong conformal quantiles/thresholds** and **wrong survival event ordering**. For fully unsorted input the corruption is widespread.

Found during the Conformal Weaning work (PR #1721): Sounio temporal-split thresholds diverged from an independent Python reference (t1 = 0.5055 vs 0.2611); bisection isolated this pattern. `data/dataframe.sio` uses a swap-based variant whose break is correct and was left untouched.

**Fix**: flag-based break preserving `j`. **Validation**: `test_sort_fix.sio` (vendored copy of the corrected algorithm) — unsorted / ascending / reverse / duplicate inputs, PASS in both engines (Madaros + lean_single).

## Português

O padrão de insertion sort de `prob/conformal.sio` e `medical/survival.sio` saía do laço interno com `j = -1` e escrevia a chave em `[j+1]` — **índice 0** — quando nenhum shift era necessário: corrupção silenciosa do menor elemento e quantis conformais/errados a jusante. Detectado quando os thresholds do split temporal divergiram da referência Python independente; bissetado até este padrão. Correção com flag de parada; teste run-pass valida 4 formatos de entrada nos dois engines.