### PR TITLE
ci: wire the witness matrix as a blocking gate, residual-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,6 +567,23 @@ jobs:
           path: test-results.xml
           retention-days: 30
 
+  madaros-witness-gate:
+    name: Madaros Witness Gate
+    needs: impact
+    if: needs.impact.outputs.compiler == 'true' || needs.impact.outputs.runtime == 'true' || needs.impact.outputs.stdlib == 'true' || needs.impact.outputs.tests == 'true' || needs.impact.outputs.full == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Madaros from this PR's own source
+        run: |
+          ulimit -s 1048576 2>/dev/null || true
+          bash scripts/ci/build_modular_madaros.sh /tmp/madaros-ci.elf
+      - name: Tier 0 witness matrix against the fresh build
+        env:
+          MADAROS_RAW_BIN: /tmp/madaros-ci.elf
+        run: bash tests/witness_matrix/run.sh ./bin/souc /tmp/madaros-ci.elf
+
   sounio-lint:
     name: Sounio Lint
     needs: impact
@@ -655,6 +672,7 @@ jobs:
       - madaros-current-source-deref-f64
       - native-selfhost-macos-arm64
       - full-test-suite
+      - madaros-witness-gate
       - sounio-lint
       - lean-proofs
       - website

--- a/scripts/ci/evaluate_ci_decision.py
+++ b/scripts/ci/evaluate_ci_decision.py
@@ -28,6 +28,9 @@ def main() -> int:
         ),
         "native-selfhost-macos-arm64": truthy(impact.get("compiler")) or truthy(impact.get("full")),
         "full-test-suite": any(truthy(impact.get(key)) for key in ("compiler", "runtime", "stdlib", "tests", "full")),
+        "madaros-witness-gate": any(
+            truthy(impact.get(key)) for key in ("compiler", "runtime", "stdlib", "tests", "full")
+        ),
         "sounio-lint": any(truthy(impact.get(key)) for key in ("compiler", "stdlib", "tests", "sio", "full")),
         "lean-proofs": truthy(impact.get("lean")) or truthy(impact.get("full")),
         "website": truthy(impact.get("website")) or truthy(impact.get("full")),

--- a/scripts/ci/impact_ci_selftest.sh
+++ b/scripts/ci/impact_ci_selftest.sh
@@ -50,7 +50,7 @@ non_pr="$(CI_EVENT_NAME=push $CLASSIFIER)"
 expect "$non_pr" full true
 expect "$non_pr" compiler true
 
-good_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"false","tests":"false","sio":"false","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"madaros-current-source-deref-f64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"sounio-lint":{"result":"skipped"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
+good_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"false","tests":"false","sio":"false","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"madaros-current-source-deref-f64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"madaros-witness-gate":{"result":"skipped"},"sounio-lint":{"result":"skipped"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
 NEEDS_JSON="$good_needs" python3 "$DECISION" | grep -Fq CI_DECISION_PASS
 
 bad_needs="${good_needs/\"contracts\":{\"result\":\"success\"}/\"contracts\":{\"result\":\"failure\"}}"
@@ -59,7 +59,7 @@ if NEEDS_JSON="$bad_needs" python3 "$DECISION" >/dev/null 2>&1; then
   exit 1
 fi
 
-compiler_needs='{"impact":{"outputs":{"compiler":"true","runtime":"false","stdlib":"false","tests":"false","sio":"true","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"success"},"source-bootstrap-selfhost-linux-x86_64":{"result":"success"},"madaros-current-source-deref-f64":{"result":"failure"},"native-selfhost-macos-arm64":{"result":"success"},"full-test-suite":{"result":"success"},"sounio-lint":{"result":"success"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
+compiler_needs='{"impact":{"outputs":{"compiler":"true","runtime":"false","stdlib":"false","tests":"false","sio":"true","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"success"},"source-bootstrap-selfhost-linux-x86_64":{"result":"success"},"madaros-current-source-deref-f64":{"result":"failure"},"native-selfhost-macos-arm64":{"result":"success"},"full-test-suite":{"result":"success"},"madaros-witness-gate":{"result":"success"},"sounio-lint":{"result":"success"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
 if NEEDS_JSON="$compiler_needs" python3 "$DECISION" >/dev/null 2>&1; then
   echo "impact-ci-selftest: decision accepted failed current-source Madaros gate" >&2
   exit 1
@@ -67,7 +67,7 @@ fi
 compiler_green_needs="${compiler_needs/\"failure\"/\"success\"}"
 NEEDS_JSON="$compiler_green_needs" python3 "$DECISION" | grep -Fq CI_DECISION_PASS
 
-stdlib_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"true","tests":"false","sio":"true","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"madaros-current-source-deref-f64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"sounio-lint":{"result":"success"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
+stdlib_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"true","tests":"false","sio":"true","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"madaros-current-source-deref-f64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"madaros-witness-gate":{"result":"success"},"sounio-lint":{"result":"success"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
 if NEEDS_JSON="$stdlib_needs" python3 "$DECISION" >/dev/null 2>&1; then
   echo "impact-ci-selftest: decision accepted stdlib suite without native compiler/full suite" >&2
   exit 1

--- a/tests/witness_matrix/run.sh
+++ b/tests/witness_matrix/run.sh
@@ -5,18 +5,52 @@
 # WHATEVER compiler is handed to it. Every defect below is CLOSED on branch
 # integration/native-v2-honest (tip 60686c617b) and was NEVER MERGED to main.
 # This answers the only question that matters for launch: does the shipped
-# tree exhibit them? Measured 2026-08-14: 8/10 closed, w4 and w7 OPEN.
+# tree exhibit them? Measured 2026-08-14: 8/10 closed, w4 and w7 OPEN --
+# both later fixed and merged to main (PR #1737).
 #
-# Usage: bash tests/witness_matrix/run.sh [path-to-souc]
+# 2026-08-15: pointing this script at "souc compile" (arg 1, default
+# ./bin/souc) measures the CHECKED-IN PREBUILT bin/madaros-linux-x86_64, not
+# a build of the PR's own self-hosted/ source. That prebuilt only updates via
+# the scheduled madaros-prebuilt-refresh.yml workflow, so it can be (and, on
+# 2026-08-15, was) stale relative to main by exactly the fixes this script
+# exists to guard. To measure the PR's own source, build Madaros fresh
+# (scripts/ci/build_modular_madaros.sh) and pass BOTH the souc wrapper (arg 1,
+# with MADAROS_RAW_BIN set to the fresh ELF so "souc compile" uses it) and the
+# raw ELF path again as arg 2 (for w14's direct --native-v2-emit-scalar
+# probe, which bypasses the wrapper entirely). See DECLARED_OPEN below for
+# the residuals that are real on a fresh build and not on the prebuilt.
+#
+# Usage: bash tests/witness_matrix/run.sh [path-to-souc] [path-to-raw-elf]
 set -u
 SOUC="${1:-./bin/souc}"
 SOUC="$(cd "$(dirname "$SOUC")" && pwd)/$(basename "$SOUC")"  # absolutise: run_mm/run_reject cd into the case dir
+RAW="${2:-}"  # optional: raw --native-v2-emit-* ELF (bypasses the souc/madaros wrapper) for w14
 ROOT="$(cd "$(dirname "$0")" && pwd)"
 CASES="$ROOT/cases"
 TMP="$(mktemp -d)"
 PASS=0
 TOTAL=0
 OPEN=0
+OPEN_IDS=""
+# Residual-by-identity allowlist (release_gate.sh pattern): a witness may be
+# declared open ONLY by exact id + reason below. The gate fails if the actual
+# open set differs from this set in ANY direction -- new opens, or a declared
+# residual silently starting to pass (promotion must be witnessed, not assumed).
+DECLARED_OPEN="w5 w14"
+# w5 and w14 are BOTH open, ONLY on a Madaros built fresh from current
+# main.sio source (not on the checked-in prebuilt bin/madaros-linux-x86_64,
+# which predates them and which run_value's default "souc compile" resolves
+# to -- so the default invocation of this script never exercises either).
+# w5:  closure-capture path fails codegen (M2 320f4d2352 origin).
+# w14: --native-v2-emit-scalar fails with "IR instruction arena contract
+#      violated (invalid handle) on region slot -1 generation -1".
+# Confirmed 2026-08-15 on a raw ELF (no souc/madaros wrapper, no
+# MADAROS_STACK_KB involved) and on a same-day rebuild (not staleness).
+# Both surfaced together on the first fresh-from-source run this script was
+# ever given -- consistent with (not yet proven to be) one arena-contract
+# defect manifesting on two distinct native-v2 entry points. Tracked here so
+# neither can be silently reintroduced, silently fixed, or silently merged
+# under "fixed" without the fix actually being witnessed.
 
 run_value() {
   id="$1"; file="$2"; want="$3"; wrong="$4"; origin="$5"
@@ -26,7 +60,7 @@ run_value() {
   "$SOUC" compile "$file" -o "$elf" >"$TMP/$id.log" 2>&1
   if [ ! -f "$elf" ]; then
     printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "COMPILE-FAIL" "-" "$want" "$origin"
-    OPEN=$((OPEN+1))
+    OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
     return
   fi
   chmod +x "$elf" 2>/dev/null
@@ -35,9 +69,9 @@ run_value() {
   if [ "$got" = "$want" ]; then
     status="CLOSED"; PASS=$((PASS+1))
   elif [ "$got" = "$wrong" ]; then
-    status="OPEN-MISCOMPILE"; OPEN=$((OPEN+1))
+    status="OPEN-MISCOMPILE"; OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
   else
-    status="OPEN-OTHER"; OPEN=$((OPEN+1))
+    status="OPEN-OTHER"; OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
   fi
   printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "$status" "$got" "$want" "$origin"
 }
@@ -47,7 +81,7 @@ run_reject() {
   TOTAL=$((TOTAL+1))
   if (cd "$(dirname "$file")" && "$SOUC" check "$(basename "$file")" >/dev/null 2>&1); then
     printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "OPEN-ACCEPTS-ILLTYPED" "accepted" "REJECT" "$origin"
-    OPEN=$((OPEN+1))
+    OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
   else
     printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "CLOSED" "rejected" "REJECT" "$origin"
     PASS=$((PASS+1))
@@ -61,7 +95,7 @@ run_mm() {
   (cd "$CASES/mm" && "$SOUC" compile prog.sio -o "$TMP/$id.elf") >"$TMP/$id.log" 2>&1
   if [ ! -f "$TMP/$id.elf" ]; then
     printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "COMPILE-FAIL" "-" "$want" "$origin"
-    OPEN=$((OPEN+1))
+    OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
     return
   fi
   chmod +x "$TMP/$id.elf" 2>/dev/null
@@ -72,7 +106,35 @@ run_mm() {
     PASS=$((PASS+1))
   else
     printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "OPEN" "$got" "$want" "$origin"
-    OPEN=$((OPEN+1))
+    OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
+  fi
+}
+
+run_scalar_emit() {
+  id="$1"; want="$2"; origin="$3"
+  TOTAL=$((TOTAL+1))
+  if [ -z "$RAW" ]; then
+    printf "%-5s %-20s %-9s %-7s %s\n" "$id" "SKIPPED-NO-RAW" "-" "$want" "$origin"
+    OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
+    return
+  fi
+  elf="$TMP/$id.elf"
+  rm -f "$elf"
+  "$RAW" --native-v2-emit-scalar "$want" "$elf" >"$TMP/$id.log" 2>&1
+  if [ ! -f "$elf" ]; then
+    printf "%-5s %-20s %-9s %-7s %s\n" "$id" "OPEN-EMIT-FAIL" "-" "$want" "$origin"
+    OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
+    return
+  fi
+  chmod +x "$elf" 2>/dev/null
+  "$elf" >/dev/null 2>&1
+  got=$?
+  if [ "$got" = "$want" ]; then
+    printf "%-5s %-20s %-9s %-7s %s\n" "$id" "CLOSED" "$got" "$want" "$origin"
+    PASS=$((PASS+1))
+  else
+    printf "%-5s %-20s %-9s %-7s %s\n" "$id" "OPEN" "$got" "$want" "$origin"
+    OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
   fi
 }
 
@@ -99,8 +161,20 @@ run_reject w12 "$CASES/w12_nonliteral_must_reject.sio" "CARDINAL: only literals 
 run_reject w13 "$CASES/w13_magnitude_must_reject.sio" "CARDINAL: magnitude guard on f32 narrowing"
 run_mm    w9  42 "release wall 8765ca1dc4"
 run_reject w10 "$CASES/mm/prog2.sio" "import typecheck bypass e1ac6f7c87"
+run_scalar_emit w14 42 "IR arena contract violated on native-v2-emit-scalar (fresh source build only) 2026-08-15"
 
 echo
 echo "correct: $PASS/$TOTAL   open: $OPEN"
+
+# Residual-by-identity gate: pass only if the actual open set equals DECLARED_OPEN exactly.
+actual_sorted="$(printf '%s\n' $OPEN_IDS | sort -u | tr '\n' ' ' | sed 's/ $//')"
+declared_sorted="$(printf '%s\n' $DECLARED_OPEN | sort -u | tr '\n' ' ' | sed 's/ $//')"
 rm -rf "$TMP"
-[ "$OPEN" = "0" ]
+if [ "$actual_sorted" = "$declared_sorted" ]; then
+  echo "residuals match declared set: [$declared_sorted]"
+  exit 0
+else
+  echo "RESIDUAL MISMATCH: actual=[$actual_sorted] declared=[$declared_sorted]"
+  echo "A new witness opened, or a declared residual changed status -- both require a human look, not a silent gate change."
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- `tests/witness_matrix/` existed but no CI job called it — the same "gate exists, never blocks" pattern already fixed for the packaging checks in #1738.
- Adds `madaros-witness-gate` to `ci.yml`: builds Madaros from the PR's own `self-hosted/` source (not the checked-in prebuilt) and runs the witness matrix against that fresh build. Wired into `ci-decision`'s required-jobs set via `scripts/ci/evaluate_ci_decision.py`.
- Pointing the matrix at `souc compile` alone only measures the checked-in prebuilt `bin/madaros-linux-x86_64`, which updates solely via the scheduled `madaros-prebuilt-refresh.yml` — confirmed stale today by exactly the fixes this matrix exists to guard (w4/w4b/w7/w11 read OPEN against it, CLOSED against a same-day source build).
- A fresh build surfaces two witnesses neither the prebuilt nor `souc`'s default wrapper exercise: `w5` (closure codegen) and a new `w14` (`--native-v2-emit-scalar` fails `IR instruction arena contract violated`). Both are real, pre-existing on-main defects — reproduced on a raw ELF with no wrapper/`MADAROS_STACK_KB` involved, and on a same-day rebuild (ruling out staleness). Neither is introduced by this change.
- `run.sh` now declares open residuals by exact id + reason (mirrors `release_gate.sh`'s residual-by-identity pattern) and fails only if the actual open set differs from the declared one in either direction — a new witness opening, or a declared residual quietly starting to pass, both require a human look rather than a silently drifting gate.

## Test plan
- [x] `bash -n tests/witness_matrix/run.sh` — syntax clean
- [x] Ran against the checked-in prebuilt (no override): correctly reports RESIDUAL MISMATCH (stale relative to main), rc=1
- [x] Built Madaros fresh from this branch via `scripts/ci/build_modular_madaros.sh`, ran the exact command the new CI step runs: `correct: 17/19 open: 2`, `residuals match declared set: [w14 w5]`, rc=0
- [ ] CI run on this PR (will exercise `madaros-witness-gate` for real)

🤖 Generated with [Claude Code](https://claude.com/claude-code)