### PR TITLE
fix(madaros): reserve 512 MiB stack for EISA lowering (bisected floor) + drift gate

### DIFF
--- a/bin/madaros
+++ b/bin/madaros
@@ -20,7 +20,7 @@
 #   SOUNIO_STDLIB_PATH     — forwarded to the raw ELF unchanged
 #   MADAROS_RAW_BIN        — override the underlying modular raw ELF
 #   SOUNIO_MADAROS_BIN     — alias for MADAROS_RAW_BIN
-#   MADAROS_STACK_KB       — soft stack limit (default 262144 = 256 MiB). Measured
+#   MADAROS_STACK_KB       — soft stack limit (default 524288 = 512 MiB). Measured
 #                            floor 2026-08-13: minimal ok at 16 MiB+, helper at 32 MiB+.
 #                            Set 0 for unlimited. See MADAROS_HARDENING_PLAN_2026-08-12.md.
 #   MADAROS_VMEM_LIMIT_KB  — virtual-memory guard (default 32 GiB)
@@ -65,11 +65,11 @@ SCIENCE_BOUNDARY_RECEIPT=""
 SCIENCE_BOUNDARY_ARGS=()
 
 # Stack reservation (Lane A2-lite of MADAROS_HARDENING_PLAN_2026-08-12).
-# Raw Madaros needs more than the default 8 MiB Linux stack for a one-function
-# program (measured: minimal fails at 8 MiB, ok at 16+; helper ok at 32+).
+# Raw Madaros needs more than the default 8 MiB Linux stack. The EISA v1 bridge
+# lowering path fails through 384 MiB and passes at 448 MiB; reserve 512 MiB.
 # Named reservation replaces blanket unlimited until IR-arena root fix lands.
 # MADAROS_STACK_KB=0 restores unlimited.
-MADAROS_STACK_KB="${MADAROS_STACK_KB:-262144}"
+MADAROS_STACK_KB="${MADAROS_STACK_KB:-524288}"
 if [[ "$MADAROS_STACK_KB" == "0" ]]; then
   ulimit -s unlimited 2>/dev/null || true
 else

--- a/scripts/ci/madaros_launcher_exit_status_gate.sh
+++ b/scripts/ci/madaros_launcher_exit_status_gate.sh
@@ -22,6 +22,10 @@ if ! grep -q 'MADAROS_STACK_KB' "$ROOT_DIR/bin/madaros"; then
   echo "FAIL: MADAROS_STACK_KB not present in launcher" >&2
   exit 1
 fi
+if ! grep -Fq 'MADAROS_STACK_KB="${MADAROS_STACK_KB:-524288}"' "$ROOT_DIR/bin/madaros"; then
+  echo "FAIL: Madaros default stack reservation must remain 524288 KiB" >&2
+  exit 1
+fi
 # Must not have unconditional unlimited without the named reservation branch.
 if grep -n 'ulimit -s unlimited' "$ROOT_DIR/bin/madaros" | grep -v MADAROS_STACK_KB >/dev/null 2>&1; then
   # Allowed only inside MADAROS_STACK_KB==0 branch — check that unlimited is gated.


### PR DESCRIPTION
## Reserve enough stack for the EISA v1 bridge lowering path

`bin/madaros` reserved a 256 MiB soft stack. The EISA v1 bridge lowering path needs more, and the boundary was **bisected rather than guessed**:

> fails through **384 MiB**, passes at **448 MiB** → reserve **512 MiB**

That is a measured floor with one step of headroom, not a round number chosen because it worked once. The previous comment in the file recorded its own measurement the same way (*minimal fails at 8 MiB, ok at 16+; helper ok at 32+*), and this continues that discipline.

## The gate is the point

```bash
if ! grep -Fq 'MADAROS_STACK_KB="${MADAROS_STACK_KB:-524288}"' "$ROOT_DIR/bin/madaros"; then
  echo "FAIL: Madaros default stack reservation must remain 524288 KiB" >&2
  exit 1
fi
```

A stack reservation is exactly the kind of value that drifts back down during an unrelated cleanup, and the failure it causes then looks like a compiler bug rather than a configuration regression. Wiring the assertion into `madaros_launcher_exit_status_gate.sh` means it cannot silently revert.

This is the same class of defect as `#1690`, where `madaros run` needed 4× the stack of compile-then-execute and CI reported the resulting crash as a 30-second timeout — a resource shortfall wearing a correctness bug's clothes.

## Reviewer note on cost

This doubles the default soft reservation. Reservation is address space rather than committed memory, so the practical cost is low, but two facts about this environment are worth stating rather than leaving implicit: `ulimit -s` is inert above roughly 1.95 GB here, and the workspace pod is recycled by the liveness probe under CPU saturation with several agents compiling at once. Neither is a reason to reject a measured floor — a compiler that cannot lower its own bridge path is worse than one that reserves address space — but the number is now within a factor of four of the ceiling, so the next increase should come with a plan rather than another doubling.
