### PR TITLE
test(portability): lock Sounio launcher and call-result references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,8 @@ jobs:
       # from source was never run. ~2 s.
       - name: Canonical lean_single fixed point
         run: bash scripts/ci/canonical_compiler_gate.sh
+      - name: Sounio launcher BSD portability
+        run: bash scripts/ci/souc_launcher_portability_gate.sh
       - name: Output-path invariants
         run: bash scripts/dev/check_outpath_invariant.sh
       - name: Output-path leading-dash guard

--- a/scripts/ci/souc_launcher_portability_gate.sh
+++ b/scripts/ci/souc_launcher_portability_gate.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="${SOUNIO_SOUC_PORTABILITY_WORK:-$(mktemp -d "${TMPDIR:-/tmp}/sounio-souc-portability.XXXXXX")}"
+
+if [[ -z "${SOUNIO_SOUC_PORTABILITY_WORK:-}" ]]; then
+  trap 'rm -rf "$WORK"' EXIT
+fi
+
+fail() {
+  echo "[souc-portability] FAIL: $*" >&2
+  exit 1
+}
+
+mkdir -p "$WORK/repo/bin" "$WORK/fake-bin"
+cp "$ROOT_DIR/bin/souc" "$WORK/repo/bin/souc"
+
+cat >"$WORK/repo/bin/souc-lean-single-x86_64" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+out="${2:?missing output path}"
+cat >"$out" <<'PROGRAM'
+#!/usr/bin/env bash
+printf '%s\n' SOUC_BSD_MKTEMP_RUN_OK
+PROGRAM
+chmod +x "$out"
+EOF
+chmod +x "$WORK/repo/bin/souc-lean-single-x86_64"
+
+# BSD mktemp requires the template Xs to be the final characters. Validate that
+# contract, then delegate uniqueness to the host mktemp inside the gate's work
+# directory so repeated launcher invocations cannot leak files into /tmp.
+cat >"$WORK/fake-bin/mktemp" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+template="${1:-}"
+case "$template" in
+  *XXXXXX) ;;
+  *)
+    echo "bsd-mktemp: template must end in XXXXXX: $template" >&2
+    exit 64
+    ;;
+esac
+exec /usr/bin/mktemp "${SOUNIO_PORTABILITY_WORK:?}/generated.XXXXXX"
+EOF
+chmod +x "$WORK/fake-bin/mktemp"
+
+printf '%s\n' 'fn main() -> i64 { 0 }' >"$WORK/probe.sio"
+
+run_launcher() {
+  PATH="$WORK/fake-bin:$PATH" \
+    SOUNIO_PORTABILITY_WORK="$WORK" \
+    SOUNIO_SOUC_ENGINE=lean_single \
+    "$WORK/repo/bin/souc" "$@"
+}
+
+for attempt in 1 2; do
+  output="$(run_launcher run "$WORK/probe.sio")" || fail "lean run attempt $attempt failed"
+  [[ "$output" == "SOUC_BSD_MKTEMP_RUN_OK" ]] || fail "lean run attempt $attempt returned: $output"
+  run_launcher check "$WORK/probe.sio" >/dev/null || fail "lean check attempt $attempt failed"
+done
+
+generated_count="$(find "$WORK" -maxdepth 1 -type f -name 'generated.*' | wc -l | tr -d ' ')"
+[[ "$generated_count" == "2" ]] || fail "expected two unique run artifacts, found $generated_count"
+
+# Negative control: recreate the old GNU-only templates and prove the BSD shim
+# rejects both paths. A gate that cannot detect its target regression is noise.
+sed \
+  -e 's/souc-lean-run-XXXXXX/souc-lean-run-XXXXXX.elf/' \
+  -e 's/souc-lean-check-XXXXXX/souc-lean-check-XXXXXX.elf/' \
+  "$WORK/repo/bin/souc" >"$WORK/repo/bin/souc-bad"
+chmod +x "$WORK/repo/bin/souc-bad"
+
+for verb in run check; do
+  set +e
+  bad_output="$(PATH="$WORK/fake-bin:$PATH" \
+    SOUNIO_PORTABILITY_WORK="$WORK" \
+    SOUNIO_SOUC_ENGINE=lean_single \
+    "$WORK/repo/bin/souc-bad" "$verb" "$WORK/probe.sio" 2>&1)"
+  bad_rc=$?
+  set -e
+  [[ "$bad_rc" -ne 0 ]] || fail "negative $verb control unexpectedly passed"
+  [[ "$bad_output" == *"template must end in XXXXXX"* ]] || fail "negative $verb control missed BSD diagnostic"
+done
+
+echo "[souc-portability] PASS: BSD mktemp run/check x2, unique artifacts=2, negative controls rejected"

--- a/tests/run-pass/reference_call_result.sio
+++ b/tests/run-pass/reference_call_result.sio
@@ -1,0 +1,14 @@
+//@ run-pass
+//@ requires: madaros
+//@ description: A reference to a call result remains valid for the binding lifetime
+
+// A reference to a call result is valid for the lifetime of the binding.
+// This used to be rejected with an unrelated arity-mismatch diagnostic.
+fn increment(x: i64) -> i64 {
+    x + 1
+}
+
+fn main() -> i64 {
+    let result = &increment(41)
+    if *result == 42 { 0 } else { 1 }
+}


### PR DESCRIPTION
## Summary

Close the remaining regression-coverage gap from chemistry remediation item 6. The implementation defects are already corrected on current `main`; this PR makes the two previously unguarded behaviors executable contracts.

- run the legacy `bin/souc` `run` and `check` paths twice behind a BSD-compatible `mktemp` shim
- require unique temporary outputs and no `/tmp` leakage
- include negative controls that restore the old `XXXXXX.elf` templates and must be rejected
- add a Madaros run-pass for `&f(x)`, preserving the lifetime of the call-result binding
- wire the launcher gate into Contracts next to the canonical lean_single fixed-point gate

## Measured audit

- current `bin/souc` templates end in `XXXXXX`; BSD shim: run/check x2 pass, two unique run artifacts
- negative GNU-only templates: run and check both rejected with nonzero status and the BSD-template diagnostic
- current-source Madaros `&increment(41)`: compile `rc=0`, runtime `rc=0`; harness `1/1 PASS`
- legacy Stage2 for the same witness: runtime `rc=1`, therefore the test is explicitly `requires: madaros` and skips on the bootstrap suite
- `gri30_full.sio` current-source check: `rc=0`, no duplicate-function warning
- `g30_sqrt` and `g30f_sqrt`: relative convergence `abs(next-g) <= 1e-14*next`, with 120 only as runaway cap
- README already states checked compiler binaries are Linux x86-64 ELF and macOS is cross-compile-only

## Reproduction

```bash
bash scripts/ci/souc_launcher_portability_gate.sh

SOUNIO_MADAROS_AVAILABLE=1 \
SOUNIO_TEST_SOUC_BIN=/tmp/madaros-current \
  bash scripts/run_sio_test_suite.sh \
  --filter-exact reference_call_result.sio --jobs 1 --verbose

bash scripts/ci/gate_vacuity_gate.sh
```

No chemistry equations, tolerances, runtime implementation, or compiler lowering code changes in this PR.