### PR TITLE
ci: run the two Madaros gates against the fresh build too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,6 +583,14 @@ jobs:
         env:
           MADAROS_RAW_BIN: /tmp/madaros-ci.elf
         run: bash tests/witness_matrix/run.sh ./bin/souc /tmp/madaros-ci.elf
+      - name: Madaros full gate against the fresh build
+        env:
+          MADAROS_RAW_BIN: /tmp/madaros-ci.elf
+        run: bash scripts/ci/madaros_full_gate.sh
+      - name: Madaros source-to-ELF gate against the fresh build
+        env:
+          MADAROS_RAW_BIN: /tmp/madaros-ci.elf
+        run: bash scripts/ci/madaros_source_to_elf_gate.sh
 
   sounio-lint:
     name: Sounio Lint


### PR DESCRIPTION
## Summary

Tier 1 item 2, closing it. `madaros_full_gate.sh` and `madaros_source_to_elf_gate.sh` previously only ran (non-blocking, `::warning::`-swallowed) in the scheduled `madaros-prebuilt-refresh.yml` against the checked-in prebuilt. Wiring them blocking against a from-source build was deliberately deferred in #1739 until the scalar42 arena-contract failure they'd hit was attributed rather than papered over with a residual entry.

That attribution and fix landed in #1741. Both gates now pass end-to-end against a Madaros built fresh from current source. This PR adds them as two more steps in the existing `madaros-witness-gate` CI job (already building Madaros from source for the witness matrix), so they get the same fresh-build treatment for free.

## Test plan
- [x] Verified locally with the exact `MADAROS_RAW_BIN` invocation these new steps use, against a from-source build: both gates PASS
- [x] `bash scripts/ci/impact_ci_selftest.sh` — no fixture changes needed (this only adds steps to an existing job, no new job name)
- [ ] CI (will run both gates for real against a from-source build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)