### PR TITLE
docs(ops): Slurm launch repair — srun supported path (sbatch unrepaired)

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1344
-- Repo-backed topics: 1194
+- Total governed topics: 1345
+- Repo-backed topics: 1195
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 399
-- Authority count `repo_only`: 757
+- Authority count `repo_only`: 758
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 772 topics
+- A2: 773 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 37 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -654,6 +654,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.migration-guide | repo_only | docs/MIGRATION_GUIDE.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.ops.dgx-spark-gpu-dev | repo_only | docs/ops/dgx_spark_gpu_dev.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.ops.foundry-slurm-handoff | repo_only | docs/ops/foundry_slurm_handoff.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.ops.slurm-launch-repair-2026-08-17 | repo_only | docs/ops/SLURM_LAUNCH_REPAIR_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.papers.168-theorem-preprint | repo_only | docs/papers/168-theorem-preprint.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.papers.arxiv-abstract | repo_only | docs/papers/arxiv_abstract.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.papers.cd-tower-seam-obstruction | repo_only | docs/papers/cd-tower-seam-obstruction.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -14522,6 +14522,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.ops.slurm-launch-repair-2026-08-17",
+      "collection": "repo",
+      "repo_doc_path": "docs/ops/SLURM_LAUNCH_REPAIR_2026-08-17.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.papers.168-theorem-preprint",
       "collection": "repo",
       "repo_doc_path": "docs/papers/168-theorem-preprint.md",

--- a/docs/ops/SLURM_LAUNCH_REPAIR_2026-08-17.md
+++ b/docs/ops/SLURM_LAUNCH_REPAIR_2026-08-17.md
@@ -1,0 +1,213 @@
+<!-- docs:meta
+topic_id: repo.docs.ops.slurm-launch-repair-2026-08-17
+authority: repo_only
+audience: users
+last_validated: 2026-08-17
+validated_by: grok-cli1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.ops.slurm-launch-repair-2026-08-17
+-->
+
+# Slurm launch repair — diagnosis + working recipe (2026-08-17)
+
+**Author:** grok-cli1  
+**Worktree:** `/workspace/.wt/slurm-launch-repair` (not shared `/workspace/sounio`)  
+**Instrument:** `SLURM_CONF=/tmp/slurm-direct.conf`  
+**Partition used for proof:** `cpu-ops` (1 node, idle)  
+**Refute control:** a broken recipe must fail or show missing `/workspace` paths; a working recipe must reach `status=pass` with `workspace_visible=no` and a receipt under `/orangefs/...`.
+
+## Held jobs (pre-existing)
+
+| Job | Partition | Reason |
+|---|---|---|
+| 9635–9637 | gpu-orangefs | `launch failed requeued held` |
+| 9668 | gpu-orangefs | `user env retrieval failed requeued held` |
+
+9668 SubmitLine included `--export=ALL`. 9635–9637 also used `--export=ALL`.  
+Hardware is up (`sinfo`: all partitions idle). **Commands were wrong / batch env retrieval broken** — not missing nodes.
+
+## Culprits (measured)
+
+### A. `sbatch` → `user_env_retrieval_failed_requeued_held` (primary for held batch jobs)
+
+Even with `--export=NONE` and `--chdir=/tmp`, **sbatch** jobs for `openvscode-server` stay PENDING with:
+
+```text
+Reason=user_env_retrieval_failed_requeued_held
+BatchFlag=2
+```
+
+Reproduced: jobs **10106**, **10108**. Never left PENDING in 40s of polling; no receipt written.
+
+**srun** of the same logical command on the same partition **succeeds**.
+
+**Conclusion:** batch launch path tries to retrieve a user environment for the submitter and fails (uid mapping / no real shell home on the cluster). This is independent of scrubbing `/workspace` vars once `--export=NONE` is set. Fleet heavy jobs should use **`srun`** until sbatch user-env is fixed on the controller, or submit as a user slurmd can resolve.
+
+### B. `--export=ALL` (or default inheritance) pulls ~40 `/workspace/*` paths onto the node
+
+Measured on node with `--export=ALL`:
+
+```text
+Unable to create TMPDIR [/workspace/.tmp]: No such file or directory
+HOME=/workspace/.home/openvscode-server/.agents/grok-cli1
+workspace_env_count=42
+home_missing
+```
+
+Node **cannot** see `/workspace`. TMPDIR is then force-rewritten to `/tmp` (noise + fragile). HOME points at a path that does not exist on the node. Matches founder note that ~26+ workspace-rooted vars are invisible on compute.
+
+### C. Relative `bash` with `--export=NONE` → `execve(): bash: No such file or directory`
+
+```text
+srun ... --export=NONE bash -lc '...'
+→ execve(): bash: No such file or directory  (exit 2)
+```
+
+Without PATH, `bash` is not found. **Use absolute `/bin/bash`.**
+
+### D. `--chdir` / submitter cwd under `/workspace`
+
+```text
+couldn't chdir to `/workspace/...': No such file or directory: going to /tmp instead
+```
+
+srun often falls back to `/tmp`, so this alone may not kill the job, but it is not reliable. **Always set `--chdir=/tmp`** (or a path on `/orangefs`).
+
+## Side-by-side: failing vs passing
+
+### FAIL A — bare `bash` + `--export=NONE`
+
+```bash
+export SLURM_CONF=/tmp/slurm-direct.conf
+srun --partition=cpu-ops --nodes=1 --ntasks=1 --time=00:01:00 \
+  --chdir=/tmp --export=NONE \
+  bash -lc 'echo no'
+```
+
+**Observed (job 10111):**
+
+```text
+srun: error: ... task 0: Exited with exit code 2
+error: execve(): bash: No such file or directory
+```
+
+Log: `docs/ops/slurm_failA_export_none_bare_bash.txt`
+
+### FAIL C — `--export=ALL` (workspace env)
+
+```bash
+export SLURM_CONF=/tmp/slurm-direct.conf
+srun --partition=cpu-ops --nodes=1 --ntasks=1 --time=00:01:00 \
+  --export=ALL \
+  /bin/bash -lc 'echo TMPDIR=$TMPDIR; echo HOME=$HOME; ...'
+```
+
+**Observed (job 10112):**
+
+```text
+Unable to create TMPDIR [/workspace/.tmp]: No such file or directory
+HOME=/workspace/.home/.../grok-cli1
+workspace_env_count=42
+home_missing
+```
+
+Log: `docs/ops/slurm_failC_export_all_workspace_env.txt`
+
+### FAIL B — `sbatch` (any export scrub we tried)
+
+```bash
+sbatch --partition=cpu-ops --chdir=/tmp --export=NONE,PATH=/usr/bin:/bin,TMPDIR=/tmp \
+  --wrap='...'
+```
+
+**Observed (jobs 10106, 10108):** stuck `PENDING (user env retrieval failed requeued held)` — same class as job 9668.
+
+### PASS — scrubbed `srun` + absolute bash + chdir=/tmp
+
+```bash
+export SLURM_CONF=/tmp/slurm-direct.conf
+srun --partition=cpu-ops --nodes=1 --ntasks=1 --time=00:05:00 \
+  --chdir=/tmp \
+  --export=NONE,PATH=/usr/bin:/bin,TMPDIR=/tmp,HOME=/tmp \
+  /bin/bash -lc 'set -euo pipefail
+    R=/orangefs/training/sounio/slurm-launch-repair/slurm_launch_receipt_YYYYMMDDTHHMMSSZ.txt
+    mkdir -p /orangefs/training/sounio/slurm-launch-repair
+    {
+      echo status=pass
+      echo mode=srun
+      echo hostname=$(hostname)
+      echo pwd=$(pwd)
+      echo TMPDIR=$TMPDIR
+      echo date_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      echo workspace_visible=$([ -d /workspace ] && echo yes || echo no)
+      echo orangefs_visible=$([ -d /orangefs ] && echo yes || echo no)
+    } | tee "$R"
+  '
+```
+
+**Observed (job 10113, COMPLETED via interactive srun):**
+
+```text
+status=pass
+mode=srun
+hostname=cpuops-t560-proxmox
+pwd=/tmp
+TMPDIR=/tmp
+date_utc=2026-08-17T14:50:42Z
+workspace_visible=no
+orangefs_visible=yes
+```
+
+Log: `docs/ops/slurm_pass_srun_scrubbed.txt`  
+Earlier staged receipt on OrangeFS:  
+`/orangefs/training/sounio/slurm-launch-repair/slurm_launch_receipt_20260817T144823Z.txt`  
+(fetch with the same srun recipe + `cat`).
+
+## Minimal working recipe (copy-paste)
+
+```bash
+export SLURM_CONF=/tmp/slurm-direct.conf
+
+# Prefer partition `all` or `cpu-ops` for CPU; `gpu-orangefs` only when you need GPU.
+# Do NOT use sbatch until user_env_retrieval is fixed for this submitter.
+
+srun --partition=cpu-ops --nodes=1 --ntasks=1 --time=00:30:00 \
+  --chdir=/tmp \
+  --export=NONE,PATH=/usr/bin:/bin:/usr/local/bin,TMPDIR=/tmp,HOME=/tmp \
+  /bin/bash -lc '
+    set -euo pipefail
+    # clone repo on node — /workspace is invisible
+    # git clone ... /tmp/sounio && cd /tmp/sounio
+    hostname
+    # heavy work here
+  '
+```
+
+**Rules:**
+
+1. `SLURM_CONF=/tmp/slurm-direct.conf`
+2. **`srun`, not `sbatch`** (until batch user-env works)
+3. **`--chdir=/tmp`** (or `/orangefs/...`)
+4. **`--export=NONE,...`** minimal allowlist — never bare `--export=ALL`
+5. **Absolute `/bin/bash`**
+6. **TMPDIR=/tmp** (or `/scratch` if present on node)
+7. Clone on node; never assume `/workspace`
+8. Stage outputs under **`/orangefs/training/...`** (visible on compute, not on login pod)
+
+Helper script: `scripts/dev/slurm_srun_minimal.sh`
+
+## Instrument validation (not boilerplate)
+
+| Control | Expectation | Result |
+|---|---|---|
+| Broken recipe (bare bash) | fail | exit 2, execve bash missing |
+| Broken recipe (export=ALL) | missing HOME, TMPDIR noise | home_missing, 42 workspace vars |
+| Broken recipe (sbatch) | held | user_env_retrieval_failed |
+| Working recipe | status=pass, workspace_visible=no | pass, receipt on orangefs |
+
+A recipe that only “worked” without a demonstrated fail would not identify the culprit. Here: **sbatch user-env retrieval** is the fleet hold; **export=ALL + workspace paths** is the srun footgun; **absolute bash + chdir + export=NONE** is the pass.
+
+## What we did not fix
+
+- Controller-side sbatch user environment for `openvscode-server` / root (needs Slurm/admin).
+- Releasing historical held jobs 9635–9668 (left for owners; `scancel` if desired).
+- GPU partition smoke (cpu-ops was sufficient to prove launch; GPU adds gres, same env rules).

--- a/docs/ops/SLURM_LAUNCH_REPAIR_2026-08-17.md
+++ b/docs/ops/SLURM_LAUNCH_REPAIR_2026-08-17.md
@@ -15,6 +15,15 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.ops.slurm-laun
 **Partition used for proof:** `cpu-ops` (1 node, idle)  
 **Refute control:** a broken recipe must fail or show missing `/workspace` paths; a working recipe must reach `status=pass` with `workspace_visible=no` and a receipt under `/orangefs/...`.
 
+## Supported path today (read this first)
+
+| Path | Status | Who can fix it |
+|---|---|---|
+| **`srun`** with scrubbed env + absolute `/bin/bash` + `--chdir=/tmp` | **Supported.** Proven COMPLETED (job **10113**). Use `scripts/dev/slurm_srun_minimal.sh`. | Lane / agent |
+| **`sbatch`** for submitter `openvscode-server` | **Not repaired.** Still fails with `user_env_retrieval_failed_requeued_held` even under `--export=NONE` and `--chdir=/tmp` (jobs 10106, 10108; same class as held 9668). | **Admin / Slurm controller** — out of reach from an agent lane |
+
+**Plain statement:** this deliverable did **not** repair `sbatch`. The `user_env_retrieval` failure is a controller-side issue for this submitter (uid / home resolution on the batch path). From a fleet lane the only honest supported path today is **`srun`** via the recipe and helper below. Do not tell downstream agents (e.g. grok-cli2 dissertation-gate re-runs) that batch is fixed.
+
 ## Held jobs (pre-existing)
 
 | Job | Partition | Reason |
@@ -40,7 +49,7 @@ Reproduced: jobs **10106**, **10108**. Never left PENDING in 40s of polling; no 
 
 **srun** of the same logical command on the same partition **succeeds**.
 
-**Conclusion:** batch launch path tries to retrieve a user environment for the submitter and fails (uid mapping / no real shell home on the cluster). This is independent of scrubbing `/workspace` vars once `--export=NONE` is set. Fleet heavy jobs should use **`srun`** until sbatch user-env is fixed on the controller, or submit as a user slurmd can resolve.
+**Conclusion:** the batch launch path tries to retrieve a user environment for the submitter and fails (uid mapping / no real shell home on the cluster). This is **independent** of scrubbing `/workspace` vars once `--export=NONE` is set. It is an **admin/controller problem**, not something a lane can patch in-repo. Fleet heavy jobs **must use `srun`** until an admin fixes sbatch user-env for this submitter (or until jobs are submitted as a principal slurmd can resolve).
 
 ### B. `--export=ALL` (or default inheritance) pulls ~40 `/workspace/*` paths onto the node
 
@@ -206,8 +215,8 @@ Helper script: `scripts/dev/slurm_srun_minimal.sh`
 
 A recipe that only “worked” without a demonstrated fail would not identify the culprit. Here: **sbatch user-env retrieval** is the fleet hold; **export=ALL + workspace paths** is the srun footgun; **absolute bash + chdir + export=NONE** is the pass.
 
-## What we did not fix
+## What we did not fix (and will not claim)
 
-- Controller-side sbatch user environment for `openvscode-server` / root (needs Slurm/admin).
+- **`sbatch` was not repaired.** Controller-side user-env retrieval for `openvscode-server` remains broken. Only an admin can fix that. This PR documents the failure and routes traffic to `srun`.
 - Releasing historical held jobs 9635–9668 (left for owners; `scancel` if desired).
 - GPU partition smoke (cpu-ops was sufficient to prove launch; GPU adds gres, same env rules).

--- a/docs/ops/slurm_failA_export_none_bare_bash.txt
+++ b/docs/ops/slurm_failA_export_none_bare_bash.txt
@@ -1,0 +1,4 @@
+srun: job 10111 queued and waiting for resources
+srun: job 10111 has been allocated resources
+srun: error: cpuops-t560-proxmox: task 0: Exited with exit code 2
+[2026-08-17T14:50:41] error: execve(): bash: No such file or directory

--- a/docs/ops/slurm_failC_export_all_workspace_env.txt
+++ b/docs/ops/slurm_failC_export_all_workspace_env.txt
@@ -1,0 +1,10 @@
+srun: job 10112 queued and waiting for resources
+srun: job 10112 has been allocated resources
+[2026-08-17T14:50:41] error: couldn't chdir to `/workspace/.wt/slurm-launch-repair': No such file or directory: going to /tmp instead
+[2026-08-17T14:50:41] error: couldn't chdir to `/workspace/.wt/slurm-launch-repair': No such file or directory: going to /tmp instead
+[2026-08-17T14:50:41] error: Unable to create TMPDIR [/workspace/.tmp]: No such file or directory
+[2026-08-17T14:50:41] error: Setting TMPDIR to /tmp
+TMPDIR=/tmp
+HOME=/workspace/.home/openvscode-server/.agents/grok-cli1
+workspace_env_count=42
+home_missing

--- a/docs/ops/slurm_launch_receipt_PASS.txt
+++ b/docs/ops/slurm_launch_receipt_PASS.txt
@@ -1,0 +1,11 @@
+status=pass
+hostname=cpuops-t560-proxmox.slurm-workers-slurm-pilot.slurm-pilot.svc.cluster.local
+pwd=/tmp
+TMPDIR=/tmp
+HOME=unset
+PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+whoami=sounio
+date_utc=2026-08-17T14:48:24Z
+workspace_visible=no
+orangefs_visible=yes
+receipt_local=/tmp/slurm_launch_receipt_20260817T144823Z.txt

--- a/docs/ops/slurm_pass_srun_scrubbed.txt
+++ b/docs/ops/slurm_pass_srun_scrubbed.txt
@@ -1,0 +1,11 @@
+srun: job 10113 queued and waiting for resources
+srun: job 10113 has been allocated resources
+status=pass
+mode=srun
+hostname=cpuops-t560-proxmox
+pwd=/tmp
+TMPDIR=/tmp
+date_utc=2026-08-17T14:50:42Z
+workspace_visible=no
+orangefs_visible=yes
+recipe=SLURM_CONF=/tmp/slurm-direct.conf_srun_cpu-ops_chdir_tmp_export_NONE

--- a/scripts/dev/slurm_srun_minimal.sh
+++ b/scripts/dev/slurm_srun_minimal.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Minimal WORKING Slurm launch for the Beagle pilot from the workspace login.
+# Proven 2026-08-17: srun COMPLETED with receipt on /orangefs.
+# Do NOT use sbatch from this submitter until user_env_retrieval is fixed.
+#
+# Usage:
+#   scripts/dev/slurm_srun_minimal.sh 'echo hello'
+#   scripts/dev/slurm_srun_minimal.sh --time=00:30:00 --partition=all -- 'your command'
+set -euo pipefail
+
+export SLURM_CONF="${SLURM_CONF:-/tmp/slurm-direct.conf}"
+
+PARTITION=cpu-ops
+TIME=00:10:00
+NODES=1
+NTASKS=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --partition=*) PARTITION="${1#*=}"; shift ;;
+    --time=*) TIME="${1#*=}"; shift ;;
+    --nodes=*) NODES="${1#*=}"; shift ;;
+    --ntasks=*) NTASKS="${1#*=}"; shift ;;
+    --) shift; break ;;
+    -*) echo "unknown flag: $1" >&2; exit 2 ;;
+    *) break ;;
+  esac
+done
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: $0 [--partition=cpu-ops] [--time=00:10:00] -- <command...>" >&2
+  exit 2
+fi
+
+# Absolute interpreter; scrub workspace env; chdir off /workspace.
+exec srun \
+  --partition="$PARTITION" \
+  --nodes="$NODES" \
+  --ntasks="$NTASKS" \
+  --time="$TIME" \
+  --chdir=/tmp \
+  --export=NONE,PATH=/usr/bin:/bin:/usr/local/bin,TMPDIR=/tmp,TMP=/tmp,TEMP=/tmp,HOME=/tmp \
+  /bin/bash -lc "$*"

--- a/scripts/dev/slurm_srun_minimal.sh
+++ b/scripts/dev/slurm_srun_minimal.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 # Minimal WORKING Slurm launch for the Beagle pilot from the workspace login.
-# Proven 2026-08-17: srun COMPLETED with receipt on /orangefs.
-# Do NOT use sbatch from this submitter until user_env_retrieval is fixed.
+# Proven 2026-08-17: srun COMPLETED (job 10113) with receipt on /orangefs.
+#
+# Supported path today: srun (this script). sbatch is NOT repaired —
+# user_env_retrieval_failed is an admin/controller issue for openvscode-server;
+# lanes cannot fix it. See docs/ops/SLURM_LAUNCH_REPAIR_2026-08-17.md.
 #
 # Usage:
 #   scripts/dev/slurm_srun_minimal.sh 'echo hello'


### PR DESCRIPTION
## Summary

Diagnose why Slurm fleet jobs stay held / fail from the workspace login, and document the **working `srun` recipe** with FAIL/PASS side-by-side evidence. Receipt: job **10113** reached **COMPLETED**.

**Plain claim (do not over-read):** `sbatch` was **not** repaired. `user_env_retrieval_failed_requeued_held` is an **admin/controller** issue for submitter `openvscode-server` and is out of reach from an agent lane. The supported path today is **`srun`** via `scripts/dev/slurm_srun_minimal.sh`. Downstream (e.g. grok-cli2 dissertation-gate re-run) should use that helper.

Full write-up: `docs/ops/SLURM_LAUNCH_REPAIR_2026-08-17.md`

## Four culprits

| # | Culprit | Symptom | Fix / status |
|---|---|---|---|
| **A** | `sbatch` user-env retrieval | `PENDING (user_env_retrieval_failed_requeued_held)` even with `--export=NONE` + `--chdir=/tmp` (jobs 10106, 10108; class of 9668) | **Admin/controller only.** Not fixed in this PR. Route to `srun`. |
| **B** | `--export=ALL` (or default inheritance) | Node gets ~42 `/workspace/*` vars; `TMPDIR=/workspace/.tmp` fails; `HOME` missing on node (job 10112) | `--export=NONE,PATH=…,TMPDIR=/tmp,HOME=/tmp` |
| **C** | Relative `bash` under `--export=NONE` | `execve(): bash: No such file or directory` (job 10111, exit 2) | Absolute `/bin/bash` |
| **D** | `--chdir` / cwd under `/workspace` | `couldn't chdir to /workspace/...` (node cannot see workspace) | Always `--chdir=/tmp` (or `/orangefs/...`) |

## Before / after

### Before (broken)

| Case | Command sketch | Result |
|---|---|---|
| FAIL A | `srun … --export=NONE bash -lc '…'` | exit 2 — bare bash not on PATH |
| FAIL B | `sbatch … --export=NONE --chdir=/tmp --wrap=…` | held — `user_env_retrieval_failed_requeued_held` |
| FAIL C | `srun … --export=ALL /bin/bash -lc '…'` | `workspace_env_count=42`, `home_missing`, TMPDIR noise |

Logs in PR: `docs/ops/slurm_failA_export_none_bare_bash.txt`, `docs/ops/slurm_failC_export_all_workspace_env.txt`

### After (working)

```bash
export SLURM_CONF=/tmp/slurm-direct.conf
# or: scripts/dev/slurm_srun_minimal.sh -- 'your command'
srun --partition=cpu-ops --nodes=1 --ntasks=1 --time=00:05:00 \
  --chdir=/tmp \
  --export=NONE,PATH=/usr/bin:/bin,TMPDIR=/tmp,HOME=/tmp \
  /bin/bash -lc '…'
```

| Field | Job **10113** (COMPLETED) |
|---|---|
| status | pass |
| mode | srun |
| hostname | cpuops-t560-proxmox |
| pwd | /tmp |
| TMPDIR | /tmp |
| workspace_visible | no |
| orangefs_visible | yes |

Log: `docs/ops/slurm_pass_srun_scrubbed.txt`  
OrangeFS receipt path: `/orangefs/training/sounio/slurm-launch-repair/slurm_launch_receipt_20260817T144823Z.txt`

## What this PR ships

- `docs/ops/SLURM_LAUNCH_REPAIR_2026-08-17.md` — diagnosis, four culprits, FAIL/PASS table, explicit “srun supported / sbatch unrepaired”
- Fail/pass log snippets under `docs/ops/slurm_*`
- `scripts/dev/slurm_srun_minimal.sh` — copy-paste helper for agents (grok-cli2 et al.)

## Test plan

- [x] FAIL A reproduced (job 10111, exit 2)
- [x] FAIL C reproduced (job 10112, workspace env leak)
- [x] FAIL B reproduced (sbatch held 10106/10108)
- [x] PASS srun COMPLETED (job 10113) with `workspace_visible=no`, receipt under `/orangefs`
- [ ] Reviewer: skim doc callout “Supported path today”; confirm no claim that sbatch is fixed
- [ ] Optional: re-run helper from login — `scripts/dev/slurm_srun_minimal.sh -- 'hostname; test ! -d /workspace && echo ok'`