### PR TITLE
fix(lower): close two live silent miscompiles (enum discriminant, f32) + Tier 0 witness matrix

### DIFF
--- a/docs/audit/SPNN_QUANTNN_MOD_EXPORT_2026-08-14.md
+++ b/docs/audit/SPNN_QUANTNN_MOD_EXPORT_2026-08-14.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.spnn-quantnn-mod-export-2026-08-14
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.spnn-quantnn-mod-export-2026-08-14
+-->
+
 # spnn / quantnn — FECHADAS, e a lição é o confundidor (2026-08-14)
 
 Status: **fechadas** (check rc=0 e run rc=0 nas duas, com HYPER_METRIC correto).

--- a/docs/audit/SPNN_QUANTNN_MOD_EXPORT_2026-08-14.md
+++ b/docs/audit/SPNN_QUANTNN_MOD_EXPORT_2026-08-14.md
@@ -1,63 +1,61 @@
-<!-- docs:meta
-topic_id: repo.docs.audit.spnn-quantnn-mod-export-2026-08-14
-authority: repo_only
-audience: users
-last_validated: 2026-03-07
-validated_by: A2
-source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.spnn-quantnn-mod-export-2026-08-14
--->
+# spnn / quantnn — FECHADAS, e a lição é o confundidor (2026-08-14)
 
-# spnn / quantnn — E175 em mod.sio (lane de closure/AST, 2026-08-14)
+Status: **fechadas** (check rc=0 e run rc=0 nas duas, com HYPER_METRIC correto).
 
-Status: **NÃO fechado**. Reduzido de falha opaca a defeito preciso com repro de 6 linhas.
+## CORREÇÃO de uma versão anterior deste documento
 
-## O que era
+Uma versão anterior afirmava: *"o pool de exports não registra `pub` para módulos-raiz de
+pacote (`mod.sio`)"*, com repro de 6 linhas. **Isso estava ERRADO.** Era artefato de medição.
 
-Os dois testes falhavam com `run_check_mode: AST closure incomplete nodes=1 unresolved=1`,
-sem nomear o import não resolvido. O diagnóstico tem os arrays `unresolved_imports` e
-`unresolved_callers` na struct `ModuleClosure` (`self-hosted/compiler/main.sio:2120`) mas
-NÃO os imprime -- exatamente a lacuna de observabilidade que o comentário logo acima diz
-ter corrigido para `parse_failed`.
+O pod exporta `SOUNIO_STDLIB_PATH=/workspace/sounio/stdlib` globalmente. Um `./bin/souc check`
+rodado de QUALQUER worktree lê a stdlib do **checkout compartilhado**, não a do worktree sob
+teste. Eu editava `stdlib/spnn/mod.sio` aqui e checava contra outra árvore -- por isso o `pub`
+parecia não surtir efeito, e por isso inventei um defeito de resolver que não existe.
 
-## Causa 1: forma de import não suportada
+Com o caminho correto:
 
-Os testes usavam `use spnn::*` / `use quantnn::*`. Medido:
+    SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check /tmp/probe_pub.sio  -> check: OK
+
+`pub` em `mod.sio` funciona normalmente.
+
+## O que era de fato, e foi corrigido
+
+Causa 1 -- forma de import. Os testes usavam `use spnn::*` / `use quantnn::*`. Medido:
 
     use spnn::*        -> AST closure incomplete, unresolved=1
-    use spnn::mod::*   -> check chega ao typecheck (2 modules)
+    use spnn::mod::*   -> resolve
 
 `docs/compiler/PACKAGE_IMPORT_RESOLUTION.md` documenta a forma nua apenas para
-`packages/<nome>/src/lib.sio`, não para diretórios de stdlib com `mod.sio`. Só 20 arquivos
-no repo usam a forma nua, vários com `;` estilo Rust (provável resíduo de doc).
+`packages/<nome>/src/lib.sio`, não para diretórios de stdlib com `mod.sio`. Corrigido.
 
-Corrigido nos dois testes para `use <pkg>::mod::*`.
+Causa 2 -- exports faltando. 7 símbolos sem `pub` (4 em spnn, 3 em quantnn), exatamente os
+que os testes chamam. Sem blanket-pub. Corrigido.
 
-## Causa 2 (a real): `pub` não é honrado em `mod.sio`
+Resultado das duas lanes:
 
-Com o import resolvendo, aparece E175 em 7 símbolos. Marquei os 7 como `pub fn`
-(4 em `stdlib/spnn/mod.sio`, 3 em `stdlib/quantnn/mod.sio`) e **o E175 permanece**.
+    tests/stdlib/spnn/test_spiking_e2e.sio      check rc=0  run rc=0
+    tests/stdlib/quantnn/test_quantum_e2e.sio   check rc=0  run rc=0
 
-Contraste medido -- `pub fn` em módulo COMUM funciona:
+## O achado que vale mais que o fix
 
-    use math::sedenion::*  + sed_zero()  -> nenhum E175 (erros são outros, internos)
-    use spnn::mod::*       + spiking_fired() -> E175 "function is private"
+O confundidor não é meu erro isolado -- é sistêmico e atinge o gate.
+`scripts/stdlib/stdlib_hyper_execution_gate.sh:174`:
 
-Repro mínimo (6 linhas), com `spiking_fired` já marcado `pub fn`:
+    export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
 
-    use spnn::mod::*
-    fn main() -> i64 {
-        let n = spiking_neuron_new(1.0, 0.5)
-        if spiking_fired(n) { 1 } else { 0 }
-    }
+O `:-` cede à variável já exportada. Logo o gate, rodado de um worktree, **mede a stdlib do
+checkout compartilhado**, não a da árvore sob teste. Qualquer correção feita num worktree lê
+como ausente para o gate; qualquer regressão do compartilhado contamina o resultado.
 
-Conclusão: o pool de exports não registra `pub` para módulos-raiz de pacote (`mod.sio`).
-Isso provavelmente explica por que os testes foram escritos com a forma nua -- a intenção
-era import de raiz de pacote, e nenhum dos dois caminhos jamais funcionou.
+Consequência prática: um agente que conserte stdlib num worktree e rode o gate verá o gate
+ignorar o conserto -- e pode concluir, como eu conclui, que o conserto não funciona.
 
-NÃO fui adiante: o conserto é no pool de exports do resolver, área que o PR #1697 acabou
-de mexer, e é decisão de API se `use pkg::*` deve resolver para `pkg/mod.sio`.
+Correção sugerida (não aplicada -- script de CI, provavelmente de outra lane):
+tornar a linha um export incondicional `"$ROOT_DIR/stdlib"`.
 
-## Sugestão barata e independente
+## Sugestão barata e independente (mantida)
 
-Fazer o diagnóstico imprimir `unresolved_imports[0]`. Custa uma linha e teria transformado
-esta investigação inteira em uma leitura.
+O diagnóstico `AST closure incomplete` não imprime `unresolved_imports[0]`, embora o array
+exista na struct `ModuleClosure` (`self-hosted/compiler/main.sio:2120`). Uma linha, e esta
+investigação teria sido uma leitura. É a mesma lacuna que o comentário logo acima diz ter
+corrigido para `parse_failed`.

--- a/docs/audit/SPNN_QUANTNN_MOD_EXPORT_2026-08-14.md
+++ b/docs/audit/SPNN_QUANTNN_MOD_EXPORT_2026-08-14.md
@@ -1,0 +1,63 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.spnn-quantnn-mod-export-2026-08-14
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.spnn-quantnn-mod-export-2026-08-14
+-->
+
+# spnn / quantnn — E175 em mod.sio (lane de closure/AST, 2026-08-14)
+
+Status: **NÃO fechado**. Reduzido de falha opaca a defeito preciso com repro de 6 linhas.
+
+## O que era
+
+Os dois testes falhavam com `run_check_mode: AST closure incomplete nodes=1 unresolved=1`,
+sem nomear o import não resolvido. O diagnóstico tem os arrays `unresolved_imports` e
+`unresolved_callers` na struct `ModuleClosure` (`self-hosted/compiler/main.sio:2120`) mas
+NÃO os imprime -- exatamente a lacuna de observabilidade que o comentário logo acima diz
+ter corrigido para `parse_failed`.
+
+## Causa 1: forma de import não suportada
+
+Os testes usavam `use spnn::*` / `use quantnn::*`. Medido:
+
+    use spnn::*        -> AST closure incomplete, unresolved=1
+    use spnn::mod::*   -> check chega ao typecheck (2 modules)
+
+`docs/compiler/PACKAGE_IMPORT_RESOLUTION.md` documenta a forma nua apenas para
+`packages/<nome>/src/lib.sio`, não para diretórios de stdlib com `mod.sio`. Só 20 arquivos
+no repo usam a forma nua, vários com `;` estilo Rust (provável resíduo de doc).
+
+Corrigido nos dois testes para `use <pkg>::mod::*`.
+
+## Causa 2 (a real): `pub` não é honrado em `mod.sio`
+
+Com o import resolvendo, aparece E175 em 7 símbolos. Marquei os 7 como `pub fn`
+(4 em `stdlib/spnn/mod.sio`, 3 em `stdlib/quantnn/mod.sio`) e **o E175 permanece**.
+
+Contraste medido -- `pub fn` em módulo COMUM funciona:
+
+    use math::sedenion::*  + sed_zero()  -> nenhum E175 (erros são outros, internos)
+    use spnn::mod::*       + spiking_fired() -> E175 "function is private"
+
+Repro mínimo (6 linhas), com `spiking_fired` já marcado `pub fn`:
+
+    use spnn::mod::*
+    fn main() -> i64 {
+        let n = spiking_neuron_new(1.0, 0.5)
+        if spiking_fired(n) { 1 } else { 0 }
+    }
+
+Conclusão: o pool de exports não registra `pub` para módulos-raiz de pacote (`mod.sio`).
+Isso provavelmente explica por que os testes foram escritos com a forma nua -- a intenção
+era import de raiz de pacote, e nenhum dos dois caminhos jamais funcionou.
+
+NÃO fui adiante: o conserto é no pool de exports do resolver, área que o PR #1697 acabou
+de mexer, e é decisão de API se `use pkg::*` deve resolver para `pkg/mod.sio`.
+
+## Sugestão barata e independente
+
+Fazer o diagnóstico imprimir `unresolved_imports[0]`. Custa uma linha e teria transformado
+esta investigação inteira em uma leitura.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1320
-- Repo-backed topics: 1170
+- Total governed topics: 1321
+- Repo-backed topics: 1171
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 399
-- Authority count `repo_only`: 733
+- Authority count `repo_only`: 734
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 750 topics
+- A2: 751 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 36 topics

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1321
-- Repo-backed topics: 1171
+- Total governed topics: 1322
+- Repo-backed topics: 1172
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 399
-- Authority count `repo_only`: 734
+- Authority count `repo_only`: 735
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 751 topics
+- A2: 752 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 36 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -262,6 +262,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.sigsegv-pbpk28-private-struct-2026-06-02 | repo_only | docs/audit/SIGSEGV_PBPK28_PRIVATE_STRUCT_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sounio-release-production-readiness-2026-06-22 | repo_only | docs/audit/SOUNIO_RELEASE_PRODUCTION_READINESS_2026-06-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sounio-science-flex-2026-07-27 | repo_only | docs/audit/SOUNIO_SCIENCE_FLEX_2026-07-27.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.spnn-quantnn-mod-export-2026-08-14 | repo_only | docs/audit/SPNN_QUANTNN_MOD_EXPORT_2026-08-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sret-large-struct-smtcontext.dispatch | repo_only | docs/audit/sret_large_struct_smtcontext/DISPATCH.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.stats-madaros-singlefile-smoke-2026-07-18 | repo_only | docs/audit/STATS_MADAROS_SINGLEFILE_SMOKE_2026-07-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.stats-ols-diag-e2e-vertical-2026-07-18 | repo_only | docs/audit/STATS_OLS_DIAG_E2E_VERTICAL_2026-07-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -1091,6 +1091,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.roadmap.2026-ontology-units-knowledge-status | repo_only | docs/roadmap/2026_ontology_units_knowledge_status.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.roadmap.2026-q2-research-milestones | repo_only | docs/roadmap/2026_Q2_research_milestones.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.roadmap.2026-technical-showcase-deep-dive | repo_only | docs/roadmap/2026_technical_showcase_deep_dive.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.serious-language.caminho-critico-cortado-2026-08-14 | repo_only | docs/serious-language/CAMINHO_CRITICO_CORTADO_2026-08-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.serious-language.compiler-maturity-snapshot | repo_only | docs/serious-language/compiler-maturity-snapshot.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.serious-language.conformance-spine | repo_only | docs/serious-language/conformance-spine.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.serious-language.paper-bundle | repo_only | docs/serious-language/paper-bundle.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -5490,6 +5490,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.spnn-quantnn-mod-export-2026-08-14",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/SPNN_QUANTNN_MOD_EXPORT_2026-08-14.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.sret-large-struct-smtcontext.dispatch",
       "collection": "repo",
       "repo_doc_path": "docs/audit/sret_large_struct_smtcontext/DISPATCH.md",

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -24213,6 +24213,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.serious-language.caminho-critico-cortado-2026-08-14",
+      "collection": "repo",
+      "repo_doc_path": "docs/serious-language/CAMINHO_CRITICO_CORTADO_2026-08-14.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.serious-language.compiler-maturity-snapshot",
       "collection": "repo",
       "repo_doc_path": "docs/serious-language/compiler-maturity-snapshot.md",

--- a/docs/serious-language/CAMINHO_CRITICO_CORTADO_2026-08-14.md
+++ b/docs/serious-language/CAMINHO_CRITICO_CORTADO_2026-08-14.md
@@ -58,3 +58,60 @@ rebuildar o prebuilt (o enviado é de 25/jul), e assistir uma pessoa de fora rod
 data -- pela `RELEASE_POLICY.md`, releases são orientados a evento, não a calendário.
 Recomendação: o deliverable acima vem DEPOIS da submissão. Ele é pequeno o bastante para
 caber antes se houver vontade, mas então é ele sozinho.
+
+---
+
+## CORREÇÃO (2026-08-14, mesmo dia) — o corte acima partia de um número errado
+
+O operador desconfiou do "~32% verde" e estava certo. Medi.
+
+### 1. O corpus, medido hoje: 62%, não 32%
+
+`bash scripts/dev/corpus_census.sh` sobre os 2.538 arquivos versionados:
+
+    stdlib     total=1567   OK=1059   (67%)   REJECT=508   TIMEOUT=0  CRASH=0
+    examples   total=971    OK=506    (52%)   REJECT=464   TIMEOUT=0  CRASH=1
+    TOTAL      1565 / 2538 aceitos por souc check
+
+O 32% vinha de `docs/EPISTEMIC_RELEASE_STATUS.md` (638/2003) e estava errado de três formas
+somadas: é doc da **branch órfã**, medido em **junho**, sobre um corpus **500 arquivos menor**.
+Aplicá-lo à main de hoje foi exatamente a falha que esta sessão passou o tempo todo evitando --
+e o plano original já dizia que o entregável era ESCREVER o censo, não escolher um dos quatro
+números publicados. Escolhi um.
+
+Ressalva do próprio censo: `souc check` não é `compile+run`. Por CLAUDE.md princípio 3, check
+mais um caller é o teste de existência para bibliotecas -- mas 62% aceito NÃO significa 62%
+executável. É uma pergunta estritamente mais forte e este script não a responde.
+
+### 2. A barra de `beta` não é o corpus -- e o gate nomeado está VERMELHO hoje
+
+A política aponta para um artefato específico. O commitado
+(`artifacts/stdlib/stdlib_reliability_status.v1.json`, gerado 2026-05-12) diz:
+
+    totals: pass=251 fail=0 skip=0    status_summary: pass
+
+Ou seja, no papel a barra de beta está cumprida e `1.0.0-beta.6` NÃO é overclaim.
+Minha recomendação de descer para alpha estava errada.
+
+Mas re-rodando `bash scripts/stdlib_reliability_gate.sh` hoje: **fail**. O sub-gate de
+execução hyper dá `pass=0 fail=7`, e os 7 têm a MESMA causa raiz:
+
+    closure parser incomplete: invalid raw AST node
+
+Atinge nn, onn, qnn, snn, spnn, quantnn e math (hyper). Mais um `golden_mismatch`
+(`lane=nn metric=sum_w missing_metric`). É **um defeito, não sete**.
+
+Hipótese não verificada: pode ser da mesma família do `w5` (closure + arena de IR). Não medi.
+
+NÃO commitei o flip pass->fail dos artefatos: a execução foi local, num worktree com o
+compilador modificado, e eu não descartei esse confundidor. O número precisa ser reproduzido
+em CI limpa antes de virar registro oficial.
+
+### 3. O corte revisado
+
+O corpus SAI do caminho crítico -- não por rebaixar o rótulo, mas porque nunca foi a barra.
+A distância para um `beta` defensável é: **uma causa raiz no parser de closures** + uma
+métrica golden. Isso é ordens de magnitude menor do que "levar o corpus a 100%".
+
+O deliverable único (um estranho instala e roda) continua valendo, e agora sem a premissa
+falsa de que era preciso rebaixar a versão para chegar lá.

--- a/docs/serious-language/CAMINHO_CRITICO_CORTADO_2026-08-14.md
+++ b/docs/serious-language/CAMINHO_CRITICO_CORTADO_2026-08-14.md
@@ -115,3 +115,60 @@ métrica golden. Isso é ordens de magnitude menor do que "levar o corpus a 100%
 
 O deliverable único (um estranho instala e roda) continua valendo, e agora sem a premissa
 falsa de que era preciso rebaixar a versão para chegar lá.
+
+---
+
+## ATUALIZAÇÃO (2026-08-14, mesmo dia) — de "um defeito" para 6 de 7 lanes verdes
+
+A seção anterior generalizou cedo demais: dizer "um defeito, não sete" a partir de um
+trecho de saída, sem rodar cada lane. Terceira vez no mesmo dia que inferir em vez de
+medir me deu um número errado -- registrado aqui porque é padrão, não acaso.
+
+Medido lane por lane, eram **três causas distintas**:
+
+| Causa | Lanes | Tamanho |
+|---|---|---|
+| Export faltando (E175) + forma de import não suportada | nn, onn, math, spnn, quantnn | 5 lanes |
+| Módulo com erros de tipo genuínos (f32/f64, `.sqrt()`, `tanh` inexistente no backend) | qnn, math, snn | sobreposto acima |
+| Coerção de literal float→f32 ausente no checker (2 sites: contextual e operando binário) | onn, nn | via o defeito 1 |
+
+3 agentes em paralelo + 1 fix de compilador depois: **6 de 7 lanes compilam, rodam e emitem
+o marcador `HYPER_*_OK`**, partindo de 0.
+
+    test_hyper_math_e2e        compile=0 run=0 HYPER_MATH_OK
+    test_hyper_qnn_e2e         compile=0 run=0 HYPER_QNN_OK
+    test_spiking_e2e           compile=0 run=0 HYPER_SPNN_OK
+    test_quantum_e2e           compile=0 run=0 HYPER_QUANTNN_OK
+    test_hyper_onn_e2e         compile=0 run=0 HYPER_ONN_OK
+    test_hyper_quaternion_e2e  compile=0 run=0 HYPER_NN_OK
+    test_snn_e2e               compile=1 NO-ELF
+
+O `golden_mismatch` de `nn sum_w` do relato original também se resolveu sozinho: não era
+defeito separado, era o `nn` nunca tendo chegado a rodar. Agora emite `sum_w 2.000000`,
+igual ao `expected: 2.0` do gate.
+
+A correção de compilador que destravou 2 das 5 lanes do primeiro grupo (onn, nn) foi a
+coerção de literal float→f32 no checker -- que também fecha, do outro lado, o miscompile
+do Tier 0 (`as f32` truncava porque não havia caminho de coerção; ver `tests/witness_matrix/`).
+Os dois problemas eram o mesmo visto de dois ângulos.
+
+`snn` fica **FAIL_HONEST**, não contornado: falha em codegen nativo (crescer array de
+struct via `++`), reduzido a 5 linhas sem imports. Dava para "passar" mudando o tipo
+público de `SedenionLayer` para array fixo, mas isso esconderia um defeito de compilador
+atrás de uma mudança de API -- não fiz.
+
+### O que isso muda no caminho crítico
+
+A barra de `beta` (`stdlib_reliability_status.v1.json` = pass) está a **uma lane** de
+distância, não sete. Mas continua valendo a ressalva anterior: não posso declarar o gate
+oficial verde a partir de execução local -- e agora sei por quê de forma mais precisa.
+`scripts/stdlib/stdlib_hyper_execution_gate.sh:174` faz
+`export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"`, e essa é a
+**mesma linha em 50 scripts de CI** -- não bug isolado, padrão deliberado do repositório
+que vira armadilha quando `SOUNIO_STDLIB_PATH` está exportado globalmente (como o
+próprio `CLAUDE.md` manda fazer fora da raiz). Rodar o gate de um worktree lê a stdlib
+do checkout compartilhado. Mudar isso é decisão de arquitetura de CI sobre 50 arquivos,
+não conserto de uma linha -- registrado, não executado.
+
+Trabalho consolidado em `worktree-witness-matrix-20260814` (PR #1737), três lanes
+paralelas mergeadas sem conflito (conjuntos de arquivos disjuntos) + o fix final.

--- a/docs/serious-language/CAMINHO_CRITICO_CORTADO_2026-08-14.md
+++ b/docs/serious-language/CAMINHO_CRITICO_CORTADO_2026-08-14.md
@@ -1,0 +1,60 @@
+<!-- docs:meta
+topic_id: repo.docs.serious-language.caminho-critico-cortado-2026-08-14
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.serious-language.caminho-critico-cortado-2026-08-14
+-->
+
+# Caminho crítico — versão cortada (2026-08-14)
+
+Substitui a versão de 5 tiers. Aquela era um mapa do território; esta é uma rota.
+
+Tier 0 está FEITO e medido (`tests/witness_matrix/`, PR #1737). O medo que a motivava
+-- portar 144 commits de uma branch órfã -- evaporou: a `main` já havia fechado 8 dos 10
+defeitos por rota própria. Sobraram dois, ambos corrigidos e verificados rodando ELF.
+
+## A jogada que corta mais escopo: assumir `alpha`, não `beta`
+
+`CITATION.cff` declara `1.0.0-beta.6`. Pela tabela do próprio `docs/RELEASE_POLICY.md`:
+
+    alpha  -> souc check passes on canonical fixtures
+    beta   -> stdlib reliability gate pass (0 fail)
+
+Com o corpus na casa de ~32% verde, **o rótulo atual já é um overclaim pela política do
+repositório**. Descer para `alpha` não é recuo: é fechar uma lacuna existente, e é a regra
+do FOUNDER_INTENT (nunca alargar a afirmação além da testemunha) aplicada ao número da
+versão. Efeito colateral: remove o corpus inteiro do caminho crítico de lançamento.
+
+## O deliverable único
+
+**Um estranho extrai o tarball e completa o first-user path de 4 comandos, com registro.**
+
+Os três vetores escolhidos (release, paper, site) compartilham uma precondição que nenhum
+tem: ninguém além do autor jamais rodou Sounio, e `docs/audit/RELEASE_PACKAGING_E2E_2026-06-07.md`
+conclui que o pacote *não funciona como documentado*. Docs sobre um tarball quebrado não são
+lançamento; paper sem usuário externo não passa em artifact evaluation.
+
+Conteúdo: portar os 6 bugs de empacotamento já corrigidos na branch órfã (VERSION com
+newline no nome do tarball, `release.sh` saindo 1 com tarball bom, `SOUNIO_STDLIB_PATH`
+ignorado, smoke check que não compila nada, CLI documentada que binário nenhum implementa),
+rebuildar o prebuilt (o enviado é de 25/jul), e assistir uma pessoa de fora rodar sem ajuda.
+
+## Adiado explicitamente, com o porquê
+
+| Item | Por que espera |
+|---|---|
+| Expandir a conformance spine (16 linhas) | Só importa para o paper, e o paper não vem antes de 22/09 |
+| Benchmarks vs Julia/Python | Idem; e o harness aponta para o compilador Rust aposentado |
+| Levar o corpus a 100% | Deixa de ser bloqueador no minuto em que se assume `alpha` |
+| Investigar o `w5` (arena de IR) | Pré-existente e fail-closed: recusa emitir binário, não corrompe em silêncio |
+| Conflito de duas vozes nas docs | Uma tarde de escrita; fazer junto com o release, não antes |
+| Ligar o `witness_matrix` no CI | Decisão do mantenedor: muda o que bloqueia merge de todos |
+
+## Sequência
+
+22/09 (submissão da dissertação) é a única data dura do repositório. O lançamento não tem
+data -- pela `RELEASE_POLICY.md`, releases são orientados a evento, não a calendário.
+Recomendação: o deliverable acima vem DEPOIS da submissão. Ele é pequeno o bastante para
+caber antes se houver vontade, mas então é ele sozinho.

--- a/scripts/dev/corpus_census.sh
+++ b/scripts/dev/corpus_census.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Corpus census: how much of stdlib/ and examples/ does the CURRENT compiler accept?
+#
+# Written because the published figures do not reconcile -- 638/2003, 767, ~633, ~689
+# predicted -- and all of them come from docs/EPISTEMIC_RELEASE_STATUS.md, which lives
+# on the ORPHAN branch integration/native-v2-honest and was measured in June against a
+# DIFFERENT tree. The corpus has since grown by ~500 files. Quoting that percentage for
+# todays main is a claim about one tree supported by a measurement of another.
+#
+# The verdict here is `souc check`, per CLAUDE.md principle 3: most files under stdlib/
+# and examples/ are libraries, not executables, so `check` plus a caller is the existence
+# test. This does NOT measure whether they compile to a working ELF -- that is a
+# strictly stronger question and this script deliberately does not answer it.
+#
+# Usage: bash scripts/dev/corpus_census.sh [path-to-souc] [jobs]
+set -u
+SOUC="${1:-./bin/souc}"
+JOBS="${2:-8}"
+SOUC="$(cd "$(dirname "$SOUC")" && pwd)/$(basename "$SOUC")"
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+OUT="${CENSUS_OUT:-/tmp/corpus_census.tsv}"
+PER_FILE_TIMEOUT="${CENSUS_TIMEOUT:-90}"
+
+export SOUC PER_FILE_TIMEOUT
+export SOUNIO_STDLIB_PATH="$ROOT/stdlib"
+
+check_one() {
+  f="$1"
+  timeout "$PER_FILE_TIMEOUT" "$SOUC" check "$f" >/dev/null 2>&1
+  rc=$?
+  if [ "$rc" = "0" ]; then
+    st=OK
+  elif [ "$rc" = "124" ]; then
+    st=TIMEOUT
+  elif [ "$rc" -ge 128 ]; then
+    st=CRASH
+  else
+    st=REJECT
+  fi
+  printf "%s\\t%s\\t%s\\n" "$f" "$rc" "$st"
+}
+export -f check_one
+
+git ls-files -- stdlib examples | grep "\\.sio$" | \
+  xargs -P "$JOBS" -I{} bash -c "check_one {}" > "$OUT"
+
+echo "census written: $OUT"
+
+summarise() {
+  area="$1"
+  tot=$(awk -F"\\t" -v a="$area" "index(\$1,a)==1" "$OUT" | wc -l)
+  ok=$(awk -F"\\t" -v a="$area" "index(\$1,a)==1 && \$3==\"OK\"" "$OUT" | wc -l)
+  rej=$(awk -F"\\t" -v a="$area" "index(\$1,a)==1 && \$3==\"REJECT\"" "$OUT" | wc -l)
+  to=$(awk -F"\\t" -v a="$area" "index(\$1,a)==1 && \$3==\"TIMEOUT\"" "$OUT" | wc -l)
+  cr=$(awk -F"\\t" -v a="$area" "index(\$1,a)==1 && \$3==\"CRASH\"" "$OUT" | wc -l)
+  pct=0
+  if [ "$tot" -gt 0 ]; then pct=$((ok * 100 / tot)); fi
+  printf "%-10s total=%-6s OK=%-6s (%s%%)  REJECT=%-6s TIMEOUT=%-4s CRASH=%s\\n" \
+    "$area" "$tot" "$ok" "$pct" "$rej" "$to" "$cr"
+}
+
+echo
+echo "=== corpus census: $($SOUC --version 2>&1 | head -1) ==="
+summarise stdlib
+summarise examples
+echo
+tot=$(wc -l < "$OUT")
+ok=$(awk -F"\\t" "\$3==\"OK\"" "$OUT" | wc -l)
+echo "TOTAL      $ok / $tot accepted by souc check"

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -5102,6 +5102,25 @@ fn checker_narrow_literal_operand_ty(operand_ty: TypeEntry, operand_was_int_lit:
     operand_ty
 }
 
+// Float mirror of checker_narrow_literal_operand_ty. `i32 + 1` already worked
+// because an i64 literal operand adopts a non-i64 integer peer; `f32 + 1.0` did
+// not, because nothing adopted the float peer. Same asymmetry as the contextual
+// path, one level down.
+// The magnitude guard lives on the LET/ARG path (checker_expected_accepts_float_literal);
+// here the literal is already bounded by having a f32 peer that type-checked.
+fn checker_narrow_float_literal_operand_ty(operand_ty: TypeEntry, operand_was_float_lit: bool, peer_ty: TypeEntry) -> TypeEntry {
+    if !operand_was_float_lit {
+        return operand_ty
+    }
+    if operand_ty.kind != TypeKind::TyF64 {
+        return operand_ty
+    }
+    if is_float_type(peer_ty) && peer_ty.kind != TypeKind::TyF64 {
+        return peer_ty
+    }
+    operand_ty
+}
+
 // *mut ExprBinary handler (split-and-bridge): check the OPERANDS in place — so a nested
 // enum path-expr (e.g. `c == Color::Red`) reaches checker_check_path_expr_inplace and
 // dodges the by-value check_path_expr SRET crash — then bridge to the by-value op-typing
@@ -5110,16 +5129,20 @@ fn checker_narrow_literal_operand_ty(operand_ty: TypeEntry, operand_was_int_lit:
 fn checker_check_binary_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
     let left_ty = checker_check_opt_expr_inplace(c, e.left)
     let left_was_int_lit = (*c).last_literal_kind == 1
+    let left_was_float_lit = (*c).last_literal_kind == 2
     (*c).last_literal_kind = 0
     let right_ty = checker_check_opt_expr_inplace(c, e.right)
     let right_was_int_lit = (*c).last_literal_kind == 1
+    let right_was_float_lit = (*c).last_literal_kind == 2
     (*c).last_literal_kind = 0
     let narrowed_left = checker_narrow_literal_operand_ty(left_ty, left_was_int_lit, right_ty)
     let narrowed_right = checker_narrow_literal_operand_ty(right_ty, right_was_int_lit, left_ty)
+    let narrowed_left_f = checker_narrow_float_literal_operand_ty(narrowed_left, left_was_float_lit, right_ty)
+    let narrowed_right_f = checker_narrow_float_literal_operand_ty(narrowed_right, right_was_float_lit, left_ty)
     // Call the *mut tail (returns only TypeEntry) — NOT the by-value bridge, whose
     // (Checker, TypeEntry) return became a 12MB local held across this fn's recursion
     // → N-deep stack overflow on deeply-nested exprs. The tail is non-recursive.
-    checker_check_binary_with_operand_types_inplace(c, e, narrowed_left, narrowed_right)
+    checker_check_binary_with_operand_types_inplace(c, e, narrowed_left_f, narrowed_right_f)
 }
 
 
@@ -15342,6 +15365,54 @@ fn checker_expected_accepts_int_literal(actual_ty: TypeEntry, expected_ty: TypeE
     actual_ty.kind == TypeKind::TyI64 && is_integer_type(expected_ty)
 }
 
+// Float-literal contextual coercion, the mirror of the int-literal path above.
+// Int literals are born i64 and adopt any integer type; float literals are born
+// f64 and adopted NOTHING, so `let x: f32 = 1.5` and passing 1.5 to an f32
+// parameter both rejected. That is what forced `as f32` everywhere -- and the
+// as-f32 lowering was silently truncating (see tests/witness_matrix w4b).
+fn checker_expr_is_float_literal_like(e: Expr) -> bool {
+    if e.kind == ExprKind::ExprFloatLit {
+        return true
+    }
+    if e.kind == ExprKind::ExprUnary && e.un_op == UnaryOp::OpNeg {
+        match e.left {
+            Some(inner) => (*inner).kind == ExprKind::ExprFloatLit
+            None => false
+        }
+    } else {
+        false
+    }
+}
+
+fn checker_float_literal_magnitude(e: Expr) -> f64 {
+    var v: f64 = 0.0
+    if e.kind == ExprKind::ExprFloatLit {
+        v = e.float_val
+    } else {
+        match e.left {
+            Some(inner) => { v = (*inner).float_val }
+            None => { v = 0.0 }
+        }
+    }
+    if v < 0.0 { 0.0 - v } else { v }
+}
+
+// CARDINAL: only LITERALS coerce, and never out of range. A float literal wider
+// than f32 max must still REJECT -- the literal-holes round found `let x: f32 =
+// 1e300` being accepted once the coercion was added without this guard.
+fn checker_expected_accepts_float_literal(e: Expr, actual_ty: TypeEntry, expected_ty: TypeEntry) -> bool {
+    if actual_ty.kind != TypeKind::TyF64 {
+        return false
+    }
+    if !is_float_type(expected_ty) {
+        return false
+    }
+    if expected_ty.kind == TypeKind::TyF64 {
+        return true
+    }
+    checker_float_literal_magnitude(e) <= 3.4028235e38
+}
+
 fn checker_array_sizes_compatible(actual_ty: TypeEntry, expected_ty: TypeEntry) -> bool {
     if actual_ty.array_size == -1 || expected_ty.array_size == -1 {
         return true
@@ -15381,6 +15452,9 @@ fn checker_contextual_expr_compatible(expr: Expr, actual_ty: TypeEntry, expected
         return true
     }
     if checker_expr_is_int_literal_like(expr) && checker_expected_accepts_int_literal(actual_ty, expected_ty) {
+        return true
+    }
+    if checker_expr_is_float_literal_like(expr) && checker_expected_accepts_float_literal(expr, actual_ty, expected_ty) {
         return true
     }
     checker_array_int_literal_compatible(expr, actual_ty, expected_ty)

--- a/self-hosted/ir/ir.sio
+++ b/self-hosted/ir/ir.sio
@@ -3595,6 +3595,33 @@ fn ir_string_list_last(sl: StringList) -> Name with Mut, Panic, Div, Alloc {
     }
 }
 
+// Second-to-last segment of a path (e.g. "Enum" from "Enum::Variant", and from
+// "module::Enum::Variant" too). Empty name when the path has fewer than two
+// segments, so callers can fall back to an unqualified lookup.
+fn ir_string_list_second_last(sl: StringList) -> Name with Mut, Panic, Div, Alloc {
+    match sl.tail {
+        Some(rest) => {
+            match (*rest).tail {
+                Some(_) => ir_string_list_second_last(*rest),
+                _ => ir_name_from_string_list(sl),
+            }
+        }
+        _ => ir_empty_name(),
+    }
+}
+
+// Get the qualifier of a path: "Color" from "Color::Mark".
+// Enum variant discriminants restart at 0 per enum, so a lookup keyed only on
+// the variant name collides across enums that share a variant name. Callers
+// pair this with the variant name to key the lookup by the full path.
+pub fn ir_path_qualifier_name(p: AstPath) -> Name with Mut, Panic, Div, Alloc {
+    if p.seg_count <= 1 {
+        ir_empty_name()
+    } else {
+        ir_string_list_second_last(p.segments)
+    }
+}
+
 // Check if a name is "Some" (for Option matching)
 pub fn ir_name_is_some(n: Name) -> bool {
     n.len == 4 && n.buf[0] == 83 as i8 && n.buf[1] == 111 as i8 && n.buf[2] == 109 as i8 && n.buf[3] == 101 as i8

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -4487,36 +4487,17 @@ fn lowerer_lower_program_items_mut(
 
 // Sprint 87: helpers for ExprCast type-aware lowering
 fn lower_cast_type_is_f64(ct: &Option<Box<TypeExpr>>) -> bool with Mut, Panic, Div {
-    match *ct {
-        Some(te) => {
-            let seg = (*te).path.segments
-            if seg.head_len != 3 { return false }
-            if seg.head_buf[0] as i64 != 102 { return false }   // 'f'
-            if seg.head_buf[1] as i64 != 54 { return false }    // '6'
-            if seg.head_buf[2] as i64 != 52 { return false }    // '4'
-            true
-        }
-        None => false,
-    }
-}
-
-// `as f32` was recognised by NEITHER the f64-target branch nor the integer
-// classifier, so a float source fell through to the float_to_int arm of
-// lower_cast_expr_ref and (1.5 as f32) became 1.0 -- a silent, value-destroying
-// truncation on a well-typed program. The backend represents f32 as f64, so a
-// float-to-f32 cast is a pass-through here.
-// KNOWN RESIDUAL (declared, not silent): this does NOT round to true single
-// precision -- it preserves the f64 value. Narrowing to real IEEE binary32
-// needs an f32 representation in the backend, which does not exist yet.
-fn lower_cast_type_is_f32(ct: &Option<Box<TypeExpr>>) -> bool with Mut, Panic, Div {
+    // Accepts f32 as well -- see lower_type_expr_is_f64. `as f32` matched neither
+    // this nor the integer classifier, so a float source fell through to the
+    // float_to_int arm of lower_cast_expr_ref and (1.5 as f32) became 1.0.
     match *ct {
         Some(te) => {
             let seg = (*te).path.segments
             if seg.head_len != 3 { return false }
             if seg.head_buf[0] as i64 != 102 { return false }   // f
-            if seg.head_buf[1] as i64 != 51 { return false }    // 3
-            if seg.head_buf[2] as i64 != 50 { return false }    // 2
-            true
+            let is_64 = seg.head_buf[1] as i64 == 54 && seg.head_buf[2] as i64 == 52
+            let is_32 = seg.head_buf[1] as i64 == 51 && seg.head_buf[2] as i64 == 50
+            is_64 || is_32
         }
         None => false,
     }
@@ -4540,10 +4521,16 @@ fn lower_type_expr_is_f64(te: &TypeExpr) -> bool with Mut, Panic, Div {
     if (*te).kind != TypeExprKind::TypeNamed { return false }
     let seg = (*te).path.segments
     if seg.head_len != 3 { return false }
-    if seg.head_buf[0] as i64 != 102 { return false }   // 'f'
-    if seg.head_buf[1] as i64 != 54 { return false }    // '6'
-    if seg.head_buf[2] as i64 != 52 { return false }    // '4'
-    true
+    if seg.head_buf[0] as i64 != 102 { return false }   // f
+    // Accept BOTH f64 and f32: the backend has no separate f32 representation
+    // (f32 is carried as f64), so all 17 call sites of this predicate mean
+    // -- is this a float scalar? -- not -- is this spelled f64?. While f32 was
+    // rejected here, a local declared f32 got scalar_kind 0 instead of 2, so
+    // `x as f64` on it took the int_to_float arm and reinterpreted the bit
+    // pattern of a double as an integer.
+    let is_64 = seg.head_buf[1] as i64 == 54 && seg.head_buf[2] as i64 == 52
+    let is_32 = seg.head_buf[1] as i64 == 51 && seg.head_buf[2] as i64 == 50
+    is_64 || is_32
 }
 
 // println i64-segfault fix: mirror lower_type_expr_is_f64 for i64 so a struct
@@ -15437,7 +15424,7 @@ impl Lowerer {
                 wi = wi + 1
             }
             (lo2, dst)
-        } else if lower_cast_type_is_f64(&e.cast_type) || lower_cast_type_is_f32(&e.cast_type) {
+        } else if lower_cast_type_is_f64(&e.cast_type) {
             if source_is_float {
                 return (lo1, src_reg)
             }

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -4500,6 +4500,28 @@ fn lower_cast_type_is_f64(ct: &Option<Box<TypeExpr>>) -> bool with Mut, Panic, D
     }
 }
 
+// `as f32` was recognised by NEITHER the f64-target branch nor the integer
+// classifier, so a float source fell through to the float_to_int arm of
+// lower_cast_expr_ref and (1.5 as f32) became 1.0 -- a silent, value-destroying
+// truncation on a well-typed program. The backend represents f32 as f64, so a
+// float-to-f32 cast is a pass-through here.
+// KNOWN RESIDUAL (declared, not silent): this does NOT round to true single
+// precision -- it preserves the f64 value. Narrowing to real IEEE binary32
+// needs an f32 representation in the backend, which does not exist yet.
+fn lower_cast_type_is_f32(ct: &Option<Box<TypeExpr>>) -> bool with Mut, Panic, Div {
+    match *ct {
+        Some(te) => {
+            let seg = (*te).path.segments
+            if seg.head_len != 3 { return false }
+            if seg.head_buf[0] as i64 != 102 { return false }   // f
+            if seg.head_buf[1] as i64 != 51 { return false }    // 3
+            if seg.head_buf[2] as i64 != 50 { return false }    // 2
+            true
+        }
+        None => false,
+    }
+}
+
 fn lower_cast_type_is_i64(ct: &Option<Box<TypeExpr>>) -> bool with Mut, Panic, Div {
     match *ct {
         Some(te) => {
@@ -10795,6 +10817,29 @@ impl Lowerer {
         -1
     }
 
+    // Lookup keyed by the FULL path (enum + variant).
+    // Discriminants restart at 0 per enum, so keying on the variant name alone
+    // returns the first match across ALL enums: with `enum Shape{Quad,Mark}` and
+    // `enum Color{Red,Green,Mark}` both present, Color::Mark resolved to the
+    // Shape discriminant instead of its own, and the match arm silently ran the
+    // wrong body on a well-typed program.
+    // Falls back to the unqualified lookup when the enum is unknown here (e.g. an
+    // unregistered imported enum) so nothing that resolves today starts failing.
+    fn lookup_variant_discriminant_by_path(self, enum_name: Name, variant_name: Name) -> i64 with Mut, Panic, Div {
+        if enum_name.len > 0 {
+            var i: i64 = 0
+            while i < (*self.enum_variants).count {
+                if ir_name_eq((*self.enum_variants).entries[i as usize].variant_name, variant_name) {
+                    if ir_name_eq((*self.enum_variants).entries[i as usize].enum_name, enum_name) {
+                        return (*self.enum_variants).entries[i as usize].discriminant
+                    }
+                }
+                i = i + 1
+            }
+        }
+        self.lookup_variant_discriminant(variant_name)
+    }
+
     // Phase 3.2: Register struct field layout
     fn register_struct_fields_ref(self, type_name: Name, fields: &Option<Box<FieldDefList>>, idx: i64) -> Lowerer with Mut, Panic, Div, Alloc, IO {
         var lo = self
@@ -13688,7 +13733,7 @@ impl Lowerer {
                 lo
             } else {
                 // Enum variant: compare scrutinee to discriminant
-                let disc = self.lookup_variant_discriminant(variant_name)
+                let disc = self.lookup_variant_discriminant_by_path(ir_path_qualifier_name(pat.path), variant_name)
                 if disc >= 0 {
                     let pair_l = self.fresh_label()
                     var lo = pair_l.0
@@ -15392,7 +15437,7 @@ impl Lowerer {
                 wi = wi + 1
             }
             (lo2, dst)
-        } else if lower_cast_type_is_f64(&e.cast_type) {
+        } else if lower_cast_type_is_f64(&e.cast_type) || lower_cast_type_is_f32(&e.cast_type) {
             if source_is_float {
                 return (lo1, src_reg)
             }
@@ -16389,7 +16434,7 @@ impl Lowerer {
                     let lo2 = lo.emit(ir_load_imm(reg, 0))
                     return (lo2, reg)
                 }
-                let disc = self.lookup_variant_discriminant(variant_name)
+                let disc = self.lookup_variant_discriminant_by_path(ir_path_qualifier_name(e.path), variant_name)
                 if disc >= 0 {
                     let pair = self.fresh_reg()
                     let lo = pair.0

--- a/stdlib/epistemic/lib.sio
+++ b/stdlib/epistemic/lib.sio
@@ -81,7 +81,7 @@ fn uncertainty_interval(lo: f64, hi: f64) -> Uncertainty {
 }
 
 // Extract std deviation from any uncertainty
-fn uncert_to_std(u: Uncertainty) -> f64 {
+pub fn uncert_to_std(u: Uncertainty) -> f64 {
     if u.tag == 0 {
         return 0.0
     } else if u.tag == 1 {
@@ -121,7 +121,7 @@ struct EpistemicValue {
 // ============================================================================
 
 // Create EpistemicValue with standard uncertainty
-fn epistemic_std(value: f64, uncertainty: f64, confidence: f64) -> EpistemicValue {
+pub fn epistemic_std(value: f64, uncertainty: f64, confidence: f64) -> EpistemicValue {
     var conf = confidence
     if conf < 0.0 { conf = 0.0 }
     if conf > 1.0 { conf = 1.0 }
@@ -212,7 +212,7 @@ fn get_interval_hi(k: EpistemicValue) -> f64 {
 
 // Add two EpistemicValues with GUM uncertainty propagation
 // INVARIANT: output.conf <= min(a.conf, b.conf)
-fn add_epistemic(a: EpistemicValue, b: EpistemicValue) -> EpistemicValue {
+pub fn add_epistemic(a: EpistemicValue, b: EpistemicValue) -> EpistemicValue {
     let value = a.value + b.value
     let conf = min_f64(a.conf, b.conf)
 
@@ -230,7 +230,7 @@ fn add_epistemic(a: EpistemicValue, b: EpistemicValue) -> EpistemicValue {
 }
 
 // Subtract two EpistemicValues
-fn sub_epistemic(a: EpistemicValue, b: EpistemicValue) -> EpistemicValue {
+pub fn sub_epistemic(a: EpistemicValue, b: EpistemicValue) -> EpistemicValue {
     let value = a.value - b.value
     let conf = min_f64(a.conf, b.conf)
 
@@ -248,7 +248,7 @@ fn sub_epistemic(a: EpistemicValue, b: EpistemicValue) -> EpistemicValue {
 }
 
 // Multiply two EpistemicValues
-fn mul_epistemic(a: EpistemicValue, b: EpistemicValue) -> EpistemicValue {
+pub fn mul_epistemic(a: EpistemicValue, b: EpistemicValue) -> EpistemicValue {
     let value = a.value * b.value
     let conf = min_f64(a.conf, b.conf)
 
@@ -277,7 +277,7 @@ fn mul_epistemic(a: EpistemicValue, b: EpistemicValue) -> EpistemicValue {
 }
 
 // Divide two EpistemicValues
-fn div_epistemic(a: EpistemicValue, b: EpistemicValue) -> EpistemicValue {
+pub fn div_epistemic(a: EpistemicValue, b: EpistemicValue) -> EpistemicValue {
     // Guard against division by zero
     if abs_f64(b.value) < 1.0e-15 {
         return EpistemicValue {

--- a/stdlib/math/octonion.sio
+++ b/stdlib/math/octonion.sio
@@ -6,25 +6,28 @@
 //! - "The Octonions" by John C. Baez (Bull. AMS, 2002)
 //! - "Deep Octonion Networks" (arXiv:1903.08478)
 //! - Used for 8x parameter-efficient neural networks and exceptional Lie groups
+extern "C" { fn sqrt(x: f64) -> f64; }
+extern "C" { fn exp(x: f64) -> f64; }
+
 
 // Octonion type: 8-dimensional hypercomplex number
 // Components: (a, b, c, d, e, f, g, h) representing
 // a + bi + cj + dk + el + fil + gjl + hkl
 // where i²=j²=k²=l²=(il)²=(jl)²=(kl)²=-1
 pub struct Octonion {
-    a: f32,  // real part
-    b: f32,  // i coefficient
-    c: f32,  // j coefficient
-    d: f32,  // k coefficient
-    e: f32,  // l coefficient
-    f: f32,  // il coefficient
-    g: f32,  // jl coefficient
-    h: f32,  // kl coefficient
+    a: f64,  // real part
+    b: f64,  // i coefficient
+    c: f64,  // j coefficient
+    d: f64,  // k coefficient
+    e: f64,  // l coefficient
+    f: f64,  // il coefficient
+    g: f64,  // jl coefficient
+    h: f64,  // kl coefficient
 }
 
 // Constructs an octonion from 8 components
 // oct(a, b, c, d, e, f, g, h) = a + bi + cj + dk + el + fil + gjl + hkl
-pub fn oct(a: f32, b: f32, c: f32, d: f32, e: f32, f: f32, g: f32, h: f32) -> Octonion {
+pub fn oct(a: f64, b: f64, c: f64, d: f64, e: f64, f: f64, g: f64, h: f64) -> Octonion {
     Octonion { a: a, b: b, c: c, d: d, e: e, f: f, g: g, h: h }
 }
 
@@ -47,15 +50,15 @@ pub fn oct_conj(o: Octonion) -> Octonion {
 // Computes the squared Euclidean norm of an octonion
 // norm_sq(o) = a² + b² + c² + d² + e² + f² + g² + h²
 // More efficient than oct_norm() for comparisons (avoids sqrt)
-pub fn oct_norm_sq(o: Octonion) -> f32 {
+pub fn oct_norm_sq(o: Octonion) -> f64 {
     o.a * o.a + o.b * o.b + o.c * o.c + o.d * o.d +
     o.e * o.e + o.f * o.f + o.g * o.g + o.h * o.h
 }
 
 // Computes the Euclidean norm (magnitude) of an octonion
 // norm(o) = sqrt(a² + b² + c² + d² + e² + f² + g² + h²)
-pub fn oct_norm(o: Octonion) -> f32 {
-    oct_norm_sq(o).sqrt()
+pub fn oct_norm(o: Octonion) -> f64 {
+    sqrt(oct_norm_sq(o))
 }
 
 // Normalizes an octonion to unit length
@@ -125,41 +128,48 @@ pub fn oct_relu(o: Octonion) -> Octonion {
 // sigmoid(o) = (σ(a), σ(b), ..., σ(h)) where σ(x) = 1/(1+e^(-x))
 pub fn oct_sigmoid(o: Octonion) -> Octonion {
     Octonion {
-        a: 1.0 / (1.0 + (-o.a).exp()),
-        b: 1.0 / (1.0 + (-o.b).exp()),
-        c: 1.0 / (1.0 + (-o.c).exp()),
-        d: 1.0 / (1.0 + (-o.d).exp()),
-        e: 1.0 / (1.0 + (-o.e).exp()),
-        f: 1.0 / (1.0 + (-o.f).exp()),
-        g: 1.0 / (1.0 + (-o.g).exp()),
-        h: 1.0 / (1.0 + (-o.h).exp())
+        a: 1.0 / (1.0 + exp(0.0 - o.a)),
+        b: 1.0 / (1.0 + exp(0.0 - o.b)),
+        c: 1.0 / (1.0 + exp(0.0 - o.c)),
+        d: 1.0 / (1.0 + exp(0.0 - o.d)),
+        e: 1.0 / (1.0 + exp(0.0 - o.e)),
+        f: 1.0 / (1.0 + exp(0.0 - o.f)),
+        g: 1.0 / (1.0 + exp(0.0 - o.g)),
+        h: 1.0 / (1.0 + exp(0.0 - o.h))
     }
+}
+
+// Scalar tanh built from exp: the native backend implements `exp` but not
+// `tanh`, so tanh(x) = 1 - 2/(exp(2x)+1). This form saturates correctly at
+// both ends: exp(2x) -> +inf gives +1, exp(2x) -> 0 gives -1.
+fn oct_tanh_scalar(x: f64) -> f64 {
+    1.0 - 2.0 / (exp(2.0 * x) + 1.0)
 }
 
 // Per-component tanh activation function for octonions
 // tanh(o) = (tanh(a), tanh(b), ..., tanh(h))
 pub fn oct_tanh(o: Octonion) -> Octonion {
     Octonion {
-        a: o.a.tanh(),
-        b: o.b.tanh(),
-        c: o.c.tanh(),
-        d: o.d.tanh(),
-        e: o.e.tanh(),
-        f: o.f.tanh(),
-        g: o.g.tanh(),
-        h: o.h.tanh()
+        a: oct_tanh_scalar(o.a),
+        b: oct_tanh_scalar(o.b),
+        c: oct_tanh_scalar(o.c),
+        d: oct_tanh_scalar(o.d),
+        e: oct_tanh_scalar(o.e),
+        f: oct_tanh_scalar(o.f),
+        g: oct_tanh_scalar(o.g),
+        h: oct_tanh_scalar(o.h)
     }
 }
 
 // Extract the real (scalar) part of an octonion
 // Real part is the component 'a' in a + bi + ... + hkl
-pub fn oct_real(o: Octonion) -> f32 {
+pub fn oct_real(o: Octonion) -> f64 {
     o.a
 }
 
 // Computes the dot product of two octonions
 // Returns the scalar a1*a2 + b1*b2 + ... + h1*h2
-pub fn oct_dot(o1: Octonion, o2: Octonion) -> f32 {
+pub fn oct_dot(o1: Octonion, o2: Octonion) -> f64 {
     o1.a * o2.a + o1.b * o2.b + o1.c * o2.c + o1.d * o2.d +
     o1.e * o2.e + o1.f * o2.f + o1.g * o2.g + o1.h * o2.h
 }
@@ -201,8 +211,8 @@ pub fn oct_mul(a: Octonion, b: Octonion) -> Octonion {
 
 // Holds the two quaternion halves of an octonion decomposition
 pub struct OctonionParts {
-    q0_a: f32, q0_b: f32, q0_c: f32, q0_d: f32,  // q0 = a + bi + cj + dk
-    q1_a: f32, q1_b: f32, q1_c: f32, q1_d: f32   // q1 = e + fi + gj + hk (l coefficient)
+    q0_a: f64, q0_b: f64, q0_c: f64, q0_d: f64,  // q0 = a + bi + cj + dk
+    q1_a: f64, q1_b: f64, q1_c: f64, q1_d: f64   // q1 = e + fi + gj + hk (l coefficient)
 }
 
 // Splits an octonion into its two quaternion halves: o = q0 + q1*l
@@ -223,7 +233,7 @@ pub fn oct_from_quaternion_parts(p: OctonionParts) -> Octonion {
 
 // Verifies the round-trip identity: oct_from_quaternion_parts(oct_to_quaternion_parts(o)) == o
 // Returns the L2 reconstruction error (should be 0.0 for exact arithmetic)
-pub fn oct_decomposition_error(o: Octonion) -> f32 {
+pub fn oct_decomposition_error(o: Octonion) -> f64 {
     let parts = oct_to_quaternion_parts(o)
     let reconstructed = oct_from_quaternion_parts(parts)
     let da = o.a - reconstructed.a

--- a/stdlib/math/sedenion.sio
+++ b/stdlib/math/sedenion.sio
@@ -21,6 +21,14 @@
 use math::octonion::{Octonion};
 
 extern "C" { fn sqrt(x: f64) -> f64; }
+extern "C" { fn exp(x: f64) -> f64; }
+
+// Scalar tanh built from exp: the native backend implements `exp` but not
+// `tanh`, so tanh(x) = 1 - 2/(exp(2x)+1). This form saturates correctly at
+// both ends: exp(2x) -> +inf gives +1, exp(2x) -> 0 gives -1.
+fn sed_tanh_scalar(x: f64) -> f64 {
+    1.0 - 2.0 / (exp(2.0 * x) + 1.0)
+}
 
 // Helper struct for oct_mul_components return value (replaces tuple)
 pub struct OctComp8 {
@@ -393,44 +401,44 @@ pub fn sed_relu(s: Sedenion) -> Sedenion {
 // Per-component sigmoid activation
 pub fn sed_sigmoid(s: Sedenion) -> Sedenion with Panic {
     Sedenion {
-        e0: 1.0 / (1.0 + (-s.e0).exp()),
-        e1: 1.0 / (1.0 + (-s.e1).exp()),
-        e2: 1.0 / (1.0 + (-s.e2).exp()),
-        e3: 1.0 / (1.0 + (-s.e3).exp()),
-        e4: 1.0 / (1.0 + (-s.e4).exp()),
-        e5: 1.0 / (1.0 + (-s.e5).exp()),
-        e6: 1.0 / (1.0 + (-s.e6).exp()),
-        e7: 1.0 / (1.0 + (-s.e7).exp()),
-        e8: 1.0 / (1.0 + (-s.e8).exp()),
-        e9: 1.0 / (1.0 + (-s.e9).exp()),
-        e10: 1.0 / (1.0 + (-s.e10).exp()),
-        e11: 1.0 / (1.0 + (-s.e11).exp()),
-        e12: 1.0 / (1.0 + (-s.e12).exp()),
-        e13: 1.0 / (1.0 + (-s.e13).exp()),
-        e14: 1.0 / (1.0 + (-s.e14).exp()),
-        e15: 1.0 / (1.0 + (-s.e15).exp())
+        e0: 1.0 / (1.0 + exp(0.0 - s.e0)),
+        e1: 1.0 / (1.0 + exp(0.0 - s.e1)),
+        e2: 1.0 / (1.0 + exp(0.0 - s.e2)),
+        e3: 1.0 / (1.0 + exp(0.0 - s.e3)),
+        e4: 1.0 / (1.0 + exp(0.0 - s.e4)),
+        e5: 1.0 / (1.0 + exp(0.0 - s.e5)),
+        e6: 1.0 / (1.0 + exp(0.0 - s.e6)),
+        e7: 1.0 / (1.0 + exp(0.0 - s.e7)),
+        e8: 1.0 / (1.0 + exp(0.0 - s.e8)),
+        e9: 1.0 / (1.0 + exp(0.0 - s.e9)),
+        e10: 1.0 / (1.0 + exp(0.0 - s.e10)),
+        e11: 1.0 / (1.0 + exp(0.0 - s.e11)),
+        e12: 1.0 / (1.0 + exp(0.0 - s.e12)),
+        e13: 1.0 / (1.0 + exp(0.0 - s.e13)),
+        e14: 1.0 / (1.0 + exp(0.0 - s.e14)),
+        e15: 1.0 / (1.0 + exp(0.0 - s.e15))
     }
 }
 
 // Per-component tanh activation
 pub fn sed_tanh(s: Sedenion) -> Sedenion {
     Sedenion {
-        e0: s.e0.tanh(),
-        e1: s.e1.tanh(),
-        e2: s.e2.tanh(),
-        e3: s.e3.tanh(),
-        e4: s.e4.tanh(),
-        e5: s.e5.tanh(),
-        e6: s.e6.tanh(),
-        e7: s.e7.tanh(),
-        e8: s.e8.tanh(),
-        e9: s.e9.tanh(),
-        e10: s.e10.tanh(),
-        e11: s.e11.tanh(),
-        e12: s.e12.tanh(),
-        e13: s.e13.tanh(),
-        e14: s.e14.tanh(),
-        e15: s.e15.tanh()
+        e0: sed_tanh_scalar(s.e0),
+        e1: sed_tanh_scalar(s.e1),
+        e2: sed_tanh_scalar(s.e2),
+        e3: sed_tanh_scalar(s.e3),
+        e4: sed_tanh_scalar(s.e4),
+        e5: sed_tanh_scalar(s.e5),
+        e6: sed_tanh_scalar(s.e6),
+        e7: sed_tanh_scalar(s.e7),
+        e8: sed_tanh_scalar(s.e8),
+        e9: sed_tanh_scalar(s.e9),
+        e10: sed_tanh_scalar(s.e10),
+        e11: sed_tanh_scalar(s.e11),
+        e12: sed_tanh_scalar(s.e12),
+        e13: sed_tanh_scalar(s.e13),
+        e14: sed_tanh_scalar(s.e14),
+        e15: sed_tanh_scalar(s.e15)
     }
 }
 

--- a/stdlib/nn/quaternion.sio
+++ b/stdlib/nn/quaternion.sio
@@ -531,7 +531,9 @@ fn exp_f64(x: f64) -> f64 {
     var term = 1.0
     var i = 1
     while i <= 20 {
-        term = term * x / i
+        // `i` is the integer loop counter; the Taylor term is f64. i64 -> f64 is
+        // exact for 1..20, so this cast preserves the series exactly.
+        term = term * x / (i as f64)
         sum = sum + term
         i = i + 1
     }

--- a/stdlib/nn/quaternion.sio
+++ b/stdlib/nn/quaternion.sio
@@ -91,7 +91,7 @@ pub struct Quaternion {
 // ============================================================================
 
 // Create quaternion from exact components (maximum confidence)
-fn quaternion_exact(w: f64, x: f64, y: f64, z: f64) -> Quaternion {
+pub fn quaternion_exact(w: f64, x: f64, y: f64, z: f64) -> Quaternion {
     let comp_confidence = 0.99
     Quaternion {
         w: epistemic_std(w, 0.0, comp_confidence),
@@ -144,12 +144,12 @@ fn quaternion_from_axis_angle(angle: f64, axis_x: f64, axis_y: f64, axis_z: f64)
 }
 
 // Create identity quaternion (no rotation)
-fn quaternion_identity() -> Quaternion {
+pub fn quaternion_identity() -> Quaternion {
     quaternion_exact(1.0, 0.0, 0.0, 0.0)
 }
 
 // Create zero quaternion
-fn quaternion_zero() -> Quaternion {
+pub fn quaternion_zero() -> Quaternion {
     quaternion_exact(0.0, 0.0, 0.0, 0.0)
 }
 
@@ -157,11 +157,11 @@ fn quaternion_zero() -> Quaternion {
 // ACCESSORS
 // ============================================================================
 
-fn quaternion_get_w(q: Quaternion) -> f64 {
+pub fn quaternion_get_w(q: Quaternion) -> f64 {
     q.w.value
 }
 
-fn quaternion_get_x(q: Quaternion) -> f64 {
+pub fn quaternion_get_x(q: Quaternion) -> f64 {
     q.x.value
 }
 
@@ -238,7 +238,7 @@ fn quaternion_inverse(q: Quaternion) -> Quaternion {
 }
 
 // Quaternion norm squared: ||q||² = w² + x² + y² + z²
-fn quaternion_norm_squared(q: Quaternion) -> EpistemicValue {
+pub fn quaternion_norm_squared(q: Quaternion) -> EpistemicValue {
     let w2 = mul_epistemic(q.w, q.w)
     let x2 = mul_epistemic(q.x, q.x)
     let y2 = mul_epistemic(q.y, q.y)
@@ -258,7 +258,7 @@ fn quaternion_norm_squared(q: Quaternion) -> EpistemicValue {
 // x = a_w*b_x + a_x*b_w + a_y*b_z - a_z*b_y
 // y = a_w*b_y - a_x*b_z + a_y*b_w + a_z*b_x
 // z = a_w*b_z + a_x*b_y - a_y*b_x + a_z*b_w
-fn quaternion_mul(a: Quaternion, b: Quaternion) -> Quaternion {
+pub fn quaternion_mul(a: Quaternion, b: Quaternion) -> Quaternion {
     let w = sub_epistemic(
         sub_epistemic(sub_epistemic(
             mul_epistemic(a.w, b.w),
@@ -304,7 +304,7 @@ fn quaternion_mul(a: Quaternion, b: Quaternion) -> Quaternion {
 }
 
 // Quaternion addition: (a_w + b_w) + (a_x + b_x)i + (a_y + b_y)j + (a_z + b_z)k
-fn quaternion_add(a: Quaternion, b: Quaternion) -> Quaternion {
+pub fn quaternion_add(a: Quaternion, b: Quaternion) -> Quaternion {
     Quaternion {
         w: add_epistemic(a.w, b.w),
         x: add_epistemic(a.x, b.x),
@@ -316,7 +316,7 @@ fn quaternion_add(a: Quaternion, b: Quaternion) -> Quaternion {
 }
 
 // Quaternion subtraction: (a_w - b_w) + (a_x - b_x)i + (a_y - b_y)j + (a_z - b_z)k
-fn quaternion_sub(a: Quaternion, b: Quaternion) -> Quaternion {
+pub fn quaternion_sub(a: Quaternion, b: Quaternion) -> Quaternion {
     Quaternion {
         w: sub_epistemic(a.w, b.w),
         x: sub_epistemic(a.x, b.x),

--- a/stdlib/onn/g2_activation.sio
+++ b/stdlib/onn/g2_activation.sio
@@ -13,7 +13,7 @@ struct OnnOctonion {
     s: f32,
 }
 
-fn onn_oct_new(w: f32, x: f32, y: f32, z: f32, t: f32, u: f32, v: f32, s: f32) -> OnnOctonion {
+pub fn onn_oct_new(w: f32, x: f32, y: f32, z: f32, t: f32, u: f32, v: f32, s: f32) -> OnnOctonion {
     OnnOctonion { w: w, x: x, y: y, z: z, t: t, u: u, v: v, s: s }
 }
 
@@ -40,7 +40,7 @@ fn oct_leaky_relu_g2_activate(o: OnnOctonion, alpha: f32) -> OnnOctonion {
     if oct_energy(o) < 0.001 { oct_scale(o, alpha) } else { o }
 }
 
-fn oct_relu_g2_activate(o: OnnOctonion) -> OnnOctonion {
+pub fn oct_relu_g2_activate(o: OnnOctonion) -> OnnOctonion {
     if oct_energy(o) > 0.0 { o } else { onn_oct_zero() }
 }
 
@@ -48,13 +48,13 @@ fn abs_f32_local(x: f32) -> f32 {
     if x < 0.0 { 0.0 - x } else { x }
 }
 
-fn oct_sigmoid_gate_g2(o: OnnOctonion) -> OnnOctonion {
+pub fn oct_sigmoid_gate_g2(o: OnnOctonion) -> OnnOctonion {
     // Bounded monotone gate that avoids exp/tanh runtime path.
     let gate = 0.5 + 0.5 * (o.w / (1.0 + abs_f32_local(o.w)))
     oct_scale(o, gate)
 }
 
-fn oct_soft_normalize(o: OnnOctonion, epsilon: f32) -> OnnOctonion {
+pub fn oct_soft_normalize(o: OnnOctonion, epsilon: f32) -> OnnOctonion {
     let scale = 1.0 / (1.0 + oct_energy(o) + epsilon)
     oct_scale(o, scale)
 }

--- a/stdlib/qnn/quaternion.sio
+++ b/stdlib/qnn/quaternion.sio
@@ -1,21 +1,37 @@
 //! stdlib/qnn/quaternion.sio - Quaternion Type and Operations
 //! Quaternion algebra: w + xi + yj + zk where i^2=j^2=k^2=ijk=-1
 
-// Quaternion type wrapper around the built-in Quat type
-// Represents rotation/orientation in 3D space
+extern "C" { fn sqrt(x: f64) -> f64; }
+
+// Quaternion value type: w + xi + yj + zk.
+// Components are f64: Sounio float literals are f64 and there is no
+// literal->f32 coercion, so an f32 layout could not be constructed
+// from literals without an explicit cast at every call site.
+struct Quat {
+    w: f64,
+    x: f64,
+    y: f64,
+    z: f64,
+}
+
+// Historical alias kept for callers that spell the type out in full.
 type Quaternion = Quat;
+
+// Constructs a quaternion from its four real components.
+fn quat(w: f64, x: f64, y: f64, z: f64) -> Quat {
+    Quat { w: w, x: x, y: y, z: z }
+}
 
 // Computes the conjugate of a quaternion: (w, -x, -y, -z)
 // The conjugate negates the vector part, useful for calculating inverse
 fn quat_conjugate(q: Quat) -> Quat {
-    quat(q.w, -q.x, -q.y, -q.z)
+    quat(q.w, 0.0 - q.x, 0.0 - q.y, 0.0 - q.z)
 }
 
 // Computes the Euclidean norm (magnitude) of a quaternion
 // norm(q) = sqrt(w^2 + x^2 + y^2 + z^2)
-fn quat_norm(q: Quat) -> f32 {
-    let norm_sq = q.w * q.w + q.x * q.x + q.y * q.y + q.z * q.z
-    norm_sq.sqrt()
+fn quat_norm(q: Quat) -> f64 {
+    sqrt(q.w * q.w + q.x * q.x + q.y * q.y + q.z * q.z)
 }
 
 // Normalizes a quaternion to unit length
@@ -23,7 +39,7 @@ fn quat_norm(q: Quat) -> f32 {
 fn quat_normalize(q: Quat) -> Quat {
     let n = quat_norm(q)
     if n == 0.0 {
-        quat(1.0, 0.0, 0.0, 0.0)  // Identity for zero quaternion
+        quat(1.0, 0.0, 0.0, 0.0)
     } else {
         let inv_n = 1.0 / n
         quat(q.w * inv_n, q.x * inv_n, q.y * inv_n, q.z * inv_n)
@@ -36,20 +52,14 @@ fn quat_normalize(q: Quat) -> Quat {
 fn quat_inverse(q: Quat) -> Quat {
     let norm_sq = q.w * q.w + q.x * q.x + q.y * q.y + q.z * q.z
     if norm_sq == 0.0 {
-        quat(1.0, 0.0, 0.0, 0.0)  // Return identity for zero quaternion
+        quat(1.0, 0.0, 0.0, 0.0)
     } else {
-        let inv_norm_sq = 1.0 / norm_sq
-        quat(
-            q.w * inv_norm_sq,
-            -q.x * inv_norm_sq,
-            -q.y * inv_norm_sq,
-            -q.z * inv_norm_sq
-        )
+        let s = 1.0 / norm_sq
+        quat(q.w * s, 0.0 - q.x * s, 0.0 - q.y * s, 0.0 - q.z * s)
     }
 }
 
 // Computes the Hamilton product of two quaternions
-// Multiplies two quaternions using Hamilton's algebra rules:
 // (w1 + x1i + y1j + z1k) * (w2 + x2i + y2j + z2k)
 // Result: (w1*w2 - x1*x2 - y1*y2 - z1*z2)
 //       + (w1*x2 + x1*w2 + y1*z2 - z1*y2)i
@@ -64,17 +74,15 @@ fn hamilton_product(a: Quat, b: Quat) -> Quat {
     let x2 = b.x
     let y2 = b.y
     let z2 = b.z
-
-    quat(
-        w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
-        w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
-        w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
-        w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2
-    )
+    let rw = w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2
+    let rx = w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2
+    let ry = w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2
+    let rz = w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2
+    quat(rw, rx, ry, rz)
 }
 
 // Computes the dot product of two quaternions
 // Returns the scalar w1*w2 + x1*x2 + y1*y2 + z1*z2
-fn quat_dot(a: Quat, b: Quat) -> f32 {
+fn quat_dot(a: Quat, b: Quat) -> f64 {
     a.w * b.w + a.x * b.x + a.y * b.y + a.z * b.z
 }

--- a/stdlib/quantnn/mod.sio
+++ b/stdlib/quantnn/mod.sio
@@ -18,7 +18,7 @@ fn quant_state_basis0() -> QuantState {
     }
 }
 
-fn quant_state_hadamard_zero() -> QuantState {
+pub fn quant_state_hadamard_zero() -> QuantState {
     let amp = 0.7071067811865475
     QuantState {
         alpha_re: amp,
@@ -28,13 +28,13 @@ fn quant_state_hadamard_zero() -> QuantState {
     }
 }
 
-fn quant_state_norm_sq(state: QuantState) -> f64 {
+pub fn quant_state_norm_sq(state: QuantState) -> f64 {
     state.alpha_re * state.alpha_re +
     state.alpha_im * state.alpha_im +
     state.beta_re * state.beta_re +
     state.beta_im * state.beta_im
 }
 
-fn quant_state_prob_one(state: QuantState) -> f64 {
+pub fn quant_state_prob_one(state: QuantState) -> f64 {
     state.beta_re * state.beta_re + state.beta_im * state.beta_im
 }

--- a/stdlib/snn/sedenion_layer_core.sio
+++ b/stdlib/snn/sedenion_layer_core.sio
@@ -81,6 +81,9 @@ fn min_i32(a: i32, b: i32) -> i32 {
     if a < b { a } else { b }
 }
 
+// Array length builtin. Same declaration idiom as stdlib/quantum/vqe.sio;
+// the checker has no implicit `len`, so the module that calls it must declare it.
+
 // ============================================================================
 // DENSE SEDENION LAYER
 // ============================================================================
@@ -132,7 +135,7 @@ pub fn sedenion_layer_new(
 
     // Add weights
     for i in 0..total_weights {
-        params = params ++ [sedenion_scale(sedenion_one(), scale as f32)]
+        params = params ++ [sedenion_scale(sedenion_one(), scale)]
     }
 
     // Add biases
@@ -163,7 +166,7 @@ pub fn sedenion_layer_from_scale(
     // Add weights
     for i in 0..total_weights {
         let real_part = init_scale * (1.0 - 2.0 * ((i % 17) as f64) / 17.0)
-        params = params ++ [sedenion_scale(sedenion_one(), real_part as f32)]
+        params = params ++ [sedenion_scale(sedenion_one(), real_part)]
     }
 
     // Add biases
@@ -378,7 +381,7 @@ pub fn sedenion_mlp_new(architecture: [i32]) -> SedenionMLP with Panic, Mut
   // requires len(architecture) >= 2
 {
     var layers: [SedenionLayer] = []
-    let n_layers = len(architecture) - 1
+    let n_layers = architecture.len() - 1
 
     for i in 0..(n_layers as i32) {
         let in_size = architecture[i]
@@ -431,7 +434,7 @@ pub fn sedenion_mse_loss(predicted: [Sedenion], target: [Sedenion]) -> f64 with 
     var total_loss = 0.0
     var count = 0
 
-    let n = min_i32(len(predicted) as i32, len(target) as i32)
+    let n = min_i32(predicted.len() as i32, target.len() as i32)
 
     for i in 0..n {
         let diff = sedenion_sub(predicted[i], target[i])
@@ -454,7 +457,7 @@ pub fn sedenion_cross_entropy_loss(
     num_classes: i32
 ) -> f64 with Panic, Mut {
     var total_loss = 0.0
-    let n = min_i32(len(predicted) as i32, len(target_classes) as i32)
+    let n = min_i32(predicted.len() as i32, target_classes.len() as i32)
 
     for i in 0..n {
         let pred = predicted[i]

--- a/stdlib/spnn/mod.sio
+++ b/stdlib/spnn/mod.sio
@@ -9,7 +9,7 @@ struct SpikingNeuron {
     fired: bool,
 }
 
-fn spiking_neuron_new(threshold: f64, decay: f64) -> SpikingNeuron {
+pub fn spiking_neuron_new(threshold: f64, decay: f64) -> SpikingNeuron {
     SpikingNeuron {
         threshold: threshold,
         decay: decay,
@@ -18,7 +18,7 @@ fn spiking_neuron_new(threshold: f64, decay: f64) -> SpikingNeuron {
     }
 }
 
-fn spiking_step(neuron: SpikingNeuron, input_current: f64) -> SpikingNeuron {
+pub fn spiking_step(neuron: SpikingNeuron, input_current: f64) -> SpikingNeuron {
     let integrated = neuron.membrane * neuron.decay + input_current
     let did_fire = integrated >= neuron.threshold
     SpikingNeuron {
@@ -29,10 +29,10 @@ fn spiking_step(neuron: SpikingNeuron, input_current: f64) -> SpikingNeuron {
     }
 }
 
-fn spiking_fired(neuron: SpikingNeuron) -> bool {
+pub fn spiking_fired(neuron: SpikingNeuron) -> bool {
     neuron.fired
 }
 
-fn spiking_membrane(neuron: SpikingNeuron) -> f64 {
+pub fn spiking_membrane(neuron: SpikingNeuron) -> f64 {
     neuron.membrane
 }

--- a/tests/stdlib/quantnn/test_quantum_e2e.sio
+++ b/tests/stdlib/quantnn/test_quantum_e2e.sio
@@ -1,7 +1,7 @@
 //@ run-pass
 //@ expect-stdout: HYPER_QUANTNN_OK
 
-use quantnn::*
+use quantnn::mod::*
 
 fn emit_metric(name: string, value: f64) with IO {
     print("HYPER_METRIC quantnn ")

--- a/tests/stdlib/spnn/test_spiking_e2e.sio
+++ b/tests/stdlib/spnn/test_spiking_e2e.sio
@@ -1,7 +1,7 @@
 //@ run-pass
 //@ expect-stdout: HYPER_SPNN_OK
 
-use spnn::*
+use spnn::mod::*
 
 fn emit_metric(name: string, value: f64) with IO {
     print("HYPER_METRIC spnn ")

--- a/tests/witness_matrix/RESULTS.md
+++ b/tests/witness_matrix/RESULTS.md
@@ -124,3 +124,36 @@ Afirmação que a evidência sustenta: **o round-trip por f32 destrói a parte f
 perda ocorre no store (`as f32`) ou no load (`as f64` de volta) — não superespecificar sem uma
 sonda que separe os dois. O que está descartado: a comparação f32 (funciona nos dois sentidos)
 e a aritmética f64.
+
+---
+
+## Verificação pós-fix (2026-08-14, controlada)
+
+Três compiladores, mesma matriz:
+
+| Compilador | Resultado | w4 | w4b | w7 | w5 |
+|---|---|---|---|---|---|
+| `bin/souc` enviado (prebuilt 25/jul) | 11/13 | 0 | 100 | 20 | **42 OK** |
+| fonte da `main`, sem meus commits | **11/15** | 0 | 100 | 20 | **COMPILE-FAIL** |
+| fonte da `main` + meus commits | **14/15** | **12** | **150** | **30** | COMPILE-FAIL |
+
+Ou seja: os fixes fecham w4, w4b e w7 e **regridem zero** casos. O w5 falha de forma
+idêntica no controle sem os meus commits, logo **não é regressão minha**.
+
+### Achado independente: o binário enviado e a fonte da main divergem
+
+w5 (closure sem captura) **compila e roda 42** sob o `bin/souc` enviado, mas o compilador
+construído da fonte atual da `main` recusa:
+
+    error: IR instruction arena contract violated (invalid handle) on region slot -1 generation -1
+    Error: refusing to write a binary built on a violated IR arena contract
+
+A recusa em si é o comportamento certo (fail-closed, sem emitir binário). O problema é a
+divergência: `bin/madaros-linux-x86_64` é de 25 de julho e antecede a landing da arena de IR
+(PR #1695/#1651). Quem usa o compilador enviado vê closures funcionando; quem constrói da
+fonte, não. O gate que pegaria isso -- `madaros_full_gate` / `madaros_source_to_elf_gate` --
+roda **apenas** no workflow agendado `madaros-prebuilt-refresh.yml`, onde falha e um
+`::warning::` que pula o refresh e nunca deixa a main vermelha.
+
+Esta e exatamente a patologia que o Tier 1 item 4 do plano descreve: gate que existe e nunca
+bloqueia. Nao investiguei a causa da violacao da arena -- esta fora do escopo despachado.

--- a/tests/witness_matrix/RESULTS.md
+++ b/tests/witness_matrix/RESULTS.md
@@ -60,10 +60,10 @@ A testemunha original atribuía isto à comparação f32. **A atribuição está
 | f32 `x > y` com 2.5/1.0 | 66 | 66 — comparação OK |
 | f32 `x > y` com 1.5/1.0 | **0** | 12 |
 
-A comparação f32 funciona nos dois sentidos. O que quebra é o **cast**: `1.5 as f32` vira `1.0`
+A comparação f32 funciona nos dois sentidos. O que quebra é o **round-trip f32**: `1.5 as f32` vira `1.0`
 e `2.5 as f32` vira `2.0` — truncamento em direção a zero, como se fosse conversão inteira.
 A testemunha `1.5 > 1.0` falha porque vira `1.0 > 1.0`; `2.5 > 1.0` passa por acidente
-(`2.0 > 1.0`). **`as f64` preserva.** Locus provável: o lowering de `as f32`, não o de comparação.
+(`2.0 > 1.0`). **f64 puro preserva.** Locus: o caminho de conversão f32, não o de comparação (ver sonda discriminante abaixo).
 
 Para uma linguagem cuja tese é impedir que um backend *silently lower away scientific meaning*,
 este é o pior caso possível: uma conversão de precisão que destrói o valor sem diagnóstico.
@@ -102,3 +102,25 @@ aqui em vez de silenciosamente corrigido, porque um gate que erra para o lado do
 FAIL treina o leitor a ignorá-lo.
 
 Contagem final do gate: **11/13 corretas, 2 abertas**, exit 1.
+
+### w4 — sonda discriminante (correção de atribuição)
+
+Objeção correta a uma primeira versão desta análise: **todas** as sondas iniciais multiplicavam
+dois valores f32, e as FACTS da rodada dizem que *f32 é representado como f64 no backend*. Logo
+elas não separavam "o cast trunca" de "a multiplicação f32 está quebrada".
+
+Sonda com um único f32 no caminho aritmético:
+
+    let x: f32 = 1.5 as f32
+    let d: f64 = x as f64
+    let t: f64 = d * 100.0     // multiplicação puramente f64
+    t as i64                    // obtido: 100 | correto: 150
+
+Como a multiplicação aqui é f64 pura (e o controle f64 puro dá 150), a multiplicação f32 está
+**descartada** como causa. O valor já chega truncado.
+
+Afirmação que a evidência sustenta: **o round-trip por f32 destrói a parte fracionária**
+(`(1.5 as f32) as f64` = 1.0, enquanto `1.5 as f64` = 1.5). As sondas **não** distinguem se a
+perda ocorre no store (`as f32`) ou no load (`as f64` de volta) — não superespecificar sem uma
+sonda que separe os dois. O que está descartado: a comparação f32 (funciona nos dois sentidos)
+e a aritmética f64.

--- a/tests/witness_matrix/RESULTS.md
+++ b/tests/witness_matrix/RESULTS.md
@@ -1,0 +1,104 @@
+# Tier 0 — Matriz de testemunhas
+
+**Medido em:** 2026-08-14  
+**Árvore:** `origin/main` @ `d8dbd487a0`, worktree `witness-matrix-20260814`  
+**Compilador:** `bin/souc` -> Madaros v0.80.0 (o binário *enviado*, não um `mc` recompilado)  
+**Superfície:** `souc compile` + executar o ELF; `souc check` para os casos de rejeição.
+
+Nota: `--native-v2-compile` (usado pelas rodadas originais) **não existe** no wrapper público.
+`souc compile` é a superfície que um usuário real encontra, então é ela que foi medida.
+
+## Pergunta
+
+Os defeitos fechados em `integration/native-v2-honest` (tip `60686c617b`) **nunca foram merjados**
+na `main`. A `main` andou 2.529 commits por conta própria. Isto ainda ocorre na árvore enviada?
+
+## Resultado: 8 de 10 fechados por rota independente, **2 miscompiles silenciosos vivos**
+
+| ID | Defeito | Origem (branch órfã) | Obtido | Esperado | Veredito |
+|---|---|---|---|---|---|
+| w1 | coerção de literal `fn main()->i32{0}` | `4acea3a59e` | 0 | 0 | **FECHADO** (parcial) |
+| w2 | float `a+b` (dois params em memória) | `2286fb6d5d` | 7 | 7 | **FECHADO** |
+| w3 | float `p.x+p.y` (dois campos) | `c2a783f270` | 7 | 7 | **FECHADO** |
+| w3c | controle mem+literal `p.x+1.0` | — | 4 | 4 | controle OK |
+| **w4** | **cast/comparação f32** | `a436a68712` | **0** | **12** | **ABERTO — miscompile** |
+| w4c | controle f64 mesma forma | — | 12 | 12 | controle OK |
+| w5 | closure sem captura `f(41)` | `320f4d2352` | 42 | 42 | **FECHADO** |
+| w6 | guarda de `match` nunca lowered | `5ca40eee31` | 7 | 7 | **FECHADO** |
+| **w7** | **discriminante de enum cego ao enum** | `e71eac8d99` | **20** | **30** | **ABERTO — miscompile** |
+| w8 | índice de campo type-blind `ax/ay` | `6534d904e5` | 42 | 42 | **FECHADO** |
+| w8c | controle sem colisão `bx/ay` | — | 42 | 42 | controle OK |
+| w9 | release wall multi-módulo `util_add(40,2)` | `8765ca1dc4` | 42 | 42 | **FECHADO** |
+| w10 | bypass do typecheck em `use` | `e1ac6f7c87` | rejeita (exit 1) | REJECT | **FECHADO** |
+
+---
+
+## Os dois defeitos abertos, caracterizados
+
+### w7 — discriminante de enum resolvido por nome, cruzando enums
+
+Confirmado e isolado por diferencial:
+
+- `enum Color{Red,Green,Mark}` **sozinho** -> `Color::Mark` roda **30 (correto)**.
+- Com `enum Shape{Quad{w:i64},Mark}` **também declarado** -> `Color::Mark` roda **20 (errado)**.
+
+A presença de um `Mark` em outro enum sequestra o discriminante. É exatamente o BUG B da
+soundness-round-3: a busca resolve por *nome de variante* e devolve o primeiro match entre
+**todos** os enums, e os discriminantes reiniciam em 0 por enum. Programa bem-tipado,
+`check: OK`, valor errado em runtime, sem aviso.
+
+### w4 — não é a comparação: **`as f32` trunca a parte fracionária**
+
+A testemunha original atribuía isto à comparação f32. **A atribuição está errada.** Medido:
+
+| Sonda | Obtido | Correto |
+|---|---|---|
+| `(1.5 as f32) * (100.0 as f32)` | **100** | 150 |
+| `(2.5 as f32) * (100.0 as f32)` | **200** | 250 |
+| `(1.5 as f64) * 100.0` | 150 | 150 — controle OK |
+| f32 `y < x` (verdadeiro) | 77 | 77 — comparação OK |
+| f32 `x > y` com 2.5/1.0 | 66 | 66 — comparação OK |
+| f32 `x > y` com 1.5/1.0 | **0** | 12 |
+
+A comparação f32 funciona nos dois sentidos. O que quebra é o **cast**: `1.5 as f32` vira `1.0`
+e `2.5 as f32` vira `2.0` — truncamento em direção a zero, como se fosse conversão inteira.
+A testemunha `1.5 > 1.0` falha porque vira `1.0 > 1.0`; `2.5 > 1.0` passa por acidente
+(`2.0 > 1.0`). **`as f64` preserva.** Locus provável: o lowering de `as f32`, não o de comparação.
+
+Para uma linguagem cuja tese é impedir que um backend *silently lower away scientific meaning*,
+este é o pior caso possível: uma conversão de precisão que destrói o valor sem diagnóstico.
+
+### Achado colateral: a coerção de literal fechou só para inteiros
+
+`fn main() -> i32 { 0 }` é **aceito** (w1 fechado). Mas `let x: f32 = 1.5` é **rejeitado**
+(`error[E001] expected f32, found f64`) — literais float não adotam `f32` do contexto. Isso
+força o `as f32` e, por consequência, expõe todo mundo ao truncamento acima. A rodada
+literal-coercion cobria `f32/f64/i8`; na `main` só a metade inteira está fechada.
+
+---
+
+## Como reproduzir
+
+    bash tests/witness_matrix/run.sh                # usa ./bin/souc
+    bash tests/witness_matrix/run.sh /caminho/souc
+
+Os dois casos multi-módulo rodam a partir de `tests/witness_matrix/cases/mm/` (precisam de
+cwd no diretório do projeto para a resolução de imports).
+
+## Consequência para o plano
+
+O Tier 1 é **muito menor do que se temia**: não é portar 144 commits de uma branch com dois
+meses de defasagem. São **dois defeitos**, ambos com testemunha mínima e locus indicado. O
+resto do lane órfão foi fechado pela `main` por rota própria — o que sobra dele de valor
+durável são os *gates*, não os patches.
+
+## Nota de harness (auto-captura)
+
+A primeira versão do `run.sh` reportou `w9 COMPILE-FAIL` enquanto minha compilação manual
+do mesmo programa rodava 42. Divergência entre gate e medição independente é **bug de
+harness, não do compilador** — causa: `./bin/souc` é relativo e quebrava após o `cd` para
+o diretório do caso multi-módulo. Corrigido absolutizando `SOUC` (linha 13). Registrado
+aqui em vez de silenciosamente corrigido, porque um gate que erra para o lado do
+FAIL treina o leitor a ignorá-lo.
+
+Contagem final do gate: **11/13 corretas, 2 abertas**, exit 1.

--- a/tests/witness_matrix/cases/mm/helper/util.sio
+++ b/tests/witness_matrix/cases/mm/helper/util.sio
@@ -1,0 +1,1 @@
+pub fn util_add(a: i64, b: i64) -> i64 { a + b }

--- a/tests/witness_matrix/cases/mm/prog.sio
+++ b/tests/witness_matrix/cases/mm/prog.sio
@@ -1,0 +1,8 @@
+// WITNESS w9 -- soundness-round-5 #3 ("the release wall")
+// FACTS: imported fn bodies were not linked into the native ELF; this ran to
+//        exit 139 (SIGSEGV), "Merged IR: 1 functions". Closed by 8765ca1dc4.
+// EXPECT: exit 42 (NOT 139).
+use helper::util::*
+fn main() -> i64 {
+    util_add(40, 2)
+}

--- a/tests/witness_matrix/cases/mm/prog2.sio
+++ b/tests/witness_matrix/cases/mm/prog2.sio
@@ -1,0 +1,9 @@
+// WITNESS w10 -- soundness-round-2 #1 (import typecheck BYPASS)
+// FACTS: ANY program with a use skipped typechecking of main ENTIRELY, in BOTH
+//        --check and --native-v2-compile. This printed check: OK. Closed by e1ac6f7c87.
+// EXPECT: REJECT (type error on the string-to-i64 let). Accepting it is the bypass.
+use helper::util::*
+fn main() -> i64 {
+    let x: i64 = "hello"
+    util_add(1, 2)
+}

--- a/tests/witness_matrix/cases/w11_float_literal_f32.sio
+++ b/tests/witness_matrix/cases/w11_float_literal_f32.sio
@@ -1,0 +1,10 @@
+// WITNESS w11 -- float literal coercion to f32 (contextual + operator).
+// Int literals were born i64 and adopted any integer type; float literals were
+// born f64 and adopted NOTHING. `let x: f32 = 1.5` was rejected, which is what
+// forced `as f32` everywhere -- and `as f32` was silently truncating (see w4b).
+// EXPECT: exit 12.
+fn main() -> i64 {
+    let x: f32 = 1.5
+    let y: f32 = x + 1.0
+    if y > 2.0 { 12 } else { 0 }
+}

--- a/tests/witness_matrix/cases/w12_nonliteral_must_reject.sio
+++ b/tests/witness_matrix/cases/w12_nonliteral_must_reject.sio
@@ -1,0 +1,10 @@
+// CARDINAL NEGATIVE w12 -- only LITERALS coerce, and never out of range.
+// A non-literal f64 must still REJECT, and a literal wider than f32 max must
+// still REJECT. The literal-holes round found `let x: f32 = 1e300` accepted once
+// coercion was added without a magnitude guard; that guard is in from the start.
+// EXPECT: REJECT.
+fn main() -> i64 {
+    let big: f64 = 1.5
+    let x: f32 = big
+    0
+}

--- a/tests/witness_matrix/cases/w13_magnitude_must_reject.sio
+++ b/tests/witness_matrix/cases/w13_magnitude_must_reject.sio
@@ -1,0 +1,6 @@
+// CARDINAL NEGATIVE w13 -- magnitude guard on float literal narrowing.
+// EXPECT: REJECT.
+fn main() -> i64 {
+    let x: f32 = 1e300
+    0
+}

--- a/tests/witness_matrix/cases/w1_literal_coercion.sio
+++ b/tests/witness_matrix/cases/w1_literal_coercion.sio
@@ -1,0 +1,7 @@
+// WITNESS w1 -- literal-coercion-round
+// FACTS: `fn main()->i32 { 0 }` was REJECTED (error[E008] expected i32, found i64);
+//        `{ 0 as i32 }` passed. Closed on integration/native-v2-honest by 4acea3a59e.
+// EXPECT: ACCEPT (check OK), exit 0.
+fn main() -> i32 {
+    0
+}

--- a/tests/witness_matrix/cases/w2_float_arith_params.sio
+++ b/tests/witness_matrix/cases/w2_float_arith_params.sio
@@ -1,0 +1,11 @@
+// WITNESS w2 -- float-arith-round
+// FACTS: float arithmetic between TWO MEMORY-LOADED operands miscompiled to 0.
+//        Closed on integration/native-v2-honest by 2286fb6d5d.
+// EXPECT: exit 7 (NOT 0).
+fn f(a: f64, b: f64) -> i64 {
+    let s: f64 = a + b
+    s as i64
+}
+fn main() -> i64 {
+    f(3.0, 4.0)
+}

--- a/tests/witness_matrix/cases/w3_float_arith_fields.sio
+++ b/tests/witness_matrix/cases/w3_float_arith_fields.sio
@@ -1,0 +1,9 @@
+// WITNESS w3 -- float-arith-round (struct-field shape)
+// FACTS: struct P{x:f64,y:f64}; p.x+p.y ran 0. Closed by c2a783f270.
+// EXPECT: exit 7 (NOT 0).
+struct P { x: f64, y: f64 }
+fn main() -> i64 {
+    let p = P{ x: 3.0, y: 4.0 }
+    let s: f64 = p.x + p.y
+    s as i64
+}

--- a/tests/witness_matrix/cases/w3c_float_memlit_control.sio
+++ b/tests/witness_matrix/cases/w3c_float_memlit_control.sio
@@ -1,0 +1,9 @@
+// CONTROL for w2/w3 -- the memory+literal shape that ALWAYS WORKED.
+// If this one fails, the harness is wrong, not the compiler.
+// EXPECT: exit 4.
+struct P { x: f64, y: f64 }
+fn main() -> i64 {
+    let p = P{ x: 3.0, y: 4.0 }
+    let s: f64 = p.x + 1.0
+    s as i64
+}

--- a/tests/witness_matrix/cases/w4_f32_compare.sio
+++ b/tests/witness_matrix/cases/w4_f32_compare.sio
@@ -1,0 +1,9 @@
+// WITNESS w4 -- miscompile-fix-round M1
+// FACTS: f32 comparison ran 0, expected 12 (the same program with f64 ran 12).
+//        Closed on integration/native-v2-honest by a436a68712.
+// EXPECT: exit 12 (NOT 0).
+fn main() -> i64 {
+    let x: f32 = 1.5 as f32
+    let y: f32 = 1.0 as f32
+    if x > y { 12 } else { 0 }
+}

--- a/tests/witness_matrix/cases/w4b_f32_roundtrip.sio
+++ b/tests/witness_matrix/cases/w4b_f32_roundtrip.sio
@@ -1,0 +1,11 @@
+// WITNESS w4b -- root cause of w4, added 2026-08-14.
+// The original w4 (1.5 > 1.0 as f32) only caught this by accident. This one
+// measures the f32 round-trip directly: `as f32` fell through to float_to_int
+// in lower_cast_expr_ref and truncated toward zero.
+// EXPECT: exit 150 (NOT 100).
+fn main() -> i64 {
+    let x: f32 = 1.5 as f32
+    let d: f64 = x as f64
+    let t: f64 = d * 100.0
+    t as i64
+}

--- a/tests/witness_matrix/cases/w4c_f64_compare_control.sio
+++ b/tests/witness_matrix/cases/w4c_f64_compare_control.sio
@@ -1,0 +1,7 @@
+// CONTROL for w4 -- the f64 shape that was already CORRECT.
+// EXPECT: exit 12.
+fn main() -> i64 {
+    let x: f64 = 1.5
+    let y: f64 = 1.0
+    if x > y { 12 } else { 0 }
+}

--- a/tests/witness_matrix/cases/w5_closure_nocapture.sio
+++ b/tests/witness_matrix/cases/w5_closure_nocapture.sio
@@ -1,0 +1,8 @@
+// WITNESS w5 -- miscompile-fix-round M2
+// FACTS: no-capture closure ran 1, expected 42. Closed by 320f4d2352.
+//        (Capturing closures crashed and were out of scope; a630ca5447 made them REJECT.)
+// EXPECT: exit 42 (NOT 1). A clean REJECT is acceptable-but-open; a wrong value is a miscompile.
+fn main() -> i64 {
+    let f = |x: i64| x + 1
+    f(41)
+}

--- a/tests/witness_matrix/cases/w6_match_guard.sio
+++ b/tests/witness_matrix/cases/w6_match_guard.sio
@@ -1,0 +1,10 @@
+// WITNESS w6 -- soundness-round-3 BUG A
+// FACTS: match guards were never lowered; ran 100, expected 7. Closed by 5ca40eee31.
+// EXPECT: exit 7 (NOT 100).
+fn main() -> i64 {
+    let x: i64 = 5
+    match x {
+        n if n > 10 => 100,
+        _ => 7,
+    }
+}

--- a/tests/witness_matrix/cases/w7_enum_discriminant.sio
+++ b/tests/witness_matrix/cases/w7_enum_discriminant.sio
@@ -1,0 +1,16 @@
+// WITNESS w7 -- soundness-round-3 BUG B
+// FACTS: lookup_variant_discriminant resolved a variant by NAME ONLY and returned the
+//        FIRST match across ALL enums; discriminants restart at 0 per enum.
+//        Color::Mark ran 20, expected 30. Closed by e71eac8d99.
+// EXPECT: exit 30 (NOT 20). Shape::Mark must NOT shadow Color::Mark.
+enum Shape { Quad{w: i64}, Mark }
+enum Color { Red, Green, Mark }
+fn main() -> i64 {
+    let c: Color = Color::Mark
+    match c {
+        Color::Red => 10,
+        Color::Green => 20,
+        Color::Mark => 30,
+        _ => 0,
+    }
+}

--- a/tests/witness_matrix/cases/w7b_enum_reverse.sio
+++ b/tests/witness_matrix/cases/w7b_enum_reverse.sio
@@ -1,0 +1,16 @@
+// CONTROL w7b -- the OTHER direction of w7, added 2026-08-14.
+// MEASURED: this already PASSES on the buggy compiler (Shape is registered first,
+// so the name-only lookup happens to return Shape=1). It is therefore a CONTROL:
+// a fix that merely reorders the table would break it -- never trade one
+// miscompile for another. Shape::Mark is 1 in Shape; Color::Mark is 2 in Color.
+// EXPECT: exit 1 (NOT 2).
+enum Shape { Quad{w: i64}, Mark }
+enum Color { Red, Green, Mark }
+fn main() -> i64 {
+    let s: Shape = Shape::Mark
+    match s {
+        Shape::Quad{w} => 99,
+        Shape::Mark => 1,
+        _ => 0,
+    }
+}

--- a/tests/witness_matrix/cases/w8_field_index_collision.sio
+++ b/tests/witness_matrix/cases/w8_field_index_collision.sio
@@ -1,0 +1,11 @@
+// WITNESS w8 -- soundness-round-3 BUG C (the catastrophic one)
+// FACTS: field_idx_from_name_simple hashed on the FIRST BYTE only (buf[0] % 64), so
+//        ax/ay collided: p.ax+p.ay ran 74 (= 37+37), expected 42. Closed by 6534d904e5.
+// NOTE: current main rewrote this fn to a real struct_layouts lookup, so this may pass
+//       on main by an independent route. That is exactly what the matrix is for.
+// EXPECT: exit 42 (NOT 74).
+struct Pair { ax: i64, ay: i64 }
+fn main() -> i64 {
+    let p = Pair{ ax: 5, ay: 37 }
+    p.ax + p.ay
+}

--- a/tests/witness_matrix/cases/w8c_field_nocollision_control.sio
+++ b/tests/witness_matrix/cases/w8c_field_nocollision_control.sio
@@ -1,0 +1,7 @@
+// CONTROL for w8 -- different first bytes, so no hash collision even in the buggy version.
+// EXPECT: exit 42.
+struct Pair { bx: i64, ay: i64 }
+fn main() -> i64 {
+    let p = Pair{ bx: 5, ay: 37 }
+    p.bx + p.ay
+}

--- a/tests/witness_matrix/run.sh
+++ b/tests/witness_matrix/run.sh
@@ -92,6 +92,8 @@ run_value w6  "$CASES/w6_match_guard.sio"                 7 100 "soundness-3 BUG
 run_value w7  "$CASES/w7_enum_discriminant.sio"          30  20 "soundness-3 BUG B e71eac8d99"
 run_value w8  "$CASES/w8_field_index_collision.sio"      42  74 "soundness-3 BUG C 6534d904e5"
 run_value w8c "$CASES/w8c_field_nocollision_control.sio" 42  99 "CONTROL no collision"
+run_value w4b "$CASES/w4b_f32_roundtrip.sio"             150 100 "ROOT CAUSE of w4: as-f32 fell through to float_to_int"
+run_value w7b "$CASES/w7b_enum_reverse.sio"                1   2 "CONTROL (passes at baseline): a table reorder must not break Shape"
 run_mm    w9  42 "release wall 8765ca1dc4"
 run_reject w10 "$CASES/mm/prog2.sio" "import typecheck bypass e1ac6f7c87"
 

--- a/tests/witness_matrix/run.sh
+++ b/tests/witness_matrix/run.sh
@@ -94,6 +94,9 @@ run_value w8  "$CASES/w8_field_index_collision.sio"      42  74 "soundness-3 BUG
 run_value w8c "$CASES/w8c_field_nocollision_control.sio" 42  99 "CONTROL no collision"
 run_value w4b "$CASES/w4b_f32_roundtrip.sio"             150 100 "ROOT CAUSE of w4: as-f32 fell through to float_to_int"
 run_value w7b "$CASES/w7b_enum_reverse.sio"                1   2 "CONTROL (passes at baseline): a table reorder must not break Shape"
+run_value w11 "$CASES/w11_float_literal_f32.sio"          12  99 "float literal coercion to f32 (contextual + operator)"
+run_reject w12 "$CASES/w12_nonliteral_must_reject.sio" "CARDINAL: only literals coerce"
+run_reject w13 "$CASES/w13_magnitude_must_reject.sio" "CARDINAL: magnitude guard on f32 narrowing"
 run_mm    w9  42 "release wall 8765ca1dc4"
 run_reject w10 "$CASES/mm/prog2.sio" "import typecheck bypass e1ac6f7c87"
 

--- a/tests/witness_matrix/run.sh
+++ b/tests/witness_matrix/run.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Tier 0 witness matrix.
+#
+# Measures the canonical witnesses from .claude/workflows/*-round.js against
+# WHATEVER compiler is handed to it. Every defect below is CLOSED on branch
+# integration/native-v2-honest (tip 60686c617b) and was NEVER MERGED to main.
+# This answers the only question that matters for launch: does the shipped
+# tree exhibit them? Measured 2026-08-14: 8/10 closed, w4 and w7 OPEN.
+#
+# Usage: bash tests/witness_matrix/run.sh [path-to-souc]
+set -u
+SOUC="${1:-./bin/souc}"
+SOUC="$(cd "$(dirname "$SOUC")" && pwd)/$(basename "$SOUC")"  # absolutise: run_mm/run_reject cd into the case dir
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+CASES="$ROOT/cases"
+TMP="$(mktemp -d)"
+PASS=0
+TOTAL=0
+OPEN=0
+
+run_value() {
+  id="$1"; file="$2"; want="$3"; wrong="$4"; origin="$5"
+  TOTAL=$((TOTAL+1))
+  elf="$TMP/$id.elf"
+  rm -f "$elf"
+  "$SOUC" compile "$file" -o "$elf" >"$TMP/$id.log" 2>&1
+  if [ ! -f "$elf" ]; then
+    printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "COMPILE-FAIL" "-" "$want" "$origin"
+    OPEN=$((OPEN+1))
+    return
+  fi
+  chmod +x "$elf" 2>/dev/null
+  "$elf" >/dev/null 2>&1
+  got=$?
+  if [ "$got" = "$want" ]; then
+    status="CLOSED"; PASS=$((PASS+1))
+  elif [ "$got" = "$wrong" ]; then
+    status="OPEN-MISCOMPILE"; OPEN=$((OPEN+1))
+  else
+    status="OPEN-OTHER"; OPEN=$((OPEN+1))
+  fi
+  printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "$status" "$got" "$want" "$origin"
+}
+
+run_reject() {
+  id="$1"; file="$2"; origin="$3"
+  TOTAL=$((TOTAL+1))
+  if (cd "$(dirname "$file")" && "$SOUC" check "$(basename "$file")" >/dev/null 2>&1); then
+    printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "OPEN-ACCEPTS-ILLTYPED" "accepted" "REJECT" "$origin"
+    OPEN=$((OPEN+1))
+  else
+    printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "CLOSED" "rejected" "REJECT" "$origin"
+    PASS=$((PASS+1))
+  fi
+}
+
+run_mm() {
+  id="$1"; want="$2"; origin="$3"
+  TOTAL=$((TOTAL+1))
+  rm -f "$TMP/$id.elf"
+  (cd "$CASES/mm" && "$SOUC" compile prog.sio -o "$TMP/$id.elf") >"$TMP/$id.log" 2>&1
+  if [ ! -f "$TMP/$id.elf" ]; then
+    printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "COMPILE-FAIL" "-" "$want" "$origin"
+    OPEN=$((OPEN+1))
+    return
+  fi
+  chmod +x "$TMP/$id.elf" 2>/dev/null
+  "$TMP/$id.elf" >/dev/null 2>&1
+  got=$?
+  if [ "$got" = "$want" ]; then
+    printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "CLOSED" "$got" "$want" "$origin"
+    PASS=$((PASS+1))
+  else
+    printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "OPEN" "$got" "$want" "$origin"
+    OPEN=$((OPEN+1))
+  fi
+}
+
+echo "witness matrix -- compiler: $SOUC"
+"$SOUC" --version 2>&1 | head -1
+echo
+printf "%-5s %-20s %-9s %-7s %s\\n" ID STATUS GOT WANT ORIGIN
+
+run_value w1  "$CASES/w1_literal_coercion.sio"            0  99 "literal-coercion 4acea3a59e"
+run_value w2  "$CASES/w2_float_arith_params.sio"          7   0 "float-arith params 2286fb6d5d"
+run_value w3  "$CASES/w3_float_arith_fields.sio"          7   0 "float-arith fields c2a783f270"
+run_value w3c "$CASES/w3c_float_memlit_control.sio"       4  99 "CONTROL mem+literal"
+run_value w4  "$CASES/w4_f32_compare.sio"                12   0 "M1 a436a68712 -- see RESULTS.md: real cause is as-f32 truncation"
+run_value w4c "$CASES/w4c_f64_compare_control.sio"       12   0 "CONTROL f64 compare"
+run_value w5  "$CASES/w5_closure_nocapture.sio"          42   1 "M2 320f4d2352"
+run_value w6  "$CASES/w6_match_guard.sio"                 7 100 "soundness-3 BUG A 5ca40eee31"
+run_value w7  "$CASES/w7_enum_discriminant.sio"          30  20 "soundness-3 BUG B e71eac8d99"
+run_value w8  "$CASES/w8_field_index_collision.sio"      42  74 "soundness-3 BUG C 6534d904e5"
+run_value w8c "$CASES/w8c_field_nocollision_control.sio" 42  99 "CONTROL no collision"
+run_mm    w9  42 "release wall 8765ca1dc4"
+run_reject w10 "$CASES/mm/prog2.sio" "import typecheck bypass e1ac6f7c87"
+
+echo
+echo "correct: $PASS/$TOTAL   open: $OPEN"
+rm -rf "$TMP"
+[ "$OPEN" = "0" ]


### PR DESCRIPTION
## What this is

The 15 release/soundness rounds in `.claude/workflows/*-round.js` closed a set of silent miscompiles on `integration/native-v2-honest` (tip `60686c617b`). **None of those 144 commits is an ancestor of `main`** — `main` moved 2,529 commits on its own — and nobody had measured whether the shipped tree still exhibits the defects.

This PR is that measurement, plus fixes for the two that turned out to be live.

## Tier 0 — the witness matrix

`tests/witness_matrix/` — 8 canonical witnesses from the rounds' own `FACTS` blocks, plus 5 controls, plus 2 root-cause witnesses I added. `run.sh` exits nonzero when anything is open.

Measured against the shipped `bin/souc`: **8 of 10 defects had already been closed on `main` by an independent route** (literal coercion for ints, float arith for params and struct fields, no-capture closures, match guards, the type-blind field-index hash, the multi-module release wall, the import typecheck bypass). Two were still live.

## The two fixes

**Enum discriminant was enum-blind.** `lookup_variant_discriminant` matched on `variant_name` alone and returned the first match across ALL enums, while discriminants restart at 0 per enum. With `enum Shape{Quad,Mark}` and `enum Color{Red,Green,Mark}` both declared, `Color::Mark` resolved to Shape's discriminant and the match ran the wrong arm — well-typed, `check: OK`, wrong value, no diagnostic. Isolated by differential: `Color` alone ran correctly. The `EnumVariantEntry` table already stored `enum_name` and both call sites still held the full path; only `ir_path_last_name` threw the qualifier away. Adds `ir_path_qualifier_name` + a path-keyed lookup that falls back to the unqualified one when the enum is unknown, so nothing that resolves today starts failing.

**`as f32` destroyed the fractional part.** The round attributed this to the f32 *comparison*; that attribution is wrong. `(1.5 as f32) * 100 = 100`, `(2.5 as f32) * 100 = 200`, while f64 preserves and f32 comparison is correct in both directions. `as f32` matched neither the f64-target branch nor the integer classifier, so a float source fell through to the `float_to_int` arm of `lower_cast_expr_ref`. The backend carries f32 as f64, so all 17 call sites of `lower_type_expr_is_f64` mean "is this a float scalar?", not "is this spelled f64" — both base classifiers now accept f32.

> **Known residual, declared not silent:** `as f32` now preserves the f64 value rather than rounding to IEEE binary32. Real narrowing needs an f32 representation in the backend, which does not exist. This trades a value-destroying truncation for a documented no-op, not for correctness.

## Verification — three compilers, same matrix

| Compiler | Score | w4 | w4b | w7 | w5 |
|---|---|---|---|---|---|
| shipped `bin/souc` (Jul 25 prebuilt) | 11/13 | 0 | 100 | 20 | **42 OK** |
| `main` source, **without** these commits | 11/15 | 0 | 100 | 20 | COMPILE-FAIL |
| `main` source, **with** these commits | **14/15** | **12** | **150** | **30** | COMPILE-FAIL |

Closes w4, w4b and w7. **Regresses nothing.**

Every verdict is the exit code of a compiled ELF that was actually run. `souc check` was green on **both** the broken and the correct version of the f32 fix — only running the binary separated them.

## Independent finding, not fixed here: shipped binary and `main` source diverge

`w5` (no-capture closure) compiles and runs 42 under the shipped `bin/souc`, but the compiler built from current `main` source refuses it:

```
error: IR instruction arena contract violated (invalid handle) on region slot -1 generation -1
Error: refusing to write a binary built on a violated IR arena contract
```

The refusal itself is correct behaviour — fail-closed, no binary emitted. The problem is the divergence: `bin/madaros-linux-x86_64` is dated Jul 25 and predates the IR arena landing (#1695/#1651). Closures work for anyone using `bin/souc` and fail for anyone building from source. **Proved pre-existing** by building a control compiler from the tree without these commits — it fails identically. Cause not investigated: outside the dispatched scope.

The gate that would catch this — `madaros_full_gate.sh` / `madaros_source_to_elf_gate.sh` — runs **only** in the scheduled `madaros-prebuilt-refresh.yml`, where a failure is a `::warning::` that skips the refresh and never reddens `main`.

## Not wired to CI

`tests/witness_matrix/run.sh` exits 1 when anything is open, but **no job runs it**. One line in a CI job turns it from a script into a gate; without that it becomes exactly the "gate exists, gate never blocks" pattern described above. Deliberately left for a reviewer decision rather than wired unilaterally.

## Reproduce

```bash
bash tests/witness_matrix/run.sh                 # shipped bin/souc
bash tests/witness_matrix/run.sh /path/to/madaros # any built compiler
```

Full three-way comparison and the discriminating probes are in `tests/witness_matrix/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
