### PR TITLE
fix(madaros): canonicalize missing env strings

### DIFF
--- a/self-hosted/io/env.sio
+++ b/self-hosted/io/env.sio
@@ -18,8 +18,10 @@ pub fn read_env(key: string) -> string with IO, Mut, Div, Panic {
     // guards against a pathological missing terminator.
     let data = read_file(env_path)
     let key_len = str_len(key)
+    var out: [i8; 512] = [0; 512]
+    var out_len: i64 = 0
     if key_len <= 0 {
-        return ""
+        return str_from_bytes(out, out_len)
     }
     var size: i64 = 0
     while size < 1048576 {
@@ -29,7 +31,7 @@ pub fn read_env(key: string) -> string with IO, Mut, Div, Panic {
         size = size + 1
     }
     if size <= 0 {
-        return ""
+        return str_from_bytes(out, out_len)
     }
 
     var i: i64 = 0
@@ -55,8 +57,6 @@ pub fn read_env(key: string) -> string with IO, Mut, Div, Panic {
                 value_end = value_end + 1
             }
 
-            var out: [i8; 512] = [0; 512]
-            var out_len: i64 = 0
             var k = value_start
             while k < value_end && out_len < 512 {
                 out[out_len as usize] = data[k as usize]
@@ -71,5 +71,5 @@ pub fn read_env(key: string) -> string with IO, Mut, Div, Panic {
         }
         i = i + 1
     }
-    ""
+    str_from_bytes(out, out_len)
 }


### PR DESCRIPTION
## Summary

Cherry-picked the real fix from `origin/work/madaros-env-cache-rootfix-codex`'s tip commit (identified in `docs/audit/BRANCH_AUDIT_2026-08-15.md` as "cherry-pick"; the branch's other 144 commits are already on main under different SHAs).

`self-hosted/io/env.sio`'s `read_env()` returned a bare `""` literal on its two early-exit paths but `str_from_bytes(out, out_len)` on the successful match path — missing keys got a different string representation than the successful-match case. Routes all three return paths through the same buffer.

**Dropped from this cherry-pick**: the source commit's `madaros_read_env_absence_gate.sh` + its `madaros_full_gate.sh` wiring. That gate greps compiler stdout for `souc-lean check-merged: begin/verdict-ready/ok` after invoking `self-hosted/compiler/lean.sio` with a `--check-merged` flag — neither the flag nor those log lines exist anywhere in the current tree (`lean.sio` only has `--check` now). The gate is stale relative to current main's compiler CLI surface and would fail as committed; wiring it needs someone to first work out what `--check-merged` became — a separate task.

## Test plan
- [x] Built Madaros fresh from source with this change (`scripts/ci/build_modular_madaros.sh`) — compiles clean
- [x] `./bin/souc check self-hosted/io/env.sio` passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)