### PR TITLE
test(witness): confirm 3-field same-first-letter collision is moot on main

### DIFF
--- a/.claude/AGENT_HANDOFF.md
+++ b/.claude/AGENT_HANDOFF.md
@@ -18,6 +18,21 @@
 >    (`souc main.sio` / `lean_single.sio` / `make build`). Bare full builds are
 >    what saturate CPU and trip the probe. Cheap `souc check` is exempt.
 
+> **⚠️ SOUNIO_STDLIB_PATH in a worktree (2026-08-15).** CLAUDE.md's own dev
+> instructions export `SOUNIO_STDLIB_PATH` globally in the interactive pod. If
+> your worktree session inherits that export, every `souc`/`madaros`/gate-script
+> invocation in your worktree silently resolves the stdlib from the SHARED
+> checkout (`/workspace/sounio/stdlib`), not your own worktree's copy — a
+> worktree edit to `stdlib/` then measures as absent no matter what you change.
+> Bit this session twice independently (a false "pub not honored in mod.sio"
+> conclusion, retracted in `f0e7869765`, and the same confound hit a parallel
+> lane separately). This is NOT a real CI bug — GitHub Actions runners are
+> ephemeral checkouts and only set the var locally per-step
+> (`madaros-prebuilt-refresh.yml`) — it is purely a worktree/dev-pod trap.
+> Before trusting any `souc check`/gate result from a worktree, run
+> `echo $SOUNIO_STDLIB_PATH` and confirm it points at *this* worktree's
+> `stdlib/`, or `unset SOUNIO_STDLIB_PATH` and pass it explicitly per-command.
+
 ---
 
 ## LANE CLAIM + ownership-conflict — 2026-08-06

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,6 +567,23 @@ jobs:
           path: test-results.xml
           retention-days: 30
 
+  madaros-witness-gate:
+    name: Madaros Witness Gate
+    needs: impact
+    if: needs.impact.outputs.compiler == 'true' || needs.impact.outputs.runtime == 'true' || needs.impact.outputs.stdlib == 'true' || needs.impact.outputs.tests == 'true' || needs.impact.outputs.full == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Madaros from this PR's own source
+        run: |
+          ulimit -s 1048576 2>/dev/null || true
+          bash scripts/ci/build_modular_madaros.sh /tmp/madaros-ci.elf
+      - name: Tier 0 witness matrix against the fresh build
+        env:
+          MADAROS_RAW_BIN: /tmp/madaros-ci.elf
+        run: bash tests/witness_matrix/run.sh ./bin/souc /tmp/madaros-ci.elf
+
   sounio-lint:
     name: Sounio Lint
     needs: impact
@@ -655,6 +672,7 @@ jobs:
       - madaros-current-source-deref-f64
       - native-selfhost-macos-arm64
       - full-test-suite
+      - madaros-witness-gate
       - sounio-lint
       - lean-proofs
       - website

--- a/docs/COMPETITIVE_POSITION_2026.md
+++ b/docs/COMPETITIVE_POSITION_2026.md
@@ -16,7 +16,7 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.competitive-po
 
 ## Executive Summary
 
-Sounio occupies a **unique and uncontested niche** in 2026: it is the only production-grade
+Sounio occupies a **unique and uncontested niche** in 2026: it is, to our knowledge, the only
 systems programming language whose type system natively encodes epistemic trust. No competitor
 provides compile-time confidence gates, GUM-compliant uncertainty propagation, or ISO 1788
 interval arithmetic *in the standard library*. The three closest challengers each miss at least
@@ -156,8 +156,11 @@ let w: Knowledge[f64] = measure(2.0,  uncertainty: 0.01)
 let result = v * w   // GUM §5.1.2: u_c² = u_v² * w² + u_w² * v²  (automatic)
 ```
 
-GUM variance propagation is computed **by the compiler**, not by a library at runtime.
-The uncertainty budget is part of the type, not a value carried at runtime.
+GUM variance propagation is computed at runtime by `stdlib/epistemic/` (e.g. the delta-method
+`mul` in `composed_effects.sio`), operating on the `Knowledge<T>` type. The compiler's role is
+type- and effect-checking: `Observe` is a registered algebraic effect (`self-hosted/check/effects.sio`)
+that a function must declare to read an unobserved epistemic value. The compiler does not itself
+evaluate the GUM formulas.
 
 ### 4. ISO 17025 Metrology in stdlib/metrology/
 

--- a/docs/serious-language/CAMINHO_CRITICO_CORTADO_2026-08-14.md
+++ b/docs/serious-language/CAMINHO_CRITICO_CORTADO_2026-08-14.md
@@ -172,3 +172,26 @@ não conserto de uma linha -- registrado, não executado.
 
 Trabalho consolidado em `worktree-witness-matrix-20260814` (PR #1737), três lanes
 paralelas mergeadas sem conflito (conjuntos de arquivos disjuntos) + o fix final.
+
+### ATUALIZAÇÃO 2026-08-15 — SOUNIO_STDLIB_PATH NÃO é bug de CI real
+
+O parágrafo acima ("mudar isso é decisão de arquitetura de CI sobre 50 arquivos")
+superestimava o escopo. Medido, não inferido:
+`grep -rn SOUNIO_STDLIB_PATH .github/workflows/*.yml` retorna só duas linhas, as
+duas em `madaros-prebuilt-refresh.yml`, as duas locais a um único step
+(`export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"`) -- não há export global em nenhum
+workflow. E cada runner do GitHub Actions é um checkout efêmero e isolado: não
+existe "árvore compartilhada" para um export vazar. O padrão
+`export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"` nos 50
+scripts é seguro em CI -- a variável nunca chega pré-setada de fora.
+
+A armadilha é real, mas só existe no pod interativo multi-agente, onde
+`CLAUDE.md` manda exportar `SOUNIO_STDLIB_PATH` fora da raiz do checkout
+principal: qualquer worktree que rode um desses 50 scripts sem sobrescrever a
+variável lê a stdlib do checkout compartilhado, não a própria. Já mordeu esta
+sessão uma vez (a falsa conclusão "pub não é honrado em mod.sio", retraída em
+`f0e7869765`) e a lane paralela B independentemente. Escopo do item, portanto:
+não é decisão de arquitetura de CI sobre 50 arquivos -- é uma nota de operação
+para agentes em worktree, que devem sempre setar `SOUNIO_STDLIB_PATH`
+explicitamente para o próprio worktree (ou rodar `unset SOUNIO_STDLIB_PATH`
+antes de qualquer `souc`/gate) em vez de confiar no fallback do script.

--- a/docs/serious-language/claim-line-annotations.v1.tsv
+++ b/docs/serious-language/claim-line-annotations.v1.tsv
@@ -8,16 +8,16 @@ realworld-not-production	docs/serious-language/real-world-defensibility.md	21	we
 realworld-gpu-downgrade	docs/serious-language/real-world-defensibility.md	21	gpu.ptx	general GPU runtime support	Primary downgrade sentence scopes GPU claims.
 realworld-claim-closure-rule	docs/serious-language/real-world-defensibility.md	83	claim.closure	public-claim closure rule	Exact rule sentence for claim closure.
 realworld-claim-line-rule	docs/serious-language/real-world-defensibility.md	83	claim.line_annotations	high-value public claims must have exact anchors	Exact rule sentence for line annotations.
-ledger-entrypoint	docs/serious-language/readiness-ledger.md	30	compiler.entrypoint	Checked compiler entry point	Ledger row for checked launcher claim.
-ledger-binary-attestation	docs/serious-language/readiness-ledger.md	31	binary.attestation	Binary attestation	Ledger row for bundle hash claim.
-ledger-conformance	docs/serious-language/readiness-ledger.md	32	conformance.spine	Bounded conformance spine	Ledger row for conformance scope.
-ledger-spec-drift	docs/serious-language/readiness-ledger.md	33	spec.drift	Spec/evidence drift gate	Ledger row for spec drift.
-ledger-claim-closure	docs/serious-language/readiness-ledger.md	34	claim.closure	Public claim closure gate	Ledger row for closure machinery.
-ledger-selfhost	docs/serious-language/readiness-ledger.md	35	selfhost	Self-hosted compiler	Ledger row for self-host claim.
-ledger-linux	docs/serious-language/readiness-ledger.md	37	platform.linux_x86_64	Linux x86-64 native compile/run	Ledger row for primary platform support.
-ledger-epistemic	docs/serious-language/readiness-ledger.md	55	epistemic.gum	Epistemic `Knowledge` and GUM propagation	Ledger row for epistemic/GUM research claim.
-ledger-gpu	docs/serious-language/readiness-ledger.md	69	gpu.ptx	GPU/PTX	Ledger row for GPU/PTX scope.
-ledger-formal	docs/serious-language/readiness-ledger.md	67	formal.lean	Formal Lean corpus	Ledger row for formal proof surface.
+ledger-entrypoint	docs/serious-language/readiness-ledger.md	37	compiler.entrypoint	Checked compiler entry point	Ledger row for checked launcher claim.
+ledger-binary-attestation	docs/serious-language/readiness-ledger.md	38	binary.attestation	Binary attestation	Ledger row for bundle hash claim.
+ledger-conformance	docs/serious-language/readiness-ledger.md	39	conformance.spine	Bounded conformance spine	Ledger row for conformance scope.
+ledger-spec-drift	docs/serious-language/readiness-ledger.md	40	spec.drift	Spec/evidence drift gate	Ledger row for spec drift.
+ledger-claim-closure	docs/serious-language/readiness-ledger.md	41	claim.closure	Public claim closure gate	Ledger row for closure machinery.
+ledger-selfhost	docs/serious-language/readiness-ledger.md	42	selfhost	Self-hosted compiler	Ledger row for self-host claim.
+ledger-linux	docs/serious-language/readiness-ledger.md	44	platform.linux_x86_64	Linux x86-64 native compile/run	Ledger row for primary platform support.
+ledger-epistemic	docs/serious-language/readiness-ledger.md	62	epistemic.gum	Epistemic `Knowledge` and GUM propagation	Ledger row for epistemic/GUM research claim.
+ledger-gpu	docs/serious-language/readiness-ledger.md	76	gpu.ptx	GPU/PTX	Ledger row for GPU/PTX scope.
+ledger-formal	docs/serious-language/readiness-ledger.md	74	formal.lean	Formal Lean corpus	Ledger row for formal proof surface.
 spine-not-complete	docs/serious-language/conformance-spine.md	16	conformance.spine	not a complete language specification suite	Explicit conformance limitation.
 spine-claim-line-rule	docs/serious-language/conformance-spine.md	87	claim.line_annotations	exact line number and anchor text	Expansion rule for high-value annotations.
 bundle-line-anchor-rule	docs/serious-language/paper-bundle.md	64	paper.bundle	exact line anchor	Required claim check for paper bundles.

--- a/docs/serious-language/readiness-ledger.md
+++ b/docs/serious-language/readiness-ledger.md
@@ -9,6 +9,13 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.serious-langua
 
 # Serious-Language Readiness Ledger
 
+> **Superseded 2026-08-15**: the current critical-path assessment for launch
+> readiness is [`CAMINHO_CRITICO_CORTADO_2026-08-14.md`](CAMINHO_CRITICO_CORTADO_2026-08-14.md),
+> not this ledger. This file's per-claim table is still useful as a reference
+> for wording individual claims, but its overall "current status" framing and
+> the specific compiler-binary-source claim below are stale (this ledger
+> predates `bin/souc` routing to Madaros by default; see the correction inline).
+
 > **Status**: Research readiness | **Operational check**: 2026-05-11 | **Source**: checked commands and current repository docs
 
 This ledger maps public-facing claims to evidence and safe wording. Use it before talks, papers, abstracts, or website updates.
@@ -33,7 +40,7 @@ This ledger maps public-facing claims to evidence and safe wording. Use it befor
 | Spec/evidence drift gate | `prototype` | `docs/serious-language/spec-evidence-matrix.v1.tsv`; `scripts/ci/serious_language_spec_drift_gate.sh`; generated bundle `spec-drift/RESULTS.md` | "Executable spec claims are tracked in a v1 spec/evidence matrix. The drift gate requires tracked executable rows to cite live repo evidence and requires cited conformance cases to pass." |
 | Public claim closure gate | `prototype` | `docs/serious-language/public-claim-registry.v1.tsv`; `docs/serious-language/doc-claim-surface.v1.tsv`; `docs/serious-language/claim-line-annotations.v1.tsv`; `scripts/ci/serious_language_claim_closure_gate.sh`; generated bundle `claim-closure/RESULTS.md` | "Public PL claims are registry-backed. A repo doc claim must either cite closed evidence or remain explicitly downgraded, internal, or historical." |
 | Self-hosted compiler | `validated research` | `scripts/ci/selfhost_host_gate.sh`; CI `native-selfhost-*` jobs; `docs/compiler/KNOWN_LIMITATIONS.md` | "Sounio has a self-hosted checked compiler path with host gates; it is a serious research compiler, not a finished general-purpose production toolchain." |
-| Binary source of truth | `prototype` | `docs/compiler/KNOWN_LIMITATIONS.md` single-source build path section | "The shipped binary is still built from `self-hosted/compiler/lean_single.sio`; the modular tree is the maintained future target until parity gates prove source-swap readiness." |
+| Binary source of truth | `stable` | `./bin/souc --version` prints `Madaros`; CLAUDE.md §4; `.github/workflows/ci.yml`'s `madaros-witness-gate` (PR #1739) builds and tests Madaros from `self-hosted/compiler/main.sio` directly | "`bin/souc` routes to Madaros, the modular self-hosted compiler built from `self-hosted/compiler/main.sio` (`make build-madaros`), not from `lean_single.sio`. `lean_single.sio` remains the bootstrap seed and the fixed-point-verified ELF (`make build`), but is no longer the default user-facing engine; force it with `SOUNIO_SOUC_ENGINE=lean_single`." (STALE CLAIM CORRECTED 2026-08-15 — see superseding note above) |
 | Linux x86-64 native compile/run | `stable` | `bin/souc info`; `examples/hello.sio`; `scripts/run_sio_test_suite.sh` | "Linux x86-64 is the primary serious lane for live compiler demonstrations." |
 | macOS artifact support | `validated research` | CI `native-selfhost-macos-arm64`; `docs/guide/MINIMUM_VIABLE_SOUNIO.md` | "macOS has checked artifact lanes, but Apple support should not be described as JIT or native-v2 parity." |
 | Windows target | `prototype` | `docs/compiler/KNOWN_LIMITATIONS.md` platform table | "The repository contains PE/COFF target support, but no public Windows binary should be promised from this checkout." |

--- a/scripts/ci/evaluate_ci_decision.py
+++ b/scripts/ci/evaluate_ci_decision.py
@@ -28,6 +28,9 @@ def main() -> int:
         ),
         "native-selfhost-macos-arm64": truthy(impact.get("compiler")) or truthy(impact.get("full")),
         "full-test-suite": any(truthy(impact.get(key)) for key in ("compiler", "runtime", "stdlib", "tests", "full")),
+        "madaros-witness-gate": any(
+            truthy(impact.get(key)) for key in ("compiler", "runtime", "stdlib", "tests", "full")
+        ),
         "sounio-lint": any(truthy(impact.get(key)) for key in ("compiler", "stdlib", "tests", "sio", "full")),
         "lean-proofs": truthy(impact.get("lean")) or truthy(impact.get("full")),
         "website": truthy(impact.get("website")) or truthy(impact.get("full")),

--- a/scripts/ci/impact_ci_selftest.sh
+++ b/scripts/ci/impact_ci_selftest.sh
@@ -50,7 +50,7 @@ non_pr="$(CI_EVENT_NAME=push $CLASSIFIER)"
 expect "$non_pr" full true
 expect "$non_pr" compiler true
 
-good_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"false","tests":"false","sio":"false","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"madaros-current-source-deref-f64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"sounio-lint":{"result":"skipped"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
+good_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"false","tests":"false","sio":"false","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"madaros-current-source-deref-f64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"madaros-witness-gate":{"result":"skipped"},"sounio-lint":{"result":"skipped"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
 NEEDS_JSON="$good_needs" python3 "$DECISION" | grep -Fq CI_DECISION_PASS
 
 bad_needs="${good_needs/\"contracts\":{\"result\":\"success\"}/\"contracts\":{\"result\":\"failure\"}}"
@@ -59,7 +59,7 @@ if NEEDS_JSON="$bad_needs" python3 "$DECISION" >/dev/null 2>&1; then
   exit 1
 fi
 
-compiler_needs='{"impact":{"outputs":{"compiler":"true","runtime":"false","stdlib":"false","tests":"false","sio":"true","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"success"},"source-bootstrap-selfhost-linux-x86_64":{"result":"success"},"madaros-current-source-deref-f64":{"result":"failure"},"native-selfhost-macos-arm64":{"result":"success"},"full-test-suite":{"result":"success"},"sounio-lint":{"result":"success"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
+compiler_needs='{"impact":{"outputs":{"compiler":"true","runtime":"false","stdlib":"false","tests":"false","sio":"true","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"success"},"source-bootstrap-selfhost-linux-x86_64":{"result":"success"},"madaros-current-source-deref-f64":{"result":"failure"},"native-selfhost-macos-arm64":{"result":"success"},"full-test-suite":{"result":"success"},"madaros-witness-gate":{"result":"success"},"sounio-lint":{"result":"success"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
 if NEEDS_JSON="$compiler_needs" python3 "$DECISION" >/dev/null 2>&1; then
   echo "impact-ci-selftest: decision accepted failed current-source Madaros gate" >&2
   exit 1
@@ -67,7 +67,7 @@ fi
 compiler_green_needs="${compiler_needs/\"failure\"/\"success\"}"
 NEEDS_JSON="$compiler_green_needs" python3 "$DECISION" | grep -Fq CI_DECISION_PASS
 
-stdlib_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"true","tests":"false","sio":"true","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"madaros-current-source-deref-f64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"sounio-lint":{"result":"success"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
+stdlib_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"true","tests":"false","sio":"true","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"madaros-current-source-deref-f64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"madaros-witness-gate":{"result":"success"},"sounio-lint":{"result":"success"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
 if NEEDS_JSON="$stdlib_needs" python3 "$DECISION" >/dev/null 2>&1; then
   echo "impact-ci-selftest: decision accepted stdlib suite without native compiler/full suite" >&2
   exit 1

--- a/tests/witness_matrix/cases/w15_field_triple_collision.sio
+++ b/tests/witness_matrix/cases/w15_field_triple_collision.sio
@@ -1,0 +1,11 @@
+// WITNESS w15 -- soundness-round-3 BUG C residue: 3+ fields sharing a first letter.
+// w8/w8c already confirmed the 2-field case (ax/ay) is CLOSED on main. This is the
+// stronger shape the round-3 doc names as unresolved residue: "3+ colliding fields".
+// Under the old buf[0]%64 hash all three would alias to the SAME slot; the real
+// struct_layouts lookup must return three DISTINCT indices.
+// EXPECT: exit 42 (10 + 20 + 12).
+struct Triple { aa: i64, ab: i64, ac: i64 }
+fn main() -> i64 {
+    let t = Triple{ aa: 10, ab: 20, ac: 12 }
+    t.aa + t.ab + t.ac
+}

--- a/tests/witness_matrix/run.sh
+++ b/tests/witness_matrix/run.sh
@@ -157,6 +157,7 @@ run_value w8c "$CASES/w8c_field_nocollision_control.sio" 42  99 "CONTROL no coll
 run_value w4b "$CASES/w4b_f32_roundtrip.sio"             150 100 "ROOT CAUSE of w4: as-f32 fell through to float_to_int"
 run_value w7b "$CASES/w7b_enum_reverse.sio"                1   2 "CONTROL (passes at baseline): a table reorder must not break Shape"
 run_value w11 "$CASES/w11_float_literal_f32.sio"          12  99 "float literal coercion to f32 (contextual + operator)"
+run_value w15 "$CASES/w15_field_triple_collision.sio"     42  99 "soundness-3 BUG C residue: 3-field same-first-letter collision"
 run_reject w12 "$CASES/w12_nonliteral_must_reject.sio" "CARDINAL: only literals coerce"
 run_reject w13 "$CASES/w13_magnitude_must_reject.sio" "CARDINAL: magnitude guard on f32 narrowing"
 run_mm    w9  42 "release wall 8765ca1dc4"

--- a/tests/witness_matrix/run.sh
+++ b/tests/witness_matrix/run.sh
@@ -5,18 +5,52 @@
 # WHATEVER compiler is handed to it. Every defect below is CLOSED on branch
 # integration/native-v2-honest (tip 60686c617b) and was NEVER MERGED to main.
 # This answers the only question that matters for launch: does the shipped
-# tree exhibit them? Measured 2026-08-14: 8/10 closed, w4 and w7 OPEN.
+# tree exhibit them? Measured 2026-08-14: 8/10 closed, w4 and w7 OPEN --
+# both later fixed and merged to main (PR #1737).
 #
-# Usage: bash tests/witness_matrix/run.sh [path-to-souc]
+# 2026-08-15: pointing this script at "souc compile" (arg 1, default
+# ./bin/souc) measures the CHECKED-IN PREBUILT bin/madaros-linux-x86_64, not
+# a build of the PR's own self-hosted/ source. That prebuilt only updates via
+# the scheduled madaros-prebuilt-refresh.yml workflow, so it can be (and, on
+# 2026-08-15, was) stale relative to main by exactly the fixes this script
+# exists to guard. To measure the PR's own source, build Madaros fresh
+# (scripts/ci/build_modular_madaros.sh) and pass BOTH the souc wrapper (arg 1,
+# with MADAROS_RAW_BIN set to the fresh ELF so "souc compile" uses it) and the
+# raw ELF path again as arg 2 (for w14's direct --native-v2-emit-scalar
+# probe, which bypasses the wrapper entirely). See DECLARED_OPEN below for
+# the residuals that are real on a fresh build and not on the prebuilt.
+#
+# Usage: bash tests/witness_matrix/run.sh [path-to-souc] [path-to-raw-elf]
 set -u
 SOUC="${1:-./bin/souc}"
 SOUC="$(cd "$(dirname "$SOUC")" && pwd)/$(basename "$SOUC")"  # absolutise: run_mm/run_reject cd into the case dir
+RAW="${2:-}"  # optional: raw --native-v2-emit-* ELF (bypasses the souc/madaros wrapper) for w14
 ROOT="$(cd "$(dirname "$0")" && pwd)"
 CASES="$ROOT/cases"
 TMP="$(mktemp -d)"
 PASS=0
 TOTAL=0
 OPEN=0
+OPEN_IDS=""
+# Residual-by-identity allowlist (release_gate.sh pattern): a witness may be
+# declared open ONLY by exact id + reason below. The gate fails if the actual
+# open set differs from this set in ANY direction -- new opens, or a declared
+# residual silently starting to pass (promotion must be witnessed, not assumed).
+DECLARED_OPEN="w5 w14"
+# w5 and w14 are BOTH open, ONLY on a Madaros built fresh from current
+# main.sio source (not on the checked-in prebuilt bin/madaros-linux-x86_64,
+# which predates them and which run_value's default "souc compile" resolves
+# to -- so the default invocation of this script never exercises either).
+# w5:  closure-capture path fails codegen (M2 320f4d2352 origin).
+# w14: --native-v2-emit-scalar fails with "IR instruction arena contract
+#      violated (invalid handle) on region slot -1 generation -1".
+# Confirmed 2026-08-15 on a raw ELF (no souc/madaros wrapper, no
+# MADAROS_STACK_KB involved) and on a same-day rebuild (not staleness).
+# Both surfaced together on the first fresh-from-source run this script was
+# ever given -- consistent with (not yet proven to be) one arena-contract
+# defect manifesting on two distinct native-v2 entry points. Tracked here so
+# neither can be silently reintroduced, silently fixed, or silently merged
+# under "fixed" without the fix actually being witnessed.
 
 run_value() {
   id="$1"; file="$2"; want="$3"; wrong="$4"; origin="$5"
@@ -26,7 +60,7 @@ run_value() {
   "$SOUC" compile "$file" -o "$elf" >"$TMP/$id.log" 2>&1
   if [ ! -f "$elf" ]; then
     printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "COMPILE-FAIL" "-" "$want" "$origin"
-    OPEN=$((OPEN+1))
+    OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
     return
   fi
   chmod +x "$elf" 2>/dev/null
@@ -35,9 +69,9 @@ run_value() {
   if [ "$got" = "$want" ]; then
     status="CLOSED"; PASS=$((PASS+1))
   elif [ "$got" = "$wrong" ]; then
-    status="OPEN-MISCOMPILE"; OPEN=$((OPEN+1))
+    status="OPEN-MISCOMPILE"; OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
   else
-    status="OPEN-OTHER"; OPEN=$((OPEN+1))
+    status="OPEN-OTHER"; OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
   fi
   printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "$status" "$got" "$want" "$origin"
 }
@@ -47,7 +81,7 @@ run_reject() {
   TOTAL=$((TOTAL+1))
   if (cd "$(dirname "$file")" && "$SOUC" check "$(basename "$file")" >/dev/null 2>&1); then
     printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "OPEN-ACCEPTS-ILLTYPED" "accepted" "REJECT" "$origin"
-    OPEN=$((OPEN+1))
+    OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
   else
     printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "CLOSED" "rejected" "REJECT" "$origin"
     PASS=$((PASS+1))
@@ -61,7 +95,7 @@ run_mm() {
   (cd "$CASES/mm" && "$SOUC" compile prog.sio -o "$TMP/$id.elf") >"$TMP/$id.log" 2>&1
   if [ ! -f "$TMP/$id.elf" ]; then
     printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "COMPILE-FAIL" "-" "$want" "$origin"
-    OPEN=$((OPEN+1))
+    OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
     return
   fi
   chmod +x "$TMP/$id.elf" 2>/dev/null
@@ -72,7 +106,35 @@ run_mm() {
     PASS=$((PASS+1))
   else
     printf "%-5s %-20s %-9s %-7s %s\\n" "$id" "OPEN" "$got" "$want" "$origin"
-    OPEN=$((OPEN+1))
+    OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
+  fi
+}
+
+run_scalar_emit() {
+  id="$1"; want="$2"; origin="$3"
+  TOTAL=$((TOTAL+1))
+  if [ -z "$RAW" ]; then
+    printf "%-5s %-20s %-9s %-7s %s\n" "$id" "SKIPPED-NO-RAW" "-" "$want" "$origin"
+    OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
+    return
+  fi
+  elf="$TMP/$id.elf"
+  rm -f "$elf"
+  "$RAW" --native-v2-emit-scalar "$want" "$elf" >"$TMP/$id.log" 2>&1
+  if [ ! -f "$elf" ]; then
+    printf "%-5s %-20s %-9s %-7s %s\n" "$id" "OPEN-EMIT-FAIL" "-" "$want" "$origin"
+    OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
+    return
+  fi
+  chmod +x "$elf" 2>/dev/null
+  "$elf" >/dev/null 2>&1
+  got=$?
+  if [ "$got" = "$want" ]; then
+    printf "%-5s %-20s %-9s %-7s %s\n" "$id" "CLOSED" "$got" "$want" "$origin"
+    PASS=$((PASS+1))
+  else
+    printf "%-5s %-20s %-9s %-7s %s\n" "$id" "OPEN" "$got" "$want" "$origin"
+    OPEN=$((OPEN+1)); OPEN_IDS="$OPEN_IDS $id"
   fi
 }
 
@@ -99,8 +161,20 @@ run_reject w12 "$CASES/w12_nonliteral_must_reject.sio" "CARDINAL: only literals 
 run_reject w13 "$CASES/w13_magnitude_must_reject.sio" "CARDINAL: magnitude guard on f32 narrowing"
 run_mm    w9  42 "release wall 8765ca1dc4"
 run_reject w10 "$CASES/mm/prog2.sio" "import typecheck bypass e1ac6f7c87"
+run_scalar_emit w14 42 "IR arena contract violated on native-v2-emit-scalar (fresh source build only) 2026-08-15"
 
 echo
 echo "correct: $PASS/$TOTAL   open: $OPEN"
+
+# Residual-by-identity gate: pass only if the actual open set equals DECLARED_OPEN exactly.
+actual_sorted="$(printf '%s\n' $OPEN_IDS | sort -u | tr '\n' ' ' | sed 's/ $//')"
+declared_sorted="$(printf '%s\n' $DECLARED_OPEN | sort -u | tr '\n' ' ' | sed 's/ $//')"
 rm -rf "$TMP"
-[ "$OPEN" = "0" ]
+if [ "$actual_sorted" = "$declared_sorted" ]; then
+  echo "residuals match declared set: [$declared_sorted]"
+  exit 0
+else
+  echo "RESIDUAL MISMATCH: actual=[$actual_sorted] declared=[$declared_sorted]"
+  echo "A new witness opened, or a declared residual changed status -- both require a human look, not a silent gate change."
+  exit 1
+fi

--- a/tools/debug/README.md
+++ b/tools/debug/README.md
@@ -4,7 +4,17 @@ This directory contains debugger integration tools for Sounio programs.
 
 ## Overview
 
-Sounio programs compiled with debug info (`-g` flag) can be debugged with standard debuggers. The tools in this directory provide:
+> **STATUS (2026-08-15, measured):** `souc build`/`compile` has no `-g` flag today
+> (`souc build file.sio -g` errors `unsupported option: -g`, rc=2), and
+> `self-hosted/native/dwarf.sio` / `debug_info.sio` are not reachable from
+> `self-hosted/compiler/main.sio`'s `use` graph -- the shipped compiler does not
+> emit DWARF debug info. This directory's pretty printers and templates are
+> real and still useful once a native debugger attaches to a Sounio binary at
+> the machine level, but the `-g`/debug-info workflow below is a design target,
+> not a working feature. Do not present this doc as describing current `souc`
+> behaviour.
+
+Sounio programs compiled with debug info (`-g` flag, planned) can be debugged with standard debuggers. The tools in this directory provide:
 
 - **Pretty printers** for Sounio's core types (Knowledge, Quantity, Effects, etc.)
 - **Custom commands** for inspecting epistemic values


### PR DESCRIPTION
## Summary
- Tier 1 item 3 of the launch-readiness plan: verify (via a real witness, not grep) whether the soundness-round-3 BUG C field-index-hash residue still applies to main.
- w8/w8c already confirmed the 2-field case (`ax`/`ay`) closes. Adds `w15`: the stronger 3-field same-first-letter shape (`aa`/`ab`/`ac`) that `soundness-round-3.js` names as open residue.
- Result: CLOSED on both the checked-in prebuilt and a Madaros built fresh from current source (exit 42, correct on both). Confirms `field_idx_from_name_simple`'s real `struct_layouts` lookup handles the N-field case.

## Test plan
- [x] `bash tests/witness_matrix/run.sh ./bin/souc` — w15 CLOSED
- [x] Fresh build + `MADAROS_RAW_BIN` override — w15 CLOSED, residual set still matches declared `[w14 w5]`
- [ ] CI (will run `madaros-witness-gate` for real, same as #1739)

🤖 Generated with [Claude Code](https://claude.com/claude-code)