### PR TITLE
fix(release): tarball version from CITATION.cff; silence advisory E-SRB-000 on plain runs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,7 +26,14 @@ On this repo snapshot, `bin/souc` is a host-aware launcher around the checked se
 - To use the compatibility legacy engine, set `SOUNIO_SOUC_ENGINE=lean_single`.
 - `--target aarch64-macos` and `--target x86_64-macos` emit Mach-O binaries
 - `--target aarch64-linux` emits Linux ARM64 ELF binaries
-- It still does not provide the broader omega-only workflows such as `repl`, `gpu-emit`, or the full pinned-release tool surface
+- **Update 2026-08-14 (checked, not assumed):** the "does not provide repl/gpu-emit/full tool surface" line just above went stale in the
+  opposite direction of the usual overclaim. Verified today with `./bin/souc --help` and
+  running each command: `souc repl` starts a working file-backed REPL; `souc format` and
+  `souc fmt` run the checked formatter; `souc lsp --stdio` starts and shuts down cleanly;
+  `souc pkg build`/`souc pkg verify` exist; GPU artifact emission is available as
+  `souc build <file.sio> --backend gpu -o out.ptx` (not a separate `gpu-emit` subcommand).
+  This section otherwise describes April 22, 2026 and has not been re-audited beyond the
+  five commands above -- do not assume anything else here is current.
 
 On macOS, the emitted binaries are Mach-O instead of ELF.
 

--- a/bin/madaros
+++ b/bin/madaros
@@ -247,7 +247,15 @@ _science_evaluate() {
     return 0
   fi
   if [[ ! -x "$SCIENCE_BOUNDARY_TOOL" ]]; then
-    echo "error[E-SRB-000]: science boundary attestor is unavailable: $SCIENCE_BOUNDARY_TOOL" >&2
+    # Advisory in auto/off mode without a requested receipt: a plain `souc run`
+    # on a released tarball (which does not bundle the internal governance
+    # tooling under tools/science_boundary/) must not print an error[...] line
+    # for a defect that is already silently non-fatal here -- both call sites
+    # only escalate to a hard failure when mode=strict. Stay loud exactly where
+    # the guarantee is claimed: strict mode, or an explicit receipt request.
+    if [[ "$SCIENCE_BOUNDARY_MODE" == "strict" || -n "$receipt" ]]; then
+      echo "error[E-SRB-000]: science boundary attestor is unavailable: $SCIENCE_BOUNDARY_TOOL" >&2
+    fi
     return 2
   fi
   local command=(

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,8 +16,16 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-VERSION="${SOUNIO_RELEASE_VERSION:-$(bin/souc --version 2>/dev/null \
-  | awk 'NR==1 {print $NF}' || echo 1.0.0-beta.5)}"
+VERSION="${SOUNIO_RELEASE_VERSION:-}"
+if [[ -z "$VERSION" ]]; then
+  # RELEASE_POLICY.md: CITATION.cff is the single source of truth for version
+  # metadata. Do NOT scrape bin/souc --version banner text -- that broke twice
+  # (a stray newline in June, then the last-field grab landing on the word
+  # "compiler" once the banner text changed again). A structured file does not
+  # drift under free-text edits the way a human-readable banner does.
+  VERSION="$(grep -m1 "^version:" "$ROOT_DIR/CITATION.cff" 2>/dev/null | sed "s/^version:[[:space:]]*//")"
+  VERSION="${VERSION:-1.0.0-beta.6}"
+fi
 TARGET=""
 OUT_DIR="$ROOT_DIR/dist"
 


### PR DESCRIPTION
## What this is

First real deliverable on the launch critical path (`docs/serious-language/CAMINHO_CRITICO_CORTADO_2026-08-14.md`): make the release tarball survive a stranger extracting it and following the bundled README.

Verified by actually doing it — build the tarball, extract in `/tmp` under a shell with no inherited `SOUNIO_STDLIB_PATH` (the same confound that produced two wrong conclusions earlier today), follow `README.txt`'s three commands, then compile and run a real `.sio` program. Two defects surfaced, both live today.

## Fix 1 — version derivation

`scripts/release.sh` derived `VERSION` by scraping line 1 of `bin/souc --version` and taking the **last field**. Today's banner is `Madaros v0.80.0 -- the Sounio self-hosted compiler` — last field is the word `compiler`. Produced `sounio-compiler-x86_64.tar.gz`.

This is the same fragility class as a June 2026 packaging audit (`docs/audit/RELEASE_PACKAGING_E2E_2026-06-07.md`), which found a different symptom (a stray newline) from the same root cause: scraping a human-readable banner for a version string. The banner wording changed since June and broke the parser again — proof the underlying fragility was never fixed, only its manifestation moved.

`docs/RELEASE_POLICY.md` already names `CITATION.cff` as *"single source of truth for version metadata."* Reading it directly is both correct per policy and immune to banner wording changes. Now produces `sounio-1.0.0-beta.6-x86_64.tar.gz`.

## Fix 2 — advisory error line on a plain run

`souc run hello.sio` from the extracted tarball printed:
```
error[E-SRB-000]: science boundary attestor is unavailable: .../tools/science_boundary/attestor.py
```
before compiling and running correctly (`rc=0`). `install.sh` does not bundle `tools/science_boundary/` — an internal governance suite (`source_removal_authorizer`, `canonical_cutover_*`, `physical_extraction_*`), not end-user runtime. Both call sites in `bin/madaros` already only escalate this to a hard failure when `SCIENCE_BOUNDARY_MODE=strict`; the `echo` was unconditional. Narrowed the print to strict mode or an explicit receipt request — exactly where the guarantee is actually claimed.

Verified both directions:
- default mode (`auto`): silent, compiles and runs cleanly
- `--science-boundary strict`: still prints the error loudly

## Verification

```
$ bash scripts/release.sh --out /tmp/rel_out
release artefact: /tmp/rel_out/sounio-1.0.0-beta.6-x86_64.tar.gz

$ tar -xzf sounio-1.0.0-beta.6-x86_64.tar.gz -C /tmp/rel_test && cd /tmp/rel_test/sounio-1.0.0-beta.6-x86_64
$ souc --version   # rc=0
$ souc info        # rc=0
$ souc run hello.sio
Compilation successful!
hello from a stranger's tarball
rc=0   # no scary lines
```

Witness matrix unchanged: 14/18 against the shipped `bin/souc`, same as the prior measurement in `tests/witness_matrix/RESULTS.md`. `bin/madaros` is a wrapper script, not the compiler — this touches neither compilation nor codegen, and the regression check confirms it.

## Not addressed here

The June audit's remaining items — most notably whether the documented CLI matches the implemented one. `bin/souc` already exposes real subcommands (`check`/`compile`/`build`/`run`/`init`/`format`/`pkg`) today, unlike the raw positional-arg binary the June audit found — but that needs its own re-verification, not an assumption that it's fixed just because the symptom looks different now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
