### PR TITLE
fix(examples): declare Mut effects sedenion Hessian demo needs

### DIFF
--- a/examples/sedenion_hessian_brain_demo.sio
+++ b/examples/sedenion_hessian_brain_demo.sio
@@ -66,7 +66,7 @@ fn sed_norm_sq(a: Sed) -> f64 {
     a.e12*a.e12 + a.e13*a.e13 + a.e14*a.e14 + a.e15*a.e15
 }
 
-fn hc_sqrt(x: f64) -> f64 {
+fn hc_sqrt(x: f64) -> f64 with Mut, Div {
     if x <= 0.0 { return 0.0 }
     var y = x
     var i = 0
@@ -76,7 +76,7 @@ fn hc_sqrt(x: f64) -> f64 {
 
 fn hc_abs(x: f64) -> f64 { if x < 0.0 { 0.0 - x } else { x } }
 
-fn sed_norm(a: Sed) -> f64 { hc_sqrt(sed_norm_sq(a)) }
+fn sed_norm(a: Sed) -> f64 with Mut, Div { hc_sqrt(sed_norm_sq(a)) }
 
 // ============================================================================
 // CAYLEY-DICKSON MULTIPLICATION (full recursive: C -> H -> O -> S)
@@ -195,7 +195,7 @@ fn sed_get(s: Sed, i: i32) -> f64 {
 }
 
 // Set component i of a sedenion
-fn sed_set(s: Sed, i: i32, val: f64) -> Sed {
+fn sed_set(s: Sed, i: i32, val: f64) -> Sed with Mut {
     var r = s
     if i == 0 { r.e0 = val }
     if i == 1 { r.e1 = val }
@@ -339,7 +339,7 @@ fn eigenvalues_16(M_in: [f64; 256]) -> [f64; 16] with Mut, Div, Panic {
 // ============================================================================
 
 // Normalize a sedenion to unit norm
-fn sed_normalize(s: Sed) -> Sed {
+fn sed_normalize(s: Sed) -> Sed with Mut, Div {
     let n = sed_norm(s)
     if n < 1.0e-15 { return s }
     let inv = 1.0 / n
@@ -347,7 +347,7 @@ fn sed_normalize(s: Sed) -> Sed {
 }
 
 // Scale to a target norm
-fn sed_to_norm(s: Sed, target: f64) -> Sed {
+fn sed_to_norm(s: Sed, target: f64) -> Sed with Mut, Div {
     let n = sed_norm(s)
     if n < 1.0e-15 { return s }
     sed_scale(s, target / n)

--- a/examples/sedenion_hessian_brain_demo.sio
+++ b/examples/sedenion_hessian_brain_demo.sio
@@ -66,7 +66,7 @@ fn sed_norm_sq(a: Sed) -> f64 {
     a.e12*a.e12 + a.e13*a.e13 + a.e14*a.e14 + a.e15*a.e15
 }
 
-fn hc_sqrt(x: f64) -> f64 with Mut, Div {
+fn hc_sqrt(x: f64) -> f64 with Mut {
     if x <= 0.0 { return 0.0 }
     var y = x
     var i = 0
@@ -76,7 +76,7 @@ fn hc_sqrt(x: f64) -> f64 with Mut, Div {
 
 fn hc_abs(x: f64) -> f64 { if x < 0.0 { 0.0 - x } else { x } }
 
-fn sed_norm(a: Sed) -> f64 with Mut, Div { hc_sqrt(sed_norm_sq(a)) }
+fn sed_norm(a: Sed) -> f64 with Mut { hc_sqrt(sed_norm_sq(a)) }
 
 // ============================================================================
 // CAYLEY-DICKSON MULTIPLICATION (full recursive: C -> H -> O -> S)
@@ -339,7 +339,7 @@ fn eigenvalues_16(M_in: [f64; 256]) -> [f64; 16] with Mut, Div, Panic {
 // ============================================================================
 
 // Normalize a sedenion to unit norm
-fn sed_normalize(s: Sed) -> Sed with Mut, Div {
+fn sed_normalize(s: Sed) -> Sed with Mut {
     let n = sed_norm(s)
     if n < 1.0e-15 { return s }
     let inv = 1.0 / n
@@ -347,7 +347,7 @@ fn sed_normalize(s: Sed) -> Sed with Mut, Div {
 }
 
 // Scale to a target norm
-fn sed_to_norm(s: Sed, target: f64) -> Sed with Mut, Div {
+fn sed_to_norm(s: Sed, target: f64) -> Sed with Mut {
     let n = sed_norm(s)
     if n < 1.0e-15 { return s }
     sed_scale(s, target / n)


### PR DESCRIPTION
## Summary

Cherry-picked from `origin/fix/sedenion-hessian-effects-20260726` (2 commits, identified in the branch audit at `docs/audit/BRANCH_AUDIT_2026-08-15.md` as "cherry-pick").

`examples/sedenion_hessian_brain_demo.sio` is missing `with Mut` effect annotations on 5 helpers (`hc_sqrt`, `sed_norm`, `sed_set`, `sed_normalize`, `sed_to_norm`) that call/are called by mutating code — main's copy fails typecheck under `lean_single`.

## Test plan
- [x] Confirmed the failure on main before the cherry-pick: `SOUNIO_SOUC_ENGINE=lean_single ./bin/souc check examples/sedenion_hessian_brain_demo.sio` → 9× "effect not declared in function signature" (lines 207-215)
- [x] Clean cherry-pick, no conflicts
- [x] After: `lean_single` check passes, compiles to a real ELF
- [x] `./bin/souc check` (default Madaros) also passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)