### PR TITLE
fix(ir): allocate the arena region for hand-built IrFunctions

### DIFF
--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -6991,6 +6991,7 @@ fn compiler_main_test_x86_allocation_order_drives_lowering() -> bool {
 fn compiler_main_make_native_v2_scalar_module(ret_value: i64) -> IrModule with Mut, Panic, Div {
     var module = ir_empty_module()
     var func = ir_empty_function()
+    ir_function_alloc_region(&! func)
     func.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     ir_arena_store(ir_region_slot_w(func.region, (0)), ir_load_imm(0, ret_value))
     ir_arena_store(ir_region_slot_w(func.region, (1)), ir_return(0))
@@ -7005,6 +7006,7 @@ fn compiler_main_make_native_v2_call_module() -> IrModule with Mut, Panic, Div, 
     var module = ir_empty_module()
 
     var helper = ir_empty_function()
+    ir_function_alloc_region(&! helper)
     helper.name = ir_name_from_bytes(104, 101, 108, 112, 4)
     helper.param_count = 1
     helper.param_regs[0] = 0
@@ -7016,6 +7018,7 @@ fn compiler_main_make_native_v2_call_module() -> IrModule with Mut, Panic, Div, 
     module.functions[0] = helper
 
     var main_fn = ir_empty_function()
+    ir_function_alloc_region(&! main_fn)
     main_fn.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     main_fn.reg_count = 2
     ir_arena_store(ir_region_slot_w(main_fn.region, (0)), ir_load_imm(0, 3))
@@ -7080,6 +7083,7 @@ fn compiler_main_make_native_v2_str_len_module() -> IrModule with Mut, Panic, Di
     var module = ir_empty_module()
 
     var str_len_fn = ir_empty_function()
+    ir_function_alloc_region(&! str_len_fn)
     str_len_fn.name = native_v2_name_str_len()
     str_len_fn.param_count = 1
     str_len_fn.param_regs[0] = 0
@@ -7092,6 +7096,7 @@ fn compiler_main_make_native_v2_str_len_module() -> IrModule with Mut, Panic, Di
     let hello = native_v2_name_bytes10(5, 104, 101, 108, 108, 111, 0, 0, 0, 0, 0)
 
     var main_fn = ir_empty_function()
+    ir_function_alloc_region(&! main_fn)
     main_fn.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     main_fn.param_count = 0
     main_fn.reg_count = 3
@@ -7112,6 +7117,7 @@ fn compiler_main_make_native_v2_str_char_at_module() -> IrModule with Mut, Panic
     var module = ir_empty_module()
 
     var sca_fn = ir_empty_function()
+    ir_function_alloc_region(&! sca_fn)
     sca_fn.name = native_v2_name_str_char_at()
     sca_fn.param_count = 2
     sca_fn.param_regs[0] = 0
@@ -7124,6 +7130,7 @@ fn compiler_main_make_native_v2_str_char_at_module() -> IrModule with Mut, Panic
     let hello = native_v2_name_bytes10(5, 104, 101, 108, 108, 111, 0, 0, 0, 0, 0)
 
     var main_fn = ir_empty_function()
+    ir_function_alloc_region(&! main_fn)
     main_fn.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     main_fn.param_count = 0
     main_fn.reg_count = 4
@@ -7157,6 +7164,7 @@ fn compiler_main_make_native_v2_str_eq_module() -> IrModule with Mut, Panic, Div
     var module = ir_empty_module()
 
     var streq_fn = ir_empty_function()
+    ir_function_alloc_region(&! streq_fn)
     streq_fn.name = native_v2_name_str_eq()
     streq_fn.param_count = 2
     streq_fn.param_regs[0] = 0
@@ -7170,6 +7178,7 @@ fn compiler_main_make_native_v2_str_eq_module() -> IrModule with Mut, Panic, Div
     let s_ab = native_v2_name_bytes10(2, 97, 98, 0, 0, 0, 0, 0, 0, 0, 0)
 
     var streq_main = ir_empty_function()
+    ir_function_alloc_region(&! streq_main)
     streq_main.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     streq_main.param_count = 0
     streq_main.reg_count = 4
@@ -7197,6 +7206,7 @@ fn compiler_main_make_native_v2_strconcat_len_module() -> IrModule with Mut, Pan
     var module = ir_empty_module()
 
     var concat_fn = ir_empty_function()
+    ir_function_alloc_region(&! concat_fn)
     concat_fn.name = native_v2_name_str_concat()
     concat_fn.param_count = 2
     concat_fn.param_regs[0] = 0
@@ -7206,6 +7216,7 @@ fn compiler_main_make_native_v2_strconcat_len_module() -> IrModule with Mut, Pan
     module.functions[0] = concat_fn
 
     var len_fn = ir_empty_function()
+    ir_function_alloc_region(&! len_fn)
     len_fn.name = native_v2_name_str_len()
     len_fn.param_count = 1
     len_fn.param_regs[0] = 0
@@ -7219,6 +7230,7 @@ fn compiler_main_make_native_v2_strconcat_len_module() -> IrModule with Mut, Pan
     let s_cde = native_v2_name_bytes10(3, 99, 100, 101, 0, 0, 0, 0, 0, 0, 0)  // "cde"
 
     var main_fn = ir_empty_function()
+    ir_function_alloc_region(&! main_fn)
     main_fn.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     main_fn.param_count = 0
     main_fn.reg_count = 5
@@ -7239,6 +7251,7 @@ fn compiler_main_make_native_v2_strconcat_charat_module() -> IrModule with Mut, 
     var module = ir_empty_module()
 
     var concat_fn = ir_empty_function()
+    ir_function_alloc_region(&! concat_fn)
     concat_fn.name = native_v2_name_str_concat()
     concat_fn.param_count = 2
     concat_fn.param_regs[0] = 0
@@ -7248,6 +7261,7 @@ fn compiler_main_make_native_v2_strconcat_charat_module() -> IrModule with Mut, 
     module.functions[0] = concat_fn
 
     var sca_fn = ir_empty_function()
+    ir_function_alloc_region(&! sca_fn)
     sca_fn.name = native_v2_name_str_char_at()
     sca_fn.param_count = 2
     sca_fn.param_regs[0] = 0
@@ -7262,6 +7276,7 @@ fn compiler_main_make_native_v2_strconcat_charat_module() -> IrModule with Mut, 
     let s_cde = native_v2_name_bytes10(3, 99, 100, 101, 0, 0, 0, 0, 0, 0, 0)  // "cde"
 
     var main_fn = ir_empty_function()
+    ir_function_alloc_region(&! main_fn)
     main_fn.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     main_fn.param_count = 0
     main_fn.reg_count = 6
@@ -7283,6 +7298,7 @@ fn compiler_main_make_native_v2_strconcat_charat_module() -> IrModule with Mut, 
 fn compiler_main_make_native_v2_strlen2_module() -> IrModule with Mut, Panic, Div, Alloc {
     var module = ir_empty_module()
     var str_len_fn = ir_empty_function()
+    ir_function_alloc_region(&! str_len_fn)
     str_len_fn.name = native_v2_name_str_len()
     str_len_fn.param_count = 1
     str_len_fn.param_regs[0] = 0
@@ -7295,6 +7311,7 @@ fn compiler_main_make_native_v2_strlen2_module() -> IrModule with Mut, Panic, Di
     let s_b = native_v2_name_bytes10(2, 120, 121, 0, 0, 0, 0, 0, 0, 0, 0)        // "xy"
 
     var main_fn = ir_empty_function()
+    ir_function_alloc_region(&! main_fn)
     main_fn.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     main_fn.param_count = 0
     main_fn.reg_count = 4
@@ -7313,6 +7330,7 @@ fn compiler_main_make_native_v2_strlen2_module() -> IrModule with Mut, Panic, Di
 fn compiler_main_make_native_v2_streq1_module() -> IrModule with Mut, Panic, Div, Alloc {
     var module = ir_empty_module()
     var streq_fn = ir_empty_function()
+    ir_function_alloc_region(&! streq_fn)
     streq_fn.name = native_v2_name_str_eq()
     streq_fn.param_count = 2
     streq_fn.param_regs[0] = 0
@@ -7325,6 +7343,7 @@ fn compiler_main_make_native_v2_streq1_module() -> IrModule with Mut, Panic, Div
     let s_ab = native_v2_name_bytes10(2, 97, 98, 0, 0, 0, 0, 0, 0, 0, 0)  // "ab"
 
     var main_fn = ir_empty_function()
+    ir_function_alloc_region(&! main_fn)
     main_fn.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     main_fn.param_count = 0
     main_fn.reg_count = 3
@@ -7342,6 +7361,7 @@ fn compiler_main_make_native_v2_streq1_module() -> IrModule with Mut, Panic, Div
 fn compiler_main_make_native_v2_streqnocall_module() -> IrModule with Mut, Panic, Div, Alloc {
     var module = ir_empty_module()
     var streq_fn = ir_empty_function()
+    ir_function_alloc_region(&! streq_fn)
     streq_fn.name = native_v2_name_str_eq()
     streq_fn.param_count = 2
     streq_fn.param_regs[0] = 0
@@ -7351,6 +7371,7 @@ fn compiler_main_make_native_v2_streqnocall_module() -> IrModule with Mut, Panic
     module.functions[0] = streq_fn
 
     var main_fn = ir_empty_function()
+    ir_function_alloc_region(&! main_fn)
     main_fn.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     main_fn.param_count = 0
     main_fn.reg_count = 2
@@ -7367,6 +7388,7 @@ fn compiler_main_make_native_v2_fnptr_module() -> IrModule with Mut, Panic, Div,
     var module = ir_empty_module()
 
     var helper = ir_empty_function()
+    ir_function_alloc_region(&! helper)
     helper.name = ir_name_from_bytes(104, 101, 108, 112, 4)
     helper.param_count = 1
     helper.param_regs[0] = 0
@@ -7378,6 +7400,7 @@ fn compiler_main_make_native_v2_fnptr_module() -> IrModule with Mut, Panic, Div,
     module.functions[0] = helper
 
     var main_fn = ir_empty_function()
+    ir_function_alloc_region(&! main_fn)
     main_fn.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     main_fn.reg_count = 3
     ir_arena_store(ir_region_slot_w(main_fn.region, (0)), ir_load_fn_ref(0, 0))
@@ -7401,6 +7424,7 @@ fn compiler_main_make_native_v2_multi_call_module() -> IrModule with Mut, Panic,
     // fn add(a, b) -> a + b
     let add_name = ir_name_from_bytes(97, 100, 100, 0, 3)
     var add_fn = ir_empty_function()
+    ir_function_alloc_region(&! add_fn)
     add_fn.name = add_name
     add_fn.param_count = 2
     add_fn.param_regs[0] = 0
@@ -7414,6 +7438,7 @@ fn compiler_main_make_native_v2_multi_call_module() -> IrModule with Mut, Panic,
     // fn mul(a, b) -> a * b
     let mul_name = ir_name_from_bytes(109, 117, 108, 0, 3)
     var mul_fn = ir_empty_function()
+    ir_function_alloc_region(&! mul_fn)
     mul_fn.name = mul_name
     mul_fn.param_count = 2
     mul_fn.param_regs[0] = 0
@@ -7427,6 +7452,7 @@ fn compiler_main_make_native_v2_multi_call_module() -> IrModule with Mut, Panic,
     // fn main() -> { x = add(10, 32); y = mul(x, 2); return y }
     let main_name = ir_name_from_bytes(109, 97, 105, 110, 4)
     var main_fn = ir_empty_function()
+    ir_function_alloc_region(&! main_fn)
     main_fn.name = main_name
     main_fn.param_count = 0
     main_fn.reg_count = 5
@@ -7446,6 +7472,7 @@ fn compiler_main_make_native_v2_multi_call_module() -> IrModule with Mut, Panic,
 fn compiler_main_make_native_v2_control_module() -> IrModule with Mut, Panic, Div {
     var module = ir_empty_module()
     var func = ir_empty_function()
+    ir_function_alloc_region(&! func)
     func.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     func.reg_count = 3
     func.label_count = 1
@@ -7473,6 +7500,7 @@ fn compiler_main_make_native_v2_control_module() -> IrModule with Mut, Panic, Di
 fn compiler_main_make_native_v2_f64cmp_module(op: BinaryOp, lhs_is_nan: i64, lhs: f64, rhs: f64) -> IrModule with Mut, Panic, Div {
     var module = ir_empty_module()
     var func = ir_empty_function()
+    ir_function_alloc_region(&! func)
     func.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     if lhs_is_nan != 0 {
         func.reg_count = 6
@@ -7549,6 +7577,7 @@ fn run_native_v2_emit_f64cmp(args: ArgList, flag_index: i64) with IO, Mut, Panic
 fn compiler_main_make_native_v2_arith_module() -> IrModule with Mut, Panic, Div {
     var module = ir_empty_module()
     var func = ir_empty_function()
+    ir_function_alloc_region(&! func)
     func.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     func.reg_count = 5
     ir_arena_store(ir_region_slot_w(func.region, (0)), ir_load_imm(0, 100))
@@ -7571,6 +7600,7 @@ fn compiler_main_make_native_v2_call5_module() -> IrModule with Mut, Panic, Div,
     // fn add5(a, b, c, d, e) -> a+b+c+d+e
     let add5_name = ir_name_from_bytes(97, 100, 100, 53, 4)
     var add5_fn = ir_empty_function()
+    ir_function_alloc_region(&! add5_fn)
     add5_fn.name = add5_name
     add5_fn.param_count = 5
     add5_fn.param_regs[0] = 0
@@ -7591,6 +7621,7 @@ fn compiler_main_make_native_v2_call5_module() -> IrModule with Mut, Panic, Div,
     // fn main() -> add5(1, 2, 4, 8, 16)
     let main_name = ir_name_from_bytes(109, 97, 105, 110, 4)
     var main_fn = ir_empty_function()
+    ir_function_alloc_region(&! main_fn)
     main_fn.name = main_name
     main_fn.param_count = 0
     main_fn.reg_count = 6
@@ -7617,6 +7648,7 @@ fn compiler_main_make_native_v2_call6_module() -> IrModule with Mut, Panic, Div,
     // fn add6(a, b, c, d, e, f) -> a+b+c+d+e+f
     let add6_name = ir_name_from_bytes(97, 100, 100, 54, 4)
     var add6_fn = ir_empty_function()
+    ir_function_alloc_region(&! add6_fn)
     add6_fn.name = add6_name
     add6_fn.param_count = 6
     add6_fn.param_regs[0] = 0
@@ -7639,6 +7671,7 @@ fn compiler_main_make_native_v2_call6_module() -> IrModule with Mut, Panic, Div,
     // fn main() -> add6(1, 2, 4, 8, 16, 32)
     let main_name = ir_name_from_bytes(109, 97, 105, 110, 4)
     var main_fn = ir_empty_function()
+    ir_function_alloc_region(&! main_fn)
     main_fn.name = main_name
     main_fn.param_count = 0
     main_fn.reg_count = 7
@@ -7664,6 +7697,7 @@ fn compiler_main_make_native_v2_call6_module() -> IrModule with Mut, Panic, Div,
 fn compiler_main_make_native_v2_control_fallthrough_module() -> IrModule with Mut, Panic, Div {
     var module = ir_empty_module()
     var func = ir_empty_function()
+    ir_function_alloc_region(&! func)
     func.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     func.reg_count = 3
     func.label_count = 1
@@ -7683,6 +7717,7 @@ fn compiler_main_make_native_v2_control_fallthrough_module() -> IrModule with Mu
 fn compiler_main_make_native_v2_unsupported_vector_module() -> IrModule with Mut, Panic, Div {
     var module = ir_empty_module()
     var func = ir_empty_function()
+    ir_function_alloc_region(&! func)
     var instr = ir_instr_new(IrOpcode::IrVecAddF64)
     func.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     instr.dst = 0
@@ -7701,6 +7736,7 @@ fn compiler_main_make_native_v2_unsupported_vector_module() -> IrModule with Mut
 fn compiler_main_make_native_v2_huge_alloc_module() -> IrModule with Mut, Panic, Div {
     var module = ir_empty_module()
     var func = ir_empty_function()
+    ir_function_alloc_region(&! func)
     func.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     func.reg_count = 2
     ir_arena_store(ir_region_slot_w(func.region, (0)), ir_alloc(0, 536870920))
@@ -7715,6 +7751,7 @@ fn compiler_main_make_native_v2_huge_alloc_module() -> IrModule with Mut, Panic,
 fn compiler_main_make_native_v2_alloc_field_module() -> IrModule with Mut, Panic, Div {
     var module = ir_empty_module()
     var func = ir_empty_function()
+    ir_function_alloc_region(&! func)
     let field_name = ir_name_from_bytes(118, 97, 108, 0, 3)
     func.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     func.reg_count = 4
@@ -7941,6 +7978,7 @@ fn compiler_main_make_native_v2_sret_plaincall_module() -> IrModule with Mut, Pa
 fn compiler_main_make_native_v2_gc_retry_module() -> IrModule with Mut, Panic, Div {
     var module = ir_empty_module()
     var func = ir_empty_function()
+    ir_function_alloc_region(&! func)
     func.name = ir_name_from_bytes(109, 97, 105, 110, 4)
     func.reg_count = 2
     ir_arena_store(ir_region_slot_w(func.region, (0)), ir_load_imm(0, 0))

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -16771,6 +16771,15 @@ impl Lowerer {
         // param_count and produced a malformed closure body.
         lo.current_fn = closure_fn_id
         lo.current_func = lowerer_box_empty_function()
+        // lowerer_box_empty_function() -> ir_empty_function() leaves region invalid
+        // by design (see ir_function_alloc_region's own comment: array-repeat
+        // initialisers would alias every slot to the same region if it allocated
+        // eagerly). Every OTHER real-function lowering entry point allocates here
+        // before writing instructions (e.g. the (*reused).region.slot < 0 guard
+        // above); the closure path skipped it, so any ir_arena_store into this
+        // function's body hit region slot -1 generation -1 -- closures miscompiled
+        // to a refused build on any Madaros built after the arena landing.
+        if (*lo.current_func).region.slot < 0 { ir_function_alloc_region(&! (*lo.current_func)) }
         (*lo.current_func).name = closure_name
         lo.current_func_loaded = true
         lo.locals = lowerer_box_empty_locals()

--- a/tests/witness_matrix/cases/w16_hof_capturing_closure.sio
+++ b/tests/witness_matrix/cases/w16_hof_capturing_closure.sio
@@ -1,0 +1,19 @@
+// WITNESS w16 -- NEW FINDING 2026-08-15, discovered while fixing w5/w14.
+// FACTS: a capturing closure called DIRECTLY (let g = |x,y| (x+y)*scale; g(2,5))
+//        computes correctly. The SAME capture, passed as an argument to a
+//        higher-order function and called THROUGH the fn-pointer parameter,
+//        silently drops the captured value from the computation.
+// This was masked until 2026-08-15: main.sio/lower.sio's IR-arena landing left
+// the closure-lowering path (lower_closure_expr_ref) without a region
+// allocation, so ANY closure hit "IR arena contract violated" and the build
+// was correctly refused before this deeper bug could ever run. Fixing the
+// arena omission (lower.sio, closure_fn region alloc) unmasked this.
+// EXPECT: exit 130 (5*6 + 100). GOT (2026-08-15, Madaros post-arena-fix): 30
+// (5*6, bias silently dropped) -- a SILENT MISCOMPILE, not a crash or reject.
+fn apply2(f: fn(i64, i64) -> i64, a: i64, b: i64) -> i64 with Mut, Panic, Div {
+    f(a, b)
+}
+fn main() -> i64 with Mut, Panic, Div {
+    let bias = 100
+    apply2(|x: i64, y: i64| x * y + bias, 5, 6)
+}

--- a/tests/witness_matrix/run.sh
+++ b/tests/witness_matrix/run.sh
@@ -36,21 +36,28 @@ OPEN_IDS=""
 # declared open ONLY by exact id + reason below. The gate fails if the actual
 # open set differs from this set in ANY direction -- new opens, or a declared
 # residual silently starting to pass (promotion must be witnessed, not assumed).
-DECLARED_OPEN="w5 w14"
-# w5 and w14 are BOTH open, ONLY on a Madaros built fresh from current
-# main.sio source (not on the checked-in prebuilt bin/madaros-linux-x86_64,
-# which predates them and which run_value's default "souc compile" resolves
-# to -- so the default invocation of this script never exercises either).
-# w5:  closure-capture path fails codegen (M2 320f4d2352 origin).
-# w14: --native-v2-emit-scalar fails with "IR instruction arena contract
-#      violated (invalid handle) on region slot -1 generation -1".
-# Confirmed 2026-08-15 on a raw ELF (no souc/madaros wrapper, no
-# MADAROS_STACK_KB involved) and on a same-day rebuild (not staleness).
-# Both surfaced together on the first fresh-from-source run this script was
-# ever given -- consistent with (not yet proven to be) one arena-contract
-# defect manifesting on two distinct native-v2 entry points. Tracked here so
-# neither can be silently reintroduced, silently fixed, or silently merged
-# under "fixed" without the fix actually being witnessed.
+DECLARED_OPEN="w16"
+# w5 and w14 were open 2026-08-14/15 on a Madaros built fresh from current
+# main.sio source: ir_empty_function() leaves its region unallocated by
+# design (see ir_function_alloc_region's comment in ir.sio), and both the
+# --native-v2-emit-{scalar,call,call5,call6} witness-harness builders in
+# main.sio (38 call sites across the file) AND lower_closure_expr_ref in
+# lower.sio (the real closure-lowering path) were never given the
+# allocation call when the arena landed -- every one of them hit "IR
+# instruction arena contract violated ... region slot -1 generation -1".
+# FIXED in the same commit that removed them from this list: main.sio gained
+# the missing ir_function_alloc_region call at all 38 sites; lower.sio's
+# closure path gained the same guard used by every other real-function
+# lowering entry point. Verified by running: all four --native-v2-emit-*
+# probes emit correct-value ELFs, and w5's no-capture closure compiles and
+# runs to 42.
+#
+# w16 is a DIFFERENT, newly-discovered defect the arena bug had been masking
+# (fail-closed hid it): a capturing closure called DIRECTLY computes
+# correctly, but the SAME capture passed as an argument to a higher-order
+# function and called through the fn-pointer parameter silently drops the
+# captured value -- a real silent miscompile, not a crash or reject. Left
+# open and undisguised rather than folded into "closures are fixed."
 
 run_value() {
   id="$1"; file="$2"; want="$3"; wrong="$4"; origin="$5"
@@ -158,6 +165,7 @@ run_value w4b "$CASES/w4b_f32_roundtrip.sio"             150 100 "ROOT CAUSE of 
 run_value w7b "$CASES/w7b_enum_reverse.sio"                1   2 "CONTROL (passes at baseline): a table reorder must not break Shape"
 run_value w11 "$CASES/w11_float_literal_f32.sio"          12  99 "float literal coercion to f32 (contextual + operator)"
 run_value w15 "$CASES/w15_field_triple_collision.sio"     42  99 "soundness-3 BUG C residue: 3-field same-first-letter collision"
+run_value w16 "$CASES/w16_hof_capturing_closure.sio"     130  30 "NEW 2026-08-15: capturing closure via HOF fn-pointer drops the capture"
 run_reject w12 "$CASES/w12_nonliteral_must_reject.sio" "CARDINAL: only literals coerce"
 run_reject w13 "$CASES/w13_magnitude_must_reject.sio" "CARDINAL: magnitude guard on f32 narrowing"
 run_mm    w9  42 "release wall 8765ca1dc4"


### PR DESCRIPTION
## Summary

Tier 1 items 2/4 of the launch-readiness plan. Two real fixes to the same class of omission, found by attribution rather than assumption:

1. **`self-hosted/compiler/main.sio`** — 38 internal `--native-v2-emit-*` witness-harness module builders (scalar, call, call5, call6, str_len, fnptr, multi_call, control, arith, str_eq, strconcat_*, ...) build an `IrFunction` via `ir_empty_function()` and immediately write instructions through the arena, but `ir_empty_function()` deliberately leaves its region unallocated (see `ir_function_alloc_region`'s own comment in `ir.sio` for why). None of these 38 call sites were given the allocation call every real lowering entry point already has. All of them hit `IR instruction arena contract violated ... region slot -1 generation -1` on a Madaros built from current source — never on the older checked-in prebuilt, which predates them.

2. **`self-hosted/ir/lower.sio`** — `lower_closure_expr_ref`, the real closure-lowering path used by `souc compile` (not a witness harness), has the identical omission. Any closure hit the same arena violation and the compiler correctly refused to emit a binary.

Root-caused via one grep comparing the working `sret` path to the failing `scalar`/`call` paths, not a deep investigation — this was almost shipped as "the arena is systemically broken," caught by running a discriminator first.

## What this unmasked

Fixing the fail-closed arena block surfaced a **third, distinct, real silent miscompile** (`w16`): a capturing closure called directly computes correctly, but the same capture passed as an argument to a higher-order function and invoked through the fn-pointer parameter silently drops the captured value (`5*6+100` → `30`, not `130`). This is a separate defect this PR does not attempt to fix — added as an open, undisguised witness (`w16`) rather than folded into "closures are fixed."

`tests/witness_matrix/run.sh`'s `DECLARED_OPEN` was `[w5 w14]`; both verified CLOSED and removed, `w16` added in their place.

## Test plan
- [x] All four fixed `--native-v2-emit-*` probes produce ELFs that execute to the documented correct value (42/6/31/63)
- [x] w5's no-capture closure witness compiles and runs to 42
- [x] `madaros_full_gate.sh` and `madaros_source_to_elf_gate.sh` both pass end-to-end against a from-source Madaros build
- [x] Full witness matrix: 20/21, residual matches declared `[w16]` exactly
- [x] Regression check: `scripts/run_sio_test_suite.sh closure` gives byte-identical pass/fail/skip counts against both the pre-fix and post-fix builds — the 10 pre-existing closure-suite failures are unrelated to this change
- [ ] CI (will build Madaros from this PR's own source and run the witness matrix against it — the real end-to-end validation of this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)