### PR TITLE
fix(ci): SIGPIPE cannot flip verdicts under pipefail (harness + probe)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,13 @@ jobs:
           done
       - name: Executable payload comparator self-test
         run: bash scripts/ci/executable_payload_compare_selftest.sh
+      # A harness that can lose writes to a broken pipe is a harness whose
+      # green is unverifiable: under pipefail, an early-exiting reader
+      # (grep -q, head) fails the pipeline and `if !` reads the verdict
+      # inside-out. Two CI incidents on 2026-08-16/17. Canary + fixed-form
+      # + shape ban, so a regression is red, not noise.
+      - name: SIGPIPE hygiene gate
+        run: bash scripts/ci/sigpipe_hygiene_gate.sh
       # Arms 1-2 need no compiler and cost <1 s, so they run on every PR
       # including docs-only ones. That is what stops the self-parse gate rotting
       # into a no-op: `--science-boundary-closure` exits 0 even on `status

--- a/scripts/ci/madaros_ir_capacity_probe.sh
+++ b/scripts/ci/madaros_ir_capacity_probe.sh
@@ -99,7 +99,7 @@ require_nonempty "$NODES" "node count"
 require_min_count "$NODES" 2 "closure nodes"
 
 IR_MAX_FUNCS="$(grep -E '^pub let IR_MAX_FUNCS: i64 = [0-9]+' self-hosted/ir/ir.sio \
-                 | grep -oE '[0-9]+$' | head -1)"
+                 | grep -oE '[0-9]+$' | sed -n 1p)"
 require_nonempty "$IR_MAX_FUNCS" "IR_MAX_FUNCS — it is no longer declared where this gate looks"
 
 FN_RE='^[[:space:]]*(pub[[:space:]]+|pub\(crate\)[[:space:]]+)?fn[[:space:]]'
@@ -128,7 +128,7 @@ fi
 FOREIGN="$(grep '^node' "$CLOSURE" | awk '{print $2}' | grep '^/' | grep -v "^$ROOT_DIR/" || true)"
 if [[ -n "$FOREIGN" ]]; then
   gate_fail "closure nodes resolve outside the tree under test ($ROOT_DIR); this census would be partly about another checkout:
-$(printf '%s' "$FOREIGN" | head -5)"
+$(printf '%s' "$FOREIGN" | sed -n '1,5p')"
 fi
 
 # A census that finds almost no functions is broken, not empty. main.sio alone
@@ -142,7 +142,12 @@ echo "fn_declarations  $TOTAL"
 echo "ir_max_funcs     $IR_MAX_FUNCS"
 echo "headroom         $((IR_MAX_FUNCS - TOTAL))"
 echo "top_contributors"
-sort -rn "$CENSUS" | head -10 | sed 's/^/  /'
+# No early-exiting reader in a pipefail pipeline: `| head -10` closes the
+# pipe after ten lines and `sort` can die on the flush (observed in CI on
+# 2026-08-17: "sort: fflush failed: Broken pipe" killed this REPORT_ONLY
+# probe before its exit 0). sed -n '1,10{...p}' reads everything and prints
+# ten. Guarded by scripts/ci/sigpipe_hygiene_gate.sh.
+sort -rn "$CENSUS" | sed -n '1,10{s/^/  /p}'
 
 if [[ "${SOUNIO_IR_CAPACITY_PROBE_REPORT_ONLY:-0}" == "1" ]]; then
   echo "MADAROS_IR_CAPACITY_REPORT_ONLY: not enforcing the cap"

--- a/scripts/ci/sigpipe_hygiene_gate.sh
+++ b/scripts/ci/sigpipe_hygiene_gate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# SIGPIPE hygiene gate (2026-08-17).
+#
+# Two CI incidents, one mechanism: a verdict-carrying pipeline under
+# `set -o pipefail` lost its writer to an early-exiting reader.
+#   * scripts/dev/run_sio_test_suite_v2.sh:434 (then-line) logged
+#     "echo: write error: Broken pipe" in a run whose single failure was a
+#     "missing error" flake on a test that passes elsewhere -- `grep -q`
+#     exits on first match, closes the pipe, and the flushing `echo` fails
+#     the pipeline; `if ! ...` then reads the match as absent.
+#   * scripts/ci/madaros_ir_capacity_probe.sh logged "sort: fflush failed:
+#     Broken pipe" and died before its REPORT_ONLY exit 0, from `| head -10`.
+#
+# The fixes remove the racy shapes (here-strings instead of `echo | grep -q`;
+# `sed -n '1,N{...p}'` instead of `| head -N`). This gate keeps them removed.
+# Three arms, because an instrument with one arm measures nothing:
+#   1. CANARY      -- this environment can still produce the failure class.
+#                     If it cannot, the gate refuses rather than certifies.
+#   2. FIXED FORM  -- the replacement still decides correctly on huge input.
+#   3. SHAPE BAN   -- the guarded files no longer contain the racy shapes.
+set -uo pipefail
+
+HARNESS="scripts/dev/run_sio_test_suite_v2.sh"
+PROBE="scripts/ci/madaros_ir_capacity_probe.sh"
+
+fail() { echo "SIGPIPE_HYGIENE_GATE_FAIL: $*" >&2; exit 1; }
+
+for f in "$HARNESS" "$PROBE"; do
+    [[ -f "$f" ]] || fail "guarded file absent: $f (nothing to scan)"
+done
+
+# Big enough to overflow any pipe buffer (Linux default 64 KiB; bash may ask
+# for more): a writer of this size is still flushing when a fast reader exits.
+BIG="needle_sigpipe_canary$(printf 'y%.0s' $(seq 1 200000))"
+
+# --- 1. CANARY -------------------------------------------------------------
+# `true` exits before reading. If this ever returns 0, the environment can no
+# longer reproduce the mechanism this gate exists to guard against, and a
+# green run would certify nothing. Refuse loudly instead.
+canary_rc=0
+printf '%s\n' "$BIG" | true || canary_rc=$?
+if [[ $canary_rc -eq 0 ]]; then
+    fail "canary did not reproduce: pipe-to-instant-exit returned 0 here, so this gate cannot certify anything on this machine"
+fi
+echo "canary: writer lost to an instant-exit reader under pipefail (rc=$canary_rc) -- the failure class is observable here"
+
+# --- 2. FIXED FORM ----------------------------------------------------------
+# The here-string form has no writer process: verdicts must be correct on
+# input far larger than any pipe buffer, present or absent needle, exactly
+# like the harness uses it.
+if ! grep -qF -- "needle_sigpipe_canary" <<<"$BIG"; then
+    fail "here-string grep lost a present needle in $BIG bytes"
+fi
+if grep -qF -- "absent_needle" <<<"$BIG"; then
+    fail "here-string grep matched an absent needle"
+fi
+# The probe's replacement shape: prints exactly the first 10, reads all input,
+# never exits early. It must succeed under pipefail with more input than any
+# buffer.
+probe_lines="$(printf 'x\n%.0s' $(seq 1 500) | sed -n '1,10{s/^/  /p}' | wc -l)"
+[[ "$probe_lines" == "10" ]] || fail "sed top-10 shape printed $probe_lines lines, expected 10"
+echo "fixed forms: here-string grep and sed top-10 decide correctly on 200 KiB+ input"
+
+# --- 3. SHAPE BAN -----------------------------------------------------------
+# Executable lines only: comments may name the forbidden shape while
+# documenting why it is forbidden, and that is not a regression.
+executable() { grep -v '^[[:space:]]*#' "$1"; }
+# No `echo "$captured" | grep -q` in the harness (the false-"missing" shape).
+if executable "$HARNESS" | grep -n 'echo "$output" | grep -q\|echo "$test_output" | grep -q' >/dev/null; then
+    executable "$HARNESS" | grep -n 'echo "$output" | grep -q\|echo "$test_output" | grep -q' | sed 's/^/  /'
+    fail "verdict-carrying echo|grep -q pipeline is back in $HARNESS"
+fi
+# No `| head` in the probe's executable lines: it runs under set -euo
+# pipefail, and any early-exiting reader there can kill the step before its
+# own exit path.
+if executable "$PROBE" | grep -n '| head' >/dev/null; then
+    executable "$PROBE" | grep -n '| head' | sed 's/^/  /'
+    fail "early-exiting '| head' reader is back in $PROBE"
+fi
+echo "shape ban: no echo|grep -q in $HARNESS, no | head in $PROBE"
+
+echo "SIGPIPE_HYGIENE_GATE_OK"

--- a/scripts/dev/run_sio_test_suite_v2.sh
+++ b/scripts/dev/run_sio_test_suite_v2.sh
@@ -401,10 +401,20 @@ run_test() {
             fi
         fi
         
-        # Check expected stdout patterns
+        # Check expected stdout patterns.
+        #
+        # PIPEFAIL RULE (2026-08-17): never feed a captured string to a
+        # verdict-carrying `grep -q` through `echo "$x" | grep -q ...`.
+        # `grep -q` exits on first match and closes the pipe; under
+        # `set -o pipefail` an `echo` still flushing a large output then
+        # fails the whole pipeline (CI log 2026-08-16 21:40:49: "line 434:
+        # echo: write error: Broken pipe", in the same run as a "missing
+        # error" flake), and `if ! ...` reads that as the pattern being
+        # absent. The here-string form has no writer process to lose writes.
+        # Guarded by scripts/ci/sigpipe_hygiene_gate.sh.
         if [[ $exit_code -eq 0 ]]; then
             for pattern in "${expect_stdout[@]}"; do
-                if ! echo "$output" | grep -qF -- "$pattern"; then
+                if ! grep -qF -- "$pattern" <<<"$output"; then
                     exit_code=1
                     test_output="missing stdout: $pattern"
                     break
@@ -420,7 +430,7 @@ run_test() {
         
         if [[ $exit_code -eq 124 ]]; then
             test_output="compile timed out after ${timeout_val}s"
-        elif [[ $exit_code -eq 0 ]] && echo "$output" | grep -qF "typecheck: failed"; then
+        elif [[ $exit_code -eq 0 ]] && grep -qF "typecheck: failed" <<<"$output"; then
             exit_code=1
         elif [[ $exit_code -eq 0 ]]; then
             test_output="expected compile failure but passed"
@@ -431,7 +441,7 @@ run_test() {
 
         if [[ $exit_code -ne 124 && $test_output != "expected compile failure but passed" ]]; then
             for pattern in "${error_patterns[@]}"; do
-                if ! echo "$output" | grep -qiF -- "$pattern"; then
+                if ! grep -qiF -- "$pattern" <<<"$output"; then
                     exit_code=1
                     test_output="missing error: $pattern"
                     break
@@ -475,7 +485,7 @@ run_test() {
                 test_output="typecheck-fail requires //@ error-pattern to pin the diagnostic"
             else
                 for pattern in "${tf_patterns[@]}"; do
-                    if ! echo "$output" | grep -qiF -- "$pattern"; then
+                    if ! grep -qiF -- "$pattern" <<<"$output"; then
                         exit_code=1
                         test_output="missing error: $pattern"
                         break


### PR DESCRIPTION
## The class

Under `set -o pipefail`, a pipeline is nonzero if ANY element fails — including a writer killed by an early-exiting reader. When that pipeline carries a test verdict, the verdict flips.

## The two incidents

1. **`scripts/dev/run_sio_test_suite_v2.sh`** — CI logged `line 434: echo: write error: Broken pipe` in a run whose single failure was a `missing error` flake on a test that passes everywhere else. Mechanism: `echo "$output" | grep -q pattern` — `grep -q` exits on first match and closes the pipe; an `echo` still flushing a large diagnostic output fails with EPIPE; pipefail makes the pipeline nonzero; `if ! ...` reads the match as **absent**. A false failure indistinguishable from a real regression — one lane spent close to an hour on exactly this today.
2. **`scripts/ci/madaros_ir_capacity_probe.sh`** — logged `sort: fflush failed: Broken pipe` and exited 2 **before** its `REPORT_ONLY` exit 0, from `sort -rn | head -10 | sed`. Two more latent sites of the same class in the same file (`| head -1` on a plain assignment under `set -e`; `| head -5` in the FOREIGN excerpt).

## The fix (minimal, and the scope is honest)

- Harness: four verdict-carrying sites → `grep -q… <<<"$output"` (no writer process, nothing to lose).
- Probe: three sites → full readers (`sed -n …p`), which read all input and never close early.

**Not fixed here, deliberately:** `run_sio_test_suite_v2.sh:396`'s `$(…)` capture drops NUL bytes from compiler output (the "ignored null byte" warning). Real, but the honest fix is capture-to-file + grep-the-file, which reshapes the harness hot path and deserves its own change; it cannot flip a grep verdict on ASCII patterns. Lines 537/541 keep `| head` inside `$( )` whose status is never checked — noise-capable, verdict-neutral, captured value complete.

## The regression guard (a harness change with no detector is how this returns in three months looking new)

`scripts/ci/sigpipe_hygiene_gate.sh`, wired into Contracts. Three arms:
1. **Canary** — reproduces the class in this environment (pipe-to-instant-exit must return nonzero) and **refuses** if it cannot, so the gate can never certify vacuously.
2. **Fixed-form behaviour** — here-string grep and sed top-N decide correctly on 200 KiB+ input, present and absent needle.
3. **Shape ban** — the racy forms may not return in the guarded files' executable lines. Teeth proven: reintroducing `echo "$output" | grep -qiF` in a scratch copy fails the gate at the offending line.

## Verification

- Canary rc=141 locally; `echo "$big" | grep -q` itself did NOT reproduce in 700+ local iterations (grep reads before exiting, so it usually loses the race — the runner is a different box under `--jobs 4` load, where the CI log shows it firing); the canary uses the deterministic shape instead.
- Negative control: red at the exact reintroduced line.
- A/B equivalence: original vs edited runner, same engine (`bin/souc`), same filter (`refinement_violation*`) — byte-identical verdicts (2 pass / 3 fail, same strings).
- Workflow refs 128 pass; vacuity gate baseline unchanged; new gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)