### PR TITLE
docs(madaros): wave-1 planning tranche — MIR port route, MLI design, preflight review, payload census

### DIFF
--- a/docs/architecture/MIR_PORT_PLAN.md
+++ b/docs/architecture/MIR_PORT_PLAN.md
@@ -2,18 +2,26 @@
 topic_id: repo.docs.architecture.mir-port-plan
 authority: repo_only
 audience: users
-last_validated: 2026-03-07
-validated_by: A2
+last_validated: 2026-08-16
+validated_by: grok-cli1
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.architecture.mir-port-plan
 -->
 
 # MIR Port Plan — WS-C route study
 
-**Status:** route recommendation for founder decision (wave 1, read-only study).  
-**Author:** grok-cli1 (`ws-c-mir-study`), 2026-08-16.  
+**Status:** Route B **approved** (founder, 2026-08-16). This document is the
+port plan + preflight amendments from
+`docs/architecture/WS_C_D_PREFLIGHT_REVIEW_2026-08-16.md` (fable-1). Route B is
+**not** re-litigated; the amendments make PR1–PR2 land at the stated cost.  
+**Author:** grok-cli1 (`ws-c-mir-study` / `amend-mir-port-plan`), 2026-08-16.  
 **Plan context:** `docs/internal/coordination/MADAROS_FOCUS_PLAN_2026-08-16.md` §WS-C.  
 **Frontier worktree:** `/workspace/.wt/mir-study` → `origin/canon/madaros-v2-sota` @ `97b5259497`.  
-**Constraint:** this study did **not** edit `self-hosted/` on main; only this doc is the write product.
+**Constraint (study):** did **not** edit `self-hosted/` on main; this file is the write product.
+
+**Preflight amendments folded (2026-08-16):** C2 (BASE_REF re-anchor), C4
+(Madaros parse + dual receipt), C5 (`loop_closed` semantic fix), C6 (WS-B
+ordering vs ENIR serialisation). C1 payload census → see §6.1 /
+`docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md`.
 
 ---
 
@@ -25,23 +33,26 @@ A real ENIR→MIR pipeline already exists on the frontier tip and **still builds
 |---|---|
 | Tip SHA | `97b525949765980406a4fefa7f533e9db89721e1` (`feat(c2): emit first divergence receipt (#837)`) |
 | `self-hosted/enir/` | 14 modules, **7310** LOC |
-| Seed compile `enir/driver.sio` | ELF produced (`/tmp/mir-study-enir/madaros-enir`, ~1.4 MiB) under `souc-lean-single` + build lock |
+| Seed compile `enir/driver.sio` | ELF produced under `souc-lean-single` + build lock; **reconfirmed under current main seed** by fable-1 preflight |
 | `madaros-enir emit` | Exit 0; canonical ENIR artifact ~2053 bytes |
 | Production wiring | Explicitly **not** imported by production codegen (`enir/mod.sio` banner) |
+| Madaros v0.80.0 check | **Fails** on `mir_join.sio` (C4) until rewrite; other 13 enir files parse clean |
 
 **Measured divergence** (do not use the swapped wording in an early draft of the focus plan):
 
 ```text
 merge-base(origin/main, frontier) = a930c8ac72
 commits only on frontier (main..frontier):  189
-commits only on main     (frontier..main): 2086
+commits only on main     (frontier..main): 2086+  (main still moving)
 ```
 
 | Route | Effort (order) | Risk | Recommendation |
 |---|---:|---|---|
-| **B · `enir/` subtree cherry-pick + resume lettered plan** | 1–2 weeks to green gates on main; then multi-week letter resume | **Lowest** | **Recommended default** |
-| **C · Fresh re-derivation from MIR_* + EISA docs** | multi-month | Medium–high scope | Only if A/B prove hostile |
+| **B · `enir/` subtree cherry-pick + resume lettered plan** | 1–2 weeks to green gates on main **after** PR1/PR2 preflight items below; then multi-week letter resume | **Lowest** | **Approved default** |
+| **C · Fresh re-derivation from MIR_* + EISA docs** | multi-month | Medium–high scope | Only if B fails bounded repair budget |
 | **A · Wholesale rebase of frontier onto main** | multi-week conflict storm | **Highest** | Reject as primary |
+
+**Route B isolation claim survives adversarial re-measurement** (fable-1, 2026-08-16): all 36 `use` lines in enir are `enir::*`; both-sides conflict surface unchanged; driver builds under *current main* seed.
 
 ---
 
@@ -59,7 +70,7 @@ commits only on main     (frontier..main): 2086
 | `qd.sio` | qd128 arithmetic (E2E/E2F+) |
 | `mir.sio` | Semantic MIR (E3A+) |
 | `mir_cfg.sio` | CFG / Memory-SSA (E3C) |
-| `mir_join.sio` | Multi-pred join MIR (E3D) |
+| `mir_join.sio` | Multi-pred join MIR (E3D) — **Madaros parse break, §4.3** |
 | `driver.sio` | CLI: emit / verify / roundtrip / lower / run / MIR cmds |
 | `mod.sio` | Public boundary; **not** production codegen |
 
@@ -67,7 +78,7 @@ commits only on main     (frontier..main): 2086
 
 ### 2.2 Lettered plan state (implementation, not the four MIR_* research PDFs)
 
-Normative narrative: `docs/architecture/MADAROS_V2_EISA_SEMANTIC_IR.md` (frontier-only on main tree; **absent** from `origin/main`).
+Normative narrative: `docs/architecture/MADAROS_V2_EISA_SEMANTIC_IR.md` (frontier-only; **absent** from `origin/main` at study time).
 
 | Stage | Status at 97b525949 | Gate script |
 |---|---|---|
@@ -92,17 +103,18 @@ Present on **both** tips (with main-side churn). They are **research / Cranelift
 
 A “re-derive from the 4 MIR_* docs” route would **not** reconstruct the E1–E3D executable gates without also re-deriving `MADAROS_V2_EISA_SEMANTIC_IR.md` and the gate/Python verifiers.
 
-### 2.4 Build evidence (this session)
+### 2.4 Build evidence
 
 ```text
 worktree: /workspace/.wt/mir-study @ 97b525949
-seed:     bin/souc-lean-single-x86_64
-cmd:      scripts/dev/souc-build-lock.sh <seed> self-hosted/enir/driver.sio /tmp/mir-study-enir/madaros-enir
-result:   ELF written; driver emit OK
-note:     seed log showed E200 `loop_closed` at line 529 (non-fatal under this seed path); ELF still emitted
+seed:     bin/souc-lean-single-x86_64 (frontier and current-main seeds both produce ELF)
+cmd:      scripts/dev/souc-build-lock.sh <seed> self-hosted/enir/driver.sio <out>
+result:   ELF written; driver emit OK (~2053 B artifact)
+note:     seed path logs E200 `loop_closed` — see §4.4 (semantic, not noise)
+Madaros:  souc check fails on mir_join.sio lines 476–489 — see §4.3
 ```
 
-Full E1–E3D gate matrix was **not** re-run end-to-end in wave 1 (Python-heavy + multi-hour). Build+emit is the hard existence proof requested for “still builds at 97b525949”.
+Full E1–E3D gate matrix was **not** re-run end-to-end in wave 1 (Python-heavy + multi-hour). Build+emit is the hard existence proof for “still builds at 97b525949”.
 
 ---
 
@@ -113,10 +125,10 @@ Full E1–E3D gate matrix was **not** re-run end-to-end in wave 1 (Python-heavy 
 | Direction | Count | Meaning |
 |---|---:|---|
 | `origin/main..frontier` | **189** | Frontier-only commits (main lacks) |
-| `frontier..origin/main` | **2086** | Main-only commits (frontier lacks) |
+| `frontier..origin/main` | **2086+** | Main-only commits (frontier lacks; tip still moves) |
 | Merge-base | `a930c8ac72` | `docs(governance): register tuple-let-desugar audit doc` |
 
-**Correction to focus-plan wording:** an early draft swapped these numbers. **Main is the long tip; frontier is a short divergent lobe (~189 commits) with the ENIR lane.**
+**Correction to early focus-plan wording:** those drafts swapped these numbers. **Main is the long tip; frontier is a short divergent lobe (~189 commits) with the ENIR lane.**
 
 ### 3.2 Tree-level
 
@@ -143,7 +155,7 @@ Highest main-side churn on shared hot files (numstat lines since merge-base):
 | `self-hosted/native/codegen_x86_linux.sio` | ~3906 | ~1211 |
 | `self-hosted/ir/ir.sio` | ~2121 | ~122 |
 
-**None of these are required imports of `enir/`.** They matter only for routes that replay frontier *compiler* history or re-open production IR.
+**None of these are required imports of `enir/`.** They matter only for routes that replay frontier *compiler* history or re-open production IR. They **do** matter for gate frozen-surface checks (§4.2).
 
 ### 3.4 Frontier-only ENIR-related commit set
 
@@ -165,84 +177,233 @@ b4142c83cb test(enir): distinguish equal values by event receipt  # E3E
 
 ---
 
-## 4. Route costings
+## 4. Preflight amendments (Route B, approved — implementation detail)
+
+Findings from `docs/architecture/WS_C_D_PREFLIGHT_REVIEW_2026-08-16.md`. None overturn Route B.
+
+### 4.1 C1 · Gate payload files (PR1/PR2 inventory)
+
+E-gates hard-reference frontier-only oracle/fixture files under `tools/eisa/`
+(~23 files measured missing on main: `eisa_enir_v1_oracle.sio`,
+`eisa_enir_v1_loop_oracle.sio`, and ~21 `eisa_enir_v1_*/v2_*.eisa` fixtures).
+
+**Canonical census (when landed):** `docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md`
+(codex-2, lane for C1 enumeration).
+
+> **PLACEHOLDER — C1 census not yet present on this branch.**  
+> When `WS_C_PR1_PAYLOAD_CENSUS.md` lands, fold its file counts and per-gate
+> transitive lists into §6 PR1/PR2 acceptance. Until then, PR1 **must not**
+> open without either that census or an equivalent measured
+> `comm -23` of `tools/eisa` frontier→main.
+
+Also flag (preflight C3, not expanded here): shared oracles
+(`tools/eisa/eisa_evm_run.sio`, `stdlib/math/qd128.sio`, `stdlib/eisa/`) have
+**drifted** on main; WS-F (EISA Madaros port) collocates on the same surface —
+coord claim boundary before PR2+.
+
+### 4.2 C2 · BASE_REF re-anchoring decision (PR2 cost — gate scripts)
+
+**Problem.** Every E-gate opens with approximately:
+
+```bash
+BASE_REF="${E1_BASE_REF:-origin/canon/madaros-v2-sota}"   # or E2*_BASE_REF / E3*_BASE_REF
+git diff --quiet "$BASE_REF" -- \
+  self-hosted/compiler/main.sio self-hosted/ir self-hosted/native \
+  self-hosted/wasm self-hosted/gpu stdlib/runtime \
+  [stdlib/eisa stdlib/math/dd64.sio stdlib/math/qd128.sio tools/eisa/eisa_evm_run.sio …]
+```
+
+On main that diff against the **frontier branch name** is never empty
+(thousands of lines of main-side IR/native drift). **Every gate fails its
+shadow-discipline check before doing any work** if left as-is.
+
+**Options and judgment**
+
+| Anchor | Behaviour on main | Verdict |
+|---|---|---|
+| Keep `origin/canon/madaros-v2-sota` | Always fails on main | **Unusable** |
+| Default `origin/main` | Clean tree OK if PR is main-based and only adds enir; **spuriously fragile** when collocated lanes leave dirty `ir/lower.sio` (constant on this pod) *or* when comparing a lagging PR branch to a racing main tip that already moved production surfaces | **Reject as default** |
+| Default `HEAD` | Checks worktree cleanliness vs this commit; empty for a clean checkout of a PR that only added enir. Weak as a “did the PR modify production IR?” check alone, but matches E3D’s internal `E3C_BASE_REF=HEAD` precedent for cascade regressions | **Accept for local/cascade** |
+| **PR-range pin (recommended CI default)** | `MERGE_BASE=$(git merge-base HEAD origin/main)` then `git diff --quiet "$MERGE_BASE" HEAD -- <prod surfaces>` — fails iff the **PR commit range** touches production IR/codegen/ABI. Independent of frontier tip and of other agents’ dirty trees on other worktrees | **Required for PR2+ CI** |
+
+**Decision (document for PR2 implementers):**
+
+1. **Primary CI mode (E1 standalone and every top-level E-gate on main):**  
+   Replace the frontier default with a **PR-range frozen-surface check**:
+   ```bash
+   MERGE_BASE=$(git merge-base HEAD "${ENIR_GATE_BASE:-origin/main}")
+   git diff --quiet "$MERGE_BASE" HEAD -- \
+     self-hosted/compiler/main.sio self-hosted/ir self-hosted/native \
+     self-hosted/wasm self-hosted/gpu stdlib/runtime
+   # plus any extra pins (eisa/qd) as today, same MERGE_BASE..HEAD range
+   ```
+   Meaning: *this PR must not edit production lowering/codegen/ABI surfaces*.
+   Env override `E1_BASE_REF` / `ENIR_GATE_BASE` remains for emergency pins to a
+   specific SHA (e.g. last ENIR-green tag).
+
+2. **Cascade regressions (E3D → E3C → … → E1):** keep and generalise the E3D
+   pattern: `E3C_BASE_REF=HEAD` + `E3C_ALLOW_DOWNSTREAM_ENIR_EXTENSION=1` (and
+   siblings) **after** the parent gate has already protected production
+   surfaces and rebuilt historical witnesses. Do not invent a second discipline.
+
+3. **Collocated dirty worktrees:** gates are **CI / clean-tree tools**. A dirty
+   `self-hosted/ir/lower.sio` in the same worktree will still fail
+   `git diff HEAD -- self-hosted/ir` — that is correct. The fix is not
+   `BASE_REF=origin/main`; it is run gates on clean checkouts or dedicated
+   worktrees (Attention Charter: control is not bench).
+
+4. **Boundary honesty (overrides Route B step 3 as originally worded):**  
+   “Fix **inside `enir/` only** until driver ELF green” remains true for
+   **enir source** typecheck/parse/semantic repairs in **PR1**.  
+   It **does not** hold for **gate scripts**: PR2 **must** edit
+   `scripts/dev/madaros_v2_e*_*.sh` (BASE_REF re-anchor, possibly payload
+   paths). That is an **unbudgeted PR2 cost item** relative to the original
+   “days 4–10 cascade” estimate — budget **+1–2 days** for gate surgery and
+   CI wiring, not “search-replace the branch name.”
+
+### 4.3 C4 · Madaros parse break + dual PR1 receipt
+
+**Receipt (fable-1):** default Madaros `souc check self-hosted/enir/mir_join.sio`
+→ parse errors at lines **476–489**; `driver.sio` / `mod.sio` fail transitively.
+Other **13** enir files parse clean under Madaros v0.80.0. Seed accepts the
+file.
+
+**Named PR1 tasks (enir-local rewrites, seed-only constructs):**
+
+| Site | Construct Madaros rejects | Fix shape |
+|---|---|---|
+| `mir_join.sio:476` | Parenthesised **`if`-expression** used as a comparison operand inside an `\|\|` chain (`b.trap_kind != (if opcode >= … { … } else { … })`) | Hoist to a `let trap = if … { … } else { … }` **before** the condition, then compare `b.trap_kind != trap` |
+| `mir_join.sio:481` | **Semicolon-joined `let` statements** on one line (`let a = …; let b = …`) | Split into two successive `let` lines (no `;`) |
+
+**PR1 acceptance (amended):**
+
+1. Seed: `souc-lean-single` (or locked seed path) **compiles** `enir/driver.sio` to ELF; optional `emit` smoke.  
+2. **Madaros:** `bin/souc check self-hosted/enir/mod.sio` (or `driver.sio`) **green**, **or** a dated FAIL_HONEST list of residual codes with owners — not “seed-only green.”  
+3. No silent merge of seed-only syntax that the default engine cannot parse.
+
+Without (2), PR1 lands code the primary compiler cannot load and the failure
+shows up as a mystery later.
+
+### 4.4 C5 · `loop_closed` is a semantic fix, not a syntax papercut
+
+**Facts:**
+
+- **Use** at `source_lower.sio:529`:  
+  `if loop_closed && !is_load { return enir_lower_fail(module, line, 15) }`  
+  (rule: no non-load `let` after loop close.)
+- **Declaration** at `source_lower.sio:645`: `var loop_closed = false` in a
+  **different** function (the CFG/`while` lowerer), with assignments at 672+ in
+  that same second function.
+- Seed path compiles the use-site as a **guarded** gate (`gates[… guarded=…]`),
+  so lower-fail-15 is **silently unenforced or trap-prone** under seed today.
+  Gate green under that seed proves less than it appears to.
+- Madaros will **hard-error** (unknown identifier / E200 class) once C4 is fixed
+  and the driver is checked under Madaros.
+
+**Budgeting:** treat as a **semantic repair** in PR1 (or a blocking PR1.1 before
+any E2 gate claim): thread `loop_closed` into the correct function scope, or
+delete/replace the check with an equivalent well-scoped rule, then **re-run
+affected E2 gates** (at least E2B/E2C/E2G class that exercise loop close). Do
+**not** classify as a one-line syntax papercut or “non-fatal noise.”
+
+### 4.5 C6 · WS-B SOIR sequencing does not protect ENIR serialisation
+
+The focus plan’s “SOIR gate before the port lands” rationale catches
+serialisation drift on **`self-hosted/ir/*` (SoIR)**. ENIR has its **own** text
+format, with canonical/roundtrip/hash checks **inside E1**.
+
+| Premise | Holds? |
+|---|---|
+| SOIR-first is still fine fleet sequencing (WS-B before heavy PR2+) | Yes, as hygiene |
+| SOIR green mechanically protects ENIR serialisation | **No** |
+| A WS-B slip must hold **PR1** hostage | **No** |
+
+**PR1** (enir sources + dual check receipts + docs + payload if censused) may
+proceed on the SOIR track in parallel. **PR2+** (gate matrix) should still
+prefer a green SOIR gate when both compete for CI attention, but PR1 is not
+blocked on a false ENIR-safety premise.
+
+---
+
+## 5. Route costings
 
 ### Route A — Wholesale rebase of frontier onto current main
 
-**What it is:** take `canon/madaros-v2-sota` (189 commits) and rebase onto `origin/main` (or merge main into frontier and resolve), landing everything the frontier carried.
+**What it is:** take `canon/madaros-v2-sota` (189 commits) and rebase onto
+`origin/main` (or merge main into frontier and resolve).
 
 **Pros**
 - Preserves full historical lettered receipts and S1–S5 / C2 scaffolding scripts if desired.
 - One-shot “bring the sota branch home.”
 
 **Cons / cost**
-- Must resolve **115 both-sides files**, including the worst IR/compiler/native hotspots above (orders of magnitude more main churn than frontier).
+- Must resolve **115 both-sides files**, including the worst IR/compiler/native hotspots above.
 - ~2086 main commits of semantic drift in the same files frontier also touched lightly.
-- Frontier also carries **276** paths main never had (research tarballs, GPU experiments, paper bundles) — noise and review load.
+- Frontier also carries **276** paths main never had — noise and review load.
 - Risk of re-introducing fixed-point / stack / SoA regressions fixed on main after the fork.
 - Wall-clock: multi-week expert conflict resolution; high probability of “rebasing forever.”
 
 **Effort estimate:** 3–6+ engineer-weeks of pure conflict surgery before any new MIR work.  
-**Verdict:** **Not recommended as primary.** Use only if founder requires full frontier history, not just ENIR/MIR capability.
+**Verdict:** **Not recommended as primary.**
 
 ---
 
-### Route B — `enir/` subtree cherry-pick + resume lettered plan (**recommended**)
+### Route B — `enir/` subtree cherry-pick + resume lettered plan (**approved**)
 
 **What it is:**
 
-1. On a branch from **current main**, add the frontier-only payload almost verbatim:
-   - `self-hosted/enir/**` (14 files)
-   - `scripts/dev/madaros_v2_e1`…`e3e_*.{sh,py}` (+ related verify helpers)
+1. On a branch from **current main**, add the frontier payload per §6 / C1 census:
+   - `self-hosted/enir/**` (14 files), with **C4/C5 repairs** in PR1
+   - gate scripts + Python verifiers (PR2+)
+   - `tools/eisa/` oracle/fixture payload (C1 — must be enumerated)
    - `bin/madaros-enir` wrapper
-   - `docs/architecture/MADAROS_V2_EISA_SEMANTIC_IR.md` (and optionally refresh the four `MIR_*` docs)
-2. Wire gates into `scripts/ci/madaros_full_gate.sh` behind the same E1–E3D sequence (or a new `enir_gate.sh` umbrella first).
-3. **Compile driver under current Madaros/seed** — expect Sounio-syntax/effect residuals from 1 month of main language drift; fix *inside enir/* only until driver ELF green.
+   - `docs/architecture/MADAROS_V2_EISA_SEMANTIC_IR.md` (and optional `MIR_*` refresh)
+2. Wire gates into CI behind E1–E3D (or umbrella `enir_pipeline_gate.sh` first),
+   with **§4.2 BASE_REF re-anchor** (PR2).
+3. **Compile driver under seed *and* Madaros check** (PR1 acceptance §4.3).  
+   Enir **source** fixes stay inside `enir/` until both receipts green.  
+   **Gate scripts are out of that boundary** (§4.2 point 4).
 4. Re-run E1 then cascade E2*→E3D; mark FAIL_HONEST with receipts rather than silent skip.
 5. Resume lettered plan at the first non-FULL item after E3D/E3E (general multipred/N-way SSA, alias, then ABI/MIR→codegen — still deferred by the E3D contract).
 
 **Pros**
 - `enir/` is **dependency-isolated** (`use enir::*` only) → near-zero textual conflict with main’s `ir/lower.sio` wars.
-- Main lacks the directory entirely → add is clean, not a 3-way merge of shared blobs.
-- Preserves executable gates + Python oracles (the real value, not just prose).
-- Aligns with shadow-lane discipline already written into E1 (zero-diff production surfaces).
-- Keeps WS-B SOIR gate sequencing: land SOIR first, then attach ENIR gates so serialization drift is caught.
+- Main lacks the directory entirely → add is clean.
+- Preserves executable gates + Python oracles.
+- Aligns with shadow-lane discipline (once BASE_REF is re-anchored for main).
 
-**Cons / cost**
-- Must still re-validate every gate under **current** seed/Madaros (frontier binaries are not evidence on main).
-- Seed may surface effect/E200 residuals (seen once on driver build); budget a small repair pass **inside `enir/`**.
-- Does not automatically bring S5 MIR-ABI / wide-sret experiment scripts unless explicitly listed.
+**Cons / cost (updated)**
+- Must re-validate every gate under **current** seed/Madaros.
+- **PR1:** Madaros parse rewrites (`mir_join.sio`) + **semantic** `loop_closed` fix + dual receipts.
+- **PR2:** BASE_REF re-anchor (+1–2 days), tools/eisa payload, possible oracle re-validation vs main’s drifted EISA (C3).
+- Shared-surface coord with WS-F.
 - Multi-week for true production MIR→codegen remains after E3D (by design).
 
-**Effort estimate:**
-- Days 1–3: subtree add + driver compile on main + E1 green.
-- Days 4–10: E2A–E3D cascade under main toolchain; fix enir-local breaks.
+**Effort estimate (amended):**
+- **PR1 (days 1–4):** subtree add + C4 rewrites + C5 semantic fix + seed ELF + Madaros check receipts.  
+- **PR2 (days 5–8):** gate BASE_REF surgery + E1 green + payload from census.  
+- **PR3–4 (days 9–14+):** E2A–E3D cascade under main toolchain.  
 - Wave 2+: resume lettered expansion (post-E3D scope).
 
-**Verdict:** **Default route.** Lowest conflict surface, highest reuse of proven work, clear resume point (E3D FULL → general SSA/ABI still open).
+**Verdict:** **Approved default.** Isolation claim holds; preflight items are scoped, not route-killers.
 
 ---
 
 ### Route C — Fresh re-derivation from the four `MIR_*` docs (+ EISA architecture)
 
-**What it is:** ignore frontier `enir/` source; redesign MIR against current main using:
-- the four `MIR_*` research docs (already on main),
-- `MADAROS_V2_EISA_SEMANTIC_IR.md` (must still be ported as a doc),
-- optional reading of frontier gates as oracles only.
+**What it is:** ignore frontier `enir/` source; redesign MIR against current main
+using the four `MIR_*` research docs, `MADAROS_V2_EISA_SEMANTIC_IR.md`, and
+optional reading of frontier gates as oracles only.
 
 **Pros**
-- Avoids carrying any frontier compiler history.
-- Can target MLI handoff (WS-D) with a cleaner module layout from day one.
-- No 115-file rebase.
+- Avoids carrying frontier compiler history; can target MLI handoff cleanly.
 
 **Cons / cost**
-- Throws away **7310 LOC** of working ENIR/MIR + ~15 sequenced gates with independent Python checkers.
+- Throws away **7310 LOC** + ~15 sequenced gates with independent Python checkers.
 - The four `MIR_*` docs alone do **not** specify E2 source grammar, qd128 ENIR ops, or E3D join schema in executable detail.
-- Re-implementation risk of silent semantic drift vs Metron/EISA oracles.
-- Calendar: multi-month to reach E3D-equivalent evidence.
+- Calendar: multi-month to E3D-equivalent evidence.
 
-**Effort estimate:** 2–4+ months to parity with frontier E3D.  
-**Verdict:** **Fallback only** if Route B’s enir sources cannot be made to typecheck under main after a bounded repair budget (e.g. >2 weeks of enir-only fixes with no E1 green).
+**Verdict:** **Fallback only** if Route B fails a bounded enir-compile budget after C4/C5 (e.g. >2 weeks of enir-only fixes with no dual green receipts).
 
 ---
 
@@ -250,31 +411,35 @@ b4142c83cb test(enir): distinguish equal values by event receipt  # E3E
 
 | Surface | Route A | Route B | Route C |
 |---|---|---|---|
-| `self-hosted/enir/**` | must merge + re-sync | **add** (no main counterpart) | rewrite |
-| E1–E3D gates/scripts | massive path noise + conflicts | **add** frontier-only scripts | rewrite |
-| `ir/lower.sio`, `module_frontend.sio`, `codegen_x86_linux.sio` | **hard conflicts** (both-sides) | **untouched** if shadow discipline holds | optional later |
-| Production Madaros | high regression risk | protected by E1 zero-diff contract | protected until explicit wire-up |
-| Founder ≤2 self-hosted writers rule | violates quickly (long rebase) | can stay enir-only writers | design-first, delayed code |
+| `self-hosted/enir/**` | must merge + re-sync | **add** (no main counterpart) + C4/C5 edits | rewrite |
+| E1–E3D gates/scripts | massive path noise + conflicts | **add** + **rewrite BASE_REF** (PR2) | rewrite |
+| `tools/eisa/` fixtures | noise | **add** per C1 census | rewrite |
+| `ir/lower.sio`, `module_frontend.sio`, `codegen_x86_linux.sio` | **hard conflicts** | **untouched** by enir source; **pinned by gate checks** | optional later |
+| Production Madaros | high regression risk | protected once PR-range pin is correct | protected until wire-up |
+| Founder ≤2 self-hosted writers rule | violates quickly | enir-only writers for PR1; PR2 is scripts/tools | design-first |
 
 ---
 
-## 6. Recommended decision
+## 6. Recommended decision and PR stack
 
-1. **Choose Route B** as the WS-C port route.  
-2. **Do not** open a wholesale frontier rebase (Route A) unless Route B fails its bounded enir-compile budget.  
-3. Keep Route C as the documented escape hatch, not the default.  
-4. Sequencing (from focus plan, unchanged): **P0-F + WS-A baseline**, **WS-B SOIR gate**, then Route B port PR stack.  
-5. After E1–E3D green on main, treat **post-E3D general SSA / ABI / MachineIR** as a new lettered tranche — do not silently expand E3D claims.
+1. **Route B remains the WS-C port route** (founder-approved; fable-1 survived).  
+2. **Do not** open Route A unless Route B fails its bounded repair budget.  
+3. Keep Route C as escape hatch only.  
+4. **PR1 is not hostage to WS-B** (§4.5); fleet may still prefer SOIR green before PR2 cascade for CI bandwidth.  
+5. After E1–E3D green on main, treat **post-E3D general SSA / ABI / MachineIR** as a new lettered tranche — do not silently expand E3D claims (also relevant to WS-D MLI S2 feed).
 
-### Suggested PR stack (Route B)
+### 6.1 Suggested PR stack (Route B, amended)
 
-| PR | Content |
-|---|---|
-| PR1 | `self-hosted/enir/**` + `bin/madaros-enir` + docs (`MADAROS_V2_EISA_SEMANTIC_IR.md`) only; driver `check`/`compile` under seed |
-| PR2 | E1 gate + Python verifier green on main |
-| PR3 | E2A–E2H gates (may split) |
-| PR4 | E3A–E3D (+ E3E) gates |
-| PR5 | Optional: umbrella `scripts/ci/enir_pipeline_gate.sh` + madaros_full_gate hooks |
+| PR | Content | Acceptance (must) |
+|---|---|---|
+| **PR1** | `self-hosted/enir/**` + `bin/madaros-enir` + `MADAROS_V2_EISA_SEMANTIC_IR.md`; **rewrite `mir_join.sio` C4 sites**; **fix `loop_closed` C5**; optional payload from census if ready | (a) seed driver ELF; (b) **Madaros `souc check` green** (or FAIL_HONEST list); (c) no production IR/codegen edits |
+| **PR2** | E1 gate + Python verifier; **BASE_REF re-anchor per §4.2**; `tools/eisa/` payload per **`WS_C_PR1_PAYLOAD_CENSUS.md`** | E1 green on clean CI; PR-range frozen-surface check fails closed if IR touched |
+| **PR3** | E2A–E2H gates (may split) | Cascade under re-anchored discipline; oracle policy vs main drift documented |
+| **PR4** | E3A–E3D (+ E3E) | FULL gates green or FAIL_HONEST with receipts |
+| **PR5** | Optional umbrella `scripts/ci/enir_pipeline_gate.sh` + madaros_full_gate hooks | CI wiring only |
+
+**C1 census reference:** `docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md`  
+> **PLACEHOLDER:** file not yet on this branch. Fold numbers into PR1/PR2 rows when codex-2 lands it.
 
 No production `use enir::` from `compiler/main.sio` until a later explicit integration tranche (post-WS-D MLI design).
 
@@ -283,7 +448,7 @@ No production `use enir::` from `compiler/main.sio` until a later explicit integ
 ## 7. Reproduction commands
 
 ```bash
-# Worktree (already created for this study)
+# Worktree (study)
 git fetch origin canon/madaros-v2-sota main
 git worktree add /workspace/.wt/mir-study origin/canon/madaros-v2-sota
 cd /workspace/.wt/mir-study
@@ -294,15 +459,22 @@ git merge-base origin/main HEAD
 git rev-list --count origin/main..HEAD   # frontier-only
 git rev-list --count HEAD..origin/main   # main-only
 
-# Build ENIR driver
+# Build ENIR driver (seed)
 scripts/dev/souc-build-lock.sh ./bin/souc-lean-single-x86_64 \
   self-hosted/enir/driver.sio /tmp/madaros-enir
 /tmp/madaros-enir emit | head
+
+# Madaros parse (C4) — expect fail on unpatched mir_join
+bin/souc check self-hosted/enir/mir_join.sio
 
 # Both-sides conflict list
 MB=$(git merge-base origin/main HEAD)
 comm -12 <(git diff --name-only $MB HEAD | sort) \
          <(git diff --name-only $MB origin/main | sort)
+
+# tools/eisa payload missing on main (C1 sketch)
+comm -23 <(git ls-tree -r --name-only origin/canon/madaros-v2-sota tools/eisa | sort) \
+         <(git ls-tree -r --name-only origin/main tools/eisa | sort)
 ```
 
 ---
@@ -310,10 +482,10 @@ comm -12 <(git diff --name-only $MB HEAD | sort) \
 ## 8. Out of scope / non-claims
 
 - Did not run the full E1–E3D wall-clock gate matrix on this pod.  
-- Did not modify `self-hosted/` on main.  
-- Did not decide MLI operand model (WS-D).  
+- Did not modify `self-hosted/` on main in the study or this amendment.  
+- Did not decide MLI operand model (WS-D) — see preflight D1 for Route-B MIR vs MLI S2 gap.  
 - Did not claim production MIR→x86.  
-- Did not re-measure divergence after future main motion past `a5548481d1`.
+- Did not re-measure divergence after every main tip motion.
 
 ---
 
@@ -322,8 +494,10 @@ comm -12 <(git diff --name-only $MB HEAD | sort) \
 | Item | Location |
 |---|---|
 | Study worktree | `/workspace/.wt/mir-study` @ `97b525949` |
-| Driver ELF (session) | `/tmp/mir-study-enir/madaros-enir` |
-| Coord claim | `grok-cli1` / `ws-c-mir-study` → `docs/architecture/MIR_PORT_PLAN.md` |
-| Next founder action | Accept/reject Route B default; then schedule port PR1 after WS-B SOIR |
+| Amendment worktree | `/workspace/.wt/amend-mir` @ branch `amend/mir-port-plan-20260816` |
+| Preflight review | `docs/architecture/WS_C_D_PREFLIGHT_REVIEW_2026-08-16.md` |
+| C1 payload census | `docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md` (**placeholder** until codex-2) |
+| Coord claim | `grok-cli1` / `amend-mir-port-plan` |
+| Next port action | PR1 per §6.1 after C1 census (or interim payload list); PR2 BASE_REF |
 
-*End of WS-C wave-1 study.*
+*End of WS-C port plan (route study + preflight amendments).*

--- a/docs/architecture/MIR_PORT_PLAN.md
+++ b/docs/architecture/MIR_PORT_PLAN.md
@@ -1,0 +1,329 @@
+<!-- docs:meta
+topic_id: repo.docs.architecture.mir-port-plan
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.architecture.mir-port-plan
+-->
+
+# MIR Port Plan — WS-C route study
+
+**Status:** route recommendation for founder decision (wave 1, read-only study).  
+**Author:** grok-cli1 (`ws-c-mir-study`), 2026-08-16.  
+**Plan context:** `docs/internal/coordination/MADAROS_FOCUS_PLAN_2026-08-16.md` §WS-C.  
+**Frontier worktree:** `/workspace/.wt/mir-study` → `origin/canon/madaros-v2-sota` @ `97b5259497`.  
+**Constraint:** this study did **not** edit `self-hosted/` on main; only this doc is the write product.
+
+---
+
+## 1. Executive summary
+
+A real ENIR→MIR pipeline already exists on the frontier tip and **still builds** at `97b525949`:
+
+| Check | Result |
+|---|---|
+| Tip SHA | `97b525949765980406a4fefa7f533e9db89721e1` (`feat(c2): emit first divergence receipt (#837)`) |
+| `self-hosted/enir/` | 14 modules, **7310** LOC |
+| Seed compile `enir/driver.sio` | ELF produced (`/tmp/mir-study-enir/madaros-enir`, ~1.4 MiB) under `souc-lean-single` + build lock |
+| `madaros-enir emit` | Exit 0; canonical ENIR artifact ~2053 bytes |
+| Production wiring | Explicitly **not** imported by production codegen (`enir/mod.sio` banner) |
+
+**Measured divergence** (do not use the swapped wording in an early draft of the focus plan):
+
+```text
+merge-base(origin/main, frontier) = a930c8ac72
+commits only on frontier (main..frontier):  189
+commits only on main     (frontier..main): 2086
+```
+
+| Route | Effort (order) | Risk | Recommendation |
+|---|---:|---|---|
+| **B · `enir/` subtree cherry-pick + resume lettered plan** | 1–2 weeks to green gates on main; then multi-week letter resume | **Lowest** | **Recommended default** |
+| **C · Fresh re-derivation from MIR_* + EISA docs** | multi-month | Medium–high scope | Only if A/B prove hostile |
+| **A · Wholesale rebase of frontier onto main** | multi-week conflict storm | **Highest** | Reject as primary |
+
+---
+
+## 2. What the frontier actually carries
+
+### 2.1 ENIR/MIR source tree (`self-hosted/enir/`)
+
+| File | Role (from imports / gates) |
+|---|---|
+| `ir.sio` | ENIR core model |
+| `parser.sio` / `canonical.sio` / `verify.sio` / `hash.sio` | Strict parse, canonicalize, verify, hash |
+| `shadow_fixture.sio` | E1 fixture corpus surface |
+| `source_lower.sio` | Source → ENIR (E2*) |
+| `interpreter.sio` | Compiler-owned interpreter |
+| `qd.sio` | qd128 arithmetic (E2E/E2F+) |
+| `mir.sio` | Semantic MIR (E3A+) |
+| `mir_cfg.sio` | CFG / Memory-SSA (E3C) |
+| `mir_join.sio` | Multi-pred join MIR (E3D) |
+| `driver.sio` | CLI: emit / verify / roundtrip / lower / run / MIR cmds |
+| `mod.sio` | Public boundary; **not** production codegen |
+
+**Import topology (critical for port cost):** every `use` inside `enir/` is **`enir::*` only**. There is no `use ir::`, `use native::`, or `use compiler::` edge. ENIR is a **shadow lane** by design: gates assert zero-diff against production lowering/codegen/ABI surfaces.
+
+### 2.2 Lettered plan state (implementation, not the four MIR_* research PDFs)
+
+Normative narrative: `docs/architecture/MADAROS_V2_EISA_SEMANTIC_IR.md` (frontier-only on main tree; **absent** from `origin/main`).
+
+| Stage | Status at 97b525949 | Gate script |
+|---|---|---|
+| E1 shadow foundation | FULL | `scripts/dev/madaros_v2_e1_enir_shadow_gate.sh` |
+| E2A–E2H source→ENIR slices | FULL (corpus slices) | `madaros_v2_e2*_enir_*.sh` |
+| E3A ENIR→MIR qd128 arith | FULL | `madaros_v2_e3a_enir_mir_qd128_gate.sh` |
+| E3B MIR memory/move | FULL | `madaros_v2_e3b_enir_mir_memory_gate.sh` |
+| E3C CFG / Memory-SSA (canonical loop) | FULL | `madaros_v2_e3c_cfg_memory_ssa_gate.sh` |
+| E3D multipred scalar + multi-slot join | FULL | `madaros_v2_e3d_multipred_scalar_memory_ssa_gate.sh` |
+| E3E equal-value distinct-event | present | `madaros_v2_e3e_equal_value_distinct_event_gate.sh` |
+
+**Explicit non-claims after E3D:** general N-way SSA, nested diamonds, loops-in-same-schema, alias analysis, ABI selection, MachineIR, production codegen.
+
+### 2.3 The four `docs/architecture/MIR_*` files
+
+Present on **both** tips (with main-side churn). They are **research / Cranelift / optim strategy** docs, not the lettered ENIR implementation contract:
+
+- `MIR_RESEARCH_STRATEGY.md`
+- `MIR_OPTIMIZATION_STRATEGY.md`
+- `MIR_OPTIMIZATION_PASES_DOCUMENTATION.md` (typo in filename preserved)
+- `MIR_CRANELIFT_INTEGRATION_REPORT.md`
+
+A “re-derive from the 4 MIR_* docs” route would **not** reconstruct the E1–E3D executable gates without also re-deriving `MADAROS_V2_EISA_SEMANTIC_IR.md` and the gate/Python verifiers.
+
+### 2.4 Build evidence (this session)
+
+```text
+worktree: /workspace/.wt/mir-study @ 97b525949
+seed:     bin/souc-lean-single-x86_64
+cmd:      scripts/dev/souc-build-lock.sh <seed> self-hosted/enir/driver.sio /tmp/mir-study-enir/madaros-enir
+result:   ELF written; driver emit OK
+note:     seed log showed E200 `loop_closed` at line 529 (non-fatal under this seed path); ELF still emitted
+```
+
+Full E1–E3D gate matrix was **not** re-run end-to-end in wave 1 (Python-heavy + multi-hour). Build+emit is the hard existence proof requested for “still builds at 97b525949”.
+
+---
+
+## 3. Divergence census (measured 2026-08-16)
+
+### 3.1 Commit counts
+
+| Direction | Count | Meaning |
+|---|---:|---|
+| `origin/main..frontier` | **189** | Frontier-only commits (main lacks) |
+| `frontier..origin/main` | **2086** | Main-only commits (frontier lacks) |
+| Merge-base | `a930c8ac72` | `docs(governance): register tuple-let-desugar audit doc` |
+
+**Correction to focus-plan wording:** an early draft swapped these numbers. **Main is the long tip; frontier is a short divergent lobe (~189 commits) with the ENIR lane.**
+
+### 3.2 Tree-level
+
+| Set | Count |
+|---|---:|
+| Paths differing tip-to-tip (`git diff --name-only HEAD...origin/main`) | ~4202 |
+| of which under `self-hosted/` | ~197 |
+| Frontier-only paths (not on main at all) | **276** |
+| of which `self-hosted/enir/*` | **14** (entire tree missing on main) |
+| Main `self-hosted/enir/` | **0** |
+
+### 3.3 Both-sides edits since merge-base (true rebase conflict surface)
+
+Files modified on **both** frontier and main since merge-base: **115** total, **41** under `self-hosted/`.
+
+Highest main-side churn on shared hot files (numstat lines since merge-base):
+
+| Path | Main churn | Frontier churn |
+|---|---:|---:|
+| `self-hosted/ir/lower.sio` | ~14178 | ~1880 |
+| `self-hosted/compiler/main.sio` | ~6737 | ~2453 |
+| `self-hosted/compiler/lean_single.sio` | ~5014 | ~763 |
+| `self-hosted/compiler/module_frontend.sio` | ~4778 | ~1677 |
+| `self-hosted/native/codegen_x86_linux.sio` | ~3906 | ~1211 |
+| `self-hosted/ir/ir.sio` | ~2121 | ~122 |
+
+**None of these are required imports of `enir/`.** They matter only for routes that replay frontier *compiler* history or re-open production IR.
+
+### 3.4 Frontier-only ENIR-related commit set
+
+~**15** commits touch `self-hosted/enir`, `scripts/dev/madaros_v2_e*`, and `MADAROS_V2_EISA_SEMANTIC_IR.md` (linear lettered delivery E1→E3D/E3E). Representative:
+
+```text
+3795ac03a0 feat(madaros): add compiler-owned ENIR shadow
+… E2A–E2H …
+6129a9f990 feat(enir): add translation-validated semantic MIR   # E3A
+73542db065 compiler: add E3B semantic MIR memory
+9f4ec85a21 compiler: add E3C explicit CFG and Memory SSA
+ce2f94407f compiler: add E3D multipred scalar and memory SSA
+b4142c83cb test(enir): distinguish equal values by event receipt  # E3E
+```
+
+### 3.5 Main-only commits on IR/compiler/native (port friction if you merge wholesale)
+
+`git rev-list --count frontier..main -- self-hosted/ir self-hosted/compiler self-hosted/check self-hosted/native` ≈ **467** commits. These include Lane B stack peels, IR arena/SoA, module frontend multi-mod walls, f32 coercion, etc. They do **not** delete or redefine `enir/` (it never existed on main).
+
+---
+
+## 4. Route costings
+
+### Route A — Wholesale rebase of frontier onto current main
+
+**What it is:** take `canon/madaros-v2-sota` (189 commits) and rebase onto `origin/main` (or merge main into frontier and resolve), landing everything the frontier carried.
+
+**Pros**
+- Preserves full historical lettered receipts and S1–S5 / C2 scaffolding scripts if desired.
+- One-shot “bring the sota branch home.”
+
+**Cons / cost**
+- Must resolve **115 both-sides files**, including the worst IR/compiler/native hotspots above (orders of magnitude more main churn than frontier).
+- ~2086 main commits of semantic drift in the same files frontier also touched lightly.
+- Frontier also carries **276** paths main never had (research tarballs, GPU experiments, paper bundles) — noise and review load.
+- Risk of re-introducing fixed-point / stack / SoA regressions fixed on main after the fork.
+- Wall-clock: multi-week expert conflict resolution; high probability of “rebasing forever.”
+
+**Effort estimate:** 3–6+ engineer-weeks of pure conflict surgery before any new MIR work.  
+**Verdict:** **Not recommended as primary.** Use only if founder requires full frontier history, not just ENIR/MIR capability.
+
+---
+
+### Route B — `enir/` subtree cherry-pick + resume lettered plan (**recommended**)
+
+**What it is:**
+
+1. On a branch from **current main**, add the frontier-only payload almost verbatim:
+   - `self-hosted/enir/**` (14 files)
+   - `scripts/dev/madaros_v2_e1`…`e3e_*.{sh,py}` (+ related verify helpers)
+   - `bin/madaros-enir` wrapper
+   - `docs/architecture/MADAROS_V2_EISA_SEMANTIC_IR.md` (and optionally refresh the four `MIR_*` docs)
+2. Wire gates into `scripts/ci/madaros_full_gate.sh` behind the same E1–E3D sequence (or a new `enir_gate.sh` umbrella first).
+3. **Compile driver under current Madaros/seed** — expect Sounio-syntax/effect residuals from 1 month of main language drift; fix *inside enir/* only until driver ELF green.
+4. Re-run E1 then cascade E2*→E3D; mark FAIL_HONEST with receipts rather than silent skip.
+5. Resume lettered plan at the first non-FULL item after E3D/E3E (general multipred/N-way SSA, alias, then ABI/MIR→codegen — still deferred by the E3D contract).
+
+**Pros**
+- `enir/` is **dependency-isolated** (`use enir::*` only) → near-zero textual conflict with main’s `ir/lower.sio` wars.
+- Main lacks the directory entirely → add is clean, not a 3-way merge of shared blobs.
+- Preserves executable gates + Python oracles (the real value, not just prose).
+- Aligns with shadow-lane discipline already written into E1 (zero-diff production surfaces).
+- Keeps WS-B SOIR gate sequencing: land SOIR first, then attach ENIR gates so serialization drift is caught.
+
+**Cons / cost**
+- Must still re-validate every gate under **current** seed/Madaros (frontier binaries are not evidence on main).
+- Seed may surface effect/E200 residuals (seen once on driver build); budget a small repair pass **inside `enir/`**.
+- Does not automatically bring S5 MIR-ABI / wide-sret experiment scripts unless explicitly listed.
+- Multi-week for true production MIR→codegen remains after E3D (by design).
+
+**Effort estimate:**
+- Days 1–3: subtree add + driver compile on main + E1 green.
+- Days 4–10: E2A–E3D cascade under main toolchain; fix enir-local breaks.
+- Wave 2+: resume lettered expansion (post-E3D scope).
+
+**Verdict:** **Default route.** Lowest conflict surface, highest reuse of proven work, clear resume point (E3D FULL → general SSA/ABI still open).
+
+---
+
+### Route C — Fresh re-derivation from the four `MIR_*` docs (+ EISA architecture)
+
+**What it is:** ignore frontier `enir/` source; redesign MIR against current main using:
+- the four `MIR_*` research docs (already on main),
+- `MADAROS_V2_EISA_SEMANTIC_IR.md` (must still be ported as a doc),
+- optional reading of frontier gates as oracles only.
+
+**Pros**
+- Avoids carrying any frontier compiler history.
+- Can target MLI handoff (WS-D) with a cleaner module layout from day one.
+- No 115-file rebase.
+
+**Cons / cost**
+- Throws away **7310 LOC** of working ENIR/MIR + ~15 sequenced gates with independent Python checkers.
+- The four `MIR_*` docs alone do **not** specify E2 source grammar, qd128 ENIR ops, or E3D join schema in executable detail.
+- Re-implementation risk of silent semantic drift vs Metron/EISA oracles.
+- Calendar: multi-month to reach E3D-equivalent evidence.
+
+**Effort estimate:** 2–4+ months to parity with frontier E3D.  
+**Verdict:** **Fallback only** if Route B’s enir sources cannot be made to typecheck under main after a bounded repair budget (e.g. >2 weeks of enir-only fixes with no E1 green).
+
+---
+
+## 5. Conflict census implications by route
+
+| Surface | Route A | Route B | Route C |
+|---|---|---|---|
+| `self-hosted/enir/**` | must merge + re-sync | **add** (no main counterpart) | rewrite |
+| E1–E3D gates/scripts | massive path noise + conflicts | **add** frontier-only scripts | rewrite |
+| `ir/lower.sio`, `module_frontend.sio`, `codegen_x86_linux.sio` | **hard conflicts** (both-sides) | **untouched** if shadow discipline holds | optional later |
+| Production Madaros | high regression risk | protected by E1 zero-diff contract | protected until explicit wire-up |
+| Founder ≤2 self-hosted writers rule | violates quickly (long rebase) | can stay enir-only writers | design-first, delayed code |
+
+---
+
+## 6. Recommended decision
+
+1. **Choose Route B** as the WS-C port route.  
+2. **Do not** open a wholesale frontier rebase (Route A) unless Route B fails its bounded enir-compile budget.  
+3. Keep Route C as the documented escape hatch, not the default.  
+4. Sequencing (from focus plan, unchanged): **P0-F + WS-A baseline**, **WS-B SOIR gate**, then Route B port PR stack.  
+5. After E1–E3D green on main, treat **post-E3D general SSA / ABI / MachineIR** as a new lettered tranche — do not silently expand E3D claims.
+
+### Suggested PR stack (Route B)
+
+| PR | Content |
+|---|---|
+| PR1 | `self-hosted/enir/**` + `bin/madaros-enir` + docs (`MADAROS_V2_EISA_SEMANTIC_IR.md`) only; driver `check`/`compile` under seed |
+| PR2 | E1 gate + Python verifier green on main |
+| PR3 | E2A–E2H gates (may split) |
+| PR4 | E3A–E3D (+ E3E) gates |
+| PR5 | Optional: umbrella `scripts/ci/enir_pipeline_gate.sh` + madaros_full_gate hooks |
+
+No production `use enir::` from `compiler/main.sio` until a later explicit integration tranche (post-WS-D MLI design).
+
+---
+
+## 7. Reproduction commands
+
+```bash
+# Worktree (already created for this study)
+git fetch origin canon/madaros-v2-sota main
+git worktree add /workspace/.wt/mir-study origin/canon/madaros-v2-sota
+cd /workspace/.wt/mir-study
+git rev-parse HEAD   # expect 97b5259497…
+
+# Divergence
+git merge-base origin/main HEAD
+git rev-list --count origin/main..HEAD   # frontier-only
+git rev-list --count HEAD..origin/main   # main-only
+
+# Build ENIR driver
+scripts/dev/souc-build-lock.sh ./bin/souc-lean-single-x86_64 \
+  self-hosted/enir/driver.sio /tmp/madaros-enir
+/tmp/madaros-enir emit | head
+
+# Both-sides conflict list
+MB=$(git merge-base origin/main HEAD)
+comm -12 <(git diff --name-only $MB HEAD | sort) \
+         <(git diff --name-only $MB origin/main | sort)
+```
+
+---
+
+## 8. Out of scope / non-claims
+
+- Did not run the full E1–E3D wall-clock gate matrix on this pod.  
+- Did not modify `self-hosted/` on main.  
+- Did not decide MLI operand model (WS-D).  
+- Did not claim production MIR→x86.  
+- Did not re-measure divergence after future main motion past `a5548481d1`.
+
+---
+
+## 9. Handoff
+
+| Item | Location |
+|---|---|
+| Study worktree | `/workspace/.wt/mir-study` @ `97b525949` |
+| Driver ELF (session) | `/tmp/mir-study-enir/madaros-enir` |
+| Coord claim | `grok-cli1` / `ws-c-mir-study` → `docs/architecture/MIR_PORT_PLAN.md` |
+| Next founder action | Accept/reject Route B default; then schedule port PR1 after WS-B SOIR |
+
+*End of WS-C wave-1 study.*

--- a/docs/architecture/MIR_PORT_PLAN.md
+++ b/docs/architecture/MIR_PORT_PLAN.md
@@ -18,10 +18,10 @@ port plan + preflight amendments from
 **Frontier worktree:** `/workspace/.wt/mir-study` → `origin/canon/madaros-v2-sota` @ `97b5259497`.  
 **Constraint (study):** did **not** edit `self-hosted/` on main; this file is the write product.
 
-**Preflight amendments folded (2026-08-16):** C2 (BASE_REF re-anchor), C4
-(Madaros parse + dual receipt), C5 (`loop_closed` semantic fix), C6 (WS-B
-ordering vs ENIR serialisation). C1 payload census → see §6.1 /
-`docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md`.
+**Preflight amendments folded (2026-08-16):** C1 (payload census: **63**
+files, not ~23), C2 (BASE_REF re-anchor), C4 (Madaros parse + dual receipt),
+C5 (`loop_closed` semantic fix), C6 (WS-B ordering vs ENIR serialisation).
+C1 authority: `docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md` (§4.1, §6.1).
 
 ---
 
@@ -183,21 +183,63 @@ Findings from `docs/architecture/WS_C_D_PREFLIGHT_REVIEW_2026-08-16.md`. None ov
 
 ### 4.1 C1 · Gate payload files (PR1/PR2 inventory)
 
-E-gates hard-reference frontier-only oracle/fixture files under `tools/eisa/`
-(~23 files measured missing on main: `eisa_enir_v1_oracle.sio`,
-`eisa_enir_v1_loop_oracle.sio`, and ~21 `eisa_enir_v1_*/v2_*.eisa` fixtures).
+**Authority:** `docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md` (codex-2,
+2026-08-16). Source refs in that file: `origin/main` @ `03416657fa`,
+`origin/canon/madaros-v2-sota` @ `97b525949`.
 
-**Canonical census (when landed):** `docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md`
-(codex-2, lane for C1 enumeration).
+**Headline (preflight was low by ~3×):** the preflight’s “~23 files” figure
+counted only the `tools/eisa` delta. Following every reference the gate
+scripts actually make — shell references, Python verifier references,
+verifier `PROGRAMS` fixture expansions, recursive regression-gate calls, and
+the `self-hosted/enir/driver.sio` import closure each gate build needs — the
+requested **E1/E2/E3** gate stack needs **63 files absent from `origin/main`**:
 
-> **PLACEHOLDER — C1 census not yet present on this branch.**  
-> When `WS_C_PR1_PAYLOAD_CENSUS.md` lands, fold its file counts and per-gate
-> transitive lists into §6 PR1/PR2 acceptance. Until then, PR1 **must not**
-> open without either that census or an equivalent measured
-> `comm -23` of `tools/eisa` frontier→main.
+| Class | Count | Role |
+|---|---:|---|
+| Gate scripts (`scripts/dev/madaros_v2_e*`) | **14** | E1, E2A–E2H, E3A–E3E shells |
+| Python verifiers | **13** | Pair with gates (E3E has shell only) |
+| `self-hosted/enir/` driver-closure | **14** | Common build closure for every gate |
+| `tools/eisa/` oracle + fixture | **22** | First needed at E2B; grows through E3E |
+| **Total add-list** | **63** | |
 
-Also flag (preflight C3, not expanded here): shared oracles
-(`tools/eisa/eisa_evm_run.sio`, `stdlib/math/qd128.sio`, `stdlib/eisa/`) have
+**Excluded (not in the 63):**
+
+- `tools/eisa/eisa_enir_c2_rump.eisa` — frontier-only, but owned by the **C2**
+  gate (`madaros_v2_c2_v0_gate.sh`), not E1/E2/E3.
+- `$TMP_DIR` negative fixtures generated inside gate scripts — not repository
+  payload.
+
+**Per-gate transitive counts** (from the census; each includes the shared 14
+enir files + inherited regression chain):
+
+| Gate | Transitive missing on main |
+|---|---:|
+| E1 shadow | 16 |
+| E2A lowering | 18 |
+| E2B CFG | 21 |
+| E2C fuel/blockargs | 24 |
+| E2D rump DD | 27 |
+| E2E qd128 | 35 |
+| E2F rump qd | 38 |
+| E2G fuel/control/frail | 43 |
+| E2H memory/move/poison | 48 |
+| E3A MIR qd128 | 50 |
+| E3B MIR memory | 52 |
+| E3C CFG memory SSA | 56 |
+| E3D multipred SSA | 60 |
+| E3E equal-value distinct event | 17 (no regression chain; +2 fixtures) |
+
+Exact path lists and “which PR carries what” are decided by the **per-gate
+transitive lists** in `WS_C_PR1_PAYLOAD_CENSUS.md` — not by this summary table
+alone. Consolidated add-list is the union (63).
+
+**Present-but-changed watchlist** (on main already; content differs from
+canon — not add-list, but PR2+ may need behavioural accounting / C3):
+`bin/souc-lean-single-x86_64`, `scripts/dev/souc-build-lock.sh`,
+`self-hosted/compiler/main.sio`, `stdlib/math/qd128.sio`,
+`tools/eisa/eisa_evm_run.sio`.
+
+Also flag (preflight C3): shared oracles above plus `stdlib/eisa/` have
 **drifted** on main; WS-F (EISA Madaros port) collocates on the same surface —
 coord claim boundary before PR2+.
 
@@ -352,14 +394,14 @@ blocked on a false ENIR-safety premise.
 
 **What it is:**
 
-1. On a branch from **current main**, add the frontier payload per §6 / C1 census:
-   - `self-hosted/enir/**` (14 files), with **C4/C5 repairs** in PR1
-   - gate scripts + Python verifiers (PR2+)
-   - `tools/eisa/` oracle/fixture payload (C1 — must be enumerated)
-   - `bin/madaros-enir` wrapper
-   - `docs/architecture/MADAROS_V2_EISA_SEMANTIC_IR.md` (and optional `MIR_*` refresh)
-2. Wire gates into CI behind E1–E3D (or umbrella `enir_pipeline_gate.sh` first),
-   with **§4.2 BASE_REF re-anchor** (PR2).
+1. On a branch from **current main**, add the frontier payload per
+   `WS_C_PR1_PAYLOAD_CENSUS.md` (**63** files total; see §4.1 / §6.1):
+   - **PR1:** `self-hosted/enir/**` (**14** driver-closure files) with **C4/C5
+     repairs**, `bin/madaros-enir`, `MADAROS_V2_EISA_SEMANTIC_IR.md`
+   - **PR2:** remaining **49** files = 14 gate scripts + 13 Python verifiers +
+     22 `tools/eisa/` oracles/fixtures, with **§4.2 BASE_REF** re-anchor on
+     every landed gate script
+2. Wire gates into CI behind E1–E3D (or umbrella `enir_pipeline_gate.sh` first).
 3. **Compile driver under seed *and* Madaros check** (PR1 acceptance §4.3).  
    Enir **source** fixes stay inside `enir/` until both receipts green.  
    **Gate scripts are out of that boundary** (§4.2 point 4).
@@ -372,20 +414,31 @@ blocked on a false ENIR-safety premise.
 - Preserves executable gates + Python oracles.
 - Aligns with shadow-lane discipline (once BASE_REF is re-anchored for main).
 
-**Cons / cost (updated)**
+**Cons / cost (updated after C1 census)**
 - Must re-validate every gate under **current** seed/Madaros.
-- **PR1:** Madaros parse rewrites (`mir_join.sio`) + **semantic** `loop_closed` fix + dual receipts.
-- **PR2:** BASE_REF re-anchor (+1–2 days), tools/eisa payload, possible oracle re-validation vs main’s drifted EISA (C3).
+- **PR1:** Madaros parse rewrites (`mir_join.sio`) + **semantic** `loop_closed` fix + dual receipts. File count stays **14 enir** (already budgeted); hard work is repair, not bulk.
+- **PR2 grows vs preflight:** not “~23 `tools/eisa` + E1”, but **49**
+  non-enir files (14 scripts + 13 verifiers + 22 fixtures). BASE_REF surgery
+  multiplies across **14** gate scripts, not one. Possible oracle re-validation
+  vs main’s drifted EISA (C3 / present-but-changed watchlist).
 - Shared-surface coord with WS-F.
 - Multi-week for true production MIR→codegen remains after E3D (by design).
 
-**Effort estimate (amended):**
-- **PR1 (days 1–4):** subtree add + C4 rewrites + C5 semantic fix + seed ELF + Madaros check receipts.  
-- **PR2 (days 5–8):** gate BASE_REF surgery + E1 green + payload from census.  
-- **PR3–4 (days 9–14+):** E2A–E3D cascade under main toolchain.  
+**Effort estimate (re-checked against 63-file census):**
+- **PR1 (days 1–4 — holds):** 14 enir subtree add + C4 rewrites + C5 semantic fix + seed ELF + Madaros check receipts + wrapper/docs. **Does not absorb the 49-file gate/payload surprise.**
+- **PR2 (days 5–10 — +2 days vs prior “5–8”):** bulk-add the 49 gate/payload files; BASE_REF re-anchor on all 14 gate scripts; E1 green as acceptance (E2+/E3 scripts may land present-but-not-yet-green). Mechanical bulk is cheap; BASE_REF ×14 + C3 drift is the real cost.
+- **PR3–4 (days 11–16+):** E2A–E3D cascade under main toolchain — **file-add work shrinks** if PR2 already landed the full 49; cascade is mostly green/FAIL_HONEST.
 - Wave 2+: resume lettered expansion (post-E3D scope).
 
-**Verdict:** **Approved default.** Isolation claim holds; preflight items are scoped, not route-killers.
+**PR-stack shape verdict:** **PR1/PR2 split still holds** — do **not** dump
+gates into PR1 (would muddle dual-receipt acceptance) and do **not** hold PR1
+for the 49-file payload. Prefer PR2 as the **bulk gate+payload** landing so
+PR3–4 are cascade-only. Optional micro-split (PR2a = E1+BASE_REF pattern,
+PR2b = remaining payload) only if review bandwidth forces it; default is one
+PR2 bulk add.
+
+**Verdict:** **Approved default.** Isolation claim holds; C1 multiplies PR2
+review surface (~3× preflight tools/eisa estimate), not the route choice.
 
 ---
 
@@ -428,18 +481,30 @@ optional reading of frontier gates as oracles only.
 4. **PR1 is not hostage to WS-B** (§4.5); fleet may still prefer SOIR green before PR2 cascade for CI bandwidth.  
 5. After E1–E3D green on main, treat **post-E3D general SSA / ABI / MachineIR** as a new lettered tranche — do not silently expand E3D claims (also relevant to WS-D MLI S2 feed).
 
-### 6.1 Suggested PR stack (Route B, amended)
+### 6.1 Suggested PR stack (Route B, amended — C1 folded)
 
-| PR | Content | Acceptance (must) |
+**Census authority:** `docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md`.
+Per-gate transitive lists there decide which PR must already contain which
+paths for a given gate to run. Union add-list = **63** files
+(14 enir + 14 scripts + 13 verifiers + 22 `tools/eisa`). Exclude C2-only
+`eisa_enir_c2_rump.eisa` and `$TMP_DIR` fixtures.
+
+| PR | Content (file budget from census) | Acceptance (must) |
 |---|---|---|
-| **PR1** | `self-hosted/enir/**` + `bin/madaros-enir` + `MADAROS_V2_EISA_SEMANTIC_IR.md`; **rewrite `mir_join.sio` C4 sites**; **fix `loop_closed` C5**; optional payload from census if ready | (a) seed driver ELF; (b) **Madaros `souc check` green** (or FAIL_HONEST list); (c) no production IR/codegen edits |
-| **PR2** | E1 gate + Python verifier; **BASE_REF re-anchor per §4.2**; `tools/eisa/` payload per **`WS_C_PR1_PAYLOAD_CENSUS.md`** | E1 green on clean CI; PR-range frozen-surface check fails closed if IR touched |
-| **PR3** | E2A–E2H gates (may split) | Cascade under re-anchored discipline; oracle policy vs main drift documented |
-| **PR4** | E3A–E3D (+ E3E) | FULL gates green or FAIL_HONEST with receipts |
+| **PR1** | **14** `self-hosted/enir/**` (driver closure) + `bin/madaros-enir` + `MADAROS_V2_EISA_SEMANTIC_IR.md`; **rewrite `mir_join.sio` C4 sites**; **fix `loop_closed` C5**. **No** gate scripts / verifiers / `tools/eisa` bulk (keeps dual-receipt surface clean) | (a) seed driver ELF; (b) **Madaros `souc check` green** (or FAIL_HONEST list); (c) no production IR/codegen edits |
+| **PR2** | **49** remaining add-list files: **14** `scripts/dev/madaros_v2_e*` gates + **13** Python verifiers + **22** `tools/eisa/` oracles/fixtures; **BASE_REF re-anchor per §4.2 on every landed gate script** | **E1 green** on clean CI (E1 transitive = 16 = 14 enir from PR1 + E1 `.sh` + E1 `.py`); PR-range frozen-surface check fails closed if IR touched; remaining E2/E3 scripts may be present-but-not-green |
+| **PR3** | E2A–E2H cascade (may split); **no new payload** if PR2 bulk-landed the 49 | Cascade under re-anchored discipline; oracle policy vs main drift (C3 / present-but-changed watchlist) documented |
+| **PR4** | E3A–E3D (+ E3E) cascade | FULL gates green or FAIL_HONEST with receipts |
 | **PR5** | Optional umbrella `scripts/ci/enir_pipeline_gate.sh` + madaros_full_gate hooks | CI wiring only |
 
-**C1 census reference:** `docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md`  
-> **PLACEHOLDER:** file not yet on this branch. Fold numbers into PR1/PR2 rows when codex-2 lands it.
+**Effort vs preflight (~23 files):**
+
+| Item | Pre-census estimate | Post-census (this amendment) |
+|---|---|---|
+| PR1 | days 1–4 | **days 1–4 holds** (14 enir + C4/C5; not the 3× surprise) |
+| PR2 | days 5–8 | **days 5–10** (49-file bulk + BASE_REF ×14 scripts + E1 green) |
+| PR3–4 | days 9–14+ | **days 11–16+** if PR2 bulk-lands; cascade-heavy, add-light |
+| Stack shape | PR1 enir / PR2 E1+payload / PR3–4 cascade | **Shape holds.** Do not move the 49 into PR1. Prefer one PR2 bulk over splitting PR1. |
 
 No production `use enir::` from `compiler/main.sio` until a later explicit integration tranche (post-WS-D MLI design).
 
@@ -472,9 +537,10 @@ MB=$(git merge-base origin/main HEAD)
 comm -12 <(git diff --name-only $MB HEAD | sort) \
          <(git diff --name-only $MB origin/main | sort)
 
-# tools/eisa payload missing on main (C1 sketch)
+# tools/eisa delta only (incomplete vs full gate stack — use census)
 comm -23 <(git ls-tree -r --name-only origin/canon/madaros-v2-sota tools/eisa | sort) \
          <(git ls-tree -r --name-only origin/main tools/eisa | sort)
+# Full E1/E2/E3 add-list: docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md (63 files)
 ```
 
 ---
@@ -496,8 +562,8 @@ comm -23 <(git ls-tree -r --name-only origin/canon/madaros-v2-sota tools/eisa | 
 | Study worktree | `/workspace/.wt/mir-study` @ `97b525949` |
 | Amendment worktree | `/workspace/.wt/amend-mir` @ branch `amend/mir-port-plan-20260816` |
 | Preflight review | `docs/architecture/WS_C_D_PREFLIGHT_REVIEW_2026-08-16.md` |
-| C1 payload census | `docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md` (**placeholder** until codex-2) |
-| Coord claim | `grok-cli1` / `amend-mir-port-plan` |
-| Next port action | PR1 per §6.1 after C1 census (or interim payload list); PR2 BASE_REF |
+| C1 payload census | `docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md` (**landed**; **63** = 14+13+14+22) |
+| Coord claim | `grok-cli1` / `amend-mir-port-plan` (release after this amendment) |
+| Next port action | PR1 per §6.1 (14 enir + C4/C5 + dual receipts); PR2 bulk 49 + BASE_REF ×14 + E1 green |
 
-*End of WS-C port plan (route study + preflight amendments).*
+*End of WS-C port plan (route study + preflight amendments + C1 census fold).*

--- a/docs/architecture/MLI_DESIGN.md
+++ b/docs/architecture/MLI_DESIGN.md
@@ -1,22 +1,27 @@
 <!-- docs:meta
 topic_id: repo.docs.architecture.mli-design
-authority: repo_only
+authority: draft_amended_pending_land
 audience: users
-last_validated: 2026-03-07
-validated_by: A2
+last_validated: 2026-08-16
+validated_by: WS-D grok-cli2 + preflight fable-1
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.architecture.mli-design
 -->
 
 # MLI Design — Machine-Level IR
 
-**Status:** draft for approval (WS-D Phase 1). **No `self-hosted/` edits** until this
-document is approved.
+**Status:** Option C **founder-approved** (2026-08-16). Preflight amendments D1–D4
+from [`WS_C_D_PREFLIGHT_REVIEW_2026-08-16.md`](WS_C_D_PREFLIGHT_REVIEW_2026-08-16.md)
+folded in (this revision). **No `self-hosted/` MLI code** until implementation
+dispatch after this amended design is accepted.
 
 **Authority:** Founder objectives 2026-08-16 (“Madaros E2E operacional, SOIR, MIR,
-MLI, HLIR EISA, f128 e f256 implantados e verificados”) and the binding design
-principle in
-[`docs/internal/coordination/MADAROS_FOCUS_PLAN_2026-08-16.md`](../internal/coordination/MADAROS_FOCUS_PLAN_2026-08-16.md)
-§WS-D.
+MLI, HLIR EISA, f128 e f256 implantados e verificados”); binding design principle
+in [`MADAROS_FOCUS_PLAN_2026-08-16.md`](../internal/coordination/MADAROS_FOCUS_PLAN_2026-08-16.md)
+§WS-D; Route B for WS-C (`MIR_PORT_PLAN.md`) is **settled** — do not re-litigate
+Route B or Option C here.
+
+**Adversarial preflight:** fable-1 reviewed Option C; it **survived**. Amendments
+below close input-contract and kind-model gaps only.
 
 ---
 
@@ -46,8 +51,9 @@ silently defaulting to “just another GPR IR.”
 register/stack discipline, verification story, staged ladder, named open
 decisions blocked on WS-C/WS-G.
 
-**Phase-2 exit (wave 3+, not this doc):** one function lowered MIR→MLI→x86
-**bit-identical** to the current direct native path.
+**Phase-2 exit (wave 3+, not this doc):** one function lowered **IR→MLI→x86**
+(see §3.2 feed choice) **bit-identical** to a **pinned** direct native path
+(see §10 O5 — resolved). Not expressible from Route-B EMIR alone.
 
 ---
 
@@ -57,12 +63,17 @@ decisions blocked on WS-C/WS-G.
 |---|---|---|
 | **SIR / HIR / IR** (`self-hosted/ir/`) | SSA-ish compiler IR with hypercomplex and epistemic opcodes | **Above** MIR/MLI; rich but not machine-level |
 | **`native::machine_ir`** (`self-hosted/native/machine_ir.sio`) | Native-v2 **legalize substrate** for x86-64 (MIR_* opcodes, GPR64 + stack slots + SSE2 float) | **Not** MLI. Today’s end-stage pseudo-ISA. MLI **feeds** this path or **replaces its pseudo layer** over time |
-| **MIR** (WS-C) | Frontier ENIR→MIR pipeline on `origin/canon/madaros-v2-sota` (not fully on `main` yet) | **Input** to MLI (pending WS-C route) |
-| **ENIR** | Epistemic numeric IR on the frontier branch; contract docs under `docs/internal/coordination/enir-*.md` | Source of MIR; verification pattern to mirror |
-| **MLI** (this doc) | **New** Machine-Level IR | Between MIR and native emit |
+| **MIR / EMIR** (WS-C Route B) | Frontier `self-hosted/enir/` → EMIR (`enir/mir.sio`): **epistemic-bundle** machine IR | **Not** a general scalar machine IR; see §3.2 gap |
+| **ENIR** | Epistemic numeric IR on `origin/canon/madaros-v2-sota`; contract docs under `docs/internal/coordination/enir-*.md` | Upstream of EMIR; verification pattern to mirror |
+| **MLI** (this doc) | **New** Machine-Level IR | Between **IR and/or EMIR** and native emit |
 
-If “MIR” is used without qualifier in this document, it means **WS-C portable MIR**
-(the MLI *input*), not `native::machine_ir`.
+**Disambiguation rule:** `native::machine_ir` constants use the historical
+`MIR_*` prefix on main — **not** the same object as Route-B EMIR. See §5.4 /
+preflight D4: renaming those constants to `X86_*` (or a header note) is a
+**precondition of WS-C PR1**, not optional later cleanup.
+
+If “MIR” is used without qualifier below, prefer **EMIR** when Route B is meant,
+and **never** mean `native::machine_ir`.
 
 ---
 
@@ -135,7 +146,8 @@ subset until “later.”
 
 ### 2.4 Recommendation and tradeoff (explicit)
 
-**Recommend Option C.**
+**Option C is founder-approved (2026-08-16).** Preflight re-affirmed it; this
+document does **not** re-open A vs B vs C.
 
 - **Scope/schedule cost:** +1–2 weeks design/fixtures for kind tags and expand
   rules; R1 emit is multi-week *after* Phase-2 (wave 3+).
@@ -143,7 +155,8 @@ subset until “later.”
   **uncertainty-aware and algebra-aware instruction selection** are *expressible*
   without pretending they are structs.
 - **Risk control:** Phase-2 success criterion remains bit-identity on a pure
-  scalar function; R1 is separately gated.
+  scalar function fed by the **IR→MLI side door** (§3.2); R1 is separately gated
+  and is the natural home for **Route-B EMIR epistemic bundles**.
 
 **Not recommended:** Option A as the *architecture* (even if R0 code looks like
 A). Documenting only A would violate the binding principle.
@@ -159,34 +172,97 @@ A). Documenting only A would violate the binding principle.
     → lexer/parser/check
     → IR / HLIR  (self-hosted/ir, self-hosted/hlir)
     → [WS-B] SOIR  (serial / durable form)
-    → [WS-C] ENIR → MIR   (portable machine IR; route TBD)
-    → [WS-D] MLI          ← THIS LAYER
-    → self-hosted/native/  (legalize / regalloc / encode / ELF)
+         │
+         ├─[WS-C Route B] ENIR → EMIR (epistemic bundles only)
+         │                      └─ emir_to_mli ──► MLI R1 Knowledge …
+         │
+         └─ ir_to_mli (S2–S3 primary) ──────────► MLI R0 scalar …
+                                                    │
+  [WS-D] MLI  ◄─────────────────────────────────────┘
+    → legalize_x86 → self-hosted/native/ (encode / ELF)
     → x86-64 ELF (today)
 ```
 
 Optional later consumers of the same MLI:
 
 - GPU path: MLI → existing KAXI/GPU IR (share kind tags; different expand).
-- Softfloat (WS-G): MLI `f128`/`f256` ops expand to routine calls or wide slots.
+- Softfloat (WS-G): MLI IEEE `f128`/`f256` ops expand to routine calls or wide slots
+  (**not** qd128 — see §4.1).
 
-### 3.2 Input contract (depends on WS-C)
+### 3.2 Input contract — Route B gap and chosen S2/S3 feed (preflight D1)
 
-**Assumed MIR properties** (must be confirmed or adapted by WS-C route decision):
+#### 3.2.1 What Route-B EMIR actually is (measured, not assumed)
 
-| Property | Requirement for MLI |
+WS-C **Route B** lands frontier `enir/mir.sio` (EMIR). It is **not** a general
+scalar machine IR. Against that source (preflight fable-1, 2026-08-16):
+
+| Fact | Consequence for MLI |
 |---|---|
-| SSA or near-SSA values | MLI may use virtual registers; φ-nodes resolved at MIR or early MLI |
-| Explicit control flow | Blocks + terminators; no unstructured IR exceptions in R0 |
-| Typed operands | MIR types map injectively into MLI kinds (see §4) |
-| Side effects | Calls, stores, foreign ABI marked; pure arith free of hidden IO |
-| Epistemic / Hyper | Either preserved as MIR types **or** already expanded with **explicit**
-  “discharged epistemic” markers (never silent drop) |
+| **10 opcodes only:** `CONST ADD SUB MUL DIV SQRT OBSERVE LOAD STORE MOVE` | **No** integer ops, **no** `call`, **no** `ret`, **no** compare/branch |
+| Module verify: `type_count == 1` and that type is an **epistemic bundle** `{value_kind: f64, error_kind: qd128, uncertainty_kind: gum1, status_tracked, provenance_tracked}` | **Every** EMIR value is a bundle, never a bare scalar |
+| Post-E3D non-claims include general N-way SSA, alias, **ABI**, **MachineIR** | Exactly the pieces a naive `mir_to_mli` for R0 would need |
 
-**If WS-C chooses a scalar-only MIR:** MLI still defines R1 kinds; expand occurs
-**at MIR→MLI** for epistemic/Hyper remaining in higher IR, or MLI accepts only
-scalar and R1 is fed from IR→MLI side door. Prefer **one choke point**:
-`mir_to_mli`.
+**Named gap:** ladder stages that assumed “MIR has functions, integers, control
+flow, and scalar f64” **cannot be fed from Route-B EMIR as shipped**. In
+particular the Phase-2 golden `add1(x: f64) -> f64` is **not expressible** in
+EMIR (no function ABI, no `ret`).
+
+This is **not** a re-litigation of Route B — EMIR is correctly scoped as an
+**epistemic numeric** machine IR. The design error was MLI assuming a
+*general* MIR that Route B does not claim to deliver.
+
+#### 3.2.2 Chosen feed for S2/S3 (decision)
+
+**Decision: re-anchor S2/S3 on the IR→MLI side door** (option (b) from
+preflight). Do **not** block Phase-2 on a post-E3D EMIR generalisation tranche.
+
+| Feed | What it carries | MLI track |
+|---|---|---|
+| **`ir_to_mli` (primary for S2–S3)** | `self-hosted/ir/` (and/or HLIR) scalar + full language surface | **R0** integers, f64, call/ret, branches |
+| **`emir_to_mli` (primary for R1 epistemic)** | Route-B EMIR epistemic bundles | **R1 `Knowledge`** — maps naturally onto Gpu4-like shape (`val`/`error≈qd`/`uncertainty`/`status`/`prov`) |
+| Optional later | Post-E3D EMIR generalisation (WS-C follow-on, **costed separately**) | Could eventually feed R0 if ABI+control land; **not** required for S2 |
+
+**Why this is correct (not a gap only):**
+
+1. Route-B EMIR’s single-type epistemic bundles are an **argument for** MLI’s
+   first-class `Knowledge` kind (R1), not a failure of Option C.
+2. EMIR `error_kind: qd128` is **double-double family**, not IEEE f128 — see
+   §4.1 exclusion (D2).
+3. Phase-2 bit-identity needs call/ret/f64 that **already exist** on the IR →
+   native path; that is the golden surface to mimic (§6.4, O5).
+
+**Choke points (two, not one):**
+
+```text
+  ir_to_mli   → R0 scalar MLI → legalize_x86 → encode   (S2–S3)
+  emir_to_mli → R1 Knowledge MLI → expand or native k_*  (S5+, parallel)
+```
+
+A single `mir_to_mli` name is **retired** for the scalar path to avoid
+implying EMIR can host `add1`.
+
+#### 3.2.3 Optional WS-C follow-on (not on S2 critical path)
+
+If product owners later want EMIR to host general functions:
+
+| Item | Rough cost | Notes |
+|---|---|---|
+| Integer + compare + branch ops | multi-week | breaks `type_count==1` or adds second type |
+| Function ABI + `call`/`ret` | multi-week | currently post-E3D non-claim |
+| N-way SSA / MachineIR claims | large | full MIR generalisation |
+
+**Do not** schedule this as a silent dependency of S2. If pursued, open a
+**costed WS-C follow-on** with its own gates.
+
+#### 3.2.4 Properties MLI itself still requires (from whatever feed)
+
+| Property | Requirement |
+|---|---|
+| Explicit control (R0) | Blocks + terminators on **IR-fed** MLI |
+| Typed operands | Map into MLI kinds (§4); EMIR→ always `Knowledge` shape |
+| Side effects | Loads/stores/calls marked; pure arith free of hidden IO |
+| No silent discharge | Epistemic lanes never dropped without `k_discharge` |
+
 
 ### 3.3 Output contract (what `native/` consumes)
 
@@ -200,8 +276,11 @@ today’s `native_v2` machine_ir consumers:
 - no unresolved virtual regs (post-regalloc) **or** a single documented
   “pre-regalloc MLI” form only used by the interpreter.
 
-**Bit-identity Phase-2:** for a golden function, `encode(mli_legalize(mli))`
-bytes equal `encode(current_direct_path)`.
+**Bit-identity Phase-2 (pinned — O5):** for a golden function,
+`encode(mli_legalize(mli))` bytes equal `encode(direct_path)` where
+`direct_path` is the **session-built** engine pinned in §10 O5 — not “any
+checked-in ELF”, and not an unspecified lean_single vs Madaros mix. See also
+§6.4: S3 is **emitter mimicry** for one function.
 
 ### 3.4 What MLI is *not*
 
@@ -221,29 +300,42 @@ Kinds are **part of the type**, not comments.
 ```text
 Kind =
   | Void
-  | Int { bits: 8|16|32|64, signed: bool }
+  | Int { bits: 8|16|32|64, signed: bool }   // NOT 128 — see exclusions
   | Ptr { aspace: flat }          // R0: single flat address space
-  | Float { fmt: f32|f64|f128|f256 }
-  | Flags                         // condition codes abstractly
+  | Float { fmt: f32|f64|f128|f256 }  // IEEE binary formats only
+  | QD128                         // double-double error lane (NOT IEEE f128)
+  | Bool                          // i1 logical; R0 branches consume this
   | VecF64 { lanes: 2|4|8 }       // XMM/YMM/ZMM geometric view (optional sugar)
-  | Knowledge { base: Float|Int, lanes: KnowledgeLanes }
+  | Knowledge { base: Float|Int, lanes: KnowledgeLanes, shape: … }
   | CD { dim: 1|2|4|8|16, coeff: Float }   // R,C,H,O,S over coeff format
   | Bundle { fields: [Kind; N] }  // rare; prefer Knowledge/CD tags
 ```
 
-**KnowledgeLanes (R1, aligned with GPU):**
+**Exclusions and non-identities (preflight D2 — freeze in S1):**
 
-| Lane | Role | GPU analogue (`epistemic_spirv.sio`) |
-|---|---|---|
-| `val` | point estimate | `val_id` |
-| `var` / `eps` | GUM variance or epsilon bound | `eps_id` |
-| `conf` or `valid` | confidence 0–1000 **or** boolean validity | `valid_id` |
-| `prov` | bit-packed provenance (optional in R0 expand) | `prov_id` |
+| Topic | Rule |
+|---|---|
+| **qd128 ≠ IEEE f128** | Frontier EMIR `error_kind: qd128` is **double-double family** (`stdlib/math/qd128.sio`). MLI `Float{f128}` is **IEEE binary128** (WS-G). **Forbidden:** silent `f128 := qd128`. Use kind **`QD128`** (or Knowledge error lane typed `QD128`) for EMIR error components. Mapping either way without an explicit conversion op is a **semantic miscompile by construction**. |
+| **No `Int{bits:128}` in R0 MLI** | Language `i128`/`u128` already reaches ELF on the **direct** wide-int path (2026-06). MLI R0 kinds intentionally list 8/16/32/64 only. **Until** an S4+ wide-int tranche: `ir_to_mli` must either (a) **reject** i128/u128 functions for the MLI path with a clear diagnostic, or (b) expand to multi-limb `i64` pairs under an explicit `WideInt` expand — never pretend coverage. Document which; default **(a) fail closed** for Phase-2 goldens (scalar i64/f64 only). |
+| **Flags** | **Retired as a first-class long-lived kind.** See §4.3 R0 control: branches consume **`Bool` vregs**; legalize may fuse `fcmp+br` into x86 flag use. Transient eflags are an **x86 legalize detail**, not an MLI value that can be stored across arbitrary ops. |
 
-Stdlib `Epistemic { val, variance, confidence }` is the **minimal CPU** shape;
-full four-lane is the **GPU-compatible** shape. MLI should tag which shape is
-active (`KnowledgeShape::Minimal3` vs `KnowledgeShape::Gpu4`) so expand rules
-do not invent lanes.
+**KnowledgeLanes (R1, aligned with GPU + EMIR):**
+
+| Lane | Role | GPU analogue | EMIR Route-B analogue |
+|---|---|---|---|
+| `val` | point estimate | `val_id` | `value_kind: f64` |
+| `var` / `eps` | GUM variance **or** epsilon | `eps_id` | uncertainty / GUM lane |
+| `err` | **qd128** arithmetic error lane when present | — | `error_kind: qd128` |
+| `conf` or `valid` | confidence 0–1000 **or** boolean validity | `valid_id` | `status_tracked` |
+| `prov` | bit-packed provenance | `prov_id` | `provenance_tracked` |
+
+Stdlib `Epistemic { val, variance, confidence }` is the **minimal CPU** shape
+(`KnowledgeShape::Minimal3`). Full GPU four-lane is `Gpu4`. EMIR bundles map
+to **`KnowledgeShape::EmirBundle`** (val + **QD128** err + gum uncertainty +
+status + provenance) — this is a **positive** Route-B → R1 argument, not only
+a feed gap.
+
+MLI must tag which shape is active so expand rules do not invent or drop lanes.
 
 **CD dimension:**
 
@@ -281,13 +373,21 @@ an explicit conversion op is a verify error.
 | Class | Examples | Notes |
 |---|---|---|
 | Transfer | `mov`, `load`, `store`, `lea` | typed by kind |
-| Integer arith | `add/sub/mul/div/rem`, shifts, logic | trapping policy flag |
-| Float arith | `fadd/fsub/fmul/fdiv`, compares | IEEE fmt on kind |
-| Convert | `i2f`, `f2i`, `fcast` (f32↔f64; f128/f256 when WS-G ready) | |
-| Control | `jmp`, `br_cc`, `ret`, `call` | call ABI attrs |
-| Compare | `cmp`, `fcmp` → Flags or bool vreg | |
+| Integer arith | `add/sub/mul/div/rem`, shifts, logic | **i8–i64 only** (no i128) |
+| Float arith | `fadd/fsub/fmul/fdiv` | IEEE fmt on kind; **not** qd128 |
+| Convert | `i2f`, `f2i`, `fcast` (f32↔f64; IEEE f128/f256 when WS-G ready) | explicit `qd_from_*` if ever needed |
+| Compare | `icmp`, `fcmp` → **`Bool` vreg** (not Flags) | |
+| Control | `jmp`, `br` (cond: **Bool**), `ret`, `call` | call ABI attrs |
 | Stack | `alloca` / frame adjust (or precomputed frame) | |
-| Pseudo | `copy`, `phi` (if not eliminated), `keep_alive` | |
+| Pseudo | `copy`, `keep_alive` | **no φ in MLI** — see §4.4 |
+
+**Flags / eflags (D2):** R0 MLI **does not** model live `Flags` values. A
+compare produces a `Bool`; `br` consumes that `Bool`. On x86, `legalize_x86`
+may fuse `fcmp`+`br` into `ucomisd`+`jcc` and must treat eflags as
+**clobbered by nearly every ALU op** — V-struct cannot catch a separated
+cmp/br pair if Flags were first-class. Optional verify rule if a future
+lowering ever reintroduces flag temps: **flags def must be adjacent to its
+sole consumer** (no intervening ops). Default for S1–S3: **Bool only**.
 
 #### R1 epistemic (first-class ops — design now, emit staged)
 
@@ -330,10 +430,22 @@ products (the historic “drift to mean” of IEEE thinking).
 ```text
 MliModule  { funcs, data, relocs, target_hint }
 MliFunction { name, args: [Kind], ret: Kind, blocks, frame_info, attrs }
-MliBlock    { id, params?, instrs, term }
+MliBlock    { id, instrs, term }   // NO block params
 ```
 
-**R0 constraint (Phase-2):** single return, no exception edges, SysV x86-64 only.
+**φ / block-params decision (D2 — pick one for S1):**
+
+| Choice | Decision |
+|---|---|
+| Representation | **No block parameters and no φ nodes in MLI.** |
+| Where SSA join is resolved | **Before** MLI: in IR / EMIR / `ir_to_mli` (copy insertion or already-straight-line). |
+| Rationale | Frontier EMIR has no general N-way SSA; Phase-2 goldens are straight-line or simple CFG with explicit moves. Avoids builder churn at S5 if both forms were half-specified. |
+
+If a future feed needs SSA joins inside MLI, that is a **versioned extension**
+(`MliBlock.params`), not the S1 default.
+
+**R0 constraint (Phase-2):** single return, no exception edges, SysV x86-64 only;
+function must come from **`ir_to_mli`** (or hand-built MLI fixture), **not** raw EMIR.
 
 ---
 
@@ -348,7 +460,7 @@ MliBlock    { id, params?, instrs, term }
 | `V256` | f64×4 / partial CD | ymm |
 | `V512` | f64×8 / O | zmm (needs EVEX path; already sketched in IR) |
 | `KMASK` | predicates | k0–k7 |
-| `FLAG` | conditions | eflags (transient) |
+| `FLAG` | **not a long-lived MLI class** | eflags only inside `legalize_x86` fusion |
 | `KNOW` | Knowledge multi-lane (R1) | **home**: consecutive stack slots or multi-phys bundle |
 | `CD` | CD multi-lane (R1) | **home**: ymm/zmm pairs or stack blob |
 
@@ -381,13 +493,28 @@ MliBlock    { id, params?, instrs, term }
 **Frame metadata** for GC/stack maps stays out of R0 unless a function already
 uses them on the direct path.
 
-### 5.4 Interaction with existing `machine_ir.sio`
+### 5.4 Interaction with existing `machine_ir.sio` (preflight D4)
 
-Proposed migration (post-approval, not in Phase 1 code):
+**Name collision is imminent:** on main, `native/machine_ir.sio` already owns
+the `MIR_*` constant prefix (`MIR_OPERAND_GPR64`, `MIR_MAX_INSTRS`, …) while
+WS-C Route B lands a different “MIR” (EMIR) under `enir/`. This plan cycle
+already produced a swapped-wording incident. Leaving the collision optional
+is insufficient.
 
-1. Treat current `MachineInstr` as **post-legalize x86 pseudo** (keep MIR_* names
-   or rename to `X86_*` later).
-2. New modules: `self-hosted/mli/{ir,builder,verify,interp,lower_from_mir,legalize_x86}.sio`.
+**Precondition of WS-C PR1 (required, not optional-later):**
+
+1. **Either** rename `MIR_*` symbols in `native/machine_ir.sio` (and call sites
+   in `codegen.sio` / regalloc) to **`X86_*`** / `NATIVE_MIR_*`, **or**
+2. At **minimum**, add a **naming-disambiguation note in the file header** of
+   `native/machine_ir.sio` stating: “These `MIR_*` constants are the **x86
+   native-v2 legalize substrate**, not Route-B EMIR / `enir/mir.sio`.”
+
+Prefer (1) when a native-touching PR is open; (2) is the floor for PR1 merge.
+
+**Migration (post-MLI approval, implementation phases):**
+
+1. Treat current `MachineInstr` as **post-legalize x86 pseudo** only.
+2. New modules: `self-hosted/mli/{ir,builder,verify,interp,ir_to_mli,emir_to_mli,legalize_x86}.sio`.
 3. `legalize_x86`: MLI → today’s machine_ir ops (R0) or EVEX sequences (R1 CD).
 4. Do **not** grow `machine_ir.sio` with Knowledge kinds ad hoc — that recreates
    erasure under a new name.
@@ -405,13 +532,13 @@ tree** (frontier / WS-C port).
 
 | Layer | What | Pass criterion |
 |---|---|---|
-| **V-struct** | Kind well-formedness, opcode arity, dominance, no raw cross-kind moves | pure static |
+| **V-struct** | Kind well-formedness, opcode arity, dominance, no raw cross-kind moves; **Bool** (not live Flags) for branches | pure static |
 | **V-interp** | MLI interpreter executes a function on concrete inputs | matches reference oracle |
 | **V-parity** | For R0 functions: shadow-exec MLI vs current native binary / direct path | bit-identical or value-identical per policy |
 
 ### 6.2 Interpreter (`mli_interp`)
 
-- State: vreg file + stack memory + flags.
+- State: vreg file + stack memory + **Bool** temps (no live Flags).
 - Knowledge ops: implement **exact GUM rules** used by GPU emitters (document the
   formula table next to `epistemic_spirv.sio` so CPU/GPU cannot diverge silently).
 - CD ops: implement **f64 component algebra** matching `stdlib/algebra` /
@@ -428,13 +555,24 @@ tree** (frontier / WS-C port).
 3. Roundtrip: text or binary dump → parse → structural equality (like IR
    serialize/normalize).
 
-### 6.4 Phase-2 golden
+### 6.4 Phase-2 golden (preflight D3 — pin before S3)
 
-- Fixture: pure function `f(x: f64, y: f64) -> f64` (e.g. `x*y + 1.0`).
-- Pipeline A: today’s native compile.
-- Pipeline B: MIR→MLI→legalize→encode.
-- **Pass:** identical `.text` bytes (or identical post-link function body under a
-  fixed seed of nops). Prefer **bytes** to avoid “same math, different spills.”
+**S3 is not a generic legaliser.** It is: *mimic the existing emitter for one
+function* — register choices, constant materialisation, and scheduling included.
+
+| Pin | Decision (O5 resolved) |
+|---|---|
+| **Golden engine** | **Madaros native-v2** via default `bin/souc` / `bin/madaros` after a **session-local rebuild** (`make build-madaros` or project equivalent under `souc-build-lock`). **Not** lean_single (different bytes). **Not** a checked-in ELF from `bin/` alone without rebuild receipt. |
+| **Provenance receipt** | Record: git SHA, engine path, `souc --version`, build command, UTC timestamp of the binary used as golden. |
+| **Fixture** | Pure scalar function expressible on IR→native today, e.g. `fn add1(x: f64) -> f64 { x + 1.0 }`. **Not** an EMIR program. |
+| **Pipeline A** | Direct path: IR → current native legalize/encode (pinned engine). |
+| **Pipeline B** | `ir_to_mli` → MLI V-struct → `legalize_x86` → same encode surface. |
+| **Pass** | **Bit-identical** `.text` (or whole function body) for that fixture. |
+| **`imm f64`** | No native x86 encoding for immediate f64 in arithmetic. Legalize **must** reproduce the **existing** emitter’s constant strategy (constant pool / `movsd` from rip-relative / `movabs`+`movq` — whichever the pinned path uses). Do not invent a cleaner constant path and call it “equivalent.” |
+
+**Estimate S3 as emitter-mimic work**, not as proof that general legalisation is
+cheap. Value-identity is a **fallback diagnostic** only if bit-identity fails;
+it is not the pass criterion once O5 is pinned to bytes.
 
 ### 6.5 R1 goldens (later)
 
@@ -449,32 +587,38 @@ tree** (frontier / WS-C port).
 
 | Stage | Deliverable | Gate |
 |---|---|---|
-| **S0** | This design approved | human sign-off |
-| **S1** | `mli` module: kinds, builder, text dump, V-struct verify | unit tests on fixtures (no full compile) |
-| **S2** | `mir_to_mli` for **scalar R0 only** (integers + f64) | interpreter tests |
-| **S3** | `legalize_x86` → existing encode path | Phase-2 **bit-identical** vertical slice |
-| **S4** | f32 + conversions; align with WS-G for f128/f256 **slots** (arith may libcall) | WS-G coordination |
-| **S5** | Knowledge kinds + `k_*` ops + expand-to-R0 | parity vs `ep_*` free functions |
+| **S0** | This design (as amended) accepted | human / orchestrator |
+| **S1** | `mli` module: kinds (**incl. QD128, no i128, Bool not Flags**), builder (**no φ**), text dump, V-struct verify | unit tests on fixtures |
+| **S2** | **`ir_to_mli`** for **scalar R0** (i64 + f64 + call/ret); **not** `emir_to_mli` | interpreter tests on IR-derived MLI |
+| **S3** | `legalize_x86` **mimicking** pinned Madaros native-v2 emitter for **one** golden | Phase-2 **bit-identical** vs session-built golden (O5) |
+| **S4** | f32 + conversions; IEEE f128/f256 **slots** (WS-G arith may libcall); still **no** qd≡f128 | WS-G coordination |
+| **S5** | Knowledge kinds + `k_*` + expand-to-R0; start **`emir_to_mli`** for Route-B bundles → `KnowledgeShape::EmirBundle` | parity vs `ep_*` and EMIR oracle lanes |
 | **S6** | CD kinds dim≤8 + `cd_mul` select (EVEX or stack loop) | parity vs stdlib / IR hyper tests |
 | **S7** | dim=16, associator, Door-β, zd_probe policy | GPU formula alignment checklist |
 | **S8** | Optional: MLI→GPU kind-preserving bridge | reuses KAXI epistemic markers |
 
-**Hard rule:** S3 does not require S5–S7, but S1 **must** define Knowledge/CD
-kinds so S5 is not a breaking rewrite.
+**Hard rules:**
+
+- S3 does **not** require S5–S7, but S1 **must** define Knowledge/CD/**QD128**
+  kinds so S5 is not a breaking rewrite.
+- **S2/S3 are not fed by Route-B EMIR.** EMIR feeds S5+ via `emir_to_mli`.
+- Optional post-E3D EMIR generalisation (WS-C follow-on) is **out of band** for
+  S2; see §3.2.3.
 
 **Parallelism:**
 
-- WS-C must freeze MIR type mapping before S2 lands on main.
-- WS-G owns f128/f256 **arithmetic**; MLI only owns **kind + expand hooks**.
+- WS-C PR1: EMIR land + **D4 naming precondition** (§5.4).
+- WS-G owns IEEE f128/f256 **arithmetic**; MLI owns kind + expand hooks + **QD128**
+  as a distinct kind for EMIR error lanes.
 - WS-F EISA remains a separate conformance consumer; may later golden MLI dumps.
 
 ---
 
 ## 8. Worked examples
 
-### 8.1 R0 scalar (Phase-2 target)
+### 8.1 R0 scalar (Phase-2 target — IR feed only)
 
-Source:
+Source (Sounio / IR — **not** EMIR):
 
 ```sounio
 fn add1(x: f64) -> f64 { x + 1.0 }
@@ -485,12 +629,14 @@ MLI sketch:
 ```text
 func @add1(v0: f64) -> f64 {
   b0:
-    v1: f64 = fadd v0, imm f64 1.0
+    v1: f64 = fadd v0, imm f64 1.0   // imm is MLI-level; x86 has no f64 imm
     ret v1
 }
 ```
 
-Legalize → `machine_ir` float binop / movsd path → ELF.
+Legalize must materialise `1.0` **exactly as the pinned Madaros native-v2
+emitter does** (pool / rip-relative / etc.), then emit the same float binop
+path. This fixture is **out of scope for `emir_to_mli`**.
 
 ### 8.2 R1 Knowledge (design now)
 
@@ -551,7 +697,7 @@ Select:
 
 | Risk | Mitigation |
 |---|---|
-| WS-C MIR shape changes | Keep `mir_to_mli` adapter thin; freeze kind enum early |
+| Route-B EMIR ≠ general MIR | S2/S3 use `ir_to_mli`; EMIR → R1 only (§3.2) |
 | R1 never funded | CI checklist items for S5/S6 as explicit unpaid debt in MADAROS status |
 | Kind explosion | No open-ended user algebras in MLI; CD dim ∈ {1,2,4,8,16} only |
 | Exact ZD vs float MLI confusion | Exact Core stays separate; MLI float CD never claims `Proved` |
@@ -568,13 +714,13 @@ Select:
 
 ## 10. Open decisions (blockers)
 
-| ID | Decision | Owner |
+| ID | Decision | Status / resolution |
 |---|---|---|
-| O1 | Final MIR type → MLI kind mapping table | WS-C + WS-D |
-| O2 | Knowledge shape default: Min3 vs Gpu4 on CPU | design review |
-| O3 | Whether `native::machine_ir` renames or remains post-legalize only | native maintainers |
-| O4 | f128/f256: softfloat libcall vs hardware when present | WS-G |
-| O5 | Bit-identity vs value-identity if encoding noise unavoidable | Phase-2 gate owners |
+| O1 | EMIR bundle → `KnowledgeShape::EmirBundle` (+ QD128 err lane); IR scalars → R0 kinds | **Draft mapping in §3.2 / §4.1**; freeze at S1 |
+| O2 | Knowledge shape default on CPU: Min3 vs Gpu4 vs EmirBundle | **Open** — default Min3 for stdlib path; EmirBundle for `emir_to_mli` |
+| O3 | `native::machine_ir` `MIR_*` → `X86_*` (or header note) | **Resolved as WS-C PR1 precondition** (§5.4 / D4) — not optional |
+| O4 | IEEE f128/f256: softfloat libcall vs hardware | **Open** — WS-G; independent of QD128 |
+| O5 | Phase-2 identity criterion + golden engine | **Resolved (D3):** **bit-identical** vs **session-built Madaros native-v2**; not lean_single; not unchecked `bin/` ELF. Value-identity is diagnostic only. |
 
 ---
 
@@ -587,14 +733,21 @@ Select:
 - [x] Verification story (struct + interp + parity), ENIR-pattern mirror
 - [x] Staged ladder with Phase-2 bit-identity isolated from R1
 - [x] Naming disambiguation vs existing `machine_ir.sio`
-- [ ] Human approval (founder / orchestrator) — **pending**
-- [ ] No `self-hosted/` MLI code until approval
+- [x] Option C founder-approved; preflight D1–D4 folded in
+- [x] Route-B EMIR gap named; S2/S3 re-anchored on `ir_to_mli`
+- [x] QD128 ≠ f128; i128 excluded; Bool not Flags; no φ in MLI
+- [x] O5 pinned before S3; S3 scoped as emitter mimicry
+- [x] D4 rename/note as WS-C PR1 precondition
+- [ ] Implementation dispatch (S1) after amended design accepted
+- [ ] No `self-hosted/` MLI code until S1 dispatch
 
 ---
 
 ## 12. References (repo-local)
 
 - Plan: `docs/internal/coordination/MADAROS_FOCUS_PLAN_2026-08-16.md` (WS-D)
+- Preflight: `docs/architecture/WS_C_D_PREFLIGHT_REVIEW_2026-08-16.md`
+- WS-C route: `docs/architecture/MIR_PORT_PLAN.md` (Route B)
 - Concepts: `docs/internal/concepts/epistemic-numeric-value.md`
 - Exact vs measured: `docs/EXACT_CORE.md`
 - ENIR contract lineage: `docs/internal/coordination/enir-semantic-interface-contract-2026-07-12.md`
@@ -612,6 +765,18 @@ Select:
 | Field | Value |
 |---|---|
 | Draft author | grok-cli2 (WS-D) |
-| Claim | `bin/sounio-coord` lane `ws-d-mli-design` |
-| Branch context | working tree may be research/*; doc is integration-agnostic |
-| Next action | Reviewer approval → open S1 implementation dispatch (still no silent R1 drop) |
+| Option C | Founder-approved 2026-08-16 (not re-litigated) |
+| Preflight | fable-1 `WS_C_D_PREFLIGHT_REVIEW_2026-08-16.md`; amendments D1–D4 |
+| Amend author | grok-cli2 lane `amend-mli-design` |
+| Worktree | `/workspace/.wt/amend-mli` branch `amend/mli-design-20260816` |
+| Next action | Land this amended doc; S1 may open; S2 = `ir_to_mli` not EMIR |
+
+### 13.1 Amendment log
+
+| Date | Change |
+|---|---|
+| 2026-08-16 | Initial WS-D draft (Option C recommended) |
+| 2026-08-16 | D1: name Route-B EMIR gap; S2/S3 feed = `ir_to_mli`; EMIR → R1 Knowledge |
+| 2026-08-16 | D2: QD128 kind; no Int128; Bool not Flags; no block-params/φ in MLI |
+| 2026-08-16 | D3: O5 pin Madaros native-v2 session binary; S3 = emitter mimic |
+| 2026-08-16 | D4: `X86_*` rename or header note = WS-C PR1 precondition |

--- a/docs/architecture/MLI_DESIGN.md
+++ b/docs/architecture/MLI_DESIGN.md
@@ -1,0 +1,617 @@
+<!-- docs:meta
+topic_id: repo.docs.architecture.mli-design
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.architecture.mli-design
+-->
+
+# MLI Design — Machine-Level IR
+
+**Status:** draft for approval (WS-D Phase 1). **No `self-hosted/` edits** until this
+document is approved.
+
+**Authority:** Founder objectives 2026-08-16 (“Madaros E2E operacional, SOIR, MIR,
+MLI, HLIR EISA, f128 e f256 implantados e verificados”) and the binding design
+principle in
+[`docs/internal/coordination/MADAROS_FOCUS_PLAN_2026-08-16.md`](../internal/coordination/MADAROS_FOCUS_PLAN_2026-08-16.md)
+§WS-D.
+
+---
+
+## 0. Executive summary
+
+**MLI** (Machine-Level IR) is a **new** lowering layer between the portable
+machine-oriented IR (**MIR**, WS-C route TBD) and the existing native emit
+surface under `self-hosted/native/` (x86-64 ELF today; AArch64/RISC-V stubs).
+
+Today, two Sounio-defining features are **erased or demoted to library/struct
+calls** before codegen:
+
+1. **`Knowledge<T>` / GUM uncertainty** — value + variance/epsilon + confidence
+   (and, on GPU, validity + provenance lanes).
+2. **Cayley–Dickson (CD) hypercomplex algebras** — dimension-tagged multiply /
+   conjugate / associator already first-class in `self-hosted/ir/ir.sio`
+   (`IrHyperMulQ/O/S`, `IrAssociator`, Door-β variance-of-associator) and
+   **validated on GPU tensor cores** (`self-hosted/gpu/emit_ossm_oct_step_ptx.sio`,
+   sedenion associator emitters; cross-backend epistemic SPIR-V 4-lane shadows).
+
+**MLI is the last layer where those need not disappear.** This design evaluates
+first-class epistemic and CD operand *kinds* alongside IEEE floats (`f32`…`f256`)
+and chooses an explicit dual-track (R0 scalar / R1 epistemic-algebra) rather than
+silently defaulting to “just another GPR IR.”
+
+**Phase-1 exit (this doc approved):** layer contract, instruction/operand model,
+register/stack discipline, verification story, staged ladder, named open
+decisions blocked on WS-C/WS-G.
+
+**Phase-2 exit (wave 3+, not this doc):** one function lowered MIR→MLI→x86
+**bit-identical** to the current direct native path.
+
+---
+
+## 1. Naming disambiguation (read first)
+
+| Name in repo | What it is today | Relation to MLI |
+|---|---|---|
+| **SIR / HIR / IR** (`self-hosted/ir/`) | SSA-ish compiler IR with hypercomplex and epistemic opcodes | **Above** MIR/MLI; rich but not machine-level |
+| **`native::machine_ir`** (`self-hosted/native/machine_ir.sio`) | Native-v2 **legalize substrate** for x86-64 (MIR_* opcodes, GPR64 + stack slots + SSE2 float) | **Not** MLI. Today’s end-stage pseudo-ISA. MLI **feeds** this path or **replaces its pseudo layer** over time |
+| **MIR** (WS-C) | Frontier ENIR→MIR pipeline on `origin/canon/madaros-v2-sota` (not fully on `main` yet) | **Input** to MLI (pending WS-C route) |
+| **ENIR** | Epistemic numeric IR on the frontier branch; contract docs under `docs/internal/coordination/enir-*.md` | Source of MIR; verification pattern to mirror |
+| **MLI** (this doc) | **New** Machine-Level IR | Between MIR and native emit |
+
+If “MIR” is used without qualifier in this document, it means **WS-C portable MIR**
+(the MLI *input*), not `native::machine_ir`.
+
+---
+
+## 2. Binding design principle — evaluation (required)
+
+### 2.1 What mainstream backends do
+
+LLVM / Cranelift / GCC treat:
+
+- uncertainty as **user structs + library calls**,
+- quaternions/octonions as **arrays of f32/f64** or SIMD vectors with **no algebra
+  identity** in the type system.
+
+Register allocation never asks “is this a GUM-coupled pair?” or “is this an
+octonion (non-associative) ZMM pair?” Instruction selection never forbids illegal
+reassociation of `Knowledge` arithmetic or Fano-line short-circuits.
+
+### 2.2 What Sounio already has (evidence)
+
+| Surface | Epistemic | CD algebra | Machine-ish? |
+|---|---|---|---|
+| Typecheck (`check/epistemic.sio`, `check/cayley_dickson.sio`) | first-class | first-class | no |
+| IR opcodes (`IrMeasure`, `IrLiftKnowledge`, `IrHyperMul*`, `IrAssociator`, Door-β) | first-class | first-class | partial |
+| GPU PTX/SPIR-V (`epistemic_spirv.sio` 4-lane shadows; `emit_ossm_oct_step_ptx.sio` WMMA L(A)·H) | first-class | first-class (layout/matrix) | **yes for GPU** |
+| Native x86 path (`native/machine_ir.sio` + `hyper_lower.sio`) | **erased** to f64 / library | **demoted** to stack-slot loops or EVEX sequences late | scalar/SIMD without kind |
+
+GPU already proves the research claim: **four-lane epistemic shadows** and
+**tensor-core octonion left-multiply** are implementable when the IR *keeps* the
+kind. CPU native is where erasure still wins by default.
+
+### 2.3 Design options (must not skip)
+
+#### Option A — Scalar-only MLI (silent default we reject as *sole* design)
+
+MLI operands = `{i8…i64, u*, f32, f64, f128, f256, ptr, flags}`.  
+Knowledge / Hyper lower to **field projections + calls** before MLI.
+
+| Pros | Cons |
+|---|---|
+| Fast path to Phase-2 bit-identity | Throws away the only “beyond any existing language” opportunity called out in the plan |
+| Matches LLVM mental model | Duplicates GPU epistemic work as a dead end on CPU |
+| Smaller regalloc | GUM and non-associativity bugs reappear as “optimizer freedom” |
+
+#### Option B — Full first-class epistemic + CD kinds from day one in emit
+
+Every MLI op is kind-polymorphic; regalloc tracks multi-lane values; no scalar
+subset until “later.”
+
+| Pros | Cons |
+|---|---|
+| Maximum novelty | Blocks Phase-2 bit-identity for months |
+| Unified CPU/GPU mental model | Couples MLI to unfinished WS-G (f128/f256) and WS-C MIR shape |
+| | Verification surface explodes before any golden exists |
+
+#### Option C — **Dual-track (recommended): kinds first-class in the type system; R0 emit first**
+
+- **MLI type system and opcode space** include epistemic and CD kinds from the
+  start (no “we’ll add tags later” lie).
+- **R0 implementation** only *emits* scalar/float subset; epistemic/CD ops are
+  **legal MLI** but lower via explicit **expand** pass to scalar MLI (or stay
+  unexpanded and fail closed).
+- **R1 implementation** enables native multi-lane regalloc + GUM op selection +
+  algebra-aware schedules without rewriting the layer contract.
+
+| Pros | Cons |
+|---|---|
+| Honours binding principle without silent default | Two stages of regalloc complexity |
+| Phase-2 vertical slice unblocked (R0) | Risk of “R1 never ships” if not gated in CI as hard TODOs |
+| GPU lessons transfer as **expand strategies**, not redesigns | Spec must freeze kind tags early |
+
+### 2.4 Recommendation and tradeoff (explicit)
+
+**Recommend Option C.**
+
+- **Scope/schedule cost:** +1–2 weeks design/fixtures for kind tags and expand
+  rules; R1 emit is multi-week *after* Phase-2 (wave 3+).
+- **Novelty gain:** MLI becomes the first CPU machine IR in this lineage where
+  **uncertainty-aware and algebra-aware instruction selection** are *expressible*
+  without pretending they are structs.
+- **Risk control:** Phase-2 success criterion remains bit-identity on a pure
+  scalar function; R1 is separately gated.
+
+**Not recommended:** Option A as the *architecture* (even if R0 code looks like
+A). Documenting only A would violate the binding principle.
+
+---
+
+## 3. Layer contract
+
+### 3.1 Pipeline position
+
+```text
+  source
+    → lexer/parser/check
+    → IR / HLIR  (self-hosted/ir, self-hosted/hlir)
+    → [WS-B] SOIR  (serial / durable form)
+    → [WS-C] ENIR → MIR   (portable machine IR; route TBD)
+    → [WS-D] MLI          ← THIS LAYER
+    → self-hosted/native/  (legalize / regalloc / encode / ELF)
+    → x86-64 ELF (today)
+```
+
+Optional later consumers of the same MLI:
+
+- GPU path: MLI → existing KAXI/GPU IR (share kind tags; different expand).
+- Softfloat (WS-G): MLI `f128`/`f256` ops expand to routine calls or wide slots.
+
+### 3.2 Input contract (depends on WS-C)
+
+**Assumed MIR properties** (must be confirmed or adapted by WS-C route decision):
+
+| Property | Requirement for MLI |
+|---|---|
+| SSA or near-SSA values | MLI may use virtual registers; φ-nodes resolved at MIR or early MLI |
+| Explicit control flow | Blocks + terminators; no unstructured IR exceptions in R0 |
+| Typed operands | MIR types map injectively into MLI kinds (see §4) |
+| Side effects | Calls, stores, foreign ABI marked; pure arith free of hidden IO |
+| Epistemic / Hyper | Either preserved as MIR types **or** already expanded with **explicit**
+  “discharged epistemic” markers (never silent drop) |
+
+**If WS-C chooses a scalar-only MIR:** MLI still defines R1 kinds; expand occurs
+**at MIR→MLI** for epistemic/Hyper remaining in higher IR, or MLI accepts only
+scalar and R1 is fed from IR→MLI side door. Prefer **one choke point**:
+`mir_to_mli`.
+
+### 3.3 Output contract (what `native/` consumes)
+
+MLI after **target legalize** must be consumable by a thin emitter that looks like
+today’s `native_v2` machine_ir consumers:
+
+- finite opcode set mappable to `encode.sio` / `codegen.sio` emitters;
+- operands resolved to **physical classes**: GPR, XMM/YMM/ZMM, k-mask, stack slot,
+  immediate, reloc;
+- ABI for calls already applied (arg moves, stack alignment);
+- no unresolved virtual regs (post-regalloc) **or** a single documented
+  “pre-regalloc MLI” form only used by the interpreter.
+
+**Bit-identity Phase-2:** for a golden function, `encode(mli_legalize(mli))`
+bytes equal `encode(current_direct_path)`.
+
+### 3.4 What MLI is *not*
+
+- Not a replacement for ENIR (epistemic *numeric* analysis IR).
+- Not HLIR (high-level GPU/tensor scheduling).
+- Not SOIR (on-disk interchange).
+- Not “rename machine_ir.sio” without a kind model — that would fake completion.
+
+---
+
+## 4. Instruction and operand model
+
+### 4.1 Operand kinds (first-class)
+
+Kinds are **part of the type**, not comments.
+
+```text
+Kind =
+  | Void
+  | Int { bits: 8|16|32|64, signed: bool }
+  | Ptr { aspace: flat }          // R0: single flat address space
+  | Float { fmt: f32|f64|f128|f256 }
+  | Flags                         // condition codes abstractly
+  | VecF64 { lanes: 2|4|8 }       // XMM/YMM/ZMM geometric view (optional sugar)
+  | Knowledge { base: Float|Int, lanes: KnowledgeLanes }
+  | CD { dim: 1|2|4|8|16, coeff: Float }   // R,C,H,O,S over coeff format
+  | Bundle { fields: [Kind; N] }  // rare; prefer Knowledge/CD tags
+```
+
+**KnowledgeLanes (R1, aligned with GPU):**
+
+| Lane | Role | GPU analogue (`epistemic_spirv.sio`) |
+|---|---|---|
+| `val` | point estimate | `val_id` |
+| `var` / `eps` | GUM variance or epsilon bound | `eps_id` |
+| `conf` or `valid` | confidence 0–1000 **or** boolean validity | `valid_id` |
+| `prov` | bit-packed provenance (optional in R0 expand) | `prov_id` |
+
+Stdlib `Epistemic { val, variance, confidence }` is the **minimal CPU** shape;
+full four-lane is the **GPU-compatible** shape. MLI should tag which shape is
+active (`KnowledgeShape::Minimal3` vs `KnowledgeShape::Gpu4`) so expand rules
+do not invent lanes.
+
+**CD dimension:**
+
+| `dim` | Algebra | Preferred machine packing (R1 hint) |
+|---:|---|---|
+| 1 | ℝ | scalar float |
+| 2 | ℂ | 2-lane / xmm pair |
+| 4 | ℍ | YMM (matches `IrHyperMulQ`) |
+| 8 | 𝕆 | ZMM (matches `IrHyperMulO` / GPU L(A)·H tile) |
+| 16 | 𝕊 | 2×ZMM (matches `IrHyperMulS`) |
+
+Associativity / zero-divisor **policy** is not a kind field; it is an
+**instruction attribute** or side table (see §4.3).
+
+### 4.2 Operands
+
+```text
+Operand =
+  | VReg { id, kind }           // virtual
+  | Phys { class, idx, kind }   // post-alloc
+  | Stack { slot, kind, offset_bytes }
+  | Imm { bits, kind }          // kind restricts legal immediates
+  | Reloc { symbol, addend }
+  | BlockRef { id }
+  | None
+```
+
+**Invariant:** every VReg/Phys/Stack carries a `kind`. Cross-kind `move` without
+an explicit conversion op is a verify error.
+
+### 4.3 Instruction classes
+
+#### R0 (required for Phase-2)
+
+| Class | Examples | Notes |
+|---|---|---|
+| Transfer | `mov`, `load`, `store`, `lea` | typed by kind |
+| Integer arith | `add/sub/mul/div/rem`, shifts, logic | trapping policy flag |
+| Float arith | `fadd/fsub/fmul/fdiv`, compares | IEEE fmt on kind |
+| Convert | `i2f`, `f2i`, `fcast` (f32↔f64; f128/f256 when WS-G ready) | |
+| Control | `jmp`, `br_cc`, `ret`, `call` | call ABI attrs |
+| Compare | `cmp`, `fcmp` → Flags or bool vreg | |
+| Stack | `alloca` / frame adjust (or precomputed frame) | |
+| Pseudo | `copy`, `phi` (if not eliminated), `keep_alive` | |
+
+#### R1 epistemic (first-class ops — design now, emit staged)
+
+| Op | Semantics (sketch) | Expand (R0) |
+|---|---|---|
+| `k_measure` | raw → Knowledge | build struct / lanes |
+| `k_add` / `k_sub` | val ±; var quadrature (GUM) | 3–4 float ops + sqrt |
+| `k_mul` / `k_div` | first-order GUM; div near-zero guard | as GPU emitters |
+| `k_fma` | optional | |
+| `k_extract_val/var/conf` | lane project | field loads |
+| `k_insert_*` | lane update | |
+| `k_cast_base` | change base float width | |
+| `k_lift` / `k_discharge` | to/from plain float (explicit) | |
+
+**Illegal without attribute:** treating `k_add` as pure `fadd` on `val` and
+discarding `var` (verify must reject).
+
+#### R1 Cayley–Dickson (first-class ops)
+
+| Op | Semantics | Expand / select |
+|---|---|---|
+| `cd_add` / `cd_sub` | componentwise | lane loop or SIMD |
+| `cd_mul` | Hamilton / CD product by `dim` | Q: EVEX seq; O: Fano ZMM; S: 4×Fano; else libcall |
+| `cd_conj` | conjugate | sign-flip imag lanes |
+| `cd_norm2` | Σ xᵢ² | horizontal add |
+| `cd_associator` | `[a,b,c]` for dim≥8 | matches `IrAssociator` |
+| `cd_var_associator` | Door-β GUM correction | Fano short-circuit when exact |
+| `cd_zd_probe` | zero-divisor proximity (policy) | exact i64 path remains **outside** MLI float path (Exact Core) |
+
+**Attributes on `cd_mul` / associator:**
+
+- `assoc_policy`: `strict` | `allow_reassoc_if_fano` | `force_expand`
+- `zd_policy`: `ignore` | `flag` | `trap` (trap may be debug-only R0)
+
+These attributes exist so optimizers **cannot silently reassociate** octonion
+products (the historic “drift to mean” of IEEE thinking).
+
+### 4.4 Module / function shape
+
+```text
+MliModule  { funcs, data, relocs, target_hint }
+MliFunction { name, args: [Kind], ret: Kind, blocks, frame_info, attrs }
+MliBlock    { id, params?, instrs, term }
+```
+
+**R0 constraint (Phase-2):** single return, no exception edges, SysV x86-64 only.
+
+---
+
+## 5. Register and stack discipline
+
+### 5.1 Abstract register classes
+
+| Class | Holds | x86-64 map (R0/R1) |
+|---|---|---|
+| `GPR` | Int, Ptr | rax…r15 |
+| `FPR` | f32/f64 | xmm (scalar SSE2) |
+| `V256` | f64×4 / partial CD | ymm |
+| `V512` | f64×8 / O | zmm (needs EVEX path; already sketched in IR) |
+| `KMASK` | predicates | k0–k7 |
+| `FLAG` | conditions | eflags (transient) |
+| `KNOW` | Knowledge multi-lane (R1) | **home**: consecutive stack slots or multi-phys bundle |
+| `CD` | CD multi-lane (R1) | **home**: ymm/zmm pairs or stack blob |
+
+### 5.2 Homing rules
+
+1. **Scalar (R0):** virtual reg → physical class by kind; spill to stack slots
+   sized by kind (`f64`=8, `f128`=16, `f256`=32 when live).
+2. **Knowledge (R1):** preferred **SoA stack home** (val, var, conf[, prov]) for
+   ABI simplicity; short-lived **FPR pairs** for val/var during GUM sequences
+   (matches GPU SoA comment in `epistemic_spirv.sio`).
+3. **CD dim=8:** prefer single ZMM home when EVEX available; else 8×f64 stack
+   (today’s `hyper_lower.sio` fallback).
+4. **CD dim=16:** two consecutive ZMM homes or 16×f64 stack.
+5. **Calling convention:** R0 SysV: integers in rdi/rsi/…; floats in xmm0…;
+   Knowledge/CD **passed by hidden pointer** unless a future ABI RFC freezes
+   multi-reg returns (Madaros multi-module sret issues make “struct return”
+   fragile today — fail closed to by-ref).
+
+### 5.3 Stack frame
+
+```text
+[ inbound args ]
+[ return addr ]
+[ saved rbp ]
+[ callee-save ]
+[ MLI slots: scalar | Knowledge homes | CD homes ]  ← downward from rbp
+[ red zone? only leaf pure R0, optional ]
+```
+
+**Frame metadata** for GC/stack maps stays out of R0 unless a function already
+uses them on the direct path.
+
+### 5.4 Interaction with existing `machine_ir.sio`
+
+Proposed migration (post-approval, not in Phase 1 code):
+
+1. Treat current `MachineInstr` as **post-legalize x86 pseudo** (keep MIR_* names
+   or rename to `X86_*` later).
+2. New modules: `self-hosted/mli/{ir,builder,verify,interp,lower_from_mir,legalize_x86}.sio`.
+3. `legalize_x86`: MLI → today’s machine_ir ops (R0) or EVEX sequences (R1 CD).
+4. Do **not** grow `machine_ir.sio` with Knowledge kinds ad hoc — that recreates
+   erasure under a new name.
+
+---
+
+## 6. Verification story
+
+Mirror the **ENIR pattern** described in the plan (`enir/interpreter.sio` +
+`verify.sio`) and the existing IR habit in `self-hosted/ir/verify.sio`
+(normalize + compare), even though `self-hosted/enir/` is **not on this branch’s
+tree** (frontier / WS-C port).
+
+### 6.1 Three layers of check
+
+| Layer | What | Pass criterion |
+|---|---|---|
+| **V-struct** | Kind well-formedness, opcode arity, dominance, no raw cross-kind moves | pure static |
+| **V-interp** | MLI interpreter executes a function on concrete inputs | matches reference oracle |
+| **V-parity** | For R0 functions: shadow-exec MLI vs current native binary / direct path | bit-identical or value-identical per policy |
+
+### 6.2 Interpreter (`mli_interp`)
+
+- State: vreg file + stack memory + flags.
+- Knowledge ops: implement **exact GUM rules** used by GPU emitters (document the
+  formula table next to `epistemic_spirv.sio` so CPU/GPU cannot diverge silently).
+- CD ops: implement **f64 component algebra** matching `stdlib/algebra` /
+  `ir` conventions (Fano table, CD doubling); optional exact-i64 path remains a
+  **separate** Exact Core concern (`docs/EXACT_CORE.md`) — do not mix “proved ZD”
+  into float MLI.
+
+### 6.3 Verify (`mli_verify`)
+
+1. Structural verify (V-struct).
+2. Optional **kind preservation** audit: every MIR epistemic/Hyper value either
+   (a) remains Knowledge/CD through MLI, or (b) has an explicit `k_discharge` /
+   `cd_expand` with source location.
+3. Roundtrip: text or binary dump → parse → structural equality (like IR
+   serialize/normalize).
+
+### 6.4 Phase-2 golden
+
+- Fixture: pure function `f(x: f64, y: f64) -> f64` (e.g. `x*y + 1.0`).
+- Pipeline A: today’s native compile.
+- Pipeline B: MIR→MLI→legalize→encode.
+- **Pass:** identical `.text` bytes (or identical post-link function body under a
+  fixed seed of nops). Prefer **bytes** to avoid “same math, different spills.”
+
+### 6.5 R1 goldens (later)
+
+- `k_add` matches stdlib `ep_add` on random inputs (value + variance + conf).
+- `cd_mul` dim=8 matches `oct_mul` bit-for-bit on f64 components for a fixed set.
+- Door-β Fano short-circuit: Fano triples emit cheap path (count ops or match
+  mask).
+
+---
+
+## 7. Staged implementation ladder
+
+| Stage | Deliverable | Gate |
+|---|---|---|
+| **S0** | This design approved | human sign-off |
+| **S1** | `mli` module: kinds, builder, text dump, V-struct verify | unit tests on fixtures (no full compile) |
+| **S2** | `mir_to_mli` for **scalar R0 only** (integers + f64) | interpreter tests |
+| **S3** | `legalize_x86` → existing encode path | Phase-2 **bit-identical** vertical slice |
+| **S4** | f32 + conversions; align with WS-G for f128/f256 **slots** (arith may libcall) | WS-G coordination |
+| **S5** | Knowledge kinds + `k_*` ops + expand-to-R0 | parity vs `ep_*` free functions |
+| **S6** | CD kinds dim≤8 + `cd_mul` select (EVEX or stack loop) | parity vs stdlib / IR hyper tests |
+| **S7** | dim=16, associator, Door-β, zd_probe policy | GPU formula alignment checklist |
+| **S8** | Optional: MLI→GPU kind-preserving bridge | reuses KAXI epistemic markers |
+
+**Hard rule:** S3 does not require S5–S7, but S1 **must** define Knowledge/CD
+kinds so S5 is not a breaking rewrite.
+
+**Parallelism:**
+
+- WS-C must freeze MIR type mapping before S2 lands on main.
+- WS-G owns f128/f256 **arithmetic**; MLI only owns **kind + expand hooks**.
+- WS-F EISA remains a separate conformance consumer; may later golden MLI dumps.
+
+---
+
+## 8. Worked examples
+
+### 8.1 R0 scalar (Phase-2 target)
+
+Source:
+
+```sounio
+fn add1(x: f64) -> f64 { x + 1.0 }
+```
+
+MLI sketch:
+
+```text
+func @add1(v0: f64) -> f64 {
+  b0:
+    v1: f64 = fadd v0, imm f64 1.0
+    ret v1
+}
+```
+
+Legalize → `machine_ir` float binop / movsd path → ELF.
+
+### 8.2 R1 Knowledge (design now)
+
+Source:
+
+```sounio
+fn add_k(a: Knowledge<f64>, b: Knowledge<f64>) -> Knowledge<f64> {
+  // desugars to GUM add
+  a + b
+}
+```
+
+MLI sketch:
+
+```text
+func @add_k(a: Knowledge<f64, Min3>, b: Knowledge<f64, Min3>) -> Knowledge<f64, Min3> {
+  b0:
+    r: Knowledge<f64, Min3> = k_add a, b   // kind preserved
+    ret r
+}
+```
+
+R0 expand (legalize):
+
+```text
+// a.val, a.var, a.conf in stack homes
+v = fadd a.val, b.val
+var = fadd a.var, b.var          // or quadrature: sqrt(var_a+var_b)
+conf = min(a.conf, b.conf)       // policy as today
+```
+
+**Without kind:** optimizers could CSE `a.val+b.val` with a plain float add
+elsewhere and drop variance — the bug class MLI is designed to make *local* and
+*checkable*.
+
+### 8.3 R1 octonion (GPU-informed)
+
+Source: `oct_mul(a, b)` or IR `IrHyperMulO`.
+
+MLI:
+
+```text
+r: CD{dim=8, f64} = cd_mul a, b   assoc_policy=strict
+```
+
+Select:
+
+- if target has EVEX ZMM: lower like current hyper EVEX sequence;
+- else: 8-lane stack loop (`hyper_lower.sio` style);
+- GPU sibling: expand to L(A)·H WMMA tile layout (not MLI’s job to emit PTX, but
+  **kind+dim** must match so a future bridge does not repack blindly).
+
+---
+
+## 9. Risks and non-goals
+
+### Risks
+
+| Risk | Mitigation |
+|---|---|
+| WS-C MIR shape changes | Keep `mir_to_mli` adapter thin; freeze kind enum early |
+| R1 never funded | CI checklist items for S5/S6 as explicit unpaid debt in MADAROS status |
+| Kind explosion | No open-ended user algebras in MLI; CD dim ∈ {1,2,4,8,16} only |
+| Exact ZD vs float MLI confusion | Exact Core stays separate; MLI float CD never claims `Proved` |
+| Madaros multi-module / sret fragility | Knowledge/CD ABI by-ref in R0/R1 |
+
+### Non-goals (Phase 1–3)
+
+- Full optimizing mid-end on MLI (DCE/GVN can wait; MIR/IR already optimize).
+- Replacing GPU IR.
+- Implementing f256 arithmetic (WS-G).
+- Porting ENIR itself (WS-C).
+
+---
+
+## 10. Open decisions (blockers)
+
+| ID | Decision | Owner |
+|---|---|---|
+| O1 | Final MIR type → MLI kind mapping table | WS-C + WS-D |
+| O2 | Knowledge shape default: Min3 vs Gpu4 on CPU | design review |
+| O3 | Whether `native::machine_ir` renames or remains post-legalize only | native maintainers |
+| O4 | f128/f256: softfloat libcall vs hardware when present | WS-G |
+| O5 | Bit-identity vs value-identity if encoding noise unavoidable | Phase-2 gate owners |
+
+---
+
+## 11. Approval checklist (Phase-1 done)
+
+- [x] Layer contract (MIR in → native out) stated
+- [x] Instruction/operand model including **first-class** Knowledge + CD kinds
+- [x] Binding principle **evaluated** with explicit R0/R1 tradeoff (Option C)
+- [x] Register/stack discipline for multi-lane kinds
+- [x] Verification story (struct + interp + parity), ENIR-pattern mirror
+- [x] Staged ladder with Phase-2 bit-identity isolated from R1
+- [x] Naming disambiguation vs existing `machine_ir.sio`
+- [ ] Human approval (founder / orchestrator) — **pending**
+- [ ] No `self-hosted/` MLI code until approval
+
+---
+
+## 12. References (repo-local)
+
+- Plan: `docs/internal/coordination/MADAROS_FOCUS_PLAN_2026-08-16.md` (WS-D)
+- Concepts: `docs/internal/concepts/epistemic-numeric-value.md`
+- Exact vs measured: `docs/EXACT_CORE.md`
+- ENIR contract lineage: `docs/internal/coordination/enir-semantic-interface-contract-2026-07-12.md`
+- IR hyper/epistemic ops: `self-hosted/ir/ir.sio`
+- Native substrate: `self-hosted/native/machine_ir.sio`, `hyper_lower.sio`, `codegen.sio`
+- GPU epistemic 4-lane: `self-hosted/gpu/epistemic_spirv.sio`
+- GPU octonion TC: `self-hosted/gpu/emit_ossm_oct_step_ptx.sio`
+- Stdlib epistemic: `stdlib/epistemic/knowledge.sio` (`Epistemic { val, variance, confidence }`)
+- IR verify pattern: `self-hosted/ir/verify.sio`
+
+---
+
+## 13. Document control
+
+| Field | Value |
+|---|---|
+| Draft author | grok-cli2 (WS-D) |
+| Claim | `bin/sounio-coord` lane `ws-d-mli-design` |
+| Branch context | working tree may be research/*; doc is integration-agnostic |
+| Next action | Reviewer approval → open S1 implementation dispatch (still no silent R1 drop) |

--- a/docs/architecture/WS_C_D_PREFLIGHT_REVIEW_2026-08-16.md
+++ b/docs/architecture/WS_C_D_PREFLIGHT_REVIEW_2026-08-16.md
@@ -1,0 +1,275 @@
+<!-- docs:meta
+topic_id: repo.docs.architecture.ws-c-d-preflight-review-2026-08-16
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.architecture.ws-c-d-preflight-review-2026-08-16
+-->
+
+# WS-C / WS-D Preflight Review — adversarial findings memo
+
+**Status:** findings memo, review only. No `self-hosted/` edits; neither source doc modified.
+**Reviewer:** fable-1 (lane `preflight-review`), 2026-08-16.
+**Scope:** `docs/architecture/MIR_PORT_PLAN.md` (Route B, approved) and
+`docs/architecture/MLI_DESIGN.md` (Option C, approved), reviewed against
+`origin/main` @ `03416657fa` and `origin/canon/madaros-v2-sota` @ `97b525949`.
+Every finding below carries a receipt command; all were run this session on this pod.
+
+**Headline:** Route B is the right route — its central isolation claim survives
+adversarial re-measurement, and the frontier `enir/` driver builds and emits
+correctly under the **current main** seed, a stronger receipt than the study's.
+But the PR stack as scoped is missing ~23 payload files, every gate script
+carries a frozen-surface contract that cannot run on main unmodified, one enir
+file does not parse under Madaros v0.80.0, and MLI_DESIGN's input contract
+describes a MIR that Route B does not deliver — the S2/S3 ladder has an
+unscoped dependency that should be named before S1 is dispatched.
+
+---
+
+## 1. What was re-verified and held (do not re-litigate)
+
+| Claim (MIR_PORT_PLAN) | Re-measurement | Verdict |
+|---|---|---|
+| `enir/` imports `enir::*` only | all 36 `use` lines across 14 files enumerated: every one is `enir::…` | **HOLDS** |
+| Divergence 189 / 2086, both-sides 115 (41 `self-hosted/`) | 189 / **2088** (main moved 2 commits), 115 / 41 unchanged; merge-base `a930c8ac72` | **HOLDS** |
+| Driver builds under seed, emit OK | rebuilt with **current main's** `bin/souc-lean-single-x86_64` (not the frontier's): ELF 1,474,279 B, `emit` rc=0, artifact 2053 B, header `enir\|1\|1\|eisa_metron_shadow\|2` | **HOLDS, strengthened** |
+| E200 `loop_closed` at `source_lower.sio:529`, "non-fatal" | reproduced — but see finding C5: it is a real bug, not noise | **Partially holds** |
+
+MLI_DESIGN factual grounding also checked: all 11 referenced repo files exist on
+main; `IrHyperMulQ/O/S`, `IrAssociator` present in `self-hosted/ir/ir.sio:137-190`;
+`Epistemic { val: f64, variance: f64, confidence: i64 }` at
+`stdlib/epistemic/knowledge.sio:62`. No fabricated references found.
+
+Receipts:
+
+```bash
+F=origin/canon/madaros-v2-sota
+for f in $(git ls-tree -r --name-only $F self-hosted/enir/); do git show $F:$f | grep -E '^\s*use '; done | sort -u
+git rev-list --count origin/main..$F; git rev-list --count $F..origin/main
+cd /workspace/.wt/mir-study && scripts/dev/souc-build-lock.sh \
+  /workspace/.wt/fable-1/bin/souc-lean-single-x86_64 self-hosted/enir/driver.sio /tmp/enir.elf
+```
+
+---
+
+## 2. WS-C findings (MIR_PORT_PLAN.md, Route B)
+
+### C1 · HIGH — PR1–PR5 payload list is missing ~23 files the gates require
+
+The gate scripts hard-reference frontier-only oracle and fixture files under
+`tools/eisa/` that are **absent from main** and absent from the plan's PR stack
+(§6: "enir/** + bin/madaros-enir + docs" / gate scripts). Measured missing set:
+`eisa_enir_v1_oracle.sio`, `eisa_enir_v1_loop_oracle.sio`, and ~21
+`eisa_enir_v1_*/v2_*.eisa` fixtures (add, mul, div, sqrt, sub, mem, mem_phi_*,
+mem_poison, join_then/else, equal_*, frail, fuel, loop, rump_dd, rump_qd,
+c2_rump, const_gate, emov).
+
+```bash
+comm -23 <(git ls-tree -r --name-only origin/canon/madaros-v2-sota tools/eisa | sort) \
+         <(git ls-tree -r --name-only origin/main tools/eisa | sort)
+```
+
+**Consequence:** PR2–PR4 fail at file-not-found unless PR1 (or each gate PR)
+also carries its `tools/eisa/` payload. **Fix:** enumerate the full transitive
+file set per gate script and add it to the PR stack definition before PR1 opens.
+
+### C2 · HIGH — every gate embeds a frozen-surface contract that cannot run on main as-is
+
+Each E-gate begins with
+`git diff --quiet "$BASE_REF" -- self-hosted/compiler/main.sio self-hosted/ir
+self-hosted/native self-hosted/wasm self-hosted/gpu stdlib/runtime
+[stdlib/eisa stdlib/math/dd64.sio stdlib/math/qd128.sio tools/eisa/eisa_evm_run.sio …]`
+with `BASE_REF` defaulting to `origin/canon/madaros-v2-sota`. On main that diff
+is never empty (thousands of lines), so **every gate fails at its shadow-discipline
+check before doing any work**. The env override (`E1_BASE_REF` etc.) exists, but
+re-anchoring is a design decision, not a search-replace: pinning to
+`origin/main` makes the gate fail spuriously whenever any collocated lane has
+in-flight edits to `ir/lower.sio` (constant on this pod), and pinning to `HEAD`
+weakens the discipline the gate encodes. E3D itself uses
+`E3C_BASE_REF=HEAD E3C_ALLOW_DOWNSTREAM_ENIR_EXTENSION=1` internally — precedent
+exists, but PR2 must choose and document the anchor. This is an unbudgeted PR2
+cost item, and the plan's "fix inside `enir/` only" boundary (Route B step 3)
+**cannot hold for the gate scripts**.
+
+### C3 · HIGH — shared oracle files have drifted on main, and WS-F is editing the same surface
+
+The gates don't just pin the shared files — E2-class gates **compile the METRON
+oracle live** (`souc-build-lock.sh $SEED $CORPUS $ORACLE`) and compare
+observations against it. Measured drift frontier→main:
+
+| File | Drift | Role in gates |
+|---|---|---|
+| `tools/eisa/eisa_evm_run.sio` | **+188/−5** | E1/E2 corpus + live oracle |
+| `stdlib/math/qd128.sio` | 18/12 | pinned qd semantics (E2E/E3D) |
+| `stdlib/eisa/` | differs (main adds `hypercomplex_zd.sio`) | pinned surface |
+
+Porting the gates therefore means either carrying frontier versions of shared
+files (a direct conflict with main's EISA evolution) or re-validating enir's qd
+semantics against **main's** oracle — a semantic re-validation, not a re-run.
+Additionally, **WS-F (grok-cli4) is concurrently porting EISA gates over the
+same `tools/eisa/` + `stdlib/eisa/` files**; neither doc flags this cross-lane
+conflict. Recommend an explicit coord claim boundary between WS-C PR2+ and WS-F
+before either lands.
+
+### C4 · HIGH — `mir_join.sio` does not parse under Madaros v0.80.0 (seed-only syntax)
+
+Receipt: `bin/souc check self-hosted/enir/mir_join.sio` (default Madaros engine,
+current main binary) → 8 parse errors at lines 476–489; `driver.sio` and
+`mod.sio` fail transitively ("module failed to parse: …/mir_join.sio"). The
+other 13 enir files parse clean under Madaros. Root causes at the failing lines:
+
+- line 476: a **parenthesised `if`-expression used as a comparison operand**
+  inside the `||` chain — `b.trap_kind != (if opcode >= EMIR_OP_ADD && … { … } else { … })`;
+- line 481: **semicolon-joined `let` statements** on one line
+  (`let a = …; let b = …`).
+
+The seed (lean_single) accepts both. PR1's acceptance criterion is
+"driver check/compile **under seed**" — as written it would merge code the
+default engine cannot parse, and the discrepancy would surface later as a
+mystery. **Fix:** cheap — rewrite the offending constructs in `mir_join.sio`
+during the PR1 repair pass, and add a Madaros `souc check` receipt (green, or an
+enumerated FAIL_HONEST list) to PR1's acceptance alongside the seed receipt.
+
+### C5 · MEDIUM — the E200 `loop_closed` is a real semantic bug, not tolerable noise
+
+`loop_closed` is **used** at `source_lower.sio:529`
+(`if loop_closed && !is_load { return enir_lower_fail(module, line, 15) }`) but
+**declared** at line 645 (`var loop_closed = false`) in a different function.
+The plan records this as "non-fatal under this seed path". Adversarially: the
+seed compiles the site as a guarded gate (build log: `gates[direct=2159
+guarded=737]`), meaning the lower-fail-15 rule — "no non-load `let` after loop
+close" — is **silently unenforced or trap-prone** on the seed path today, and
+gate results that passed with it in place prove less than they appear to.
+Madaros will hard-error on it once C4 is fixed. Fixing it (threading the flag or
+deleting the check) **changes lowering semantics** and may shift E2-gate
+expectations; budget it as a semantic fix with a gate re-run, not a syntax
+papercut.
+
+### C6 · LOW — WS-B ordering rationale doesn't actually cover ENIR
+
+The focus plan justifies "SOIR gate before the port lands" as catching
+serialisation drift mechanically. The SOIR gate covers `self-hosted/ir/*`; ENIR
+has its **own** text format with its own canonical/roundtrip/hash checks inside
+the E1 gate. SOIR-first is still fine sequencing, but it is not protection for
+ENIR serialisation — don't let a WS-B slip hold PR1 hostage on a false safety
+premise.
+
+### C7 · PROCESS, HIGH — both approved docs exist only as uncommitted files
+
+`MIR_PORT_PLAN.md` and `MLI_DESIGN.md` are **untracked** (`??`) in the shared
+checkout `/workspace/sounio`, whose worktree is parked on a research branch
+(`research/zd-fiber-antisymmetry-lemma-20260731`); the focus plan itself is a
+locally-modified tracked file there. Founder-approved architecture is currently
+one `git clean` / concurrent-agent collision away from loss — this exact
+failure mode has occurred on this pod before. **Commit all three to a docs lane
+targeting main immediately**; both docs also carry stale `docs:meta`
+(`last_validated: 2026-03-07`) and will need the governance registry sync
+(generated — never hand-edit) after landing.
+
+---
+
+## 3. WS-D findings (MLI_DESIGN.md, Option C)
+
+### D1 · HIGH — the input contract describes a MIR that Route B does not deliver
+
+MLI_DESIGN §3.2 assumes MIR arrives with SSA-ish values, explicit control flow,
+and "typed operands map injectively into MLI kinds"; ladder S2 is
+"`mir_to_mli` for **scalar R0 only (integers + f64)**". Measured against the
+frontier MIR that Route B actually lands (`enir/mir.sio`):
+
+- **10 opcodes total**: `CONST ADD SUB MUL DIV SQRT OBSERVE LOAD STORE MOVE`
+  (`mir.sio:17-26`). **No integer ops, no call, no ret, no compare/branch ops.**
+- **One type per module, enforced**: module verify requires `type_count == 1`
+  and the single type to be exactly `{value_kind: f64, error_kind: qd128,
+  uncertainty_kind: gum1, status_tracked, provenance_tracked}` (`mir.sio:306`).
+  Every MIR value is an epistemic bundle, not a scalar.
+- The post-E3D non-claims (general N-way SSA, loops-in-schema, alias, **ABI,
+  MachineIR**) are precisely the pieces `mir_to_mli` needs.
+
+**Consequence:** S2 cannot be fed from Route-B MIR as it exists, and the
+Phase-2 golden `add1(x: f64) -> f64` is not even expressible in EMIR (no
+function ABI, no ret). The real dependency of S2/S3 is a **post-E3D MIR
+generalisation tranche that neither approved doc scopes or costs**. §3.2's own
+fallback ("IR→MLI side door") covers this — but the ladder names `mir_to_mli`
+as the only choke point. **Fix before S1 dispatch:** either (a) add the
+generalisation tranche to WS-C as an explicitly costed follow-on, or (b)
+re-anchor S2/S3 on the IR→MLI side door and record that Route-B MIR feeds R1
+epistemic kinds, not the R0 scalar path. Option (b) is likely correct — note
+Route-B MIR's bundles map naturally onto MLI's `Knowledge` kind (Gpu4-like
+shape), which is an argument the design can use, not just a gap.
+
+### D2 · MEDIUM — kind-model gaps to close in S1, cheap now, breaking later
+
+1. **qd128 is not IEEE f128.** Frontier MIR's error lanes are qd128
+   (double-double family); MLI's `Float { f128 }` (IEEE binary128, WS-G) must
+   never be conflated with it. Add an explicit exclusion note or a distinct
+   kind; a silent `f128 := qd128` mapping in O1 would be a semantic miscompile
+   by construction.
+2. **No `Int { bits: 128 }`** despite language-level i128/u128
+   (wide-int source→ELF, 2026-06-05). State the exclusion explicitly so the
+   direct-path-replacement story doesn't silently shrink language coverage.
+3. **Flags liveness is unmodelled.** `Flags` exists as a kind, but on x86
+   nearly every ALU op clobbers eflags; V-struct as specced ("no raw cross-kind
+   moves") will not catch a `cmp`/`br_cc` pair separated by a flag-clobbering
+   instruction. Either add a verify rule (a flags def must be immediately
+   consumed) or make `br_cc` consume a bool vreg in R0 and let legalize fuse.
+4. **Block params vs φ**: §3.2 says "φ resolved at MIR or early MLI", §4.4 has
+   optional `params?`. Frontier MIR has neither in general form (E3D joins
+   only). Pick one representation in S1 or the builder API churns in S5.
+
+### D3 · MEDIUM — Phase-2 bit-identity is underspecified in two load-bearing ways
+
+1. **Which direct path is the golden?** lean_single and Madaros native-v2 emit
+   different bytes. O5 gestures at this; it must be resolved (pin the engine
+   and the exact binary provenance — built this session, per focus-plan risk
+   item 6) **before** S3 starts, not during.
+2. **`imm f64` has no x86 encoding.** The worked example (`fadd v0, imm f64
+   1.0`) is fine as IR, but byte-identity forces legalize to reproduce the
+   existing emitter's exact constant-materialisation strategy (constant
+   pool / rip-relative / movabs+movq), register choices, and scheduling.
+   S3 is therefore "mimic the existing emitter's choices for one function",
+   not a generic legaliser — estimate it as such, and don't let its smallness
+   inflate confidence about general legalisation cost.
+
+### D4 · LOW — the `MIR_*` name collision is now imminent, not theoretical
+
+`native/machine_ir.sio` already owns the `MIR_` constant prefix
+(`MIR_OPERAND_GPR64`, `MIR_MAX_INSTRS`, … — verified on main) while Route B
+lands a different "MIR" in `enir/`. §5.4 treats the rename as optional-later;
+once both trees coexist on main, every grep, gate log, and dispatch doc mixing
+them will mislead (this plan cycle already produced one swapped-wording
+incident). Recommend: promote the `X86_*` rename (or at minimum a
+naming-disambiguation note in `native/machine_ir.sio`'s header) to a
+precondition of the WS-C PR1 tranche.
+
+---
+
+## 4. Recommended pre-implementation actions (ordered)
+
+1. **Commit the three planning docs to main** (C7) — before anything else.
+2. **Amend MIR_PORT_PLAN PR stack**: add the `tools/eisa/` payload enumeration
+   (C1), the BASE_REF re-anchoring decision (C2), a Madaros-check receipt in
+   PR1 acceptance (C4), and the `loop_closed` semantic fix as a named PR1 task
+   (C5). All are small edits to the plan, not re-litigation of Route B.
+3. **Coordinate WS-C ↔ WS-F** on `tools/eisa/` + `stdlib/eisa/` ownership (C3)
+   via explicit coord claims before either lands.
+4. **Amend MLI_DESIGN §3.2/§7**: name the Route-B-MIR gap and pick the S2
+   feed (D1); fold D2's four kind-model notes into §4; resolve O5 + golden
+   engine pin before S3 (D3).
+5. None of the above changes the approved decisions (Route B, Option C). Both
+   survive this review; the findings are about making S1/PR1 land at the
+   estimated cost instead of discovering these in-flight.
+
+---
+
+## 5. Receipts index
+
+All commands runnable from `/workspace/.wt/fable-1` (main-based) with the
+frontier via `origin/canon/madaros-v2-sota`; frontier worktree at
+`/workspace/.wt/mir-study` @ `97b525949`. Session artefacts:
+`/tmp/fable1-preflight-enir-seed.elf`, `/tmp/fable1-enir-emit.out` (2053 B),
+`/tmp/fable1-enir-madaros-check.log` (mir_join parse failure),
+`/tmp/fable1-enir-seed-build.log` (E200 + gates counts).
+
+*End of preflight review. Reviewer: fable-1, 2026-08-16.*

--- a/docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md
+++ b/docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md
@@ -1,0 +1,630 @@
+<!-- docs:meta
+topic_id: repo.docs.architecture.ws-c-pr1-payload-census
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.architecture.ws-c-pr1-payload-census
+-->
+
+# WS-C PR1 Payload Census
+
+Date: 2026-08-16
+
+Source refs: `origin/main` = `03416657fa3e10667867e8a00bbfa4e7ec44261d`; `origin/canon/madaros-v2-sota` = `97b525949765980406a4fefa7f533e9db89721e1`.
+
+Scope: census only for `scripts/dev/madaros_v2_e1_enir_shadow_gate.sh` and the `madaros_v2_e2*` / `madaros_v2_e3*` gate scripts on `origin/canon/madaros-v2-sota`. This follows shell-script references, Python verifier references, verifier `PROGRAMS` fixture expansions, recursive regression-gate calls, and the `self-hosted/enir/driver.sio` import closure required by each gate build. `$TMP_DIR` negative fixtures generated inside scripts are excluded because they are not repository payload.
+
+Headline: the requested E1/E2/E3 gate stack needs **63 files absent from `origin/main`**: 14 gate scripts, 13 Python verifiers, 14 `self-hosted/enir` driver-closure files, and 22 `tools/eisa` oracle/fixture files. The 23rd frontier-only `tools/eisa` file, `tools/eisa/eisa_enir_c2_rump.eisa`, is referenced by the C2 gate, not by the requested E1/E2/E3 gate set.
+
+## Common references
+
+These paths are referenced by most or all gates through seed/build, protected diff scopes, or the frozen METRON corpus. They are present on `origin/main` unless noted; changed means present on both refs with different blob content.
+
+| Path | Present on main | Notes |
+| --- | --- | --- |
+| `bin/souc-lean-single-x86_64` | yes (changed) | common seed/helper/corpus/protected scope |
+| `scripts/dev/souc-build-lock.sh` | yes (changed) | common seed/helper/corpus/protected scope |
+| `self-hosted/compiler/main.sio` | yes (changed) | common seed/helper/corpus/protected scope |
+| `self-hosted/gpu` | yes (tree) | common seed/helper/corpus/protected scope |
+| `self-hosted/ir` | yes (tree) | common seed/helper/corpus/protected scope |
+| `self-hosted/native` | yes (tree) | common seed/helper/corpus/protected scope |
+| `self-hosted/wasm` | yes (tree) | common seed/helper/corpus/protected scope |
+| `stdlib/eisa` | yes (tree) | common seed/helper/corpus/protected scope |
+| `stdlib/math/dd64.sio` | yes (same) | common seed/helper/corpus/protected scope |
+| `stdlib/math/qd128.sio` | yes (changed) | common seed/helper/corpus/protected scope |
+| `tools/eisa/eisa_evm_run.sio` | yes (changed) | common seed/helper/corpus/protected scope |
+| `stdlib/runtime` | no | guard-only path named by several scripts; absent on both compared refs, so not an add-list item |
+
+## Common ENIR driver closure
+
+Every gate builds `self-hosted/enir/driver.sio`. Its `use enir::*` closure requires these repository files. All are present on the canon branch and absent from `origin/main`, so each applies to the per-gate transitive missing set.
+
+| Path | Present on main |
+| --- | --- |
+| `self-hosted/enir/mod.sio` | no |
+| `self-hosted/enir/driver.sio` | no |
+| `self-hosted/enir/ir.sio` | no |
+| `self-hosted/enir/parser.sio` | no |
+| `self-hosted/enir/canonical.sio` | no |
+| `self-hosted/enir/verify.sio` | no |
+| `self-hosted/enir/hash.sio` | no |
+| `self-hosted/enir/shadow_fixture.sio` | no |
+| `self-hosted/enir/source_lower.sio` | no |
+| `self-hosted/enir/interpreter.sio` | no |
+| `self-hosted/enir/qd.sio` | no |
+| `self-hosted/enir/mir.sio` | no |
+| `self-hosted/enir/mir_cfg.sio` | no |
+| `self-hosted/enir/mir_join.sio` | no |
+
+## Per-gate transitive census
+
+### E1 shadow
+
+Gate script: `scripts/dev/madaros_v2_e1_enir_shadow_gate.sh`
+Regression chain followed: none.
+Transitive files absent from `origin/main`: **16**.
+
+| Direct gate-specific path | Present on main | Notes |
+| --- | --- | --- |
+| `scripts/dev/madaros_v2_e1_enir_shadow_gate.sh` | no | gate/verifier |
+| `scripts/dev/madaros_v2_e1_enir_shadow_verify.py` | no | gate/verifier |
+
+Common missing driver closure applies: `self-hosted/enir/*` listed above.
+
+### E2A lowering
+
+Gate script: `scripts/dev/madaros_v2_e2_enir_lowering_gate.sh`
+Regression chain followed: `E1 shadow`.
+Transitive files absent from `origin/main`: **18**.
+
+| Direct gate-specific path | Present on main | Notes |
+| --- | --- | --- |
+| `scripts/dev/madaros_v2_e2_enir_lowering_gate.sh` | no | gate/verifier |
+| `scripts/dev/madaros_v2_e2_enir_lowering_verify.py` | no | gate/verifier |
+
+Inherited missing paths from regression chain:
+- `scripts/dev/madaros_v2_e1_enir_shadow_gate.sh`
+- `scripts/dev/madaros_v2_e1_enir_shadow_verify.py`
+
+Common missing driver closure applies: `self-hosted/enir/*` listed above.
+
+### E2B CFG
+
+Gate script: `scripts/dev/madaros_v2_e2b_enir_cfg_gate.sh`
+Regression chain followed: `E2A lowering`.
+Transitive files absent from `origin/main`: **21**.
+
+| Direct gate-specific path | Present on main | Notes |
+| --- | --- | --- |
+| `scripts/dev/madaros_v2_e2b_enir_cfg_gate.sh` | no | gate/verifier |
+| `scripts/dev/madaros_v2_e2b_enir_cfg_verify.py` | no | gate/verifier |
+| `tools/eisa/eisa_enir_v1_oracle.sio` | no | oracle/fixture |
+
+Inherited missing paths from regression chain:
+- `scripts/dev/madaros_v2_e1_enir_shadow_gate.sh`
+- `scripts/dev/madaros_v2_e1_enir_shadow_verify.py`
+- `scripts/dev/madaros_v2_e2_enir_lowering_gate.sh`
+- `scripts/dev/madaros_v2_e2_enir_lowering_verify.py`
+
+Common missing driver closure applies: `self-hosted/enir/*` listed above.
+
+### E2C fuel/blockargs
+
+Gate script: `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_gate.sh`
+Regression chain followed: `E2B CFG`.
+Transitive files absent from `origin/main`: **24**.
+
+| Direct gate-specific path | Present on main | Notes |
+| --- | --- | --- |
+| `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_gate.sh` | no | gate/verifier |
+| `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_verify.py` | no | gate/verifier |
+| `tools/eisa/eisa_enir_v1_loop_oracle.sio` | no | oracle/fixture |
+
+Inherited missing paths from regression chain:
+- `scripts/dev/madaros_v2_e1_enir_shadow_gate.sh`
+- `scripts/dev/madaros_v2_e1_enir_shadow_verify.py`
+- `scripts/dev/madaros_v2_e2_enir_lowering_gate.sh`
+- `scripts/dev/madaros_v2_e2_enir_lowering_verify.py`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_gate.sh`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_verify.py`
+- `tools/eisa/eisa_enir_v1_oracle.sio`
+
+Common missing driver closure applies: `self-hosted/enir/*` listed above.
+
+### E2D rump DD
+
+Gate script: `scripts/dev/madaros_v2_e2d_enir_rump_dd_gate.sh`
+Regression chain followed: `E2C fuel/blockargs`.
+Transitive files absent from `origin/main`: **27**.
+
+| Direct gate-specific path | Present on main | Notes |
+| --- | --- | --- |
+| `scripts/dev/madaros_v2_e2d_enir_rump_dd_gate.sh` | no | gate/verifier |
+| `scripts/dev/madaros_v2_e2d_enir_rump_dd_verify.py` | no | gate/verifier |
+| `tools/eisa/eisa_enir_v1_rump_dd.eisa` | no | oracle/fixture |
+
+Inherited missing paths from regression chain:
+- `scripts/dev/madaros_v2_e1_enir_shadow_gate.sh`
+- `scripts/dev/madaros_v2_e1_enir_shadow_verify.py`
+- `scripts/dev/madaros_v2_e2_enir_lowering_gate.sh`
+- `scripts/dev/madaros_v2_e2_enir_lowering_verify.py`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_gate.sh`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_verify.py`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_gate.sh`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_verify.py`
+- `tools/eisa/eisa_enir_v1_loop_oracle.sio`
+- `tools/eisa/eisa_enir_v1_oracle.sio`
+
+Common missing driver closure applies: `self-hosted/enir/*` listed above.
+
+### E2E qd128 arithmetic
+
+Gate script: `scripts/dev/madaros_v2_e2e_enir_qd128_gate.sh`
+Regression chain followed: `E2D rump DD`.
+Transitive files absent from `origin/main`: **35**.
+
+| Direct gate-specific path | Present on main | Notes |
+| --- | --- | --- |
+| `scripts/dev/madaros_v2_e2e_enir_qd128_gate.sh` | no | gate/verifier |
+| `scripts/dev/madaros_v2_e2e_enir_qd128_verify.py` | no | gate/verifier |
+| `tools/eisa/eisa_enir_v2_const_gate.eisa` | no | oracle/fixture |
+| `tools/eisa/eisa_enir_v2_add.eisa` | no | oracle/fixture |
+| `tools/eisa/eisa_enir_v2_sub.eisa` | no | oracle/fixture |
+| `tools/eisa/eisa_enir_v2_mul.eisa` | no | oracle/fixture |
+| `tools/eisa/eisa_enir_v2_div.eisa` | no | oracle/fixture |
+| `tools/eisa/eisa_enir_v2_sqrt.eisa` | no | oracle/fixture |
+
+Inherited missing paths from regression chain:
+- `scripts/dev/madaros_v2_e1_enir_shadow_gate.sh`
+- `scripts/dev/madaros_v2_e1_enir_shadow_verify.py`
+- `scripts/dev/madaros_v2_e2_enir_lowering_gate.sh`
+- `scripts/dev/madaros_v2_e2_enir_lowering_verify.py`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_gate.sh`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_verify.py`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_gate.sh`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_verify.py`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_gate.sh`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_verify.py`
+- `tools/eisa/eisa_enir_v1_loop_oracle.sio`
+- `tools/eisa/eisa_enir_v1_oracle.sio`
+- `tools/eisa/eisa_enir_v1_rump_dd.eisa`
+
+Common missing driver closure applies: `self-hosted/enir/*` listed above.
+
+### E2F rump qd
+
+Gate script: `scripts/dev/madaros_v2_e2f_enir_rump_qd_gate.sh`
+Regression chain followed: `E2E qd128 arithmetic`.
+Transitive files absent from `origin/main`: **38**.
+
+| Direct gate-specific path | Present on main | Notes |
+| --- | --- | --- |
+| `scripts/dev/madaros_v2_e2f_enir_rump_qd_gate.sh` | no | gate/verifier |
+| `scripts/dev/madaros_v2_e2f_enir_rump_qd_verify.py` | no | gate/verifier |
+| `tools/eisa/eisa_enir_v2_rump_qd.eisa` | no | oracle/fixture |
+
+Inherited missing paths from regression chain:
+- `scripts/dev/madaros_v2_e1_enir_shadow_gate.sh`
+- `scripts/dev/madaros_v2_e1_enir_shadow_verify.py`
+- `scripts/dev/madaros_v2_e2_enir_lowering_gate.sh`
+- `scripts/dev/madaros_v2_e2_enir_lowering_verify.py`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_gate.sh`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_verify.py`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_gate.sh`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_verify.py`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_gate.sh`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_verify.py`
+- `scripts/dev/madaros_v2_e2e_enir_qd128_gate.sh`
+- `scripts/dev/madaros_v2_e2e_enir_qd128_verify.py`
+- `tools/eisa/eisa_enir_v1_loop_oracle.sio`
+- `tools/eisa/eisa_enir_v1_oracle.sio`
+- `tools/eisa/eisa_enir_v1_rump_dd.eisa`
+- `tools/eisa/eisa_enir_v2_add.eisa`
+- `tools/eisa/eisa_enir_v2_const_gate.eisa`
+- `tools/eisa/eisa_enir_v2_div.eisa`
+- `tools/eisa/eisa_enir_v2_mul.eisa`
+- `tools/eisa/eisa_enir_v2_sqrt.eisa`
+- `tools/eisa/eisa_enir_v2_sub.eisa`
+
+Common missing driver closure applies: `self-hosted/enir/*` listed above.
+
+### E2G fuel/control/frail
+
+Gate script: `scripts/dev/madaros_v2_e2g_enir_fuel_control_frail_gate.sh`
+Regression chain followed: `E2F rump qd`.
+Transitive files absent from `origin/main`: **43**.
+
+| Direct gate-specific path | Present on main | Notes |
+| --- | --- | --- |
+| `scripts/dev/madaros_v2_e2g_enir_fuel_control_frail_gate.sh` | no | gate/verifier |
+| `scripts/dev/madaros_v2_e2g_enir_fuel_control_frail_verify.py` | no | gate/verifier |
+| `tools/eisa/eisa_enir_v2_fuel.eisa` | no | oracle/fixture |
+| `tools/eisa/eisa_enir_v2_loop.eisa` | no | oracle/fixture |
+| `tools/eisa/eisa_enir_v2_frail.eisa` | no | oracle/fixture |
+
+Inherited missing paths from regression chain:
+- `scripts/dev/madaros_v2_e1_enir_shadow_gate.sh`
+- `scripts/dev/madaros_v2_e1_enir_shadow_verify.py`
+- `scripts/dev/madaros_v2_e2_enir_lowering_gate.sh`
+- `scripts/dev/madaros_v2_e2_enir_lowering_verify.py`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_gate.sh`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_verify.py`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_gate.sh`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_verify.py`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_gate.sh`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_verify.py`
+- `scripts/dev/madaros_v2_e2e_enir_qd128_gate.sh`
+- `scripts/dev/madaros_v2_e2e_enir_qd128_verify.py`
+- `scripts/dev/madaros_v2_e2f_enir_rump_qd_gate.sh`
+- `scripts/dev/madaros_v2_e2f_enir_rump_qd_verify.py`
+- `tools/eisa/eisa_enir_v1_loop_oracle.sio`
+- `tools/eisa/eisa_enir_v1_oracle.sio`
+- `tools/eisa/eisa_enir_v1_rump_dd.eisa`
+- `tools/eisa/eisa_enir_v2_add.eisa`
+- `tools/eisa/eisa_enir_v2_const_gate.eisa`
+- `tools/eisa/eisa_enir_v2_div.eisa`
+- `tools/eisa/eisa_enir_v2_mul.eisa`
+- `tools/eisa/eisa_enir_v2_rump_qd.eisa`
+- `tools/eisa/eisa_enir_v2_sqrt.eisa`
+- `tools/eisa/eisa_enir_v2_sub.eisa`
+
+Common missing driver closure applies: `self-hosted/enir/*` listed above.
+
+### E2H memory/move/poison
+
+Gate script: `scripts/dev/madaros_v2_e2h_enir_memory_move_poison_gate.sh`
+Regression chain followed: `E2G fuel/control/frail`.
+Transitive files absent from `origin/main`: **48**.
+
+| Direct gate-specific path | Present on main | Notes |
+| --- | --- | --- |
+| `scripts/dev/madaros_v2_e2h_enir_memory_move_poison_gate.sh` | no | gate/verifier |
+| `scripts/dev/madaros_v2_e2h_enir_memory_move_poison_verify.py` | no | gate/verifier |
+| `tools/eisa/eisa_enir_v2_mem.eisa` | no | oracle/fixture |
+| `tools/eisa/eisa_enir_v2_emov.eisa` | no | oracle/fixture |
+| `tools/eisa/eisa_enir_v2_mem_poison.eisa` | no | oracle/fixture |
+
+Inherited missing paths from regression chain:
+- `scripts/dev/madaros_v2_e1_enir_shadow_gate.sh`
+- `scripts/dev/madaros_v2_e1_enir_shadow_verify.py`
+- `scripts/dev/madaros_v2_e2_enir_lowering_gate.sh`
+- `scripts/dev/madaros_v2_e2_enir_lowering_verify.py`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_gate.sh`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_verify.py`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_gate.sh`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_verify.py`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_gate.sh`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_verify.py`
+- `scripts/dev/madaros_v2_e2e_enir_qd128_gate.sh`
+- `scripts/dev/madaros_v2_e2e_enir_qd128_verify.py`
+- `scripts/dev/madaros_v2_e2f_enir_rump_qd_gate.sh`
+- `scripts/dev/madaros_v2_e2f_enir_rump_qd_verify.py`
+- `scripts/dev/madaros_v2_e2g_enir_fuel_control_frail_gate.sh`
+- `scripts/dev/madaros_v2_e2g_enir_fuel_control_frail_verify.py`
+- `tools/eisa/eisa_enir_v1_loop_oracle.sio`
+- `tools/eisa/eisa_enir_v1_oracle.sio`
+- `tools/eisa/eisa_enir_v1_rump_dd.eisa`
+- `tools/eisa/eisa_enir_v2_add.eisa`
+- `tools/eisa/eisa_enir_v2_const_gate.eisa`
+- `tools/eisa/eisa_enir_v2_div.eisa`
+- `tools/eisa/eisa_enir_v2_frail.eisa`
+- `tools/eisa/eisa_enir_v2_fuel.eisa`
+- `tools/eisa/eisa_enir_v2_loop.eisa`
+- `tools/eisa/eisa_enir_v2_mul.eisa`
+- `tools/eisa/eisa_enir_v2_rump_qd.eisa`
+- `tools/eisa/eisa_enir_v2_sqrt.eisa`
+- `tools/eisa/eisa_enir_v2_sub.eisa`
+
+Common missing driver closure applies: `self-hosted/enir/*` listed above.
+
+### E3A MIR qd128
+
+Gate script: `scripts/dev/madaros_v2_e3a_enir_mir_qd128_gate.sh`
+Regression chain followed: `E2H memory/move/poison`.
+Transitive files absent from `origin/main`: **50**.
+
+| Direct gate-specific path | Present on main | Notes |
+| --- | --- | --- |
+| `scripts/dev/madaros_v2_e3a_enir_mir_qd128_gate.sh` | no | gate/verifier |
+| `scripts/dev/madaros_v2_e3a_enir_mir_qd128_verify.py` | no | gate/verifier |
+
+Inherited missing paths from regression chain:
+- `scripts/dev/madaros_v2_e1_enir_shadow_gate.sh`
+- `scripts/dev/madaros_v2_e1_enir_shadow_verify.py`
+- `scripts/dev/madaros_v2_e2_enir_lowering_gate.sh`
+- `scripts/dev/madaros_v2_e2_enir_lowering_verify.py`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_gate.sh`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_verify.py`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_gate.sh`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_verify.py`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_gate.sh`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_verify.py`
+- `scripts/dev/madaros_v2_e2e_enir_qd128_gate.sh`
+- `scripts/dev/madaros_v2_e2e_enir_qd128_verify.py`
+- `scripts/dev/madaros_v2_e2f_enir_rump_qd_gate.sh`
+- `scripts/dev/madaros_v2_e2f_enir_rump_qd_verify.py`
+- `scripts/dev/madaros_v2_e2g_enir_fuel_control_frail_gate.sh`
+- `scripts/dev/madaros_v2_e2g_enir_fuel_control_frail_verify.py`
+- `scripts/dev/madaros_v2_e2h_enir_memory_move_poison_gate.sh`
+- `scripts/dev/madaros_v2_e2h_enir_memory_move_poison_verify.py`
+- `tools/eisa/eisa_enir_v1_loop_oracle.sio`
+- `tools/eisa/eisa_enir_v1_oracle.sio`
+- `tools/eisa/eisa_enir_v1_rump_dd.eisa`
+- `tools/eisa/eisa_enir_v2_add.eisa`
+- `tools/eisa/eisa_enir_v2_const_gate.eisa`
+- `tools/eisa/eisa_enir_v2_div.eisa`
+- `tools/eisa/eisa_enir_v2_emov.eisa`
+- `tools/eisa/eisa_enir_v2_frail.eisa`
+- `tools/eisa/eisa_enir_v2_fuel.eisa`
+- `tools/eisa/eisa_enir_v2_loop.eisa`
+- `tools/eisa/eisa_enir_v2_mem.eisa`
+- `tools/eisa/eisa_enir_v2_mem_poison.eisa`
+- `tools/eisa/eisa_enir_v2_mul.eisa`
+- `tools/eisa/eisa_enir_v2_rump_qd.eisa`
+- `tools/eisa/eisa_enir_v2_sqrt.eisa`
+- `tools/eisa/eisa_enir_v2_sub.eisa`
+
+Common missing driver closure applies: `self-hosted/enir/*` listed above.
+
+### E3B MIR memory
+
+Gate script: `scripts/dev/madaros_v2_e3b_enir_mir_memory_gate.sh`
+Regression chain followed: `E3A MIR qd128`.
+Transitive files absent from `origin/main`: **52**.
+
+| Direct gate-specific path | Present on main | Notes |
+| --- | --- | --- |
+| `scripts/dev/madaros_v2_e3b_enir_mir_memory_gate.sh` | no | gate/verifier |
+| `scripts/dev/madaros_v2_e3b_enir_mir_memory_verify.py` | no | gate/verifier |
+
+Inherited missing paths from regression chain:
+- `scripts/dev/madaros_v2_e1_enir_shadow_gate.sh`
+- `scripts/dev/madaros_v2_e1_enir_shadow_verify.py`
+- `scripts/dev/madaros_v2_e2_enir_lowering_gate.sh`
+- `scripts/dev/madaros_v2_e2_enir_lowering_verify.py`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_gate.sh`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_verify.py`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_gate.sh`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_verify.py`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_gate.sh`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_verify.py`
+- `scripts/dev/madaros_v2_e2e_enir_qd128_gate.sh`
+- `scripts/dev/madaros_v2_e2e_enir_qd128_verify.py`
+- `scripts/dev/madaros_v2_e2f_enir_rump_qd_gate.sh`
+- `scripts/dev/madaros_v2_e2f_enir_rump_qd_verify.py`
+- `scripts/dev/madaros_v2_e2g_enir_fuel_control_frail_gate.sh`
+- `scripts/dev/madaros_v2_e2g_enir_fuel_control_frail_verify.py`
+- `scripts/dev/madaros_v2_e2h_enir_memory_move_poison_gate.sh`
+- `scripts/dev/madaros_v2_e2h_enir_memory_move_poison_verify.py`
+- `scripts/dev/madaros_v2_e3a_enir_mir_qd128_gate.sh`
+- `scripts/dev/madaros_v2_e3a_enir_mir_qd128_verify.py`
+- `tools/eisa/eisa_enir_v1_loop_oracle.sio`
+- `tools/eisa/eisa_enir_v1_oracle.sio`
+- `tools/eisa/eisa_enir_v1_rump_dd.eisa`
+- `tools/eisa/eisa_enir_v2_add.eisa`
+- `tools/eisa/eisa_enir_v2_const_gate.eisa`
+- `tools/eisa/eisa_enir_v2_div.eisa`
+- `tools/eisa/eisa_enir_v2_emov.eisa`
+- `tools/eisa/eisa_enir_v2_frail.eisa`
+- `tools/eisa/eisa_enir_v2_fuel.eisa`
+- `tools/eisa/eisa_enir_v2_loop.eisa`
+- `tools/eisa/eisa_enir_v2_mem.eisa`
+- `tools/eisa/eisa_enir_v2_mem_poison.eisa`
+- `tools/eisa/eisa_enir_v2_mul.eisa`
+- `tools/eisa/eisa_enir_v2_rump_qd.eisa`
+- `tools/eisa/eisa_enir_v2_sqrt.eisa`
+- `tools/eisa/eisa_enir_v2_sub.eisa`
+
+Common missing driver closure applies: `self-hosted/enir/*` listed above.
+
+### E3C CFG memory SSA
+
+Gate script: `scripts/dev/madaros_v2_e3c_cfg_memory_ssa_gate.sh`
+Regression chain followed: `E3B MIR memory`.
+Transitive files absent from `origin/main`: **56**.
+
+| Direct gate-specific path | Present on main | Notes |
+| --- | --- | --- |
+| `scripts/dev/madaros_v2_e3c_cfg_memory_ssa_gate.sh` | no | gate/verifier |
+| `scripts/dev/madaros_v2_e3c_cfg_memory_ssa_verify.py` | no | gate/verifier |
+| `tools/eisa/eisa_enir_v2_mem_phi_zero.eisa` | no | oracle/fixture |
+| `tools/eisa/eisa_enir_v2_mem_phi_once.eisa` | no | oracle/fixture |
+
+Inherited missing paths from regression chain:
+- `scripts/dev/madaros_v2_e1_enir_shadow_gate.sh`
+- `scripts/dev/madaros_v2_e1_enir_shadow_verify.py`
+- `scripts/dev/madaros_v2_e2_enir_lowering_gate.sh`
+- `scripts/dev/madaros_v2_e2_enir_lowering_verify.py`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_gate.sh`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_verify.py`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_gate.sh`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_verify.py`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_gate.sh`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_verify.py`
+- `scripts/dev/madaros_v2_e2e_enir_qd128_gate.sh`
+- `scripts/dev/madaros_v2_e2e_enir_qd128_verify.py`
+- `scripts/dev/madaros_v2_e2f_enir_rump_qd_gate.sh`
+- `scripts/dev/madaros_v2_e2f_enir_rump_qd_verify.py`
+- `scripts/dev/madaros_v2_e2g_enir_fuel_control_frail_gate.sh`
+- `scripts/dev/madaros_v2_e2g_enir_fuel_control_frail_verify.py`
+- `scripts/dev/madaros_v2_e2h_enir_memory_move_poison_gate.sh`
+- `scripts/dev/madaros_v2_e2h_enir_memory_move_poison_verify.py`
+- `scripts/dev/madaros_v2_e3a_enir_mir_qd128_gate.sh`
+- `scripts/dev/madaros_v2_e3a_enir_mir_qd128_verify.py`
+- `scripts/dev/madaros_v2_e3b_enir_mir_memory_gate.sh`
+- `scripts/dev/madaros_v2_e3b_enir_mir_memory_verify.py`
+- `tools/eisa/eisa_enir_v1_loop_oracle.sio`
+- `tools/eisa/eisa_enir_v1_oracle.sio`
+- `tools/eisa/eisa_enir_v1_rump_dd.eisa`
+- `tools/eisa/eisa_enir_v2_add.eisa`
+- `tools/eisa/eisa_enir_v2_const_gate.eisa`
+- `tools/eisa/eisa_enir_v2_div.eisa`
+- `tools/eisa/eisa_enir_v2_emov.eisa`
+- `tools/eisa/eisa_enir_v2_frail.eisa`
+- `tools/eisa/eisa_enir_v2_fuel.eisa`
+- `tools/eisa/eisa_enir_v2_loop.eisa`
+- `tools/eisa/eisa_enir_v2_mem.eisa`
+- `tools/eisa/eisa_enir_v2_mem_poison.eisa`
+- `tools/eisa/eisa_enir_v2_mul.eisa`
+- `tools/eisa/eisa_enir_v2_rump_qd.eisa`
+- `tools/eisa/eisa_enir_v2_sqrt.eisa`
+- `tools/eisa/eisa_enir_v2_sub.eisa`
+
+Common missing driver closure applies: `self-hosted/enir/*` listed above.
+
+### E3D multipred scalar/memory SSA
+
+Gate script: `scripts/dev/madaros_v2_e3d_multipred_scalar_memory_ssa_gate.sh`
+Regression chain followed: `E3C CFG memory SSA`.
+Transitive files absent from `origin/main`: **60**.
+
+| Direct gate-specific path | Present on main | Notes |
+| --- | --- | --- |
+| `scripts/dev/madaros_v2_e3d_multipred_scalar_memory_ssa_gate.sh` | no | gate/verifier |
+| `scripts/dev/madaros_v2_e3d_multipred_scalar_memory_ssa_verify.py` | no | gate/verifier |
+| `tools/eisa/eisa_enir_v2_join_then.eisa` | no | oracle/fixture |
+| `tools/eisa/eisa_enir_v2_join_else.eisa` | no | oracle/fixture |
+
+Inherited missing paths from regression chain:
+- `scripts/dev/madaros_v2_e1_enir_shadow_gate.sh`
+- `scripts/dev/madaros_v2_e1_enir_shadow_verify.py`
+- `scripts/dev/madaros_v2_e2_enir_lowering_gate.sh`
+- `scripts/dev/madaros_v2_e2_enir_lowering_verify.py`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_gate.sh`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_verify.py`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_gate.sh`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_verify.py`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_gate.sh`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_verify.py`
+- `scripts/dev/madaros_v2_e2e_enir_qd128_gate.sh`
+- `scripts/dev/madaros_v2_e2e_enir_qd128_verify.py`
+- `scripts/dev/madaros_v2_e2f_enir_rump_qd_gate.sh`
+- `scripts/dev/madaros_v2_e2f_enir_rump_qd_verify.py`
+- `scripts/dev/madaros_v2_e2g_enir_fuel_control_frail_gate.sh`
+- `scripts/dev/madaros_v2_e2g_enir_fuel_control_frail_verify.py`
+- `scripts/dev/madaros_v2_e2h_enir_memory_move_poison_gate.sh`
+- `scripts/dev/madaros_v2_e2h_enir_memory_move_poison_verify.py`
+- `scripts/dev/madaros_v2_e3a_enir_mir_qd128_gate.sh`
+- `scripts/dev/madaros_v2_e3a_enir_mir_qd128_verify.py`
+- `scripts/dev/madaros_v2_e3b_enir_mir_memory_gate.sh`
+- `scripts/dev/madaros_v2_e3b_enir_mir_memory_verify.py`
+- `scripts/dev/madaros_v2_e3c_cfg_memory_ssa_gate.sh`
+- `scripts/dev/madaros_v2_e3c_cfg_memory_ssa_verify.py`
+- `tools/eisa/eisa_enir_v1_loop_oracle.sio`
+- `tools/eisa/eisa_enir_v1_oracle.sio`
+- `tools/eisa/eisa_enir_v1_rump_dd.eisa`
+- `tools/eisa/eisa_enir_v2_add.eisa`
+- `tools/eisa/eisa_enir_v2_const_gate.eisa`
+- `tools/eisa/eisa_enir_v2_div.eisa`
+- `tools/eisa/eisa_enir_v2_emov.eisa`
+- `tools/eisa/eisa_enir_v2_frail.eisa`
+- `tools/eisa/eisa_enir_v2_fuel.eisa`
+- `tools/eisa/eisa_enir_v2_loop.eisa`
+- `tools/eisa/eisa_enir_v2_mem.eisa`
+- `tools/eisa/eisa_enir_v2_mem_phi_once.eisa`
+- `tools/eisa/eisa_enir_v2_mem_phi_zero.eisa`
+- `tools/eisa/eisa_enir_v2_mem_poison.eisa`
+- `tools/eisa/eisa_enir_v2_mul.eisa`
+- `tools/eisa/eisa_enir_v2_rump_qd.eisa`
+- `tools/eisa/eisa_enir_v2_sqrt.eisa`
+- `tools/eisa/eisa_enir_v2_sub.eisa`
+
+Common missing driver closure applies: `self-hosted/enir/*` listed above.
+
+### E3E equal value distinct event
+
+Gate script: `scripts/dev/madaros_v2_e3e_equal_value_distinct_event_gate.sh`
+Regression chain followed: none.
+Transitive files absent from `origin/main`: **17**.
+
+| Direct gate-specific path | Present on main | Notes |
+| --- | --- | --- |
+| `scripts/dev/madaros_v2_e3e_equal_value_distinct_event_gate.sh` | no | gate/verifier |
+| `tools/eisa/eisa_enir_v2_equal_then.eisa` | no | oracle/fixture |
+| `tools/eisa/eisa_enir_v2_equal_else.eisa` | no | oracle/fixture |
+
+Common missing driver closure applies: `self-hosted/enir/*` listed above.
+
+## Consolidated add-list
+
+These are the exact repository files referenced by the requested gate stack, present on `origin/canon/madaros-v2-sota`, and absent from `origin/main`.
+
+- `scripts/dev/madaros_v2_e1_enir_shadow_gate.sh`
+- `scripts/dev/madaros_v2_e1_enir_shadow_verify.py`
+- `scripts/dev/madaros_v2_e2_enir_lowering_gate.sh`
+- `scripts/dev/madaros_v2_e2_enir_lowering_verify.py`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_gate.sh`
+- `scripts/dev/madaros_v2_e2b_enir_cfg_verify.py`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_gate.sh`
+- `scripts/dev/madaros_v2_e2c_enir_fuel_blockargs_verify.py`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_gate.sh`
+- `scripts/dev/madaros_v2_e2d_enir_rump_dd_verify.py`
+- `scripts/dev/madaros_v2_e2e_enir_qd128_gate.sh`
+- `scripts/dev/madaros_v2_e2e_enir_qd128_verify.py`
+- `scripts/dev/madaros_v2_e2f_enir_rump_qd_gate.sh`
+- `scripts/dev/madaros_v2_e2f_enir_rump_qd_verify.py`
+- `scripts/dev/madaros_v2_e2g_enir_fuel_control_frail_gate.sh`
+- `scripts/dev/madaros_v2_e2g_enir_fuel_control_frail_verify.py`
+- `scripts/dev/madaros_v2_e2h_enir_memory_move_poison_gate.sh`
+- `scripts/dev/madaros_v2_e2h_enir_memory_move_poison_verify.py`
+- `scripts/dev/madaros_v2_e3a_enir_mir_qd128_gate.sh`
+- `scripts/dev/madaros_v2_e3a_enir_mir_qd128_verify.py`
+- `scripts/dev/madaros_v2_e3b_enir_mir_memory_gate.sh`
+- `scripts/dev/madaros_v2_e3b_enir_mir_memory_verify.py`
+- `scripts/dev/madaros_v2_e3c_cfg_memory_ssa_gate.sh`
+- `scripts/dev/madaros_v2_e3c_cfg_memory_ssa_verify.py`
+- `scripts/dev/madaros_v2_e3d_multipred_scalar_memory_ssa_gate.sh`
+- `scripts/dev/madaros_v2_e3d_multipred_scalar_memory_ssa_verify.py`
+- `scripts/dev/madaros_v2_e3e_equal_value_distinct_event_gate.sh`
+- `self-hosted/enir/canonical.sio`
+- `self-hosted/enir/driver.sio`
+- `self-hosted/enir/hash.sio`
+- `self-hosted/enir/interpreter.sio`
+- `self-hosted/enir/ir.sio`
+- `self-hosted/enir/mir.sio`
+- `self-hosted/enir/mir_cfg.sio`
+- `self-hosted/enir/mir_join.sio`
+- `self-hosted/enir/mod.sio`
+- `self-hosted/enir/parser.sio`
+- `self-hosted/enir/qd.sio`
+- `self-hosted/enir/shadow_fixture.sio`
+- `self-hosted/enir/source_lower.sio`
+- `self-hosted/enir/verify.sio`
+- `tools/eisa/eisa_enir_v1_loop_oracle.sio`
+- `tools/eisa/eisa_enir_v1_oracle.sio`
+- `tools/eisa/eisa_enir_v1_rump_dd.eisa`
+- `tools/eisa/eisa_enir_v2_add.eisa`
+- `tools/eisa/eisa_enir_v2_const_gate.eisa`
+- `tools/eisa/eisa_enir_v2_div.eisa`
+- `tools/eisa/eisa_enir_v2_emov.eisa`
+- `tools/eisa/eisa_enir_v2_equal_else.eisa`
+- `tools/eisa/eisa_enir_v2_equal_then.eisa`
+- `tools/eisa/eisa_enir_v2_frail.eisa`
+- `tools/eisa/eisa_enir_v2_fuel.eisa`
+- `tools/eisa/eisa_enir_v2_join_else.eisa`
+- `tools/eisa/eisa_enir_v2_join_then.eisa`
+- `tools/eisa/eisa_enir_v2_loop.eisa`
+- `tools/eisa/eisa_enir_v2_mem.eisa`
+- `tools/eisa/eisa_enir_v2_mem_phi_once.eisa`
+- `tools/eisa/eisa_enir_v2_mem_phi_zero.eisa`
+- `tools/eisa/eisa_enir_v2_mem_poison.eisa`
+- `tools/eisa/eisa_enir_v2_mul.eisa`
+- `tools/eisa/eisa_enir_v2_rump_qd.eisa`
+- `tools/eisa/eisa_enir_v2_sqrt.eisa`
+- `tools/eisa/eisa_enir_v2_sub.eisa`
+
+## Present-but-changed watchlist
+
+These referenced files already exist on `origin/main` but differ from the canon branch. They are not add-list entries, but a PR that expects canon behavior may need to account for the content delta separately.
+
+- `bin/souc-lean-single-x86_64`
+- `scripts/dev/souc-build-lock.sh`
+- `self-hosted/compiler/main.sio`
+- `stdlib/math/qd128.sio`
+- `tools/eisa/eisa_evm_run.sio`
+
+## Explicitly not in this add-list
+
+- `tools/eisa/eisa_enir_c2_rump.eisa`: absent from `origin/main` and present on the canon branch, but referenced by `scripts/dev/madaros_v2_c2_v0_gate.sh`, not by the requested E1/E2/E3 gate set.
+- `$TMP_DIR/*.eisa` negative fixtures: generated by the gate scripts at runtime and not repository payload.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1326
-- Repo-backed topics: 1176
+- Total governed topics: 1330
+- Repo-backed topics: 1180
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 399
-- Authority count `repo_only`: 739
+- Authority count `repo_only`: 743
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 754 topics
+- A2: 758 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 37 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -39,7 +39,9 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.architecture.mir-cranelift-integration-report | historical | docs/architecture/MIR_CRANELIFT_INTEGRATION_REPORT.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.architecture.mir-optimization-pases-documentation | historical | docs/architecture/MIR_OPTIMIZATION_PASES_DOCUMENTATION.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.architecture.mir-optimization-strategy | historical | docs/architecture/MIR_OPTIMIZATION_STRATEGY.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.architecture.mir-port-plan | repo_only | docs/architecture/MIR_PORT_PLAN.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.architecture.mir-research-strategy | historical | docs/architecture/MIR_RESEARCH_STRATEGY.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.architecture.mli-design | repo_only | docs/architecture/MLI_DESIGN.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.architecture.module-closure-truth | repo_only | docs/architecture/module-closure-truth.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.architecture.phase2-hir-generation | repo_only | docs/architecture/PHASE2_HIR_GENERATION.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.architecture.science-research-boundary | repo_only | docs/architecture/science-research-boundary.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -49,6 +51,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.architecture.soir-reference | repo_only | docs/architecture/SOIR_REFERENCE.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.architecture.truth-frontier | repo_only | docs/architecture/truth-frontier.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.architecture.truth-layers | repo_only | docs/architecture/truth-layers.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.architecture.ws-c-d-preflight-review-2026-08-16 | repo_only | docs/architecture/WS_C_D_PREFLIGHT_REVIEW_2026-08-16.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.archived.announcement | archived | docs/archived/ANNOUNCEMENT.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.archived.architecture | archived | docs/archived/ARCHITECTURE.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.archived.compiler-roadmap | archived | docs/archived/COMPILER_ROADMAP.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -542,6 +545,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.internal.coordination.ci-watch-contract | repo_only | docs/internal/coordination/CI_WATCH_CONTRACT.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.coordination.compiler-lane-contract | repo_only | docs/internal/coordination/COMPILER_LANE_CONTRACT.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.coordination.enir-semantic-interface-contract-2026-07-12 | repo_only | docs/internal/coordination/enir-semantic-interface-contract-2026-07-12.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.coordination.madaros-focus-plan-2026-08-16 | repo_only | docs/internal/coordination/MADAROS_FOCUS_PLAN_2026-08-16.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.coordination.semantic-hotspot-triage-2026-07-12 | repo_only | docs/internal/coordination/semantic-hotspot-triage-2026-07-12.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.e175-triage-2026-08-02 | repo_only | docs/internal/E175_TRIAGE_2026-08-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.garden.readme | repo_only | docs/internal/garden/README.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -387,6 +387,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.architecture.mir-port-plan",
+      "collection": "repo",
+      "repo_doc_path": "docs/architecture/MIR_PORT_PLAN.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.architecture.mir-research-strategy",
       "collection": "repo",
       "repo_doc_path": "docs/architecture/MIR_RESEARCH_STRATEGY.md",
@@ -405,6 +428,29 @@
       },
       "validation_commands": [
         "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.architecture.mli-design",
+      "collection": "repo",
+      "repo_doc_path": "docs/architecture/MLI_DESIGN.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
       ],
       "related_artifacts": []
     },
@@ -596,6 +642,29 @@
       "topic_id": "repo.docs.architecture.truth-layers",
       "collection": "repo",
       "repo_doc_path": "docs/architecture/truth-layers.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.architecture.ws-c-d-preflight-review-2026-08-16",
+      "collection": "repo",
+      "repo_doc_path": "docs/architecture/WS_C_D_PREFLIGHT_REVIEW_2026-08-16.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",
@@ -11926,6 +11995,29 @@
       "topic_id": "repo.docs.internal.coordination.enir-semantic-interface-contract-2026-07-12",
       "collection": "repo",
       "repo_doc_path": "docs/internal/coordination/enir-semantic-interface-contract-2026-07-12.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.internal.coordination.madaros-focus-plan-2026-08-16",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/coordination/MADAROS_FOCUS_PLAN_2026-08-16.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",

--- a/docs/internal/coordination/MADAROS_FOCUS_PLAN_2026-08-16.md
+++ b/docs/internal/coordination/MADAROS_FOCUS_PLAN_2026-08-16.md
@@ -1,0 +1,261 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.coordination.madaros-focus-plan-2026-08-16
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.coordination.madaros-focus-plan-2026-08-16
+-->
+
+# Madaros Focus Plan — Fleet Redirection
+
+Status: **active operational plan**, wave 1 dispatched.
+Authored: 2026-08-16T00:25:20Z. Drafted by Fable 5 (`claude-fable-5`) at founder
+request, from ground truth gathered by two research passes over `/workspace/sounio`
+the same session. Orchestrated by `claude-1` (tmux session `fleet`, coordination
+bus lane `fleet-orchestrator`).
+Supersedes: `.claude/OPERATIONAL_CANONICAL_INDEX.md`'s Track B skeleton (orphaned —
+its referenced `.claude/prompts/*.md` files no longer exist; retire or rewrite that
+doc once this plan is established).
+
+Founder objectives (verbatim, 2026-08-16): "Madaros E2E operacional, SOIR, MIR,
+MLI, HLIR EISA, f128 e f256 implantados e verificados." Confirmed definitions:
+**MLI** = Machine-Level IR, a genuinely new layer (does not exist yet; sits
+between MIR and codegen). **EISA** = the `tools/eisa/` + `stdlib/eisa/`
+instruction-set/bridge conformance suite (not the already-shipped EISA
+thinlink/CodeBuffer linker fix, PR #724).
+
+Governance this plan operates under (unchanged, binding):
+`.claude/ATTENTION_CHARTER.md` (5 = 1 + 2, ≤1 active P0),
+`CLAUDE.md` §4 (**≤2 agents editing `self-hosted/` at once** on this pod),
+`docs/internal/coordination/COMPILER_LANE_CONTRACT.md`,
+`bin/sounio-coord` / MCP `sounio-coord` for claims and messaging.
+
+---
+
+## 1. Workstream decomposition
+
+**WS-A · Madaros E2E operational** — verify + close residuals.
+Done = a fresh, dated `make madaros-full-gate` at 10/10 under the *current*
+binary (not the Feb-2026 numbers in `docs/MADAROS_STATUS.md` /
+`artifacts/omega/*.v1.json`, both ~6 months stale), extern "C" FFI silent-noop
+closed (P0-F), witness-matrix residuals dispositioned (enum-discriminant
+collision; `as f32` truncation — f32 still carried as f64 internally, no real
+narrowing, declared residual), and `docs/MADAROS_STATUS.md` +
+`artifacts/omega/*.v1.json` regenerated from that run.
+
+**WS-B · SOIR** — verify existing, add one gate. Done = a numeric
+`scripts/ci/soir_roundtrip_gate.sh` (serialize→deserialize→structural compare
+over a representative corpus of `self-hosted/ir/*`) green under default
+Madaros, plus a coverage census of what already exercised SOIR before the gate
+existed. Must land **before** the MIR port lands, so serialization drift
+during the port is caught mechanically.
+
+**WS-C · MIR port** — multi-week build/integrate. Real ENIR/MIR pipeline
+(`self-hosted/enir/{ir,mir,mir_cfg,mir_join,canonical,hash,interpreter,parser,
+qd,shadow_fixture,source_lower,verify,driver,mod}.sio`, 4 architecture docs
+`docs/architecture/MIR_*`) exists only on frontier branch
+`canon/madaros-v2-sota`, stalled at `97b525949` (2026-07-12). **Correction
+(grok-cli1, `MIR_PORT_PLAN.md`, 2026-08-16): the divergence direction in the
+original draft of this plan was backwards.** Measured:
+`origin/main..frontier` = **189** commits (frontier-only), `frontier..origin/main`
+= **2086** commits (main-only) — main is the long tip, the frontier is a short
+189-commit divergent lobe carrying the ENIR lane. 115 files touched on both
+sides since merge-base (41 under `self-hosted/`); the ENIR tree itself
+(14 files, 7310 LOC) has **zero** main-side counterpart and imports only
+`enir::*`, so it is not on the conflict surface.
+
+**Route decision: Route B — `enir/` subtree cherry-pick + resume the lettered
+plan — APPROVED by founder 2026-08-16**, per the costed recommendation in
+`docs/architecture/MIR_PORT_PLAN.md` (Route A wholesale rebase rejected —
+3–6+ engineer-weeks of conflict surgery on the worst IR/compiler/native
+hotspots; Route C fresh re-derivation kept only as a fallback if Route B's
+enir sources fail to typecheck under main within a bounded repair budget).
+Suggested PR stack: PR1 add `self-hosted/enir/**` + `bin/madaros-enir` + docs
+only (driver check/compile under seed) → PR2 E1 gate green on main → PR3
+E2A–E2H → PR4 E3A–E3D(+E3E) → PR5 optional umbrella gate. No production
+`use enir::` from `compiler/main.sio` until a later explicit integration
+tranche, post-WS-D MLI design.
+
+**WS-D · MLI design** — greenfield, multi-week.
+Phase 1 done = an approved `docs/architecture/MLI_DESIGN.md`: layer contract
+(input = MIR, WS-C route now B), instruction/operand model, register/stack
+discipline, verification story (interpreter or shadow-execution parity,
+mirroring `enir/interpreter.sio` / `verify.sio`), staged implementation
+ladder. Phase 2 (wave 3+) = a first vertical slice, one function lowered
+MIR→MLI→x86 bit-identical to the existing direct path.
+
+**Design option: Option C — dual-track (kinds first-class in the type
+system; R0 scalar-only emit first, R1 epistemic/CD emit staged) — APPROVED
+by founder 2026-08-16**, per `docs/architecture/MLI_DESIGN.md` §2.4 (Option A
+scalar-only rejected as sole architecture — would forfeit the plan's one
+"beyond any existing language" bet; Option B full-first-class-from-day-one
+rejected — blocks Phase-2 bit-identity for months). Implementation ladder
+S0 (this approval) → S1 `mli` module/kinds/builder/V-struct verify → S2
+`mir_to_mli` scalar R0 → S3 `legalize_x86`, Phase-2 bit-identical vertical
+slice → S4 f32/f128/f256 slots (WS-G coordination) → S5–S7 Knowledge/CD
+kinds staged. **S1 implementation dispatch (touches `self-hosted/`) HELD
+pending P0-F close**, same 1-active-P0 discipline the founder set for WS-C
+— not re-asked separately, applying the precedent.
+
+> **Design principle, binding for the design doc** (founder + orchestrator,
+> 2026-08-16): Sounio already has two features no mainstream compiler backend
+> treats as native machine-level types — `Knowledge<T>` / GUM-propagated
+> uncertainty, and Cayley-Dickson hypercomplex algebras (already lowered to
+> GPU tensor cores in `self-hosted/gpu/`, "Validated research" status, PR
+> #1207). Today both are erased or reduced to library/struct calls by the
+> time code reaches codegen. **MLI is the one layer where this doesn't have
+> to happen.** The design doc must evaluate — not silently default away from
+> — carrying `Knowledge<T>` provenance and CD-algebra dimension as first-class
+> MLI operand *kinds* (alongside `f32`/`f64`/`f128`/`f256`), so register
+> allocation and instruction selection can be uncertainty- and
+> algebra-aware rather than erasing that information before codegen. This is
+> the concrete "beyond any existing language" opportunity in this plan; it is
+> a research-grade design decision, not a default, and the doc must state the
+> tradeoff explicitly (scope/schedule cost vs. novelty) rather than assume it.
+
+**WS-E · HLIR re-verify** — verify existing, days. Real source
+(`self-hosted/hlir/`, `hlir_to_gpu.sio`, `hlir2wasm_driver.sio`,
+`test_epistemic_hlir_gpu.sio`); its "pass" status is from the stale Feb-2026
+snapshot. Done = fresh pass/fail evidence under current Madaros, replacing
+that snapshot; failures filed as scoped dispatches, not patched ad hoc.
+
+**WS-F · EISA Madaros port** — bounded build, 1-2 weeks.
+`scripts/ci/eisa_bridge_conformance_gate.sh` hardcodes
+`SOUNIO_SOUC_ENGINE=lean_single`, never touches Madaros — this is the real
+gap. `scripts/ci/eisa_h_zd_reference_gate.sh` is already Madaros-aware
+(tolerates a documented `BLOCKED` rc=12) — use it as the structural template.
+Done = the bridge-conformance gate running its full matrix under default
+Madaros, golden `artifacts/eisa/*.eisax.elf` reproduced byte-identical or
+divergence-receipted. Check for `extern "C"` dependence first — may be gated
+on P0-F.
+
+**WS-G · f128/f256** — greenfield from V0-A, multi-week, the largest single
+item. `docs/EXACT_CORE.md:55-57`: "no f256 arithmetic is implemented" by
+design; `self-hosted/parser/types.sio:41` rejects f128/f256 literals on
+purpose, staged "V0-A". Existing: `ty_f128()`/`ty_f256()` table entries,
+probe/scaffold files `self-hosted/compiler/f128_f256_{numeric_wire,
+format_descriptor,numeric_payload}_probe.sio` (wire encoding only). Staged
+done: **V0-B** literals accepted end-to-end through check; **V0-C** wire
+format/limb pools live (extend the probe files into real modules); **V0-D**
+softfloat arithmetic (add/sub/mul/div/cmp, compiler-owned limb routines in
+Sounio); **V0-E** stdlib surface + printing + GUM interaction. Each stage
+gated, with external-oracle test vectors (MPFR-derived, generation receipts
+checked in; verification runs in Sounio).
+
+---
+
+## 2. Sequencing
+
+```
+P0-F (extern C) ──► WS-A fresh gate ──► trustworthy baseline for everything
+WS-B (SOIR gate) ──► must land BEFORE WS-C port lands
+WS-C route decision ──► WS-C port ──► WS-D MLI implementation (input contract)
+WS-D design doc ── parallel now (needs only frontier docs + native/ reading)
+WS-E, WS-F ── independent; WS-F possibly gated on P0-F
+WS-G V0-B/C ── independent, wave 2
+WS-G V0-D ── recommend: land on current pipeline now, accept small re-lower
+              cost after MLI, rather than waiting
+```
+
+---
+
+## 3. Wave plan (≤2 self-hosted/ writers at a time)
+
+Ceiling counts only lanes editing `self-hosted/`. Gate runs, script/spec/test
+authoring, `tools/`/`stdlib/`/`docs/` work, and read-only frontier study do
+not count — but full builds still serialize through
+`scripts/dev/souc-build-lock.sh`; cap concurrent heavy gate runs at 2.
+
+### Wave 1 (now, ~5-7 days) — dispatched 2026-08-16
+
+Hot writers (unchanged, already in flight): **glm-cli1** (P0-F to completion),
+**claude-3** (land PR #1737, then the f32-narrowing residual).
+
+Cold lanes (dispatched this wave):
+
+| Lane | Task |
+|---|---|
+| codex-1 | WS-A: fresh `make madaros-full-gate` under the build lock; regenerate `artifacts/omega/*.v1.json`; diff vs the stale Feb-2026 claims |
+| codex-2 | WS-B: SOIR coverage census + author `scripts/ci/soir_roundtrip_gate.sh` |
+| grok-cli1 | WS-C: frontier study in an isolated worktree off `origin/canon/madaros-v2-sota`; author `docs/architecture/MIR_PORT_PLAN.md` (3 routes costed, conflict census) |
+| grok-cli2 | WS-D: draft `docs/architecture/MLI_DESIGN.md`, honoring the binding design principle in §1 |
+| grok-cli3 | WS-G: spec doc lifting the V0-A boundary into the V0-B..E ladder |
+| grok-cli4 | WS-F: Madaros-engine EISA gate variant (template off `eisa_h_zd_reference_gate.sh`); run + classify failures; check `extern "C"` dependence |
+| grok-cli5 | WS-E: inventory + run existing HLIR-exercising tests/gates; dated status note |
+| glm-cli2 | WS-A support: author `tests/run-pass` / `tests/compile-fail` witnesses for the f32-narrowing and enum-discriminant fixes, queued for claude-3 |
+| minimax-cli1 | Fleet hygiene: inspect `cursor-1`/`cursor-3` current tasks and report; draft retirement note for `.claude/OPERATIONAL_CANONICAL_INDEX.md` |
+| minimax-cli2 | WS-A: write the explicit "E2E operational" acceptance checklist (which gates constitute E2E), cross-check each `MADAROS_STATUS.md` claim |
+| minimax-cli3 | WS-G: generate + receipt the MPFR binary128/256 test-vector corpus |
+| cursor-2 | Land this doc in the docs registry (`bash scripts/dev/docs_registry_sync.sh` or equivalent — sync **after**, not before, per known gate behavior) |
+
+Held, not redirected (founder decision, 2026-08-16): **claude-2**,
+**kimi-cli1**, **kimi-cli2** finish PR #1580 (ZD-fiber theorems) first — Garden
+work close to done, do not interrupt. **codex-3** finishes its current SLURM
+run first, then reallocate. Both re-evaluated at start of wave 2.
+
+### Wave 2 (10-14 days, gated on P0-F closing + WS-C route decision)
+
+Next P0 nomination (founder decision, 2026-08-16): **WS-C, the MIR port
+route**, once WS-A's baseline is trustworthy and P0-F closes — highest
+runaway-scope risk in the whole plan, decide the route early.
+Hot writers: (1) WS-C port lane per the chosen route; (2) WS-G V0-B/V0-C lane
+(parser + wire modules — candidate: glm-cli1 rolling off P0-F). Cold: WS-F
+source fixes if needed; WS-B/WS-E gates land in CI; WS-D doc review + MLI
+vertical-slice test fixtures; freed lanes rotate to reviewing the port plan
+and running new gates nightly. claude-2/kimi-cli1/kimi-cli2/codex-3
+reallocated here if their current work has closed.
+
+### Wave 3 (3-4 weeks+, continuing)
+
+Hot writers: (1) WS-D MLI vertical slice (only once MIR is stable on main);
+(2) WS-G V0-D softfloat routines. Cold: conformance fixtures, divergence
+receipts, EISA golden reproduction, omega/status regeneration cadence. WS-C
+and WS-G both extend past wave 3 — treat these as checkpoints, not
+completion dates.
+
+---
+
+## 4. Founder decisions taken (2026-08-16, interactive)
+
+- (a) claude-2 / kimi-cli1 / kimi-cli2 (ZD-fiber, PR #1580): **let finish**,
+  do not interrupt.
+- (b) codex-3 (SLURM cs6_v7b research): **let current job finish**, reallocate
+  after.
+- (c) MIR port route: **still open** — decide from grok-cli1's wave-1
+  conflict census (`MIR_PORT_PLAN.md`), not before.
+- (d) Next P0 after F: **WS-C, MIR port route decision.**
+- (e) WS-G V0-D timing: land on current pipeline now (Fable 5 recommendation,
+  not separately re-litigated).
+
+---
+
+## 5. Risk register
+
+1. **MIR port becomes a multi-month rabbit hole.** 189 main-side commits can
+   silently invalidate frontier assumptions. Mitigation: no port work lands
+   before the wave-1 conflict census; hard checkpoint at day 10 of wave 2 — if
+   the chosen route hasn't produced a compiling `enir/` on main by then,
+   escalate to route re-decision, not more effort.
+2. **f128/f256 destabilizes the parser/checker.** V0-A rejection is a
+   deliberate boundary; lifting it touches literal parsing and type inference
+   shared by every test. Mitigation: smallest possible V0-B diff, full
+   run-pass + witness-matrix regression gate before merge, detectable refusal
+   on new-type paths (never silent zeros — cf. the token-ceiling lesson).
+3. **Stale-status false confidence.** `MADAROS_STATUS.md`/omega numbers are 6
+   months old. Mitigation: wave 1's first deliverable is the fresh full-gate
+   run; forbid citing pre-refresh numbers anywhere downstream.
+4. **Silent ceiling violation.** An eager cold lane edits `self-hosted/`
+   without claiming. Mitigation: coord claims mandatory before edits;
+   minimax-cli1's hygiene lane audits `git status` across worktrees daily; a
+   third self-hosted/ editor releases immediately.
+5. **CPU-saturation pod eviction.** Has killed this pod twice already. All
+   full compiles through `souc-build-lock.sh`; cap concurrent heavy gate runs
+   at 2; cold lanes schedule gate runs via coord messages, not ad hoc.
+6. **Instrument trust.** Prebuilt `bin/souc` staleness has cost a full false
+   investigation before (#1689). Every new gate ships with a positive control
+   that must fire; codegen claims are made against a binary built this
+   session, never the checked-in ELF.
+
+Retire or rewrite `.claude/OPERATIONAL_CANONICAL_INDEX.md` once this plan is
+established (minimax-cli1's wave-1 task).


### PR DESCRIPTION
Lands the architecture that governed this session's fleet work, plus the adversarial review that stress-tested it and the census that re-sized it. Documentation only — no `self-hosted/` changes.

## Why this exists as a PR

All of this began the session as untracked files in a shared checkout parked on a research branch: one `git clean` or concurrent-agent collision from loss, a failure mode this repo has hit before. The preflight review flagged it as finding C7, and it is itself one of the documents that was at risk.

## What's here

| Document | What it is |
|---|---|
| `MADAROS_FOCUS_PLAN_2026-08-16.md` | Workstream decomposition (E2E, SOIR, MIR port, MLI, HLIR, EISA, f128/f256), 3-wave dispatch under the existing ≤2 self-hosted-writer ceiling, and the recorded decisions: WS-C **Route B** approved, WS-D **Option C** approved |
| `MIR_PORT_PLAN.md` | The costed three-route study behind Route B, plus preflight amendments C2/C4/C5/C6 |
| `MLI_DESIGN.md` | Machine-Level IR layer contract and the Option C dual-track recommendation, plus amendments D1–D4 |
| `WS_C_D_PREFLIGHT_REVIEW_2026-08-16.md` | Adversarial review of both approved documents — 5 HIGH / 3 MEDIUM / 2 LOW, every finding with a receipt command |
| `WS_C_PR1_PAYLOAD_CENSUS.md` | Transitive enumeration of what the ENIR gate stack actually needs |

## Both approved decisions survived review — but three things changed

**The payload is 63 files, not ~23.** The preflight estimated ~23 by counting only the `tools/eisa` delta. Following every reference the gate scripts actually make — shell references, Python verifier references, verifier `PROGRAMS` fixture expansions, recursive regression-gate calls, and the `self-hosted/enir/driver.sio` import closure each gate build needs — the E1/E2/E3 stack needs **63 files absent from `origin/main`**: 14 gate scripts, 13 Python verifiers, 14 enir driver-closure files, 22 `tools/eisa` oracle/fixture files.

The stack was then re-checked against that number rather than assumed to still fit: **the PR1/PR2 split holds**, PR1 stays days 1–4 and does not absorb the gate surface, but **PR2 grows to days 5–10 (+2 days)**, taking the 49-file gate/payload bulk plus BASE_REF re-anchoring across 14 scripts. The real cost is the C3 shared-oracle drift, not the mechanical add.

**Two judgement calls were made, not deferred.** C2 pins the gate `BASE_REF` anchor (`HEAD` for local/cascade, following E3D's own `E3C_BASE_REF=HEAD` precedent; `origin/main` for clean-checkout gates; env override retained). D1 picks the S2/S3 feed — re-anchor on the IR→MLI side door, and explicitly do **not** block Phase-2 on a post-E3D EMIR generalisation tranche.

**A cross-lane collision neither approved doc had flagged.** C3: the ENIR gates do not merely *pin* the shared EISA files, they compile the METRON oracle live and compare against it — while WS-F is concurrently porting the EISA bridge gate over those same `tools/eisa` + `stdlib/eisa` files. An ownership boundary is now posted on the coordination bus and recorded in the plan.

## Other findings worth reading before implementation starts

- **C4** — `enir/mir_join.sio` does not parse under Madaros v0.80.0 (two seed-only constructs). PR1's acceptance as originally written was "driver check under seed", which would have merged code the default engine cannot parse. A Madaros `souc check` receipt is now required alongside the seed receipt.
- **C5** — the E200 `loop_closed` is a real semantic bug, not tolerable noise: used at `source_lower.sio:529`, declared at line 645 in a different function, so the lower-fail-15 rule is silently unenforced on the seed path today. Reclassified as a semantic fix needing a gate re-run.
- **D3** — Phase-2 bit-identity was underspecified: lean_single and Madaros native-v2 emit different bytes, so the golden engine and exact binary provenance must be pinned before S3 starts.

## Verification

Documentation only. `node scripts/docs/sync_governance_metadata.mjs` was run and its output is included; the three `docs/governance/` files in this diff are that generated registry sync, not hand edits.

Route B remains the cheapest of the three costed routes. What changed is that WS-C PR1 now starts from measured numbers instead of an estimate that would have broken mid-flight.