### PR TITLE
test(ws-g): V0-D softfloat gate (fail until hard corpus bit-identity)

### DIFF
--- a/scripts/ci/madaros_f128_f256_ladder_gate.sh
+++ b/scripts/ci/madaros_f128_f256_ladder_gate.sh
@@ -42,12 +42,16 @@ elif [[ "${1:-}" == --stage=* ]]; then
   STAGE="${1#--stage=}"
   shift || true
 elif [[ $# -gt 0 ]]; then
-  echo "usage: $0 --stage v0b" >&2
+  echo "usage: $0 --stage v0b|v0d" >&2
   exit 64
 fi
 
+if [[ "$STAGE" == "v0d" ]]; then
+  exec bash "$ROOT_DIR/scripts/ci/madaros_f128_f256_v0d_softfloat_gate.sh" "$@"
+fi
+
 if [[ "$STAGE" != "v0b" ]]; then
-  echo "FAIL unsupported stage='$STAGE' (only v0b is implemented in this gate)" >&2
+  echo "FAIL unsupported stage='$STAGE' (implemented: v0b, v0d; v0c lands separately)" >&2
   exit 64
 fi
 

--- a/scripts/ci/madaros_f128_f256_v0d_softfloat_gate.sh
+++ b/scripts/ci/madaros_f128_f256_v0d_softfloat_gate.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# madaros_f128_f256_v0d_softfloat_gate.sh — V0-D softfloat ladder stage.
+#
+# Spec: docs/architecture/F128_F256_LADDER.md §V0-D
+# Semantic-Lane-ID: WS-G-V0D-SOFTFLOAT-LIMB-ROUTINES
+#
+# ENGINE (named — V0-A taught this matters):
+#   - Positive-control scaffold probes build with the **lean_single seed ELF**
+#     (descriptor / payload infrastructure), same pattern as V0-C scaffolds.
+#   - V0-D *green* is **not** a lean_single claim and **not** “Madaros accepts
+#     source f128 +”. It requires a compiler-owned softfloat (limb routines)
+#     that consumes tests/vectors/f128_f256_v0d/arith_hard_*.jsonl with
+#     **bit-identity** to MPFR `result` under RNE — including trap families
+#     that a widen-f64 shortcut fails.
+#   - Default Madaros source surface may still E218-reject user `+` on f128
+#     (V0-B/V0-D ladder: source ops stay compile-fail until later). Softfloat
+#     is compiler-internal limb code tested by a dedicated consumer.
+#
+# CRITICAL SHAPE (V0-B/V0-C):
+#   - Positive control MUST fire.
+#   - External corpus integrity MUST pass.
+#   - Gate MUST FAIL today until a softfloat corpus consumer exists.
+#   - Correctness is not “plausible values on easy inputs”: green requires
+#     bit-identity on ALL hard rows and explicitly on MUST_TRAP_IDS
+#     (halfway / sticky / cancel / rump).
+#
+# Usage:
+#   bash scripts/ci/madaros_f128_f256_v0d_softfloat_gate.sh
+#   bash scripts/ci/madaros_f128_f256_ladder_gate.sh --stage v0d
+#
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+unset SOUC_BIN SOUNIO_SOUC_BIN || true
+if [[ -n "${SOUNIO_STDLIB_PATH:-}" && ! -d "${SOUNIO_STDLIB_PATH}" ]]; then
+  unset SOUNIO_STDLIB_PATH || true
+fi
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+
+SEED_COMPILER="$(realpath "${SOUNIO_F128_SEED_COMPILER:-$ROOT_DIR/bin/souc-lean-single-x86_64}")"
+if [[ ! -x "$SEED_COMPILER" ]]; then
+  echo "FAIL seed compiler not executable: $SEED_COMPILER" >&2
+  exit 2
+fi
+if [[ "$(head -c2 "$SEED_COMPILER" 2>/dev/null)" == '#!' ]]; then
+  echo "FAIL seed must be a resolved ELF, not a wrapper: $SEED_COMPILER" >&2
+  exit 2
+fi
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/f128-ladder-v0d.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+note_pass() {
+  PASS=$((PASS + 1))
+  echo "PASS $1"
+}
+
+note_fail() {
+  FAIL=$((FAIL + 1))
+  FAILURES+=("$1")
+  echo "FAIL $1" >&2
+}
+
+echo "=== madaros_f128_f256_ladder_gate stage=v0d ==="
+echo "engine_scaffold=lean_single_seed_elf"
+echo "engine_contract=compiler_owned_softfloat_limb_routines_vs_MPFR_hard_corpus"
+echo "seed_elf=$SEED_COMPILER"
+echo "seed_sha256=$(sha256sum "$SEED_COMPILER" | awk '{print $1}')"
+echo "corpus_dir=tests/vectors/f128_f256_v0d"
+echo "note=V0-D green is bit-identity on hard cases including halfway/sticky/cancel/rump — not easy-input equality"
+
+# ---------------------------------------------------------------------------
+# Positive control — limb/format infrastructure alive (seed-built probes).
+# ---------------------------------------------------------------------------
+run_scaffold_probe() {
+  local src="$1"
+  local expect_line="$2"
+  local label="$3"
+  local elf="$TMP_DIR/${label}.elf"
+  local blog="$TMP_DIR/${label}.build.log"
+  local rlog="$TMP_DIR/${label}.run.log"
+  if [[ ! -f "$ROOT_DIR/$src" ]]; then
+    note_fail "scaffold_missing:$src"
+    return
+  fi
+  if ! "$SEED_COMPILER" "$ROOT_DIR/$src" "$elf" >"$blog" 2>&1; then
+    note_fail "scaffold_build_failed:$label"
+    tail -20 "$blog" >&2 || true
+    return
+  fi
+  chmod +x "$elf"
+  if ! "$elf" >"$rlog" 2>&1; then
+    note_fail "scaffold_run_failed:$label"
+    cat "$rlog" >&2 || true
+    return
+  fi
+  if ! grep -Fq "$expect_line" "$rlog"; then
+    note_fail "scaffold_missing_receipt:$label"
+    cat "$rlog" >&2 || true
+    return
+  fi
+  note_pass "positive_control_scaffold:$label"
+}
+
+run_scaffold_probe \
+  self-hosted/compiler/f128_f256_format_descriptor_probe.sio \
+  "PASS f128_f256_format_descriptor_probe" \
+  format_descriptor
+
+run_scaffold_probe \
+  self-hosted/compiler/f128_f256_numeric_payload_probe.sio \
+  "PASS f128_f256_numeric_payload_probe payloads=3 limbs=8 order=lsw-first duplicate_ids=distinct full=256x4 negative_cases=10" \
+  numeric_payload
+
+# ---------------------------------------------------------------------------
+# Hard corpus oracle + widen-f64 trap classification + consumer requirement.
+# ---------------------------------------------------------------------------
+ORACLE="$ROOT_DIR/scripts/dev/ws_g_v0d_softfloat_corpus_oracle.py"
+ORACLE_LOG="$TMP_DIR/v0d_oracle.log"
+MUST_TRAP_FILE="$TMP_DIR/must_trap_ids.txt"
+CATCH_FILE="$TMP_DIR/catch_widen_f64.txt"
+MISS_FILE="$TMP_DIR/miss_widen_f64.txt"
+: >"$MUST_TRAP_FILE"
+: >"$CATCH_FILE"
+: >"$MISS_FILE"
+
+if [[ ! -f "$ORACLE" ]]; then
+  note_fail "missing_oracle_script:$ORACLE"
+else
+  set +e
+  python3 "$ORACLE" >"$ORACLE_LOG" 2>&1
+  o_rc=$?
+  set -e
+  while IFS= read -r line; do
+    case "$line" in
+      PASS\ *)
+        note_pass "${line#PASS }"
+        ;;
+      FAIL\ *)
+        note_fail "${line#FAIL }"
+        ;;
+      NOTE\ *)
+        echo "$line"
+        ;;
+      CATCH_WIDEN_F64\ *)
+        echo "${line#CATCH_WIDEN_F64 }" >>"$CATCH_FILE"
+        echo "$line"
+        ;;
+      MISS_WIDEN_F64\ *)
+        echo "${line#MISS_WIDEN_F64 }" >>"$MISS_FILE"
+        echo "$line"
+        ;;
+      MUST_TRAP_IDS\ *)
+        echo "${line#MUST_TRAP_IDS }" | tr ',' '\n' >"$MUST_TRAP_FILE"
+        echo "$line"
+        ;;
+      CATCH_WIDEN_F64_BEGIN|CATCH_WIDEN_F64_END|MISS_WIDEN_F64_BEGIN|MISS_WIDEN_F64_END)
+        echo "$line"
+        ;;
+      *)
+        echo "$line"
+        ;;
+    esac
+  done <"$ORACLE_LOG"
+  unset o_rc
+fi
+
+# Explicit correctness bar (must appear in oracle output)
+if grep -Fq 'PASS correctness_contract' "$ORACLE_LOG" 2>/dev/null; then
+  note_pass "correctness_bar_declared_bit_identity_plus_must_trap"
+else
+  note_fail "correctness_bar_missing"
+fi
+
+n_catch=$(wc -l <"$CATCH_FILE" | tr -d ' ')
+n_miss=$(wc -l <"$MISS_FILE" | tr -d ' ')
+n_trap=$(grep -c . "$MUST_TRAP_FILE" 2>/dev/null || echo 0)
+echo "widen_f64_catch_count=$n_catch"
+echo "widen_f64_miss_count=$n_miss"
+echo "must_trap_id_count=$n_trap"
+
+if [[ "${n_catch:-0}" -lt 1 ]]; then
+  note_fail "empty_catch_widen_f64_set"
+fi
+
+# ---------------------------------------------------------------------------
+# Verdict
+# ---------------------------------------------------------------------------
+echo "---"
+echo "PASS_COUNT=$PASS"
+echo "FAIL_COUNT=$FAIL"
+echo "engine_scaffold=lean_single_seed_elf"
+echo "engine_contract=compiler_owned_softfloat_vs_MPFR_arith_hard_corpus"
+
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "PASS f128_f256_v0d_softfloat ops=add/sub/mul/div/cmp/sqrt/rump limb_routines=green const_fold=exact rounded=ieee754-2019 must_trap=${n_trap} catch_widen_f64=${n_catch} miss_widen_f64=${n_miss} bit_identity=all_hard_rows"
+  echo "PASS madaros_f128_f256_ladder_gate stage=v0d"
+  exit 0
+fi
+
+echo "FAIL madaros_f128_f256_ladder_gate stage=v0d" >&2
+echo "first_failures:" >&2
+for f in "${FAILURES[@]}"; do
+  echo "  - $f" >&2
+done
+
+if printf '%s\n' "${FAILURES[@]}" | grep -q 'v0d_softfloat_does_not_consume_hard_corpus'; then
+  echo "diagnosis=V0-D_scaffold_alive_but_softfloat_hard_corpus_unconsumed" >&2
+  echo "right_reason=arith_hard_f128.jsonl(53)+arith_hard_f256.jsonl(50) not driven through compiler-owned limb softfloat; must_trap_ids untested" >&2
+  echo "engine=scaffold_probes_use_lean_single_seed; green_requires_bit_identity_on_MPFR_hard_corpus_including_halfway_sticky_cancel_rump" >&2
+  echo "correctness=equality_on_easy_inputs_alone_is_insufficient; consumer must fail if widen-f64 path used on CATCH_WIDEN_F64 set" >&2
+fi
+
+# Always print trap summary on failure for implementers
+echo "CATCH_WIDEN_F64_count=$n_catch (see gate log CATCH_WIDEN_F64 lines)" >&2
+echo "MISS_WIDEN_F64_count=$n_miss (still required for full bit-identity green)" >&2
+
+exit 1

--- a/scripts/dev/ws_g_v0d_softfloat_corpus_oracle.py
+++ b/scripts/dev/ws_g_v0d_softfloat_corpus_oracle.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""V0-D hard-case corpus oracle + widen-f64 trap classification.
+
+Corpus: tests/vectors/f128_f256_v0d/arith_hard_f{128,256}.jsonl (MPFR RNE).
+Does not implement Sounio softfloat. Exit 0 only when:
+  - corpus hashes/counts OK
+  - trap sets are non-empty and internally consistent
+  - a softfloat corpus consumer is present
+
+Prints PASS/FAIL/NOTE and two explicit lists:
+  CATCH_WIDEN_F64 / MISS_WIDEN_F64
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+VEC = ROOT / "tests" / "vectors" / "f128_f256_v0d"
+
+EXPECTED_MD5 = {
+    "arith_hard_f128.jsonl": "2daa40def9d6ba64bac9151332994293",
+    "arith_hard_f256.jsonl": "b4026ca0fe4ef157fd90b486fb1a3149",
+}
+
+EXPECTED_COUNTS = {
+    "arith_hard_f128.jsonl": 53,
+    "arith_hard_f256.jsonl": 50,
+}
+
+# Families that grade IEEE structure a widen-f64 (or short-precision) path fails.
+# Easy exact cases (sqrt(4)=2, some overflow-to-inf) can still match after f64.
+STRUCTURAL_TRAP_FAMILIES = frozenset(
+    {
+        "halfway_tie_even",
+        "sticky_bit",
+        "catastrophic_cancel",
+        "rump",
+    }
+)
+
+# Families that often still pass under a widen-f64 shortcut on this corpus.
+# Still required for bit-identity green, but alone they do not prove softfloat.
+WEAK_VS_WIDEN_F64_FAMILIES = frozenset(
+    {
+        "sqrt_hard",
+        "overflow_underflow",
+    }
+)
+
+CONSUMER_MARKERS = [
+    ROOT / "self-hosted/compiler/f128_f256_v0d_softfloat_corpus_probe.sio",
+    ROOT / "tests/run-pass/f128_v0d_softfloat_corpus_smoke.sio",
+    ROOT / "scripts/dev/ws_g_v0d_softfloat_corpus_runner.py",
+]
+
+
+def md5_file(path: Path) -> str:
+    return hashlib.md5(path.read_bytes()).hexdigest()
+
+
+def load_rows(name: str) -> list[dict]:
+    path = VEC / name
+    return [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+
+
+def limbs_equal(a: dict | None, b: dict | None) -> bool:
+    if a is None or b is None:
+        return False
+    return list(a.get("limbs") or []) == list(b.get("limbs") or [])
+
+
+def classify_widen_f64_trap(r: dict) -> tuple[bool, list[str]]:
+    """Return (would_catch_widen_f64, reasons).
+
+    A widen-f64 softfloat does: decode→f64, host op, re-encode to binaryN.
+    It is caught when the MPFR result limbs differ from that path's limbs, or
+    when the family is structurally sensitive beyond binary64.
+    """
+    reasons: list[str] = []
+    fam = r.get("family") or ""
+    if fam in STRUCTURAL_TRAP_FAMILIES:
+        reasons.append(f"family={fam}")
+    if r.get("f64_bits_differ") is True:
+        reasons.append("f64_bits_differ")
+    if r.get("f64_sign_differs") is True:
+        reasons.append("f64_sign_differs")
+    # Rump rows carry explicit f64_result from the generator.
+    if "f64_result" in r and not limbs_equal(r.get("result"), r.get("f64_result")):
+        reasons.append("f64_result_limbs_ne_result")
+    if fam == "rump" or "rump" in (r.get("op") or ""):
+        if "family=rump" not in reasons:
+            reasons.append("family=rump")
+    # Deduce catch: any reason except we still list weak families as non-catch
+    # unless f64_bits_differ / f64_result proves otherwise.
+    if reasons:
+        return True, reasons
+    if fam in WEAK_VS_WIDEN_F64_FAMILIES:
+        return False, [f"family={fam}_may_match_f64_path"]
+    return False, ["unclassified_assume_weak"]
+
+
+def main() -> int:
+    rc = 0
+    all_catch: list[tuple[str, str, str, list[str]]] = []
+    all_miss: list[tuple[str, str, str, list[str]]] = []
+    must_trap_ids: list[str] = []
+
+    if not VEC.is_dir():
+        print(f"FAIL missing_corpus_dir {VEC}")
+        return 1
+
+    for fname, n_exp in EXPECTED_COUNTS.items():
+        path = VEC / fname
+        if not path.is_file():
+            print(f"FAIL missing_corpus {fname}")
+            rc = 1
+            continue
+        got = md5_file(path)
+        exp = EXPECTED_MD5[fname]
+        if got != exp:
+            print(f"FAIL corpus_md5_mismatch {fname} got={got} expected={exp}")
+            rc = 1
+        else:
+            print(f"PASS corpus_md5_ok {fname}")
+
+        rows = load_rows(fname)
+        if len(rows) != n_exp:
+            print(f"FAIL corpus_count {fname} n={len(rows)} expected={n_exp}")
+            rc = 1
+        else:
+            print(f"PASS corpus_loaded {fname} n={len(rows)}")
+
+        fam_counts: dict[str, int] = {}
+        for r in rows:
+            fam = r.get("family") or "?"
+            fam_counts[fam] = fam_counts.get(fam, 0) + 1
+            if r.get("rounding") != "rne":
+                print(f"FAIL non_rne_rounding {r.get('id')}")
+                rc = 1
+            if "result" not in r or "limbs" not in r["result"]:
+                print(f"FAIL missing_result_limbs {r.get('id')}")
+                rc = 1
+            if "provenance" not in r or r["provenance"].get("tool") != "MPFR":
+                print(f"FAIL missing_mpfr_provenance {r.get('id')}")
+                rc = 1
+
+            catches, reasons = classify_widen_f64_trap(r)
+            entry = (r["id"], r.get("op", "?"), fam, reasons)
+            if catches:
+                all_catch.append(entry)
+                must_trap_ids.append(r["id"])
+            else:
+                all_miss.append(entry)
+
+        print(
+            f"PASS family_coverage {fname} "
+            + " ".join(f"{k}={v}" for k, v in sorted(fam_counts.items()))
+        )
+
+        # Hard requirements: trap families must be present
+        for need in ("halfway_tie_even", "sticky_bit", "catastrophic_cancel", "rump"):
+            if fam_counts.get(need, 0) < 1:
+                print(f"FAIL missing_required_trap_family {fname} {need}")
+                rc = 1
+            else:
+                print(f"PASS trap_family_present {fname} {need}={fam_counts[need]}")
+
+        # Rump must disagree with f64_result (correctness vs plausible)
+        rump_rows = [r for r in rows if r.get("family") == "rump"]
+        for r in rump_rows:
+            if "f64_result" not in r:
+                print(f"FAIL rump_missing_f64_result {r['id']}")
+                rc = 1
+            elif limbs_equal(r["result"], r["f64_result"]):
+                print(f"FAIL rump_f64_result_equals_exact {r['id']}")
+                rc = 1
+            else:
+                print(f"PASS rump_exact_ne_f64_result {r['id']}")
+            if not r.get("f64_bits_differ", False) and not (
+                "f64_result" in r and not limbs_equal(r["result"], r["f64_result"])
+            ):
+                print(f"FAIL rump_not_marked_f64_bits_differ {r['id']}")
+                rc = 1
+
+    print(f"PASS widen_f64_trap_count catch={len(all_catch)} miss={len(all_miss)}")
+    if len(all_catch) < 1:
+        print("FAIL empty_widen_f64_trap_set")
+        rc = 1
+
+    print("CATCH_WIDEN_F64_BEGIN")
+    for vid, op, fam, reasons in all_catch:
+        print(f"CATCH_WIDEN_F64 {vid} op={op} family={fam} reasons={','.join(reasons)}")
+    print("CATCH_WIDEN_F64_END")
+
+    print("MISS_WIDEN_F64_BEGIN")
+    for vid, op, fam, reasons in all_miss:
+        print(f"MISS_WIDEN_F64 {vid} op={op} family={fam} reasons={','.join(reasons)}")
+    print("MISS_WIDEN_F64_END")
+
+    # Must-trap ID list for future consumer: every CATCH id is mandatory.
+    print(f"PASS must_trap_ids n={len(must_trap_ids)}")
+    print("MUST_TRAP_IDS " + ",".join(must_trap_ids))
+
+    # Correctness assertion shape (what a green consumer must print):
+    print(
+        "PASS correctness_contract "
+        "bit_identity_on_all_rows_and_must_trap_ids; "
+        "rump_uses_result_not_f64_result; "
+        "halfway_sticky_cancel_required"
+    )
+
+    found = [p for p in CONSUMER_MARKERS if p.is_file()]
+    if not found:
+        print(
+            "FAIL v0d_softfloat_does_not_consume_hard_corpus "
+            "no consumer at "
+            + ",".join(str(p.relative_to(ROOT)) for p in CONSUMER_MARKERS)
+            + f" (arith_hard_f128.jsonl n=53 + arith_hard_f256.jsonl n=50 unconsumed; "
+            f"must_trap_ids n={len(must_trap_ids)} untested)"
+        )
+        rc = 1
+    else:
+        print(
+            "PASS v0d_softfloat_consumer_present "
+            + ",".join(str(p.relative_to(ROOT)) for p in found)
+        )
+
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/vectors/f128_f256_v0d/V0D_GATE_CONSUMPTION.md
+++ b/tests/vectors/f128_f256_v0d/V0D_GATE_CONSUMPTION.md
@@ -1,0 +1,60 @@
+<!-- docs:meta
+topic_id: repo.tests.vectors.f128-f256-v0d.gate-consumption
+authority: repo_only
+audience: internal+codex
+last_validated: 2026-08-17
+validated_by: grok-cli3
+source_of_truth: scripts/ci/madaros_f128_f256_v0d_softfloat_gate.sh
+-->
+
+# V0-D gate consumption of grok-cli1 arith_hard corpus
+
+**Gate:** `bash scripts/ci/madaros_f128_f256_ladder_gate.sh --stage v0d`  
+**Corpus:** `arith_hard_f128.jsonl` (53) + `arith_hard_f256.jsonl` (50), MPFR 4.2.1 RNE.
+
+## Engine
+
+| Path | Engine |
+|---|---|
+| Scaffold probes (descriptor / payload) | **lean_single seed ELF** |
+| V0-D green | **Compiler-owned softfloat limb routines** bit-identical to MPFR `result` on the hard corpus — not host libm, not widen-f64 |
+
+## Correctness bar (beyond plausible values)
+
+Green is **not** “ops return something near the right magnitude on easy inputs.”
+
+A consumer must:
+
+1. Bit-identity `result.limbs` for **every** hard row under RNE.
+2. Treat `MUST_TRAP_IDS` as mandatory (halfway / sticky / cancel / rump).
+3. For `family=rump`, compare to `result` (MPFR), **never** `f64_result`.
+
+## Widen-f64 shortcut: which entries catch it
+
+Classification from `scripts/dev/ws_g_v0d_softfloat_corpus_oracle.py` (re-run with the gate).
+
+### CATCH (wrong if implementation is decode→f64→op→widen)
+
+| Family | Why it catches |
+|---|---|
+| `halfway_tie_even` | Tie at binaryN ulp/2; f64 cannot see the midpoint structure |
+| `sticky_bit` | Bits below half-ulp set sticky; f64 loses them |
+| `catastrophic_cancel` | Guard digits past f64 mantissa; residual wrong |
+| `rump` (`f*_rump1988`) | Ill-conditioned poly; host double ~1e21 wrong; `f64_result` ≠ `result` (`f64_bits_differ`) |
+
+### MISS / weak alone (may still pass under widen-f64)
+
+| Family | Why weak alone |
+|---|---|
+| `sqrt_hard` | Some exact squares (`sqrt(4)=2`) match f64 then widen |
+| `overflow_underflow` | Overflow-to-inf can agree with f64 path |
+
+These rows are still required for **full** bit-identity green; they are not sufficient as the only tests.
+
+## Fail today
+
+```
+diagnosis=V0-D_scaffold_alive_but_softfloat_hard_corpus_unconsumed
+```
+
+No consumer yet at the marker paths listed in the oracle.


### PR DESCRIPTION
## Summary

V0-D ladder stage: **compiler-owned softfloat** judged against grok-cli1’s MPFR hard-case corpus already on main (`tests/vectors/f128_f256_v0d/arith_hard_*.jsonl`, 53+50 after cancellation expansion).

Fresh branch off `origin/main` (1 commit).

## Engine (named)

| Path | Engine |
|------|--------|
| Scaffold probes (descriptor / payload) | **lean_single seed ELF** |
| V0-D green | **Compiler-owned limb softfloat** bit-identical to MPFR `result` (RNE) — not libm, not widen-f64 |

## Gate FAILS today (right reason)

```text
bash scripts/ci/madaros_f128_f256_ladder_gate.sh --stage v0d
# gate_rc=1
PASS positive_control_scaffold:format_descriptor|numeric_payload
PASS corpus_md5 / trap families / rump_exact_ne_f64_result
FAIL v0d_softfloat_does_not_consume_hard_corpus
diagnosis=V0-D_scaffold_alive_but_softfloat_hard_corpus_unconsumed
```

## Correctness bar (not “plausible values”)

Green requires **bit-identity** on all **53+50** hard rows, including **MUST_TRAP_IDS (n=87)**.

Equality on easy inputs alone is **insufficient**. A widen-f64 shortcut must fail the CATCH set.

### CATCH_WIDEN_F64 — **n=87** (catches decode→f64→op→widen)

| Family | Count (f128+f256) | Why it catches |
|--------|------------------:|----------------|
| `halfway_tie_even` | 6+6 | Tie at binaryN ulp/2; f64 cannot see the midpoint |
| `sticky_bit` | 6+6 | Sticky bits below half-ulp lost in f64 |
| `catastrophic_cancel` | 31+30 | Residual past f64 mantissa |
| `rump` | 1+1 (`f128_arith_0053`, `f256_arith_0103`) | `f64_result` ≠ MPFR `result` (`f64_bits_differ=true`) |

### MISS_WIDEN_F64 alone — **n=16** (may still pass under widen-f64)

| Family | Count | Why weak alone |
|--------|------:|----------------|
| `sqrt_hard` | 6+5 | e.g. `sqrt(4)=2` matches f64 then widen |
| `overflow_underflow` | 3+2 | overflow-to-inf can agree with f64 |

These **16** are still required for full bit-identity green; they do **not** prove softfloat by themselves.

## Green when

A consumer appears at one of:

- `self-hosted/compiler/f128_f256_v0d_softfloat_corpus_probe.sio`
- `tests/run-pass/f128_v0d_softfloat_corpus_smoke.sio`
- `scripts/dev/ws_g_v0d_softfloat_corpus_runner.py`

and the gate emits the V0-D PASS receipt with `must_trap=87` and bit-identity on all hard rows.