### PR TITLE
Fix compiler lane status gate premise expiry

### DIFF
--- a/scripts/ci/compiler_lane_status_gate.sh
+++ b/scripts/ci/compiler_lane_status_gate.sh
@@ -14,10 +14,11 @@ global_output="$(bash "$SCANNER" --main-ref HEAD)"
 grep -q '^Sounio compiler lane status$' <<< "$current_output"
 grep -Eq '^main_ref=HEAD main_sha=[0-9a-f]{10}$' <<< "$current_output"
 grep -q '^scanner_mode=current-only$' <<< "$current_output"
-# This gate's own HEAD changes coordination files only. It must not be
-# misreported as a compiler review lane.
-if grep -q '^state=' <<< "$current_output"; then
-  echo 'compiler-lanes: non-compiler current worktree leaked into lane output' >&2
+# The checked-out HEAD may itself include compiler files. That is still the
+# integrated product in CI because this gate pins --main-ref HEAD. What must not
+# leak into this read-only gate is an active/stale/review compiler lane.
+if grep -Eq '^state=(ACTIVE|STALE_WITH_RESIDUE|SCRATCH_COPY|REVIEW_READY|FRONTIER|FRONTIER_INTEGRATED|UNCLASSIFIED)' <<< "$current_output"; then
+  echo 'compiler-lanes: current worktree was reported as an outstanding compiler lane' >&2
   exit 1
 fi
 grep -q '^scanner_mode=all-worktrees$' <<< "$global_output"


### PR DESCRIPTION
## Summary

Fixes the Contracts red on main at 750f61da40 by narrowing scripts/ci/compiler_lane_status_gate.sh to the invariant it actually owns.

The original gate came from #809/#811 and its comment matched that authoring PR: the gate's own HEAD touched coordination files only, so asserting that current-only scanner output contained no state= line was true there. On main now, HEAD is the FFI system() fix and legitimately touches self-hosted/compiler/lean_single.sio. The scanner is correct to emit state=INTEGRATED with committed_compiler_paths=1 same_as_main=1 when run with --main-ref HEAD.

This was premise expiry, not a compiler regression: 6327421a27 passed Contracts because it touched no compiler files; 750f61da40 failed because it changed commit category. The gate was conflating "this commit touches compiler files" with "this checkout is an outstanding compiler review lane". Only the second is the assertion this read-only gate means to enforce.

## Fix

Allow integrated current HEAD classifications, while still failing if the current worktree is reported as an outstanding compiler lane: ACTIVE, STALE_WITH_RESIDUE, SCRATCH_COPY, REVIEW_READY, FRONTIER, FRONTIER_INTEGRATED, or UNCLASSIFIED.

This keeps the assertion meaningful; it does not delete the assertion or turn the gate into a pass-on-nothing check.

## Verification

- bash -n scripts/ci/compiler_lane_status_gate.sh
- bash scripts/ci/compiler_lane_status_gate.sh -> [compiler-lanes] PASS: read-only lane classification is executable
- git diff --check

## LLM-offload reviews invoked

None. CI gate premise repair only; no math claims, clinical-pathway code, or external-facing artifact content touched.
