### PR TITLE
fix(docs): correct an unsupported regression-check claim, add w17

### DIFF
--- a/.claude/AGENT_HANDOFF.md
+++ b/.claude/AGENT_HANDOFF.md
@@ -33,6 +33,21 @@
 > `echo $SOUNIO_STDLIB_PATH` and confirm it points at *this* worktree's
 > `stdlib/`, or `unset SOUNIO_STDLIB_PATH` and pass it explicitly per-command.
 
+> **⚠️ SOUC_BIN does the SAME thing, for the compiler binary itself
+> (2026-08-15).** The pod also exports `SOUC_BIN=/workspace/sounio/bin/souc`
+> globally. `scripts/lib/resolve_souc.sh`'s `_sounio_resolve_bin()` honors a
+> pre-set `SOUC_BIN` before it ever tries `$ROOT_DIR/bin/souc` relative to the
+> script's own location — so `scripts/run_sio_test_suite.sh` (and anything
+> else that sources `resolve_souc.sh`) silently runs against the SHARED
+> checkout's compiler from a worktree, regardless of `MADAROS_RAW_BIN`. This
+> one is more dangerous than the stdlib-path trap because it fails silently
+> with plausible-looking numbers rather than an obvious "file not found": a
+> regression check can report "identical results before/after" while never
+> having touched your build at all (caught this session — see
+> `CAMINHO_CRITICO_CORTADO_2026-08-14.md`'s 2026-08-15 update, which corrects
+> an already-landed commit's unsupported claim). `unset SOUC_BIN` before any
+> regression check in a worktree, alongside `SOUNIO_STDLIB_PATH`.
+
 ---
 
 ## LANE CLAIM + ownership-conflict — 2026-08-06

--- a/docs/serious-language/CAMINHO_CRITICO_CORTADO_2026-08-14.md
+++ b/docs/serious-language/CAMINHO_CRITICO_CORTADO_2026-08-14.md
@@ -195,3 +195,40 @@ não é decisão de arquitetura de CI sobre 50 arquivos -- é uma nota de opera�
 para agentes em worktree, que devem sempre setar `SOUNIO_STDLIB_PATH`
 explicitamente para o próprio worktree (ou rodar `unset SOUNIO_STDLIB_PATH`
 antes de qualquer `souc`/gate) em vez de confiar no fallback do script.
+
+### ATUALIZAÇÃO 2026-08-15 — a MESMA armadilha existe para `SOUC_BIN`, e ela
+### invalidou uma alegação já publicada num commit
+
+O commit `751e495b2c` (fix do arena de IR, mergeado via PR #1741) alegou:
+*"Regression-checked: `scripts/run_sio_test_suite.sh closure` gives
+byte-identical pass/fail/skip counts against both the pre-fix and post-fix
+builds."* Essa alegação está **sem sustentação pelo método descrito** --
+medido depois, não antes de publicar, o que é exatamente o tipo de erro que
+uma auditoria adversarial pega.
+
+`SOUC_BIN` vem exportado globalmente no pod interativo (`SOUC_BIN=/workspace/sounio/bin/souc`),
+e `scripts/lib/resolve_souc.sh`'s `_sounio_resolve_bin()` respeita uma
+`SOUC_BIN` pré-setada ANTES de tentar `$ROOT_DIR/bin/souc` do próprio
+worktree. Resultado: a suíte `closure` nunca rodou contra o binário
+corrigido desta sessão -- rodou contra o `bin/souc` do checkout
+compartilhado o tempo todo, independente de `MADAROS_RAW_BIN`. Os números
+"idênticos" antes/depois não provavam ausência de regressão; provavam que a
+suíte não tinha testado a mudança.
+
+Refeito com `unset SOUC_BIN` (e `MADAROS_RAW_BIN` apontando para o build do
+worktree): baseline pré-fix tinha 16 falhas na suíte `closure`; pós-fix tem
+15 -- **duas** falhas resolvidas de verdade (`closure_basic.sio`,
+`closure_effect_transparent_hof.sio`, ambas o caso simples que w5 testemunha)
+e **um** achado novo, não uma regressão: `closure_effect_escape.sio` estava
+"passando" (rejeitado corretamente) pelo motivo ERRADO -- o lowering
+crashava no mesmo bug de arena antes de alcançar o vazamento de efeito real
+que o teste pretende verificar. `souc check` nesse arquivo hoje retorna
+`check: OK`; o verificador de efeitos não pega o vazamento de `IO` através
+de uma HOF sem anotação. Gap pré-existente em `self-hosted/check/`, não
+relacionado ao fix de lowering, documentado como `w17` (não corrigido).
+
+Lição: `SOUNIO_STDLIB_PATH` não é o único var de ambiente do pod que
+sombreia um worktree -- `SOUC_BIN` faz o mesmo, e é mais perigoso porque
+seu efeito é silencioso (a suíte roda, dá números, só que sobre o binário
+errado). Antes de qualquer checagem de regressão neste pod: `unset SOUC_BIN
+SOUNIO_STDLIB_PATH` primeiro.

--- a/tests/witness_matrix/cases/w17_effect_leak_via_hof.sio
+++ b/tests/witness_matrix/cases/w17_effect_leak_via_hof.sio
@@ -1,0 +1,25 @@
+// WITNESS w17 -- NEW FINDING 2026-08-15, discovered while regression-checking
+// the w5/w14 arena fix against tests/compile-fail/closure_effect_escape.sio.
+// FACTS: an IO-effect closure passed to an unannotated (non-IO) HOF, called
+// from a pure (no-IO) function, should be a compile error -- the HOF is
+// effect-transparent, so it propagates the closure's IO effect to the call
+// site, and pure_fn() never declared IO. This is exactly
+// tests/compile-fail/closure_effect_escape.sio's own stated intent
+// (`//@ compile-fail`).
+// It "passed" (correctly rejected) before 2026-08-15 for the WRONG reason:
+// compilation crashed during IR lowering on the SAME arena-region omission
+// this session fixed (see w5/w14/lower_closure_expr_ref), before it ever
+// reached this file's actual effect-leak. `souc check` on this exact file
+// now returns "check: OK" -- the effect checker does not catch it. A
+// pre-existing gap, unrelated to the arena fix, unmasked by it.
+// EXPECT: REJECT (a type/effect error). GOT (2026-08-15): accepted.
+fn map_apply(f: fn(i64) -> i64, x: i64) -> i64 { f(x) }
+
+fn pure_fn() -> i64 {
+    map_apply(|x: i64| -> i64 { print("io\n"); x }, 5)
+}
+
+fn main() -> i32 with IO {
+    let r = pure_fn()
+    0
+}

--- a/tests/witness_matrix/run.sh
+++ b/tests/witness_matrix/run.sh
@@ -36,7 +36,7 @@ OPEN_IDS=""
 # declared open ONLY by exact id + reason below. The gate fails if the actual
 # open set differs from this set in ANY direction -- new opens, or a declared
 # residual silently starting to pass (promotion must be witnessed, not assumed).
-DECLARED_OPEN="w16"
+DECLARED_OPEN="w16 w17"
 # w5 and w14 were open 2026-08-14/15 on a Madaros built fresh from current
 # main.sio source: ir_empty_function() leaves its region unallocated by
 # design (see ir_function_alloc_region's comment in ir.sio), and both the
@@ -58,6 +58,15 @@ DECLARED_OPEN="w16"
 # function and called through the fn-pointer parameter silently drops the
 # captured value -- a real silent miscompile, not a crash or reject. Left
 # open and undisguised rather than folded into "closures are fixed."
+#
+# w17 is a SECOND thing the arena bug's fail-closed had been masking: the
+# effect checker does not catch an IO-effect closure passed to an
+# unannotated HOF and called from a pure function (checked:
+# tests/compile-fail/closure_effect_escape.sio itself, which had been
+# "passing" -- correctly rejected -- for the wrong reason: lowering crashed
+# on the arena bug before it ever reached this file's actual effect leak).
+# `souc check` on that file returns "check: OK" post-fix. Pre-existing gap
+# in self-hosted/check/, unrelated to the IR-lowering fix, not attempted.
 
 run_value() {
   id="$1"; file="$2"; want="$3"; wrong="$4"; origin="$5"
@@ -168,6 +177,7 @@ run_value w15 "$CASES/w15_field_triple_collision.sio"     42  99 "soundness-3 BU
 run_value w16 "$CASES/w16_hof_capturing_closure.sio"     130  30 "NEW 2026-08-15: capturing closure via HOF fn-pointer drops the capture"
 run_reject w12 "$CASES/w12_nonliteral_must_reject.sio" "CARDINAL: only literals coerce"
 run_reject w13 "$CASES/w13_magnitude_must_reject.sio" "CARDINAL: magnitude guard on f32 narrowing"
+run_reject w17 "$CASES/w17_effect_leak_via_hof.sio" "NEW 2026-08-15: IO effect leaks through an unannotated HOF, uncaught"
 run_mm    w9  42 "release wall 8765ca1dc4"
 run_reject w10 "$CASES/mm/prog2.sio" "import typecheck bypass e1ac6f7c87"
 run_scalar_emit w14 42 "IR arena contract violated on native-v2-emit-scalar (fresh source build only) 2026-08-15"


### PR DESCRIPTION
## Summary

Follow-up to #1741. The prior commit claimed a byte-identical `closure` test-suite run before/after the arena-region fix proved no regression. It didn't: `SOUC_BIN` is exported globally in this pod's interactive sessions, and `resolve_souc.sh` honors a pre-set `SOUC_BIN` before trying the worktree-local `bin/souc` — the regression check never actually ran against the fixed binary. Same shape of trap as the already-documented `SOUNIO_STDLIB_PATH` one, but silent (plausible numbers, wrong binary) rather than an obvious path error.

Redone correctly (`unset SOUC_BIN`): pre-fix baseline has 16 closure-suite failures, post-fix has 15.
- Two real fixes confirmed: `closure_basic.sio`, `closure_effect_transparent_hof.sio` (both the simple no-capture case `w5` already witnesses).
- One new item, not a regression: `closure_effect_escape.sio` had been "passing" (correctly rejected) for the wrong reason — lowering crashed on the arena bug before ever reaching the effect leak the test exists to catch. `souc check` on that file now returns `check: OK`; the effect checker doesn't catch an `IO`-effect closure leaking through an unannotated HOF from a pure function. Pre-existing gap in `self-hosted/check/`, unrelated to the lowering fix, not attempted — added as `w17` (a `REJECT` witness, currently `OPEN-ACCEPTS-ILLTYPED`).

`DECLARED_OPEN` is now `"w16 w17"`; the gate still passes with residuals matching exactly.

Also documents the `SOUC_BIN` trap in `.claude/AGENT_HANDOFF.md` alongside `SOUNIO_STDLIB_PATH`'s, and the correction + method in `CAMINHO_CRITICO_CORTADO_2026-08-14.md`, so the earlier unsupported claim doesn't stand uncorrected in the tree.

## Test plan
- [x] `unset SOUC_BIN; MADAROS_RAW_BIN=<fresh build> bash tests/witness_matrix/run.sh ./bin/souc <fresh build>` — 20/22, residuals match `[w16 w17]` exactly
- [x] Confirmed `SOUC_BIN` resolution directly (`source scripts/lib/resolve_souc.sh; sounio_require_souc; echo $SOUC_BIN`) before and after `unset`
- [ ] CI (will build Madaros from source and run the witness matrix, exercising w17 for real)

🤖 Generated with [Claude Code](https://claude.com/claude-code)