### PR TITLE
MLI S1: kind model, builder, dump, V-struct — and the rungs that grew on this lane

### DIFF
--- a/docs/audit/MLI_S3_UNCERTAINTY_TO_BYTES_2026-08-17.md
+++ b/docs/audit/MLI_S3_UNCERTAINTY_TO_BYTES_2026-08-17.md
@@ -1,0 +1,163 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.mli-s3-uncertainty-to-bytes-2026-08-17
+authority: repo_only
+audience: users
+last_validated: 2026-08-17
+validated_by: cursor-2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.mli-s3-uncertainty-to-bytes-2026-08-17
+-->
+
+# MLI S3 — Uncertainty in the instruction stream
+
+**Date:** 2026-08-17
+**Lane:** `cursor-2` / `mli-s3b-knowledge-to-hardware`
+**Status:** research result. Both answers were publishable; this one is the first.
+**Gates:** `self-hosted/mli/s3_gate_runner.sio`, `self-hosted/mli/s3b_gate_runner.sio`
+
+## 1. The question
+
+Every production compiler erases uncertainty before machine code. LLVM, GCC
+and Cranelift lower a value and drop its variance, because no backend has a
+notion of an operand that carries its own error. MLI was designed so
+`Knowledge<T>` stays a KIND all the way down. S3 is where that either
+becomes the first backend that lowers uncertainty as a first-class operand,
+or is revealed as ornament.
+
+The same question applies to Cayley–Dickson multiplication. Octonion `cd_mul`
+as a compiler primitive with associator-aware lowering is unclaimed ground,
+and the associator is a positive graded invariant in this project's own
+theory (`stdlib/algebra/octonion.sio`, `stdlib/epistemic/uncertain_octonion.sio`).
+
+## 2. What S3 now does
+
+The sanctioned route is still expand-then-legalize (Option C, design §2.3 /
+§8.2). That is not a library above the backend: `expand_k` / `expand_cd`
+are compiler passes that rewrite first-class kinds into scalar MLI, and
+`legalize_x86` (S3b) emits those scalars — including the branch diamonds
+the confidence lane requires — as measured x86-64 bytes.
+
+An unexpanded `Knowledge` or `CD` operand that reaches `legalize_x86` is
+still refused with `MLI_L_KNOWLEDGE_UNEXPANDED`, checked before any shape
+check. Stripping the variance here would be one `if` cheaper. That `if`
+is the difference between a kind and decoration.
+
+## 3. The named temptation — Knowledge
+
+### 3.1 `k_add` — the second `addsd`
+
+After `expand_k` rewrites
+
+```
+kc = k_add(ka, kb)
+ret k_extract_var(kc)
+```
+
+the first float instruction in the stream is
+
+```
+addsd xmm0, xmm1    ; f2 0f 58 c1     val = a.val + b.val
+```
+
+**That is the instruction at which erasure becomes tempting.** A production
+backend would `ret` the first `addsd`. Keeping the variance is exactly one
+more `addsd` of the variance slots, plus their load/store:
+
+```
+addsd xmm0, xmm1    ; f2 0f 58 c1     var = a.var + b.var
+                    ; GUM: Var(X+Y) = Var(X)+Var(Y)   (JCGM 100:2008 §5.1.2)
+```
+
+Cost to keep, measured: 4 bytes of encoding + the two slot loads and one
+store already in the mimicry shape. Gate X7 requires `addsd` count ≥ 2
+even when the function returns the *value* lane — unused-lane DCE of the
+variance `addsd` would be erasure, and is therefore a future-pass
+forbidden transformation unless a dedicated "variance-dead" analysis
+exists.
+
+### 3.2 `k_mul` — the first `mulsd`
+
+```
+mulsd xmm0, xmm1    ; f2 0f 59 c1     val = a.val * b.val
+```
+
+**That is the product-form temptation.** GUM (delta method, stdlib
+`ep_mul`, JCGM 100:2008 §5.1.2) requires four more `mulsd` and one
+`addsd`:
+
+```
+Var(XY) ≈ Y²·Var(X) + X²·Var(Y)
+```
+
+The σx²σy² Gaussian-product term is **not** added. That omission is the
+stdlib oracle (`knowledge.sio`), documented in `knightian.sio` as a
+standard GUM convention — not a guess. Gate X13 requires `mulsd` count ≥ 5
+and `addsd` count ≥ 1.
+
+Confidence decay is `*99/100` for add and `*98/100` for mul, matching
+`ep_add` / `ep_mul`. The conf lane still costs three branch diamonds
+(9 extra blocks) because MLI R0 has no `select` and `Bool` does not
+participate in integer arithmetic. That is the *second* temptation, named
+in S3 and now paid: S3b encodes `test %rax,%rax; je rel32`.
+
+`k_div` / `k_fma` remain refused. Division by an uncertain Y needs its
+own documented derivation; it is not guessed here.
+
+## 4. The named temptation — Cayley–Dickson
+
+### 4.1 `cd_mul` — the first `mulsd` of `a0*b0`
+
+A backend that treated the algebra as a real would emit `a0*b0` and
+return. Keeping the product costs, measured against today's walls:
+
+| dim | algebra | ops | exploded args | expand | legalize |
+|---:|---|---:|---:|---|---|
+| 2 | complex | 4 fmul + 1 fsub + 1 fadd | 4 | yes | yes (4 `mulsd` + 1 `addsd` + 1 `subsd`) |
+| 4 | quaternion | 16 fmul + 12 fadd/fsub | 8 | yes (fits `MAX_INSTRS=32`) | **refuses** — measured GPR convention is 6 registers |
+| 8 | octonion | 64 fmul + 56 fadd/fsub | 16 | **`MLI_XC_OCTONION_WALL`** | never reached |
+| 16 | sedenion | larger | 32 | same wall | never reached |
+
+The octonion overflow is the named wall. Raising `MAX_ARGS` / `MAX_INSTRS`
+is the deferred module-arena decision, triggered now by a corpus (this
+gate), not guessed in advance.
+
+### 4.2 `cd_associator` — not an instruction below dim 8; a wall at 8
+
+The S1 kind model already encodes the algebra grade: `cd_associator`
+with `dim < 8` is `MLI_VERR_OPERAND_RULE`. An identically-zero
+associator is not an instruction. That is associator-aware at the
+verifier, not at emit.
+
+For dim ≥ 8 the associator is a positive graded invariant. Emitting
+zero — or emitting `a0*b0*c0` — would be a semantic miscompile of this
+project's own theory. `expand_cd` refuses with
+`MLI_XC_ASSOCIATOR_WALL` before exploding args, so the refusal is
+named as the associator, not as a generic capacity error.
+
+Computing the octonion associator is four `oct_mul` (two triple
+products) plus 8 subtractions: well above both walls. The op is
+legal MLI and cannot reach bytes today. That named inability is the
+contribution.
+
+## 5. What was *not* claimed
+
+- Bit-identity of the Knowledge / CD sequences against the pinned
+  native-v2 emitter. The golden `add1` bit-identity gate is unchanged
+  (pin O5). The Knowledge / CD sequences have no pinned-emitter twin:
+  the pinned emitter has never carried these kinds.
+- Executed ELF parity of the GUM bytes against a host oracle. The
+  interpreter (host = Sounio under Madaros, single semantic clock)
+  matches `ep_add` / `ep_mul` / complex and quaternion products. Wrapping
+  the legalized bytes in a runnable ELF is the next measured tranche,
+  not this one.
+- `k_div`, `k_fma`, CD dim=8 expansion, a by-ref CD ABI, or DCE of
+  unused variance lanes.
+
+## 6. Files
+
+| path | role |
+|---|---|
+| `self-hosted/mli/legalize_x86.sio` | S3b: multi-arg, integer, `je rel32` / `jmp rel32` |
+| `self-hosted/mli/expand_k.sio` | `k_add` + `k_mul` GUM, shared conf diamonds |
+| `self-hosted/mli/expand_cd.sio` | complex / quaternion mul; associator vanishing; named walls |
+| `self-hosted/mli/s3_gate_runner.sio` | X1–X13 |
+| `self-hosted/mli/s3b_gate_runner.sio` | C1–C8 |

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1348
-- Repo-backed topics: 1198
+- Total governed topics: 1349
+- Repo-backed topics: 1199
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 399
-- Authority count `repo_only`: 761
+- Authority count `repo_only`: 762
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 776 topics
+- A2: 777 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 37 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -235,6 +235,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-wave15a-global-list-multistmt-paramful-2026-07-22 | repo_only | docs/audit/MADAROS_WAVE15A_GLOBAL_LIST_MULTISTMT_PARAMFUL_2026-07-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-wave15c-issue901-scale-closeout-2026-07-22 | repo_only | docs/audit/MADAROS_WAVE15C_ISSUE901_SCALE_CLOSEOUT_2026-07-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-wave15e-global-string-bss-2026-07-22 | repo_only | docs/audit/MADAROS_WAVE15E_GLOBAL_STRING_BSS_2026-07-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.mli-s3-uncertainty-to-bytes-2026-08-17 | repo_only | docs/audit/MLI_S3_UNCERTAINTY_TO_BYTES_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.modular-compiler-audit-2026-06-10 | repo_only | docs/audit/MODULAR_COMPILER_AUDIT_2026-06-10.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.modular-compiler-stack-clash-2026-05-29 | repo_only | docs/audit/MODULAR_COMPILER_STACK_CLASH_2026-05-29.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.modular-pipe-coverage-map-2026-06-01 | repo_only | docs/audit/MODULAR_PIPE_COVERAGE_MAP_2026-06-01.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -4869,6 +4869,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.mli-s3-uncertainty-to-bytes-2026-08-17",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MLI_S3_UNCERTAINTY_TO_BYTES_2026-08-17.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.modular-compiler-audit-2026-06-10",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MODULAR_COMPILER_AUDIT_2026-06-10.md",

--- a/self-hosted/mli/builder.sio
+++ b/self-hosted/mli/builder.sio
@@ -205,6 +205,18 @@ pub fn mli_inst_cd_mul(dst: MliOperand, a: MliOperand, b: MliOperand, assoc_poli
     inst
 }
 
+pub fn mli_inst_cd_associator(dst: MliOperand, a: MliOperand, b: MliOperand, c: MliOperand, assoc_policy: i64, zd_policy: i64) -> MliInst {
+    var inst = mli_inst4(MLI_OP_CD_ASSOCIATOR, dst, a, b, c)
+    inst.assoc_policy = assoc_policy
+    inst.zd_policy = zd_policy
+    inst
+}
+
+// lane is the component index (0 = real). Stored as an i64 immediate in src2.
+pub fn mli_inst_cd_extract(dst: MliOperand, src: MliOperand, lane: i64) -> MliInst {
+    mli_inst3(MLI_OP_CD_EXTRACT, dst, src, mli_opd_imm_int(lane, mli_kind_int(64, 1)))
+}
+
 // ---------------------------------------------------------------------------
 // Terminator constructors.
 // ---------------------------------------------------------------------------

--- a/self-hosted/mli/dump.sio
+++ b/self-hosted/mli/dump.sio
@@ -34,7 +34,17 @@ pub fn mli_dump_kind(k: MliKind) with IO {
     if k.tag == MLI_KIND_VECF64 { print("vecf64x"); print_int(k.dim); return }
     if k.tag == MLI_KIND_KNOWLEDGE {
         print("Knowledge<")
-        if k.base_tag == MLI_KIND_FLOAT { print("f") } else { print("i") }
+        // Closed base set (mli_kind_valid): FLOAT or INT. Anything else is
+        // not "i" — that guess is the same default class as E219 / #1784.
+        if k.base_tag == MLI_KIND_FLOAT {
+            print("f")
+        } else {
+            if k.base_tag == MLI_KIND_INT {
+                if k.signed == 1 { print("i") } else { print("u") }
+            } else {
+                print("?")
+            }
+        }
         print_int(k.bits)
         if k.shape == MLI_KSHAPE_MIN3 { print(",Min3") }
         if k.shape == MLI_KSHAPE_GPU4 { print(",Gpu4") }
@@ -166,12 +176,15 @@ pub fn mli_dump_opcode(opcode: i64) with IO {
 }
 
 fn mli_dump_cc(cc: i64) with IO {
+    if cc == MLI_CC_NONE { return }
     if cc == MLI_CC_EQ { print(".eq"); return }
     if cc == MLI_CC_NE { print(".ne"); return }
     if cc == MLI_CC_LT { print(".lt"); return }
     if cc == MLI_CC_LE { print(".le"); return }
     if cc == MLI_CC_GT { print(".gt"); return }
     if cc == MLI_CC_GE { print(".ge"); return }
+    print(".?cc")
+    print_int(cc)
 }
 
 fn mli_dump_policies_v(assoc: i64, zd: i64) with IO {

--- a/self-hosted/mli/dump.sio
+++ b/self-hosted/mli/dump.sio
@@ -160,6 +160,7 @@ pub fn mli_dump_opcode(opcode: i64) with IO {
     if opcode == MLI_OP_CD_ASSOCIATOR { print("cd_associator"); return }
     if opcode == MLI_OP_CD_VAR_ASSOCIATOR { print("cd_var_associator"); return }
     if opcode == MLI_OP_CD_ZD_PROBE { print("cd_zd_probe"); return }
+    if opcode == MLI_OP_CD_EXTRACT { print("cd_extract"); return }
     print("?op")
     print_int(opcode)
 }

--- a/self-hosted/mli/expand_cd.sio
+++ b/self-hosted/mli/expand_cd.sio
@@ -1,0 +1,329 @@
+// MLI S3 — expand_cd: the SANCTIONED route from Cayley-Dickson kinds to
+// scalar MLI. Associator-aware at TWO layers:
+//   - V-struct (S1): cd_associator with dim<8 is MLI_VERR_OPERAND_RULE —
+//     an identically-zero associator is not an instruction.
+//   - this pass: dim>=8 (octonion / sedenion) is where the associator is
+//     a positive graded invariant; expanding it is refused with a
+//     measured wall, not a silent real-part multiply. A dim<8 associator
+//     that somehow reaches this pass (unverified input) still lowers to
+//     zero without reading the operands — defense in depth, not the
+//     primary gate.
+//
+// NAMED TEMPTATION (cd_mul): the first `mulsd` of a0*b0 — the real
+// component. A production backend that treated the algebra as a real
+// would emit that one multiply and return. Keeping the product costs:
+//   dim=2 (complex)     : 4 fmul + 1 fsub + 1 fadd     (fits; 4 args)
+//   dim=4 (quaternion)  : 16 fmul + 12 fadd/fsub       (fits 32-instr
+//                         wall; 8 args — legalize_x86 then refuses
+//                         because the measured GPR convention is 6)
+//   dim=8 (octonion)    : 64 fmul + 56 fadd/fsub, 16 exploded args.
+//                         MAX_ARGS=8 and MAX_INSTRS=32 both fire.
+//                         That overflow IS the named octonion wall.
+//
+// NAMED TEMPTATION (cd_associator): treating [a,b,c] as zero at dim=8.
+// For dim<8 the zero lowering is a theorem (associative algebras). For
+// dim>=8 it would be a semantic miscompile of this project's own
+// invariant. Refuse, do not emit a0*b0*c0.
+
+module mli::expand_cd
+
+use mli::ir::*
+use mli::builder::*
+
+pub let MLI_XC_OK: i64 = 0
+pub let MLI_XC_UNSUPPORTED_OP: i64 = 1
+pub let MLI_XC_CFG_INPUT: i64 = 2
+pub let MLI_XC_CD_RET: i64 = 3
+pub let MLI_XC_SHAPE: i64 = 4
+pub let MLI_XC_BUILDER_OVERFLOW: i64 = 5
+pub let MLI_XC_OPERAND: i64 = 6
+pub let MLI_XC_OCTONION_WALL: i64 = 7
+pub let MLI_XC_ASSOCIATOR_WALL: i64 = 8
+pub let MLI_XC_POLICY: i64 = 9
+
+pub struct MliCdExpandStatus {
+    pub ok: bool,
+    pub code: i64,
+    pub at_index: i64,
+}
+
+fn xc_ok() -> MliCdExpandStatus {
+    MliCdExpandStatus { ok: true, code: MLI_XC_OK, at_index: 0 - 1 }
+}
+
+fn xc_err(code: i64, at: i64) -> MliCdExpandStatus {
+    MliCdExpandStatus { ok: false, code: code, at_index: at }
+}
+
+pub struct S3CMap {
+    pub c0: [i64; 128],
+    pub c1: [i64; 128],
+    pub c2: [i64; 128],
+    pub c3: [i64; 128],
+    pub scalar: [i64; 128],
+}
+
+fn cmap_empty() -> S3CMap {
+    S3CMap {
+        c0: [0 - 1; 128],
+        c1: [0 - 1; 128],
+        c2: [0 - 1; 128],
+        c3: [0 - 1; 128],
+        scalar: [0 - 1; 128],
+    }
+}
+
+fn is_cd_f64(k: MliKind, dim: i64) -> bool {
+    k.tag == MLI_KIND_CD && k.bits == 64 && k.dim == dim
+}
+
+fn emit_fbinop(out: &!MliFunction, cur: i64, op: i64, a: i64, b: i64) -> i64 with Mut, Panic {
+    let fk = mli_kind_float(64)
+    let d = mli_new_vreg(out, fk)
+    if d < 0 { return 0 - 1 }
+    if !mli_emit(out, cur, mli_inst3(op, mli_opd_vreg(d, fk), mli_opd_vreg(a, fk), mli_opd_vreg(b, fk))) {
+        return 0 - 1
+    }
+    d
+}
+
+fn emit_fzero(out: &!MliFunction, cur: i64) -> i64 with Mut, Panic {
+    let fk = mli_kind_float(64)
+    let d = mli_new_vreg(out, fk)
+    if d < 0 { return 0 - 1 }
+    if !mli_emit(out, cur, mli_inst2(MLI_OP_MOV, mli_opd_vreg(d, fk), mli_opd_imm_f64(0.0))) {
+        return 0 - 1
+    }
+    d
+}
+
+fn lane_of(m: &S3CMap, id: i64, lane: i64) -> i64 with Panic {
+    if lane == 0 { return m.c0[id] }
+    if lane == 1 { return m.c1[id] }
+    if lane == 2 { return m.c2[id] }
+    if lane == 3 { return m.c3[id] }
+    0 - 1
+}
+
+fn set_lane(m: &!S3CMap, id: i64, lane: i64, v: i64) with Mut, Panic {
+    if lane == 0 { m.c0[id] = v }
+    if lane == 1 { m.c1[id] = v }
+    if lane == 2 { m.c2[id] = v }
+    if lane == 3 { m.c3[id] = v }
+}
+
+fn explode_cd_arg(out: &!MliFunction, m: &!S3CMap, arg_id: i64, dim: i64) -> bool with Mut, Panic {
+    var i: i64 = 0
+    while i < dim {
+        let v = mli_add_arg(out, mli_kind_float(64))
+        if v < 0 { return false }
+        set_lane(m, arg_id, i, v)
+        i = i + 1
+    }
+    true
+}
+
+// Complex product (a0+a1 i)(b0+b1 i) = (a0 b0 − a1 b1) + (a0 b1 + a1 b0) i
+fn emit_complex_mul(out: &!MliFunction, cur: i64, m: &!S3CMap, did: i64, a: i64, b: i64) -> bool with Mut, Panic {
+    let a0 = m.c0[a]
+    let a1 = m.c1[a]
+    let b0 = m.c0[b]
+    let b1 = m.c1[b]
+    let p00 = emit_fbinop(out, cur, MLI_OP_FMUL, a0, b0)
+    let p11 = emit_fbinop(out, cur, MLI_OP_FMUL, a1, b1)
+    let r0 = emit_fbinop(out, cur, MLI_OP_FSUB, p00, p11)
+    let p01 = emit_fbinop(out, cur, MLI_OP_FMUL, a0, b1)
+    let p10 = emit_fbinop(out, cur, MLI_OP_FMUL, a1, b0)
+    let r1 = emit_fbinop(out, cur, MLI_OP_FADD, p01, p10)
+    if r0 < 0 || r1 < 0 { return false }
+    m.c0[did] = r0
+    m.c1[did] = r1
+    true
+}
+
+// Hamilton product. 16 fmul + 12 fadd/fsub. Fits MLI_MAX_INSTRS=32 when
+// followed by a single extract.
+fn emit_quat_mul(out: &!MliFunction, cur: i64, m: &!S3CMap, did: i64, a: i64, b: i64) -> bool with Mut, Panic {
+    let a0 = m.c0[a]
+    let a1 = m.c1[a]
+    let a2 = m.c2[a]
+    let a3 = m.c3[a]
+    let b0 = m.c0[b]
+    let b1 = m.c1[b]
+    let b2 = m.c2[b]
+    let b3 = m.c3[b]
+
+    let a0b0 = emit_fbinop(out, cur, MLI_OP_FMUL, a0, b0)
+    let a1b1 = emit_fbinop(out, cur, MLI_OP_FMUL, a1, b1)
+    let a2b2 = emit_fbinop(out, cur, MLI_OP_FMUL, a2, b2)
+    let a3b3 = emit_fbinop(out, cur, MLI_OP_FMUL, a3, b3)
+    let t0 = emit_fbinop(out, cur, MLI_OP_FSUB, a0b0, a1b1)
+    let t1 = emit_fbinop(out, cur, MLI_OP_FSUB, t0, a2b2)
+    let r0 = emit_fbinop(out, cur, MLI_OP_FSUB, t1, a3b3)
+
+    let a0b1 = emit_fbinop(out, cur, MLI_OP_FMUL, a0, b1)
+    let a1b0 = emit_fbinop(out, cur, MLI_OP_FMUL, a1, b0)
+    let a2b3 = emit_fbinop(out, cur, MLI_OP_FMUL, a2, b3)
+    let a3b2 = emit_fbinop(out, cur, MLI_OP_FMUL, a3, b2)
+    let u0 = emit_fbinop(out, cur, MLI_OP_FADD, a0b1, a1b0)
+    let u1 = emit_fbinop(out, cur, MLI_OP_FADD, u0, a2b3)
+    let r1 = emit_fbinop(out, cur, MLI_OP_FSUB, u1, a3b2)
+
+    let a0b2 = emit_fbinop(out, cur, MLI_OP_FMUL, a0, b2)
+    let a1b3 = emit_fbinop(out, cur, MLI_OP_FMUL, a1, b3)
+    let a2b0 = emit_fbinop(out, cur, MLI_OP_FMUL, a2, b0)
+    let a3b1 = emit_fbinop(out, cur, MLI_OP_FMUL, a3, b1)
+    let v0 = emit_fbinop(out, cur, MLI_OP_FSUB, a0b2, a1b3)
+    let v1 = emit_fbinop(out, cur, MLI_OP_FADD, v0, a2b0)
+    let r2 = emit_fbinop(out, cur, MLI_OP_FADD, v1, a3b1)
+
+    let a0b3 = emit_fbinop(out, cur, MLI_OP_FMUL, a0, b3)
+    let a1b2 = emit_fbinop(out, cur, MLI_OP_FMUL, a1, b2)
+    let a2b1 = emit_fbinop(out, cur, MLI_OP_FMUL, a2, b1)
+    let a3b0 = emit_fbinop(out, cur, MLI_OP_FMUL, a3, b0)
+    let w0 = emit_fbinop(out, cur, MLI_OP_FADD, a0b3, a1b2)
+    let w1 = emit_fbinop(out, cur, MLI_OP_FSUB, w0, a2b1)
+    let r3 = emit_fbinop(out, cur, MLI_OP_FADD, w1, a3b0)
+
+    if r0 < 0 || r1 < 0 || r2 < 0 || r3 < 0 { return false }
+    m.c0[did] = r0
+    m.c1[did] = r1
+    m.c2[did] = r2
+    m.c3[did] = r3
+    true
+}
+
+pub fn mli_expand_cd(src: &MliFunction, out: &!MliFunction) -> MliCdExpandStatus with Mut, Panic, Div {
+    if src.block_count != 1 { return xc_err(MLI_XC_CFG_INPUT, 0 - 1) }
+    if src.blk_has_term[0] != 1 { return xc_err(MLI_XC_CFG_INPUT, 0 - 1) }
+    if src.ret.tag == MLI_KIND_CD { return xc_err(MLI_XC_CD_RET, 0 - 1) }
+
+    // Name the wall BEFORE exploding args, so an octonion associator is
+    // not reported as a generic arg overflow.
+    var pj: i64 = 0
+    while pj < src.blk_instr_count[0] {
+        let pop = mli_slot_opcode(src, mli_slot(0, pj))
+        let pd = mli_slot_dst(src, mli_slot(0, pj))
+        if pop == MLI_OP_CD_ASSOCIATOR && pd.kind.dim >= 8 {
+            return xc_err(MLI_XC_ASSOCIATOR_WALL, pj)
+        }
+        if pop == MLI_OP_CD_MUL && pd.kind.dim >= 8 {
+            return xc_err(MLI_XC_OCTONION_WALL, pj)
+        }
+        pj = pj + 1
+    }
+
+    out.name = "expand_cd"
+    out.ret = src.ret
+
+    var m = cmap_empty()
+
+    var a: i64 = 0
+    while a < src.arg_count {
+        let ak = src.arg_kinds[a]
+        if ak.tag == MLI_KIND_CD {
+            if ak.bits != 64 { return xc_err(MLI_XC_SHAPE, 0 - 1) }
+            if ak.dim >= 8 { return xc_err(MLI_XC_OCTONION_WALL, 0 - 1) }
+            if ak.dim != 2 && ak.dim != 4 { return xc_err(MLI_XC_SHAPE, 0 - 1) }
+            if !explode_cd_arg(out, &!m, a, ak.dim) { return xc_err(MLI_XC_BUILDER_OVERFLOW, 0 - 1) }
+        } else {
+            let v = mli_add_arg(out, ak)
+            if v < 0 { return xc_err(MLI_XC_BUILDER_OVERFLOW, 0 - 1) }
+            m.scalar[a] = v
+        }
+        a = a + 1
+    }
+
+    var cur = mli_new_block(out)
+    if cur < 0 { return xc_err(MLI_XC_BUILDER_OVERFLOW, 0 - 1) }
+
+    var j: i64 = 0
+    while j < src.blk_instr_count[0] {
+        let slot = mli_slot(0, j)
+        let op = mli_slot_opcode(src, slot)
+        let d = mli_slot_dst(src, slot)
+        let s1 = mli_slot_src1(src, slot)
+        let s2 = mli_slot_src2(src, slot)
+        let assoc = mli_slot_assoc(src, slot)
+        let zd = mli_slot_zd(src, slot)
+
+        if op == MLI_OP_NOP || op == MLI_OP_KEEP_ALIVE {
+            j = j + 1
+            continue
+        }
+
+        if op == MLI_OP_CD_MUL {
+            if assoc == MLI_ASSOC_NONE || zd == MLI_ZD_NONE { return xc_err(MLI_XC_POLICY, j) }
+            if d.tag != MLI_OPD_VREG || s1.tag != MLI_OPD_VREG || s2.tag != MLI_OPD_VREG {
+                return xc_err(MLI_XC_OPERAND, j)
+            }
+            if d.kind.dim >= 8 { return xc_err(MLI_XC_OCTONION_WALL, j) }
+            var okm = false
+            if is_cd_f64(d.kind, 2) {
+                okm = emit_complex_mul(out, cur, &!m, d.id, s1.id, s2.id)
+            } else {
+                if is_cd_f64(d.kind, 4) {
+                    okm = emit_quat_mul(out, cur, &!m, d.id, s1.id, s2.id)
+                } else {
+                    return xc_err(MLI_XC_SHAPE, j)
+                }
+            }
+            if !okm || out.overflowed { return xc_err(MLI_XC_BUILDER_OVERFLOW, j) }
+            j = j + 1
+            continue
+        }
+
+        if op == MLI_OP_CD_ASSOCIATOR {
+            if assoc == MLI_ASSOC_NONE || zd == MLI_ZD_NONE { return xc_err(MLI_XC_POLICY, j) }
+            if d.tag != MLI_OPD_VREG { return xc_err(MLI_XC_OPERAND, j) }
+            if d.kind.dim >= 8 { return xc_err(MLI_XC_ASSOCIATOR_WALL, j) }
+            if d.kind.dim != 2 && d.kind.dim != 4 { return xc_err(MLI_XC_SHAPE, j) }
+            // Associative algebras: [a,b,c] ≡ 0. Do not read s1/s2/s3.
+            var li: i64 = 0
+            while li < d.kind.dim {
+                let z = emit_fzero(out, cur)
+                if z < 0 { return xc_err(MLI_XC_BUILDER_OVERFLOW, j) }
+                set_lane(&!m, d.id, li, z)
+                li = li + 1
+            }
+            if out.overflowed { return xc_err(MLI_XC_BUILDER_OVERFLOW, j) }
+            j = j + 1
+            continue
+        }
+
+        if op == MLI_OP_CD_EXTRACT {
+            if d.tag != MLI_OPD_VREG || s1.tag != MLI_OPD_VREG { return xc_err(MLI_XC_OPERAND, j) }
+            if s2.tag != MLI_OPD_IMM { return xc_err(MLI_XC_OPERAND, j) }
+            let lane = lane_of(&m, s1.id, s2.aux)
+            if lane < 0 { return xc_err(MLI_XC_OPERAND, j) }
+            let nd = mli_new_vreg(out, mli_kind_float(64))
+            if nd < 0 { return xc_err(MLI_XC_BUILDER_OVERFLOW, j) }
+            if !mli_emit(out, cur, mli_inst2(MLI_OP_MOV, mli_opd_vreg(nd, mli_kind_float(64)), mli_opd_vreg(lane, mli_kind_float(64)))) {
+                return xc_err(MLI_XC_BUILDER_OVERFLOW, j)
+            }
+            m.scalar[d.id] = nd
+            j = j + 1
+            continue
+        }
+
+        return xc_err(MLI_XC_UNSUPPORTED_OP, j)
+    }
+
+    let ts = mli_term_slot(0)
+    let top = mli_slot_opcode(src, ts)
+    if top != MLI_OP_RET { return xc_err(MLI_XC_CFG_INPUT, 0 - 1) }
+    let rv = mli_slot_src1(src, ts)
+    if src.ret.tag == MLI_KIND_VOID {
+        if !mli_set_term(out, cur, mli_term_ret_void()) { return xc_err(MLI_XC_BUILDER_OVERFLOW, 0 - 1) }
+        return xc_ok()
+    }
+    if rv.tag != MLI_OPD_VREG { return xc_err(MLI_XC_OPERAND, 0 - 1) }
+    if rv.kind.tag == MLI_KIND_CD { return xc_err(MLI_XC_CD_RET, 0 - 1) }
+    let sid = m.scalar[rv.id]
+    if sid < 0 { return xc_err(MLI_XC_OPERAND, 0 - 1) }
+    if !mli_set_term(out, cur, mli_term_ret(mli_opd_vreg(sid, out.vreg_kinds[sid]))) {
+        return xc_err(MLI_XC_BUILDER_OVERFLOW, 0 - 1)
+    }
+    if out.overflowed { return xc_err(MLI_XC_BUILDER_OVERFLOW, 0 - 1) }
+    xc_ok()
+}

--- a/self-hosted/mli/expand_k.sio
+++ b/self-hosted/mli/expand_k.sio
@@ -10,24 +10,36 @@
 //   var  = a.variance + b.variance          (GUM: Var(X+Y) = Var+Var)
 //   conf = clamp_0_1000(min(a.conf, b.conf) * 99 / 100)
 //
-// MEASURED COST (the honest number S3 was asked for): the val and var lanes
-// cost 2 fadds. The conf lane costs 4 constant materialisations, 1 icmp +
-// 1 mul + 1 div + 2 more icmps, and THREE branch diamonds (min, clamp-low,
-// clamp-high) = 9 extra blocks per k_add, because MLI R0 has no select op
-// and Bool deliberately does not participate in integer arithmetic. One
-// k_add fits the S1 walls (1+9 of 16 blocks); a second k_add in the same
-// function overflows fail-closed — that overflow is the concrete trigger
-// for the deferred module-arena decision, measured not guessed.
+// MEASURED COST (the honest number S3 was asked for):
+//   k_add val+var : 2 fadds. THE named temptation is the second fadd —
+//                   `addsd` of the variance slots. Emitting only the first
+//                   `addsd` (val) and returning is one instruction; that is
+//                   exactly what LLVM/GCC/Cranelift do. Keeping the variance
+//                   is one more `addsd` (encoding `f2 0f 58 c1`, 4 bytes)
+//                   plus the load/store of the var slots.
+//   k_mul val+var : 1 fmul (val) + 4 fmul + 1 fadd (GUM delta method,
+//                   JCGM 100:2008 §5.1.2 / stdlib ep_mul):
+//                     Var(XY) ≈ Y²·Var(X) + X²·Var(Y)
+//                   THE named temptation is the first `mulsd` of a.val*b.val.
+//                   Four more `mulsd` and one `addsd` are the cost of not
+//                   erasing. The σx²σy² Gaussian-product term is NOT added
+//                   — that is the stdlib oracle, not a guess (knightian.sio
+//                   documents the omission as a GUM convention).
+//   conf lane     : 4–5 constant materialisations, 1 icmp + 1 mul + 1 div +
+//                   2 more icmps, THREE branch diamonds (min, clamp-low,
+//                   clamp-high) = 9 extra blocks per k_op, because MLI R0
+//                   has no select and Bool does not do integer arithmetic.
+//                   Decay is *99/100 for add (ep_add) and *98/100 for mul
+//                   (ep_mul). One k_op fits the S1 walls (1+9 of 16 blocks);
+//                   a second overflows fail-closed — the arena trigger.
 //
 // Refusals (never partial-drop a lane):
-//   X_UNSUPPORTED_OP   k_mul/k_div/k_fma/k_measure/k_cast/cd_* (S5+ surface:
-//                      first-order GUM products need documented derivations)
-//   X_CFG_INPUT        multi-block input (expansion INSERTS blocks; remapping
-//                      an input CFG through inserted diamonds is S5)
-//   X_KNOWLEDGE_RET    returning a Knowledge value (ABI by-ref is S5, design
-//                      §5.2 rule 5)
-//   X_SHAPE            Knowledge shapes other than Min3/f64 (Gpu4/EmirBundle
-//                      lanes differ; never guess)
+//   X_UNSUPPORTED_OP   k_div/k_fma/k_measure/k_cast/cd_* (division by an
+//                      uncertain Y needs a documented GUM derivation of its
+//                      own; not guessed here)
+//   X_CFG_INPUT        multi-block input (expansion INSERTS blocks)
+//   X_KNOWLEDGE_RET    returning a Knowledge value (ABI by-ref is S5)
+//   X_SHAPE            Knowledge shapes other than Min3/f64
 
 module mli::expand_k
 
@@ -80,6 +92,79 @@ fn is_min3_f64(k: MliKind) -> bool {
 // Remap a source operand of a SCALAR op into the output function.
 // Knowledge vregs are illegal here (the verifier would refuse the input
 // anyway); immediates pass through.
+// Conf-lane diamonds: min -> *decay/100 -> clamp_0_1000. Shared by k_add
+// (decay=99) and k_mul (decay=98) so the two ops cannot drift.
+pub struct ConfLaneEmit {
+    pub ok: bool,
+    pub cur: i64,
+    pub dest: i64,
+}
+
+fn conf_lane_fail() -> ConfLaneEmit {
+    ConfLaneEmit { ok: false, cur: 0 - 1, dest: 0 - 1 }
+}
+
+fn emit_conf_lane(out: &!MliFunction, cur0: i64, ac: i64, bc: i64, c_decay: i64, c100: i64, c0: i64, c1000: i64) -> ConfLaneEmit with Mut, Panic {
+    let ik = mli_kind_int(64, 1)
+    let bk = mli_kind_bool()
+    var cur = cur0
+    var okv = true
+
+    let cnd1 = mli_new_vreg(out, bk)
+    let cm = mli_new_vreg(out, ik)
+    if cnd1 < 0 || cm < 0 { return conf_lane_fail() }
+    okv = okv && mli_emit(out, cur, mli_inst_icmp(MLI_CC_LT, mli_opd_vreg(cnd1, bk), mli_opd_vreg(ac, ik), mli_opd_vreg(bc, ik)))
+    let bt1 = mli_new_block(out)
+    let be1 = mli_new_block(out)
+    let bj1 = mli_new_block(out)
+    if bt1 < 0 || be1 < 0 || bj1 < 0 { return conf_lane_fail() }
+    okv = okv && mli_set_term(out, cur, mli_term_br(mli_opd_vreg(cnd1, bk), bt1, be1))
+    okv = okv && mli_emit(out, bt1, mli_inst2(MLI_OP_MOV, mli_opd_vreg(cm, ik), mli_opd_vreg(ac, ik)))
+    okv = okv && mli_set_term(out, bt1, mli_term_jmp(bj1))
+    okv = okv && mli_emit(out, be1, mli_inst2(MLI_OP_MOV, mli_opd_vreg(cm, ik), mli_opd_vreg(bc, ik)))
+    okv = okv && mli_set_term(out, be1, mli_term_jmp(bj1))
+    cur = bj1
+
+    let cx = mli_new_vreg(out, ik)
+    let cy = mli_new_vreg(out, ik)
+    if cx < 0 || cy < 0 { return conf_lane_fail() }
+    okv = okv && mli_emit(out, cur, mli_inst3(MLI_OP_MUL, mli_opd_vreg(cx, ik), mli_opd_vreg(cm, ik), mli_opd_vreg(c_decay, ik)))
+    okv = okv && mli_emit(out, cur, mli_inst3(MLI_OP_DIV, mli_opd_vreg(cy, ik), mli_opd_vreg(cx, ik), mli_opd_vreg(c100, ik)))
+
+    let cnd2 = mli_new_vreg(out, bk)
+    let cz = mli_new_vreg(out, ik)
+    if cnd2 < 0 || cz < 0 { return conf_lane_fail() }
+    okv = okv && mli_emit(out, cur, mli_inst_icmp(MLI_CC_LT, mli_opd_vreg(cnd2, bk), mli_opd_vreg(cy, ik), mli_opd_vreg(c0, ik)))
+    let bt2 = mli_new_block(out)
+    let be2 = mli_new_block(out)
+    let bj2 = mli_new_block(out)
+    if bt2 < 0 || be2 < 0 || bj2 < 0 { return conf_lane_fail() }
+    okv = okv && mli_set_term(out, cur, mli_term_br(mli_opd_vreg(cnd2, bk), bt2, be2))
+    okv = okv && mli_emit(out, bt2, mli_inst2(MLI_OP_MOV, mli_opd_vreg(cz, ik), mli_opd_vreg(c0, ik)))
+    okv = okv && mli_set_term(out, bt2, mli_term_jmp(bj2))
+    okv = okv && mli_emit(out, be2, mli_inst2(MLI_OP_MOV, mli_opd_vreg(cz, ik), mli_opd_vreg(cy, ik)))
+    okv = okv && mli_set_term(out, be2, mli_term_jmp(bj2))
+    cur = bj2
+
+    let cnd3 = mli_new_vreg(out, bk)
+    let cf = mli_new_vreg(out, ik)
+    if cnd3 < 0 || cf < 0 { return conf_lane_fail() }
+    okv = okv && mli_emit(out, cur, mli_inst_icmp(MLI_CC_GT, mli_opd_vreg(cnd3, bk), mli_opd_vreg(cz, ik), mli_opd_vreg(c1000, ik)))
+    let bt3 = mli_new_block(out)
+    let be3 = mli_new_block(out)
+    let bj3 = mli_new_block(out)
+    if bt3 < 0 || be3 < 0 || bj3 < 0 { return conf_lane_fail() }
+    okv = okv && mli_set_term(out, cur, mli_term_br(mli_opd_vreg(cnd3, bk), bt3, be3))
+    okv = okv && mli_emit(out, bt3, mli_inst2(MLI_OP_MOV, mli_opd_vreg(cf, ik), mli_opd_vreg(c1000, ik)))
+    okv = okv && mli_set_term(out, bt3, mli_term_jmp(bj3))
+    okv = okv && mli_emit(out, be3, mli_inst2(MLI_OP_MOV, mli_opd_vreg(cf, ik), mli_opd_vreg(cz, ik)))
+    okv = okv && mli_set_term(out, be3, mli_term_jmp(bj3))
+    cur = bj3
+
+    if !okv || out.overflowed { return conf_lane_fail() }
+    ConfLaneEmit { ok: true, cur: cur, dest: cf }
+}
+
 fn remap_scalar_opd(m: &S3KMap, out: &MliFunction, o: MliOperand) -> MliOperand with Panic {
     if o.tag == MLI_OPD_IMM || o.tag == MLI_OPD_NONE { return o }
     if o.tag == MLI_OPD_VREG {
@@ -132,9 +217,10 @@ pub fn mli_expand_min3(src: &MliFunction, out: &!MliFunction) -> MliExpandStatus
     var cur = mli_new_block(out)
     if cur < 0 { return x_err(MLI_X_BUILDER_OVERFLOW, 0 - 1) }
 
-    // Conf-arithmetic constants, materialised on first k_add.
+    // Conf-arithmetic constants, materialised on first k_add / k_mul.
     var consts_done = false
     var c99: i64 = 0 - 1
+    var c98: i64 = 0 - 1
     var c100: i64 = 0 - 1
     var c0: i64 = 0 - 1
     var c1000: i64 = 0 - 1
@@ -176,81 +262,91 @@ pub fn mli_expand_min3(src: &MliFunction, out: &!MliFunction) -> MliExpandStatus
             if dr < 0 { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
             okv = okv && mli_emit(out, cur, mli_inst3(MLI_OP_FADD, mli_opd_vreg(dr, mli_kind_float(64)), mli_opd_vreg(ar, mli_kind_float(64)), mli_opd_vreg(br, mli_kind_float(64))))
 
-            // conf lane: min -> *99/100 -> clamp. Three diamonds, because
-            // MLI R0 has no select and Bool does not do integer arithmetic.
-            // THIS is where erasure gets tempting — see module header.
+            // conf lane: min -> *99/100 -> clamp. THIS is the second
+            // temptation (after the var addsd) — see module header.
             if !consts_done {
                 c99 = mli_new_vreg(out, mli_kind_int(64, 1))
+                c98 = mli_new_vreg(out, mli_kind_int(64, 1))
                 c100 = mli_new_vreg(out, mli_kind_int(64, 1))
                 c0 = mli_new_vreg(out, mli_kind_int(64, 1))
                 c1000 = mli_new_vreg(out, mli_kind_int(64, 1))
-                if c99 < 0 || c100 < 0 || c0 < 0 || c1000 < 0 { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
-                okv = okv && mli_emit(out, cur, mli_inst2(MLI_OP_MOV, mli_opd_vreg(c99, mli_kind_int(64, 1)), mli_opd_imm_int(99, mli_kind_int(64, 1))))
-                okv = okv && mli_emit(out, cur, mli_inst2(MLI_OP_MOV, mli_opd_vreg(c100, mli_kind_int(64, 1)), mli_opd_imm_int(100, mli_kind_int(64, 1))))
-                okv = okv && mli_emit(out, cur, mli_inst2(MLI_OP_MOV, mli_opd_vreg(c0, mli_kind_int(64, 1)), mli_opd_imm_int(0, mli_kind_int(64, 1))))
-                okv = okv && mli_emit(out, cur, mli_inst2(MLI_OP_MOV, mli_opd_vreg(c1000, mli_kind_int(64, 1)), mli_opd_imm_int(1000, mli_kind_int(64, 1))))
+                if c99 < 0 || c98 < 0 || c100 < 0 || c0 < 0 || c1000 < 0 { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
+                let ik = mli_kind_int(64, 1)
+                okv = okv && mli_emit(out, cur, mli_inst2(MLI_OP_MOV, mli_opd_vreg(c99, ik), mli_opd_imm_int(99, ik)))
+                okv = okv && mli_emit(out, cur, mli_inst2(MLI_OP_MOV, mli_opd_vreg(c98, ik), mli_opd_imm_int(98, ik)))
+                okv = okv && mli_emit(out, cur, mli_inst2(MLI_OP_MOV, mli_opd_vreg(c100, ik), mli_opd_imm_int(100, ik)))
+                okv = okv && mli_emit(out, cur, mli_inst2(MLI_OP_MOV, mli_opd_vreg(c0, ik), mli_opd_imm_int(0, ik)))
+                okv = okv && mli_emit(out, cur, mli_inst2(MLI_OP_MOV, mli_opd_vreg(c1000, ik), mli_opd_imm_int(1000, ik)))
                 consts_done = true
             }
-
-            // Diamond 1: cm = min(ac, bc)
-            let cnd1 = mli_new_vreg(out, mli_kind_bool())
-            let cm = mli_new_vreg(out, mli_kind_int(64, 1))
-            if cnd1 < 0 || cm < 0 { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
-            okv = okv && mli_emit(out, cur, mli_inst_icmp(MLI_CC_LT, mli_opd_vreg(cnd1, mli_kind_bool()), mli_opd_vreg(ac, mli_kind_int(64, 1)), mli_opd_vreg(bc, mli_kind_int(64, 1))))
-            let bt1 = mli_new_block(out)
-            let be1 = mli_new_block(out)
-            let bj1 = mli_new_block(out)
-            if bt1 < 0 || be1 < 0 || bj1 < 0 { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
-            okv = okv && mli_set_term(out, cur, mli_term_br(mli_opd_vreg(cnd1, mli_kind_bool()), bt1, be1))
-            okv = okv && mli_emit(out, bt1, mli_inst2(MLI_OP_MOV, mli_opd_vreg(cm, mli_kind_int(64, 1)), mli_opd_vreg(ac, mli_kind_int(64, 1))))
-            okv = okv && mli_set_term(out, bt1, mli_term_jmp(bj1))
-            okv = okv && mli_emit(out, be1, mli_inst2(MLI_OP_MOV, mli_opd_vreg(cm, mli_kind_int(64, 1)), mli_opd_vreg(bc, mli_kind_int(64, 1))))
-            okv = okv && mli_set_term(out, be1, mli_term_jmp(bj1))
-            cur = bj1
-
-            // Decay: cy = cm * 99 / 100.
-            let cx = mli_new_vreg(out, mli_kind_int(64, 1))
-            let cy = mli_new_vreg(out, mli_kind_int(64, 1))
-            if cx < 0 || cy < 0 { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
-            okv = okv && mli_emit(out, cur, mli_inst3(MLI_OP_MUL, mli_opd_vreg(cx, mli_kind_int(64, 1)), mli_opd_vreg(cm, mli_kind_int(64, 1)), mli_opd_vreg(c99, mli_kind_int(64, 1))))
-            okv = okv && mli_emit(out, cur, mli_inst3(MLI_OP_DIV, mli_opd_vreg(cy, mli_kind_int(64, 1)), mli_opd_vreg(cx, mli_kind_int(64, 1)), mli_opd_vreg(c100, mli_kind_int(64, 1))))
-
-            // Diamond 2: clamp low (cz = cy < 0 ? 0 : cy).
-            let cnd2 = mli_new_vreg(out, mli_kind_bool())
-            let cz = mli_new_vreg(out, mli_kind_int(64, 1))
-            if cnd2 < 0 || cz < 0 { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
-            okv = okv && mli_emit(out, cur, mli_inst_icmp(MLI_CC_LT, mli_opd_vreg(cnd2, mli_kind_bool()), mli_opd_vreg(cy, mli_kind_int(64, 1)), mli_opd_vreg(c0, mli_kind_int(64, 1))))
-            let bt2 = mli_new_block(out)
-            let be2 = mli_new_block(out)
-            let bj2 = mli_new_block(out)
-            if bt2 < 0 || be2 < 0 || bj2 < 0 { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
-            okv = okv && mli_set_term(out, cur, mli_term_br(mli_opd_vreg(cnd2, mli_kind_bool()), bt2, be2))
-            okv = okv && mli_emit(out, bt2, mli_inst2(MLI_OP_MOV, mli_opd_vreg(cz, mli_kind_int(64, 1)), mli_opd_vreg(c0, mli_kind_int(64, 1))))
-            okv = okv && mli_set_term(out, bt2, mli_term_jmp(bj2))
-            okv = okv && mli_emit(out, be2, mli_inst2(MLI_OP_MOV, mli_opd_vreg(cz, mli_kind_int(64, 1)), mli_opd_vreg(cy, mli_kind_int(64, 1))))
-            okv = okv && mli_set_term(out, be2, mli_term_jmp(bj2))
-            cur = bj2
-
-            // Diamond 3: clamp high (cf = cz > 1000 ? 1000 : cz).
-            let cnd3 = mli_new_vreg(out, mli_kind_bool())
-            let cf = mli_new_vreg(out, mli_kind_int(64, 1))
-            if cnd3 < 0 || cf < 0 { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
-            okv = okv && mli_emit(out, cur, mli_inst_icmp(MLI_CC_GT, mli_opd_vreg(cnd3, mli_kind_bool()), mli_opd_vreg(cz, mli_kind_int(64, 1)), mli_opd_vreg(c1000, mli_kind_int(64, 1))))
-            let bt3 = mli_new_block(out)
-            let be3 = mli_new_block(out)
-            let bj3 = mli_new_block(out)
-            if bt3 < 0 || be3 < 0 || bj3 < 0 { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
-            okv = okv && mli_set_term(out, cur, mli_term_br(mli_opd_vreg(cnd3, mli_kind_bool()), bt3, be3))
-            okv = okv && mli_emit(out, bt3, mli_inst2(MLI_OP_MOV, mli_opd_vreg(cf, mli_kind_int(64, 1)), mli_opd_vreg(c1000, mli_kind_int(64, 1))))
-            okv = okv && mli_set_term(out, bt3, mli_term_jmp(bj3))
-            okv = okv && mli_emit(out, be3, mli_inst2(MLI_OP_MOV, mli_opd_vreg(cf, mli_kind_int(64, 1)), mli_opd_vreg(cz, mli_kind_int(64, 1))))
-            okv = okv && mli_set_term(out, be3, mli_term_jmp(bj3))
-            cur = bj3
-
-            if !okv || out.overflowed { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
+            if !okv { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
+            let ce = emit_conf_lane(out, cur, ac, bc, c99, c100, c0, c1000)
+            if !ce.ok { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
+            cur = ce.cur
             m.kv_val[d.id] = dv
             m.kv_var[d.id] = dr
-            m.kv_conf[d.id] = cf
+            m.kv_conf[d.id] = ce.dest
+            j = j + 1
+            continue
+        }
+
+        if op == MLI_OP_K_MUL {
+            if d.tag != MLI_OPD_VREG || s1.tag != MLI_OPD_VREG || s2.tag != MLI_OPD_VREG {
+                return x_err(MLI_X_OPERAND, j)
+            }
+            if !is_min3_f64(d.kind) { return x_err(MLI_X_SHAPE, j) }
+            let av = m.kv_val[s1.id]
+            let ar = m.kv_var[s1.id]
+            let ac = m.kv_conf[s1.id]
+            let bv = m.kv_val[s2.id]
+            let br = m.kv_var[s2.id]
+            let bc = m.kv_conf[s2.id]
+            if av < 0 || bv < 0 { return x_err(MLI_X_OPERAND, j) }
+            let fk = mli_kind_float(64)
+
+            // val lane: one fmul. THE named temptation for products —
+            // emitting only this mulsd and dropping the four that follow
+            // is how every production backend erases Var(XY).
+            let dv = mli_new_vreg(out, fk)
+            if dv < 0 { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
+            var okv = mli_emit(out, cur, mli_inst3(MLI_OP_FMUL, mli_opd_vreg(dv, fk), mli_opd_vreg(av, fk), mli_opd_vreg(bv, fk)))
+
+            // var lane: GUM delta method, stdlib ep_mul / JCGM 100:2008 §5.1.2
+            //   Var(XY) ≈ Y²·Var(X) + X²·Var(Y)
+            let y2 = mli_new_vreg(out, fk)
+            let x2 = mli_new_vreg(out, fk)
+            let t1 = mli_new_vreg(out, fk)
+            let t2 = mli_new_vreg(out, fk)
+            let dr = mli_new_vreg(out, fk)
+            if y2 < 0 || x2 < 0 || t1 < 0 || t2 < 0 || dr < 0 { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
+            okv = okv && mli_emit(out, cur, mli_inst3(MLI_OP_FMUL, mli_opd_vreg(y2, fk), mli_opd_vreg(bv, fk), mli_opd_vreg(bv, fk)))
+            okv = okv && mli_emit(out, cur, mli_inst3(MLI_OP_FMUL, mli_opd_vreg(x2, fk), mli_opd_vreg(av, fk), mli_opd_vreg(av, fk)))
+            okv = okv && mli_emit(out, cur, mli_inst3(MLI_OP_FMUL, mli_opd_vreg(t1, fk), mli_opd_vreg(y2, fk), mli_opd_vreg(ar, fk)))
+            okv = okv && mli_emit(out, cur, mli_inst3(MLI_OP_FMUL, mli_opd_vreg(t2, fk), mli_opd_vreg(x2, fk), mli_opd_vreg(br, fk)))
+            okv = okv && mli_emit(out, cur, mli_inst3(MLI_OP_FADD, mli_opd_vreg(dr, fk), mli_opd_vreg(t1, fk), mli_opd_vreg(t2, fk)))
+
+            if !consts_done {
+                c99 = mli_new_vreg(out, mli_kind_int(64, 1))
+                c98 = mli_new_vreg(out, mli_kind_int(64, 1))
+                c100 = mli_new_vreg(out, mli_kind_int(64, 1))
+                c0 = mli_new_vreg(out, mli_kind_int(64, 1))
+                c1000 = mli_new_vreg(out, mli_kind_int(64, 1))
+                if c99 < 0 || c98 < 0 || c100 < 0 || c0 < 0 || c1000 < 0 { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
+                let ik = mli_kind_int(64, 1)
+                okv = okv && mli_emit(out, cur, mli_inst2(MLI_OP_MOV, mli_opd_vreg(c99, ik), mli_opd_imm_int(99, ik)))
+                okv = okv && mli_emit(out, cur, mli_inst2(MLI_OP_MOV, mli_opd_vreg(c98, ik), mli_opd_imm_int(98, ik)))
+                okv = okv && mli_emit(out, cur, mli_inst2(MLI_OP_MOV, mli_opd_vreg(c100, ik), mli_opd_imm_int(100, ik)))
+                okv = okv && mli_emit(out, cur, mli_inst2(MLI_OP_MOV, mli_opd_vreg(c0, ik), mli_opd_imm_int(0, ik)))
+                okv = okv && mli_emit(out, cur, mli_inst2(MLI_OP_MOV, mli_opd_vreg(c1000, ik), mli_opd_imm_int(1000, ik)))
+                consts_done = true
+            }
+            if !okv { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
+            let ce = emit_conf_lane(out, cur, ac, bc, c98, c100, c0, c1000)
+            if !ce.ok { return x_err(MLI_X_BUILDER_OVERFLOW, j) }
+            cur = ce.cur
+            m.kv_val[d.id] = dv
+            m.kv_var[d.id] = dr
+            m.kv_conf[d.id] = ce.dest
             j = j + 1
             continue
         }

--- a/self-hosted/mli/interp.sio
+++ b/self-hosted/mli/interp.sio
@@ -9,7 +9,8 @@
 //      (width/mask semantics unpinned), memory ops (no MLI memory model yet:
 //      load/store/lea/alloca), calls, fcast, every k_* and cd_* op, f32/
 //      f128/f256/qd128/Knowledge/CD/vec/ptr VALUES, phys/stack/reloc
-//      operands, control flow (S2b), i64 div-by-zero and INT_MIN/-1.
+//      operands, unclassified compare-codes (not "false"), i64 div-by-zero
+//      and INT_MIN/-1. Control flow is implemented (S2b) with a fuel cap.
 //   2. Where behaviour IS defined, the interp delegates to the host — and
 //      the host is the claim oracle itself (Sounio under Madaros, ADR-008
 //      single semantic clock). i64 two's-complement arithmetic, IEEE f64
@@ -164,14 +165,16 @@ fn mli_exec_slot(rf: &!MliRegFile, f: &MliFunction, slot: i64) -> i64 with Mut, 
             if x == min_i64 && y == 0 - 1 { return MLI_I_DIV_OVERFLOW }
         }
         var r: i64 = 0
-        if op == MLI_OP_ADD { r = x + y }
-        if op == MLI_OP_SUB { r = x - y }
-        if op == MLI_OP_MUL { r = x * y }
-        if op == MLI_OP_DIV { r = x / y }
-        if op == MLI_OP_REM { r = x % y }
-        if op == MLI_OP_AND { r = x & y }
-        if op == MLI_OP_OR { r = x | y }
-        if op == MLI_OP_XOR { r = x ^ y }
+        var matched = false
+        if op == MLI_OP_ADD { r = x + y; matched = true }
+        if op == MLI_OP_SUB { r = x - y; matched = true }
+        if op == MLI_OP_MUL { r = x * y; matched = true }
+        if op == MLI_OP_DIV { r = x / y; matched = true }
+        if op == MLI_OP_REM { r = x % y; matched = true }
+        if op == MLI_OP_AND { r = x & y; matched = true }
+        if op == MLI_OP_OR { r = x | y; matched = true }
+        if op == MLI_OP_XOR { r = x ^ y; matched = true }
+        if !matched { return MLI_I_UNSUPPORTED_OP }
         rf.vi[d.id] = r
         return MLI_I_OK
     }
@@ -186,10 +189,12 @@ fn mli_exec_slot(rf: &!MliRegFile, f: &MliFunction, slot: i64) -> i64 with Mut, 
         var y: f64 = 0.0
         if s2.tag == MLI_OPD_IMM { y = s2.fimm } else { y = rf.vf[s2.id] }
         var r: f64 = 0.0
-        if op == MLI_OP_FADD { r = x + y }
-        if op == MLI_OP_FSUB { r = x - y }
-        if op == MLI_OP_FMUL { r = x * y }
-        if op == MLI_OP_FDIV { r = x / y }
+        var matched = false
+        if op == MLI_OP_FADD { r = x + y; matched = true }
+        if op == MLI_OP_FSUB { r = x - y; matched = true }
+        if op == MLI_OP_FMUL { r = x * y; matched = true }
+        if op == MLI_OP_FDIV { r = x / y; matched = true }
+        if !matched { return MLI_I_UNSUPPORTED_OP }
         rf.vf[d.id] = r
         return MLI_I_OK
     }
@@ -217,7 +222,7 @@ fn mli_exec_slot(rf: &!MliRegFile, f: &MliFunction, slot: i64) -> i64 with Mut, 
     }
 
     if op == MLI_OP_ICMP {
-        if cc == MLI_CC_NONE { return MLI_I_BAD_CC }
+        if !mli_cc_known(cc) { return MLI_I_BAD_CC }
         if d.tag != MLI_OPD_VREG { return MLI_I_UNSUPPORTED_OPERAND }
         if d.id < 0 || d.id >= 128 { return MLI_I_VREG_RANGE }
         if !opd_runnable_tag(s1.tag) || !opd_runnable_tag(s2.tag) { return MLI_I_UNSUPPORTED_OPERAND }
@@ -237,7 +242,7 @@ fn mli_exec_slot(rf: &!MliRegFile, f: &MliFunction, slot: i64) -> i64 with Mut, 
     }
 
     if op == MLI_OP_FCMP {
-        if cc == MLI_CC_NONE { return MLI_I_BAD_CC }
+        if !mli_cc_known(cc) { return MLI_I_BAD_CC }
         if d.tag != MLI_OPD_VREG { return MLI_I_UNSUPPORTED_OPERAND }
         if d.id < 0 || d.id >= 128 { return MLI_I_VREG_RANGE }
         if !opd_runnable_tag(s1.tag) || !opd_runnable_tag(s2.tag) { return MLI_I_UNSUPPORTED_OPERAND }

--- a/self-hosted/mli/interp.sio
+++ b/self-hosted/mli/interp.sio
@@ -1,9 +1,12 @@
 // MLI S2a — minimal interpreter (V-interp, design §6.2), refuse-first.
 //
-// BINDING CONSTRAINT (orchestrator, 2026-08-16; restated after #1788):
-// this interpreter must not become a second semantics. A well-typed
-// program produces a value or a detectable refuse — it never fabricates
-// a zero. Two rules implement that:
+// BINDING CONSTRAINT (orchestrator, 2026-08-16; restated after #1788,
+// #1801, #1792): this interpreter must not become a second semantics.
+// A well-typed program produces a value or a detectable refuse — it
+// never fabricates a zero. #1801 found the compiler returning a declared
+// type after a refuse, and an empty stub exiting as prologue+ret with
+// the caller reading rax. #1792 found a fabricated zero variance in
+// print. Those are the same default. Two rules implement the opposite:
 //
 //   1. Where MLI behaviour is genuinely underspecified today, the interp
 //      REFUSES with a named code instead of picking — so the ambiguity fails
@@ -57,6 +60,7 @@ pub let MLI_I_VREG_RANGE: i64 = 9
 pub let MLI_I_BAD_CC: i64 = 10
 pub let MLI_I_FUEL: i64 = 11
 pub let MLI_I_BAD_TARGET: i64 = 12
+pub let MLI_I_UNDEF_VREG: i64 = 13
 
 // Execution budget: control flow means loops, and a non-terminating program
 // must fail LOUDLY rather than hang (refuse-first applied to termination).
@@ -70,6 +74,10 @@ pub struct MliInterpArgs {
 pub struct MliRegFile {
     pub vi: [i64; 128],
     pub vf: [f64; 128],
+    // Definedness is a SoA flag column, not an instruction-pool AoS.
+    // A never-written vreg must refuse, not return the file's zero
+    // initializer (#1801 rax-after-stub / #1788 fabricated zero).
+    pub def: [i64; 128],
 }
 
 pub fn mli_interp_args_empty() -> MliInterpArgs {
@@ -84,21 +92,29 @@ pub struct MliInterpResult {
     pub code: i64,
     pub block: i64,
     pub index: i64,
+    pub has_value: bool,
     pub ret_is_float: bool,
     pub ret_i: i64,
     pub ret_f: f64,
 }
 
 fn i_ok_int(v: i64) -> MliInterpResult {
-    MliInterpResult { ok: true, code: MLI_I_OK, block: 0 - 1, index: 0 - 1, ret_is_float: false, ret_i: v, ret_f: 0.0 }
+    MliInterpResult { ok: true, code: MLI_I_OK, block: 0 - 1, index: 0 - 1, has_value: true, ret_is_float: false, ret_i: v, ret_f: 0.0 }
 }
 
 fn i_ok_float(v: f64) -> MliInterpResult {
-    MliInterpResult { ok: true, code: MLI_I_OK, block: 0 - 1, index: 0 - 1, ret_is_float: true, ret_i: 0, ret_f: v }
+    MliInterpResult { ok: true, code: MLI_I_OK, block: 0 - 1, index: 0 - 1, has_value: true, ret_is_float: true, ret_i: 0, ret_f: v }
+}
+
+fn i_ok_void() -> MliInterpResult {
+    // Success without a value. ret_i/ret_f stay 0 as padding — has_value
+    // is the load-bearing bit. Treating void as integer 0 is the #1801
+    // empty-stub/rax defect.
+    MliInterpResult { ok: true, code: MLI_I_OK, block: 0 - 1, index: 0 - 1, has_value: false, ret_is_float: false, ret_i: 0, ret_f: 0.0 }
 }
 
 fn i_err(code: i64, block: i64, index: i64) -> MliInterpResult {
-    MliInterpResult { ok: false, code: code, block: block, index: index, ret_is_float: false, ret_i: 0, ret_f: 0.0 }
+    MliInterpResult { ok: false, code: code, block: block, index: index, has_value: false, ret_is_float: false, ret_i: 0, ret_f: 0.0 }
 }
 
 // Kind predicates take scalar fields — scalar args are the proven call shape.
@@ -113,6 +129,15 @@ fn krun_f64(tag: i64, bits: i64) -> bool {
 
 fn opd_runnable_tag(tag: i64) -> bool {
     tag == MLI_OPD_VREG || tag == MLI_OPD_IMM
+}
+
+fn rf_defined(rf: &MliRegFile, id: i64) -> bool {
+    if id < 0 || id >= 128 { return false }
+    rf.def[id] == 1
+}
+
+fn rf_mark(rf: &!MliRegFile, id: i64) with Mut, Panic {
+    rf.def[id] = 1
 }
 
 // Execute one body instruction against the register file, reading through
@@ -135,14 +160,26 @@ fn mli_exec_slot(rf: &!MliRegFile, f: &MliFunction, slot: i64) -> i64 with Mut, 
         if !opd_runnable_tag(s1.tag) { return MLI_I_UNSUPPORTED_OPERAND }
         if krun_int(d.kind.tag, d.kind.bits) {
             var x: i64 = 0
-            if s1.tag == MLI_OPD_IMM { x = s1.aux } else { x = rf.vi[s1.id] }
+            if s1.tag == MLI_OPD_IMM {
+                x = s1.aux
+            } else {
+                if !rf_defined(rf, s1.id) { return MLI_I_UNDEF_VREG }
+                x = rf.vi[s1.id]
+            }
             rf.vi[d.id] = x
+            rf_mark(rf, d.id)
             return MLI_I_OK
         }
         if krun_f64(d.kind.tag, d.kind.bits) {
             var xf: f64 = 0.0
-            if s1.tag == MLI_OPD_IMM { xf = s1.fimm } else { xf = rf.vf[s1.id] }
+            if s1.tag == MLI_OPD_IMM {
+                xf = s1.fimm
+            } else {
+                if !rf_defined(rf, s1.id) { return MLI_I_UNDEF_VREG }
+                xf = rf.vf[s1.id]
+            }
             rf.vf[d.id] = xf
+            rf_mark(rf, d.id)
             return MLI_I_OK
         }
         // f32/f128/f256/qd128/Knowledge/CD/vec/ptr values have no model
@@ -160,9 +197,19 @@ fn mli_exec_slot(rf: &!MliRegFile, f: &MliFunction, slot: i64) -> i64 with Mut, 
         if !krun_int(d.kind.tag, d.kind.bits) { return MLI_I_UNSUPPORTED_OPERAND }
         if !opd_runnable_tag(s1.tag) || !opd_runnable_tag(s2.tag) { return MLI_I_UNSUPPORTED_OPERAND }
         var x: i64 = 0
-        if s1.tag == MLI_OPD_IMM { x = s1.aux } else { x = rf.vi[s1.id] }
+        if s1.tag == MLI_OPD_IMM {
+            x = s1.aux
+        } else {
+            if !rf_defined(rf, s1.id) { return MLI_I_UNDEF_VREG }
+            x = rf.vi[s1.id]
+        }
         var y: i64 = 0
-        if s2.tag == MLI_OPD_IMM { y = s2.aux } else { y = rf.vi[s2.id] }
+        if s2.tag == MLI_OPD_IMM {
+            y = s2.aux
+        } else {
+            if !rf_defined(rf, s2.id) { return MLI_I_UNDEF_VREG }
+            y = rf.vi[s2.id]
+        }
         let min_i64 = (0 - 9223372036854775807) - 1
         if op == MLI_OP_DIV || op == MLI_OP_REM {
             if y == 0 { return MLI_I_DIV_ZERO }
@@ -180,6 +227,7 @@ fn mli_exec_slot(rf: &!MliRegFile, f: &MliFunction, slot: i64) -> i64 with Mut, 
         if op == MLI_OP_XOR { r = x ^ y; matched = true }
         if !matched { return MLI_I_UNSUPPORTED_OP }
         rf.vi[d.id] = r
+        rf_mark(rf, d.id)
         return MLI_I_OK
     }
 
@@ -189,9 +237,19 @@ fn mli_exec_slot(rf: &!MliRegFile, f: &MliFunction, slot: i64) -> i64 with Mut, 
         if !krun_f64(d.kind.tag, d.kind.bits) { return MLI_I_UNSUPPORTED_OPERAND }
         if !opd_runnable_tag(s1.tag) || !opd_runnable_tag(s2.tag) { return MLI_I_UNSUPPORTED_OPERAND }
         var x: f64 = 0.0
-        if s1.tag == MLI_OPD_IMM { x = s1.fimm } else { x = rf.vf[s1.id] }
+        if s1.tag == MLI_OPD_IMM {
+            x = s1.fimm
+        } else {
+            if !rf_defined(rf, s1.id) { return MLI_I_UNDEF_VREG }
+            x = rf.vf[s1.id]
+        }
         var y: f64 = 0.0
-        if s2.tag == MLI_OPD_IMM { y = s2.fimm } else { y = rf.vf[s2.id] }
+        if s2.tag == MLI_OPD_IMM {
+            y = s2.fimm
+        } else {
+            if !rf_defined(rf, s2.id) { return MLI_I_UNDEF_VREG }
+            y = rf.vf[s2.id]
+        }
         var r: f64 = 0.0
         var matched = false
         if op == MLI_OP_FADD { r = x + y; matched = true }
@@ -200,6 +258,7 @@ fn mli_exec_slot(rf: &!MliRegFile, f: &MliFunction, slot: i64) -> i64 with Mut, 
         if op == MLI_OP_FDIV { r = x / y; matched = true }
         if !matched { return MLI_I_UNSUPPORTED_OP }
         rf.vf[d.id] = r
+        rf_mark(rf, d.id)
         return MLI_I_OK
     }
 
@@ -209,8 +268,14 @@ fn mli_exec_slot(rf: &!MliRegFile, f: &MliFunction, slot: i64) -> i64 with Mut, 
         if !krun_f64(d.kind.tag, d.kind.bits) { return MLI_I_UNSUPPORTED_OPERAND }
         if !opd_runnable_tag(s1.tag) { return MLI_I_UNSUPPORTED_OPERAND }
         var x: i64 = 0
-        if s1.tag == MLI_OPD_IMM { x = s1.aux } else { x = rf.vi[s1.id] }
+        if s1.tag == MLI_OPD_IMM {
+            x = s1.aux
+        } else {
+            if !rf_defined(rf, s1.id) { return MLI_I_UNDEF_VREG }
+            x = rf.vi[s1.id]
+        }
         rf.vf[d.id] = x as f64
+        rf_mark(rf, d.id)
         return MLI_I_OK
     }
 
@@ -220,8 +285,14 @@ fn mli_exec_slot(rf: &!MliRegFile, f: &MliFunction, slot: i64) -> i64 with Mut, 
         if !krun_int(d.kind.tag, d.kind.bits) { return MLI_I_UNSUPPORTED_OPERAND }
         if !opd_runnable_tag(s1.tag) { return MLI_I_UNSUPPORTED_OPERAND }
         var x: f64 = 0.0
-        if s1.tag == MLI_OPD_IMM { x = s1.fimm } else { x = rf.vf[s1.id] }
+        if s1.tag == MLI_OPD_IMM {
+            x = s1.fimm
+        } else {
+            if !rf_defined(rf, s1.id) { return MLI_I_UNDEF_VREG }
+            x = rf.vf[s1.id]
+        }
         rf.vi[d.id] = x as i64
+        rf_mark(rf, d.id)
         return MLI_I_OK
     }
 
@@ -231,17 +302,30 @@ fn mli_exec_slot(rf: &!MliRegFile, f: &MliFunction, slot: i64) -> i64 with Mut, 
         if d.id < 0 || d.id >= 128 { return MLI_I_VREG_RANGE }
         if !opd_runnable_tag(s1.tag) || !opd_runnable_tag(s2.tag) { return MLI_I_UNSUPPORTED_OPERAND }
         var x: i64 = 0
-        if s1.tag == MLI_OPD_IMM { x = s1.aux } else { x = rf.vi[s1.id] }
+        if s1.tag == MLI_OPD_IMM {
+            x = s1.aux
+        } else {
+            if !rf_defined(rf, s1.id) { return MLI_I_UNDEF_VREG }
+            x = rf.vi[s1.id]
+        }
         var y: i64 = 0
-        if s2.tag == MLI_OPD_IMM { y = s2.aux } else { y = rf.vi[s2.id] }
+        if s2.tag == MLI_OPD_IMM {
+            y = s2.aux
+        } else {
+            if !rf_defined(rf, s2.id) { return MLI_I_UNDEF_VREG }
+            y = rf.vi[s2.id]
+        }
         var hold = false
-        if cc == MLI_CC_EQ { hold = x == y }
-        if cc == MLI_CC_NE { hold = x != y }
-        if cc == MLI_CC_LT { hold = x < y }
-        if cc == MLI_CC_LE { hold = x <= y }
-        if cc == MLI_CC_GT { hold = x > y }
-        if cc == MLI_CC_GE { hold = x >= y }
+        var cc_hit = false
+        if cc == MLI_CC_EQ { hold = x == y; cc_hit = true }
+        if cc == MLI_CC_NE { hold = x != y; cc_hit = true }
+        if cc == MLI_CC_LT { hold = x < y; cc_hit = true }
+        if cc == MLI_CC_LE { hold = x <= y; cc_hit = true }
+        if cc == MLI_CC_GT { hold = x > y; cc_hit = true }
+        if cc == MLI_CC_GE { hold = x >= y; cc_hit = true }
+        if !cc_hit { return MLI_I_BAD_CC }
         rf.vi[d.id] = if hold { 1 } else { 0 }
+        rf_mark(rf, d.id)
         return MLI_I_OK
     }
 
@@ -251,17 +335,30 @@ fn mli_exec_slot(rf: &!MliRegFile, f: &MliFunction, slot: i64) -> i64 with Mut, 
         if d.id < 0 || d.id >= 128 { return MLI_I_VREG_RANGE }
         if !opd_runnable_tag(s1.tag) || !opd_runnable_tag(s2.tag) { return MLI_I_UNSUPPORTED_OPERAND }
         var x: f64 = 0.0
-        if s1.tag == MLI_OPD_IMM { x = s1.fimm } else { x = rf.vf[s1.id] }
+        if s1.tag == MLI_OPD_IMM {
+            x = s1.fimm
+        } else {
+            if !rf_defined(rf, s1.id) { return MLI_I_UNDEF_VREG }
+            x = rf.vf[s1.id]
+        }
         var y: f64 = 0.0
-        if s2.tag == MLI_OPD_IMM { y = s2.fimm } else { y = rf.vf[s2.id] }
+        if s2.tag == MLI_OPD_IMM {
+            y = s2.fimm
+        } else {
+            if !rf_defined(rf, s2.id) { return MLI_I_UNDEF_VREG }
+            y = rf.vf[s2.id]
+        }
         var hold = false
-        if cc == MLI_CC_EQ { hold = x == y }
-        if cc == MLI_CC_NE { hold = x != y }
-        if cc == MLI_CC_LT { hold = x < y }
-        if cc == MLI_CC_LE { hold = x <= y }
-        if cc == MLI_CC_GT { hold = x > y }
-        if cc == MLI_CC_GE { hold = x >= y }
+        var cc_hit = false
+        if cc == MLI_CC_EQ { hold = x == y; cc_hit = true }
+        if cc == MLI_CC_NE { hold = x != y; cc_hit = true }
+        if cc == MLI_CC_LT { hold = x < y; cc_hit = true }
+        if cc == MLI_CC_LE { hold = x <= y; cc_hit = true }
+        if cc == MLI_CC_GT { hold = x > y; cc_hit = true }
+        if cc == MLI_CC_GE { hold = x >= y; cc_hit = true }
+        if !cc_hit { return MLI_I_BAD_CC }
         rf.vi[d.id] = if hold { 1 } else { 0 }
+        rf_mark(rf, d.id)
         return MLI_I_OK
     }
 
@@ -276,6 +373,7 @@ pub fn mli_interp_run(f: &MliFunction, args: &MliInterpArgs) -> MliInterpResult 
     var rf = MliRegFile {
         vi: [0; 128],
         vf: [0.0; 128],
+        def: [0; 128],
     }
 
     // Arguments: arg a is vreg a (MLI invariant).
@@ -284,14 +382,16 @@ pub fn mli_interp_run(f: &MliFunction, args: &MliInterpArgs) -> MliInterpResult 
         let ak = f.arg_kinds[a]
         if krun_int(ak.tag, ak.bits) {
             rf.vi[a] = args.ai[a]
+            rf_mark(&!rf, a)
         } else {
             if krun_f64(ak.tag, ak.bits) {
                 rf.vf[a] = args.af[a]
+                rf_mark(&!rf, a)
             }
             // else: Knowledge/CD/ptr/vec/qd128 have no value model.
             // Do not write a register and do not invent a zero payload
-            // (#1788 fabrication). The first opcode that consumes the
-            // arg must refuse detectably. RET_KIND covers a bare return.
+            // (#1788 fabrication). def stays 0 so a later scalar read
+            // of this vreg is UNDEF, not a silent 0.
         }
         a = a + 1
     }
@@ -322,7 +422,7 @@ pub fn mli_interp_run(f: &MliFunction, args: &MliInterpArgs) -> MliInterpResult 
         if top == MLI_OP_RET {
             let rk = f.ret
             if rk.tag == MLI_KIND_VOID {
-                return i_ok_int(0)
+                return i_ok_void()
             }
             let ts1 = mli_slot_src1(f, ts)
             if !opd_runnable_tag(ts1.tag) {
@@ -330,12 +430,22 @@ pub fn mli_interp_run(f: &MliFunction, args: &MliInterpArgs) -> MliInterpResult 
             }
             if krun_f64(rk.tag, rk.bits) {
                 var rfv: f64 = 0.0
-                if ts1.tag == MLI_OPD_IMM { rfv = ts1.fimm } else { rfv = rf.vf[ts1.id] }
+                if ts1.tag == MLI_OPD_IMM {
+                    rfv = ts1.fimm
+                } else {
+                    if !rf_defined(&rf, ts1.id) { return i_err(MLI_I_UNDEF_VREG, cur, 0 - 1) }
+                    rfv = rf.vf[ts1.id]
+                }
                 return i_ok_float(rfv)
             }
             if krun_int(rk.tag, rk.bits) {
                 var ri: i64 = 0
-                if ts1.tag == MLI_OPD_IMM { ri = ts1.aux } else { ri = rf.vi[ts1.id] }
+                if ts1.tag == MLI_OPD_IMM {
+                    ri = ts1.aux
+                } else {
+                    if !rf_defined(&rf, ts1.id) { return i_err(MLI_I_UNDEF_VREG, cur, 0 - 1) }
+                    ri = rf.vi[ts1.id]
+                }
                 return i_ok_int(ri)
             }
             return i_err(MLI_I_RET_KIND, cur, 0 - 1)
@@ -354,6 +464,7 @@ pub fn mli_interp_run(f: &MliFunction, args: &MliInterpArgs) -> MliInterpResult 
                 cv = c.aux
             } else {
                 if c.tag != MLI_OPD_VREG { return i_err(MLI_I_UNSUPPORTED_OPERAND, cur, 0 - 1) }
+                if !rf_defined(&rf, c.id) { return i_err(MLI_I_UNDEF_VREG, cur, 0 - 1) }
                 cv = rf.vi[c.id]
             }
             if cv != 0 {

--- a/self-hosted/mli/interp.sio
+++ b/self-hosted/mli/interp.sio
@@ -1,7 +1,9 @@
 // MLI S2a — minimal interpreter (V-interp, design §6.2), refuse-first.
 //
-// BINDING CONSTRAINT (orchestrator, 2026-08-16): this interpreter must not
-// become a second semantics. Two rules implement that:
+// BINDING CONSTRAINT (orchestrator, 2026-08-16; restated after #1788):
+// this interpreter must not become a second semantics. A well-typed
+// program produces a value or a detectable refuse — it never fabricates
+// a zero. Two rules implement that:
 //
 //   1. Where MLI behaviour is genuinely underspecified today, the interp
 //      REFUSES with a named code instead of picking — so the ambiguity fails
@@ -11,6 +13,8 @@
 //      f128/f256/qd128/Knowledge/CD/vec/ptr VALUES, phys/stack/reloc
 //      operands, unclassified compare-codes (not "false"), i64 div-by-zero
 //      and INT_MIN/-1. Control flow is implemented (S2b) with a fuel cap.
+//      Unimplemented argument kinds are skipped (no register write) so the
+//      first consuming opcode can refuse; they are not loaded as zero.
 //   2. Where behaviour IS defined, the interp delegates to the host — and
 //      the host is the claim oracle itself (Sounio under Madaros, ADR-008
 //      single semantic clock). i64 two's-complement arithmetic, IEEE f64
@@ -283,9 +287,11 @@ pub fn mli_interp_run(f: &MliFunction, args: &MliInterpArgs) -> MliInterpResult 
         } else {
             if krun_f64(ak.tag, ak.bits) {
                 rf.vf[a] = args.af[a]
-            } else {
-                return i_err(MLI_I_ARG_KIND, 0 - 1, a)
             }
+            // else: Knowledge/CD/ptr/vec/qd128 have no value model.
+            // Do not write a register and do not invent a zero payload
+            // (#1788 fabrication). The first opcode that consumes the
+            // arg must refuse detectably. RET_KIND covers a bare return.
         }
         a = a + 1
     }

--- a/self-hosted/mli/ir.sio
+++ b/self-hosted/mli/ir.sio
@@ -184,6 +184,10 @@ pub let MLI_OP_CD_NORM2: i64 = 154
 pub let MLI_OP_CD_ASSOCIATOR: i64 = 155
 pub let MLI_OP_CD_VAR_ASSOCIATOR: i64 = 156
 pub let MLI_OP_CD_ZD_PROBE: i64 = 157
+// Scalar projection: the ONLY legal CD → float path (lane index in src2.aux).
+// Analogous to k_discharge / k_extract_*. Without this, a CD value can never
+// leave the kind and S3 cannot witness a component in the instruction stream.
+pub let MLI_OP_CD_EXTRACT: i64 = 158
 
 // Compare condition codes (icmp/fcmp produce a Bool vreg — rule 3).
 pub let MLI_CC_NONE: i64 = 0
@@ -193,6 +197,12 @@ pub let MLI_CC_LT: i64 = 3
 pub let MLI_CC_LE: i64 = 4
 pub let MLI_CC_GT: i64 = 5
 pub let MLI_CC_GE: i64 = 6
+
+// Closed set. Anything else (including NONE) is not a runnable compare —
+// verify and interp must refuse, not treat it as "false".
+pub fn mli_cc_known(cc: i64) -> bool {
+    cc == MLI_CC_EQ || cc == MLI_CC_NE || cc == MLI_CC_LT || cc == MLI_CC_LE || cc == MLI_CC_GT || cc == MLI_CC_GE
+}
 
 // Instruction attributes (design §4.3): associativity / zero-divisor policy.
 pub let MLI_ASSOC_NONE: i64 = 0

--- a/self-hosted/mli/legalize_x86.sio
+++ b/self-hosted/mli/legalize_x86.sio
@@ -1,39 +1,38 @@
-// MLI S3 — legalize_x86: emitter MIMICRY for the Phase-2 golden (design
-// §6.4, pin O5). This is deliberately NOT a generic legaliser: it reproduces
-// the pinned Madaros native-v2 emitter's exact choices for the golden
-// surface — register choices, constant materialisation, scheduling, frame
-// layout — measured 2026-08-17 on this lane by disassembling a session
-// compile of `fn add1(x: f64) -> f64 { x + 1.0 }`:
+// MLI S3/S3b — legalize_x86: emitter MIMICRY for the golden surface (design
+// §6.4, pin O5), extended in S3b to the measured multi-arg, integer and
+// BRANCH encodings so the expanded Knowledge lanes can reach machine code.
 //
-//   - internal calling convention: arg 0 arrives in RDI as raw f64 BITS
-//     (not SysV xmm0); return value leaves in RAX as raw bits;
-//   - f64 constants materialise as `movabs rax, <ieee-bits>` + store to a
-//     stack slot — immediate-in-stream, NO rip-relative pool (this resolves
-//     the O5 constant question by measurement, not by choice);
-//   - float values live in [rbp - 8k] slots; each fadd loads via
-//     rax -> movq xmm, computes addsd xmm0,xmm1, stores back through rax;
-//   - prologue: push rbp; mov rbp,rsp; sub rsp,frame; then a 0x1000-page
-//     stack-probe loop; epilogue: mov rsp,rbp; pop rbp; ret;
-//   - displacements always disp32, frame rounded up to 16.
+// Every encoding below was measured by disassembling session compiles of
+// probe functions under the pinned Madaros native-v2 emitter (2026-08-17,
+// this lane): add1 (f64 + movabs constants), poly (2 f64 args, fsub/fmul),
+// six (6-arg register order rdi/rsi/rdx/rcx/r8/r9, small-int `mov $imm32`),
+// imin (cmp via push/pop with SWAPPED setcc, test+je rel32, jmp rel32,
+// per-ret epilogues), qd (idiv via rcx/cqto). Mimicry facts:
 //
-// THE COMMITMENT TEST (S3 dispatch): a Knowledge/CD/QD128 operand reaching
-// this stage UNEXPANDED is refused with a DEDICATED code
-// (MLI_L_KNOWLEDGE_UNEXPANDED) — never silently lowered to its base value.
-// Stripping the variance here would be one `if` cheaper than refusing; that
-// `if` is the entire difference between a first-class kind and decoration.
-// The sanctioned route to bytes for epistemic values is mli::expand_k
-// first (lanes become real scalar computation), then this legaliser.
+//   - args arrive in rdi, rsi, rdx, rcx, r8, r9 as RAW BITS regardless of
+//     kind (f64 too — not SysV xmm); spilled to [rbp-8k] in order;
+//   - f64 constants: movabs rax, <ieee-bits>; small ints: mov $imm32, rax;
+//   - float arith: slot -> rax -> movq xmm0/xmm1, op, movq back, store;
+//   - int arith: lhs -> push; rhs -> rax; pop rbx; op %rbx,%rax (so the
+//     machine op sees flags/results of (rhs OP lhs) — compares therefore
+//     use the SWAPPED setcc: lt -> setg, gt -> setl, le -> setge, ...);
+//   - idiv: rhs -> rcx, lhs -> rax, cqto, idiv %rcx;
+//   - branches: cond slot -> rax; test %rax,%rax; je rel32 to the false
+//     edge; unconditional jmp is e9 rel32; every RET emits its own
+//     epilogue (mov %rbp,%rsp; pop %rbp; ret) exactly like the pinned
+//     emitter's early returns;
+//   - prologue: push rbp; mov rbp,rsp; sub rsp,frame(16-aligned);
+//     0x1000-page stack-probe loop.
 //
-// Fail-closed refusals (all named):
-//   MLI_L_KNOWLEDGE_UNEXPANDED  epistemic/CD/QD/vec/bundle kind at codegen
-//   MLI_L_BRANCH_UNSUPPORTED    multi-block / jmp / br (branch encoding is
-//                               the next mimicry tranche; today it BLOCKS
-//                               the expanded conf lane from reaching bytes)
-//   MLI_L_UNSUPPORTED_OP        anything outside {mov, fadd..fdiv, ret}
-//   MLI_L_UNSUPPORTED_SHAPE     arg counts/kinds outside the measured
-//                               surface (exactly one f64 arg today)
-//   MLI_L_CONST_UNSUPPORTED     NaN/inf/subnormal/-0.0 f64 immediates
-//   MLI_L_CAPACITY              byte buffer or slot table exhausted
+// THE COMMITMENT GUARD is unchanged: a Knowledge/CD/QD operand reaching
+// this stage UNEXPANDED refuses with MLI_L_KNOWLEDGE_UNEXPANDED (checked
+// before any shape check so it cannot be shadowed). The sanctioned route is
+// mli::expand_k first; with S3b the expanded conf diamonds LEGALIZE, so all
+// three Min3 lanes now reach bytes.
+//
+// Still refused, fail-closed and named: fcmp (unmeasured ucomisd matrix),
+// rem/bit-ops (unmeasured), calls, memory ops, f32/f128/f256 values,
+// NaN/inf/subnormal constants, >6 args, capacity walls.
 
 module mli::legalize_x86
 
@@ -48,25 +47,36 @@ pub let MLI_L_CONST_UNSUPPORTED: i64 = 5
 pub let MLI_L_CAPACITY: i64 = 6
 pub let MLI_L_OPERAND: i64 = 7
 
-pub let MLI_L_MAX_BYTES: i64 = 1024
+pub let MLI_L_MAX_BYTES: i64 = 4096
+pub let MLI_L_MAX_FIXUPS: i64 = 64
 
 pub struct MliCodeBuf {
-    pub bytes: [i64; 1024],
+    pub bytes: [i64; 4096],
     pub len: i64,
     pub ok: bool,
     pub code: i64,
     pub at_block: i64,
     pub at_index: i64,
+    // rel32 fixups: patch site (offset of the 4 displacement bytes) and the
+    // target MLI block id; resolved once all block offsets are known.
+    pub fix_site: [i64; 64],
+    pub fix_block: [i64; 64],
+    pub fix_count: i64,
+    pub block_off: [i64; 16],
 }
 
 pub fn mli_codebuf_empty() -> MliCodeBuf {
     MliCodeBuf {
-        bytes: [0; 1024],
+        bytes: [0; 4096],
         len: 0,
         ok: true,
         code: MLI_L_OK,
         at_block: 0 - 1,
         at_index: 0 - 1,
+        fix_site: [0; 64],
+        fix_block: [0; 64],
+        fix_count: 0,
+        block_off: [0; 16],
     }
 }
 
@@ -107,18 +117,24 @@ fn cb_i64le(cb: &!MliCodeBuf, v: i64) with Mut, Panic {
         var byte = u % 256
         if byte < 0 { byte = byte + 256 }
         cb_u8(cb, byte)
-        // Arithmetic shift-right by 8 without shift ops: subtract the low
-        // byte then divide. Exact for negative values too.
         u = (u - (u % 256)) / 256
         k = k + 1
     }
 }
 
+// Patch a previously-emitted 4-byte site with a rel32 value.
+fn cb_patch_i32le(cb: &!MliCodeBuf, site: i64, v: i64) with Mut, Panic {
+    var u = v
+    if u < 0 { u = u + 4294967296 }
+    cb.bytes[site] = u % 256
+    cb.bytes[site + 1] = (u / 256) % 256
+    cb.bytes[site + 2] = (u / 65536) % 256
+    cb.bytes[site + 3] = (u / 16777216) % 256
+}
+
 // ---------------------------------------------------------------------------
-// f64 -> IEEE-754 bits, by arithmetic decomposition (no bitcast primitive is
-// relied on). Exact for finite normal doubles; refuses NaN/inf/subnormal
-// and -0.0 (MLI_L_CONST_UNSUPPORTED) rather than guessing.
-// Returns the bit pattern in an i64; ok flag via the out-param struct.
+// f64 -> IEEE-754 bits by arithmetic decomposition. Exact for finite normal
+// doubles; refuses NaN/inf/subnormal and -0.0 rather than guessing.
 // ---------------------------------------------------------------------------
 
 pub struct F64Bits {
@@ -131,8 +147,6 @@ pub fn mli_f64_bits(v: f64) -> F64Bits with Mut, Panic, Div {
     let min_i64 = (0 - 9223372036854775807) - 1
 
     if v == 0.0 {
-        // +0.0 only; a negative zero cannot be distinguished without division
-        // tricks — the golden surface never carries one.
         return F64Bits { ok: true, bits: 0 }
     }
     if v != v {
@@ -145,8 +159,6 @@ pub fn mli_f64_bits(v: f64) -> F64Bits with Mut, Panic, Div {
         neg = true
         m = 0.0 - m
     }
-
-    // Infinity check: doubling an infinite value keeps it equal to itself.
     if m > 8.98846567431158e307 {
         return F64Bits { ok: false, bits: 0 }
     }
@@ -162,11 +174,9 @@ pub fn mli_f64_bits(v: f64) -> F64Bits with Mut, Panic, Div {
     }
     let biased = e + 1023
     if biased <= 0 || biased >= 2047 {
-        // Subnormal or out of range — refuse, never approximate a constant.
         return F64Bits { ok: false, bits: 0 }
     }
 
-    // 52 mantissa bits, exact: frac ops touch only powers of two.
     var frac = m - 1.0
     var mant: i64 = 0
     var k: i64 = 0
@@ -189,10 +199,8 @@ pub fn mli_f64_bits(v: f64) -> F64Bits with Mut, Panic, Div {
 
 // ---------------------------------------------------------------------------
 // Slot allocation (mimicry): slot k lives at [rbp - 8k]. Args claim slots
-// first in order; thereafter slots are claimed in EMISSION order — an f64
-// immediate claims its slot at the moment it is materialised, a dst vreg on
-// its first definition. This reproduces the pinned emitter's layout for the
-// golden (x @ -8, 1.0 @ -0x10, result @ -0x18).
+// first in order; thereafter in EMISSION order (imm at materialisation, dst
+// on first definition) — reproduces the pinned layout.
 // ---------------------------------------------------------------------------
 
 pub struct MliSlotMap {
@@ -229,11 +237,20 @@ fn slot_alloc_anon(sm: &!MliSlotMap) -> i64 with Mut, Panic {
 // Instruction encodings (bytes exactly as measured).
 // ---------------------------------------------------------------------------
 
-// mov [rbp+disp32], rdi      48 89 bd <disp32>
-fn emit_store_rdi(cb: &!MliCodeBuf, disp: i64) with Mut, Panic {
-    cb_u8(cb, 72)
+// mov [rbp+disp32], <argreg k>   (measured order rdi,rsi,rdx,rcx,r8,r9)
+fn emit_store_argreg(cb: &!MliCodeBuf, k: i64, disp: i64) with Mut, Panic {
+    if k <= 3 {
+        cb_u8(cb, 72)
+    } else {
+        cb_u8(cb, 76)
+    }
     cb_u8(cb, 137)
-    cb_u8(cb, 189)
+    if k == 0 { cb_u8(cb, 189) }
+    if k == 1 { cb_u8(cb, 181) }
+    if k == 2 { cb_u8(cb, 149) }
+    if k == 3 { cb_u8(cb, 141) }
+    if k == 4 { cb_u8(cb, 133) }
+    if k == 5 { cb_u8(cb, 141) }
     cb_i32le(cb, disp)
 }
 
@@ -242,6 +259,14 @@ fn emit_movabs_rax(cb: &!MliCodeBuf, bits: i64) with Mut, Panic {
     cb_u8(cb, 72)
     cb_u8(cb, 184)
     cb_i64le(cb, bits)
+}
+
+// mov rax, imm32 (sign-extended)   48 c7 c0 <imm32>   (small ints, measured)
+fn emit_mov_rax_imm32(cb: &!MliCodeBuf, v: i64) with Mut, Panic {
+    cb_u8(cb, 72)
+    cb_u8(cb, 199)
+    cb_u8(cb, 192)
+    cb_i32le(cb, v)
 }
 
 // mov [rbp+disp32], rax      48 89 85 <disp32>
@@ -260,7 +285,16 @@ fn emit_load_rax(cb: &!MliCodeBuf, disp: i64) with Mut, Panic {
     cb_i32le(cb, disp)
 }
 
-// movq xmm0, rax             66 48 0f 6e c0
+// push rax / pop rbx
+fn emit_push_rax(cb: &!MliCodeBuf) with Mut, Panic {
+    cb_u8(cb, 80)
+}
+
+fn emit_pop_rbx(cb: &!MliCodeBuf) with Mut, Panic {
+    cb_u8(cb, 91)
+}
+
+// movq xmm0/xmm1, rax and back
 fn emit_movq_xmm0_rax(cb: &!MliCodeBuf) with Mut, Panic {
     cb_u8(cb, 102)
     cb_u8(cb, 72)
@@ -269,7 +303,6 @@ fn emit_movq_xmm0_rax(cb: &!MliCodeBuf) with Mut, Panic {
     cb_u8(cb, 192)
 }
 
-// movq xmm1, rax             66 48 0f 6e c8
 fn emit_movq_xmm1_rax(cb: &!MliCodeBuf) with Mut, Panic {
     cb_u8(cb, 102)
     cb_u8(cb, 72)
@@ -278,7 +311,6 @@ fn emit_movq_xmm1_rax(cb: &!MliCodeBuf) with Mut, Panic {
     cb_u8(cb, 200)
 }
 
-// movq rax, xmm0             66 48 0f 7e c0
 fn emit_movq_rax_xmm0(cb: &!MliCodeBuf) with Mut, Panic {
     cb_u8(cb, 102)
     cb_u8(cb, 72)
@@ -287,7 +319,7 @@ fn emit_movq_rax_xmm0(cb: &!MliCodeBuf) with Mut, Panic {
     cb_u8(cb, 192)
 }
 
-// addsd/subsd/mulsd/divsd xmm0, xmm1     f2 0f <op> c1
+// addsd/subsd/mulsd/divsd xmm0, xmm1:  f2 0f <op> c1
 fn emit_f64_binop_xmm(cb: &!MliCodeBuf, opbyte: i64) with Mut, Panic {
     cb_u8(cb, 242)
     cb_u8(cb, 15)
@@ -295,8 +327,87 @@ fn emit_f64_binop_xmm(cb: &!MliCodeBuf, opbyte: i64) with Mut, Panic {
     cb_u8(cb, 193)
 }
 
-// Prologue exactly as measured: push rbp; mov rbp,rsp; sub rsp,frame;
-// stack-probe loop; (arg spills appended by the caller).
+// add %rbx,%rax (48 01 d8) / imul %rbx,%rax (48 0f af c3)
+fn emit_add_rbx_rax(cb: &!MliCodeBuf) with Mut, Panic {
+    cb_u8(cb, 72)
+    cb_u8(cb, 1)
+    cb_u8(cb, 216)
+}
+
+fn emit_imul_rbx_rax(cb: &!MliCodeBuf) with Mut, Panic {
+    cb_u8(cb, 72)
+    cb_u8(cb, 15)
+    cb_u8(cb, 175)
+    cb_u8(cb, 195)
+}
+
+// mov rcx,rax; (reload lhs); cqto; idiv rcx  — the measured idiv shape.
+fn emit_mov_rcx_rax(cb: &!MliCodeBuf) with Mut, Panic {
+    cb_u8(cb, 72)
+    cb_u8(cb, 137)
+    cb_u8(cb, 193)
+}
+
+fn emit_cqto_idiv_rcx(cb: &!MliCodeBuf) with Mut, Panic {
+    cb_u8(cb, 72)
+    cb_u8(cb, 153)
+    cb_u8(cb, 72)
+    cb_u8(cb, 247)
+    cb_u8(cb, 249)
+}
+
+// cmp %rbx,%rax (48 39 d8) + setcc %al + movzbq %al,%rax
+fn emit_cmp_rbx_rax(cb: &!MliCodeBuf) with Mut, Panic {
+    cb_u8(cb, 72)
+    cb_u8(cb, 57)
+    cb_u8(cb, 216)
+}
+
+fn emit_setcc_movzbq(cb: &!MliCodeBuf, setcc_byte: i64) with Mut, Panic {
+    cb_u8(cb, 15)
+    cb_u8(cb, setcc_byte)
+    cb_u8(cb, 192)
+    cb_u8(cb, 72)
+    cb_u8(cb, 15)
+    cb_u8(cb, 182)
+    cb_u8(cb, 192)
+}
+
+// test %rax,%rax (48 85 c0)
+fn emit_test_rax(cb: &!MliCodeBuf) with Mut, Panic {
+    cb_u8(cb, 72)
+    cb_u8(cb, 133)
+    cb_u8(cb, 192)
+}
+
+// je rel32 (0f 84 <rel32 placeholder>) — records a fixup to `block`.
+fn emit_je_block(cb: &!MliCodeBuf, block: i64) with Mut, Panic {
+    cb_u8(cb, 15)
+    cb_u8(cb, 132)
+    if cb.fix_count >= MLI_L_MAX_FIXUPS {
+        cb_fail(cb, MLI_L_CAPACITY, 0 - 1, 0 - 1)
+        return
+    }
+    cb.fix_site[cb.fix_count] = cb.len
+    cb.fix_block[cb.fix_count] = block
+    cb.fix_count = cb.fix_count + 1
+    cb_i32le(cb, 0)
+}
+
+// jmp rel32 (e9 <rel32 placeholder>) — records a fixup to `block`.
+fn emit_jmp_block(cb: &!MliCodeBuf, block: i64) with Mut, Panic {
+    cb_u8(cb, 233)
+    if cb.fix_count >= MLI_L_MAX_FIXUPS {
+        cb_fail(cb, MLI_L_CAPACITY, 0 - 1, 0 - 1)
+        return
+    }
+    cb.fix_site[cb.fix_count] = cb.len
+    cb.fix_block[cb.fix_count] = block
+    cb.fix_count = cb.fix_count + 1
+    cb_i32le(cb, 0)
+}
+
+// Prologue exactly as measured (frame + stack-probe loop).
 fn emit_prologue(cb: &!MliCodeBuf, frame: i64) with Mut, Panic {
     cb_u8(cb, 85)
     cb_u8(cb, 72)
@@ -306,31 +417,25 @@ fn emit_prologue(cb: &!MliCodeBuf, frame: i64) with Mut, Panic {
     cb_u8(cb, 129)
     cb_u8(cb, 236)
     cb_i32le(cb, frame)
-    // mov rax, rbp
     cb_u8(cb, 72)
     cb_u8(cb, 137)
     cb_u8(cb, 232)
-    // sub rax, 0x1000
     cb_u8(cb, 72)
     cb_u8(cb, 45)
     cb_i32le(cb, 4096)
-    // cmp rax, rsp
     cb_u8(cb, 72)
     cb_u8(cb, 57)
     cb_u8(cb, 224)
-    // jbe +5
     cb_u8(cb, 118)
     cb_u8(cb, 5)
-    // orb [rax], 0
     cb_u8(cb, 128)
     cb_u8(cb, 8)
     cb_u8(cb, 0)
-    // jmp -16
     cb_u8(cb, 235)
     cb_u8(cb, 240)
 }
 
-// Epilogue: mov rsp,rbp; pop rbp; ret
+// Epilogue: mov rsp,rbp; pop rbp; ret — emitted per RET (measured).
 fn emit_epilogue(cb: &!MliCodeBuf) with Mut, Panic {
     cb_u8(cb, 72)
     cb_u8(cb, 137)
@@ -343,11 +448,18 @@ fn kind_is_scalar_f64(k: MliKind) -> bool {
     k.tag == MLI_KIND_FLOAT && k.bits == 64
 }
 
-// The commitment check: any kind that carries structure the scalar emitter
-// would have to throw away.
+fn kind_is_scalar_int(k: MliKind) -> bool {
+    if k.tag == MLI_KIND_BOOL { return true }
+    k.tag == MLI_KIND_INT && k.bits == 64
+}
+
 fn kind_is_unexpanded_structure(k: MliKind) -> bool {
     k.tag == MLI_KIND_KNOWLEDGE || k.tag == MLI_KIND_CD || k.tag == MLI_KIND_QD128
         || k.tag == MLI_KIND_VECF64 || k.tag == MLI_KIND_BUNDLE
+}
+
+fn kind_is_emittable(k: MliKind) -> bool {
+    kind_is_scalar_f64(k) || kind_is_scalar_int(k)
 }
 
 fn fadd_family_opbyte(op: i64) -> i64 {
@@ -358,16 +470,37 @@ fn fadd_family_opbyte(op: i64) -> i64 {
     0 - 1
 }
 
-// Ensure a source operand is in a slot; materialise f64 immediates exactly
-// like the pinned emitter (movabs + store, slot claimed at this moment).
-// Returns the slot, or 0-1 with the buffer failed.
+// SWAPPED setcc mapping (measured): int compares run with rbx=lhs, rax=rhs,
+// cmp %rbx,%rax => flags of (rhs - lhs).
+fn icmp_setcc_byte(cc: i64) -> i64 {
+    if cc == MLI_CC_EQ { return 148 }
+    if cc == MLI_CC_NE { return 149 }
+    if cc == MLI_CC_LT { return 159 }
+    if cc == MLI_CC_LE { return 157 }
+    if cc == MLI_CC_GT { return 156 }
+    if cc == MLI_CC_GE { return 158 }
+    0 - 1
+}
+
+// Materialise an integer immediate into rax (small ints via mov $imm32 as
+// measured; wide via movabs).
+fn emit_int_imm_to_rax(cb: &!MliCodeBuf, v: i64) with Mut, Panic {
+    if v >= 0 && v < 2147483648 {
+        emit_mov_rax_imm32(cb, v)
+    } else {
+        emit_movabs_rax(cb, v)
+    }
+}
+
+// Ensure a source operand is in a slot, materialising immediates exactly as
+// the pinned emitter does. Returns the slot, or 0-1 with the buffer failed.
 fn ensure_src_slot(cb: &!MliCodeBuf, sm: &!MliSlotMap, o: MliOperand, b: i64, i: i64) -> i64 with Mut, Panic, Div {
     if o.tag == MLI_OPD_VREG {
         if kind_is_unexpanded_structure(o.kind) {
             cb_fail(cb, MLI_L_KNOWLEDGE_UNEXPANDED, b, i)
             return 0 - 1
         }
-        if !kind_is_scalar_f64(o.kind) {
+        if !kind_is_emittable(o.kind) {
             cb_fail(cb, MLI_L_UNSUPPORTED_SHAPE, b, i)
             return 0 - 1
         }
@@ -383,121 +516,153 @@ fn ensure_src_slot(cb: &!MliCodeBuf, sm: &!MliSlotMap, o: MliOperand, b: i64, i:
             cb_fail(cb, MLI_L_KNOWLEDGE_UNEXPANDED, b, i)
             return 0 - 1
         }
-        if !kind_is_scalar_f64(o.kind) {
-            cb_fail(cb, MLI_L_UNSUPPORTED_SHAPE, b, i)
-            return 0 - 1
+        if kind_is_scalar_f64(o.kind) {
+            let fb = mli_f64_bits(o.fimm)
+            if !fb.ok {
+                cb_fail(cb, MLI_L_CONST_UNSUPPORTED, b, i)
+                return 0 - 1
+            }
+            let s = slot_alloc_anon(sm)
+            emit_movabs_rax(cb, fb.bits)
+            emit_store_rax(cb, slot_disp(s))
+            return s
         }
-        let fb = mli_f64_bits(o.fimm)
-        if !fb.ok {
-            cb_fail(cb, MLI_L_CONST_UNSUPPORTED, b, i)
-            return 0 - 1
+        if kind_is_scalar_int(o.kind) {
+            let s = slot_alloc_anon(sm)
+            emit_int_imm_to_rax(cb, o.aux)
+            emit_store_rax(cb, slot_disp(s))
+            return s
         }
-        let s = slot_alloc_anon(sm)
-        emit_movabs_rax(cb, fb.bits)
-        emit_store_rax(cb, slot_disp(s))
-        return s
+        cb_fail(cb, MLI_L_UNSUPPORTED_SHAPE, b, i)
+        return 0 - 1
     }
     cb_fail(cb, MLI_L_OPERAND, b, i)
     0 - 1
 }
 
 // ---------------------------------------------------------------------------
-// Slot-count pre-pass: replicates the allocation order WITHOUT emitting, so
-// the frame size in the prologue matches the slots the body will claim
-// (mimics the pinned emitter's fixed frame). Kind/shape refusals fire here
-// first so the caller gets the earliest honest error.
+// Slot-count pre-pass over ALL blocks (mirrors emission order so the frame
+// matches). Kind refusals fire here first — the commitment check outranks
+// every shape check.
 // ---------------------------------------------------------------------------
 
 fn count_slots(f: &MliFunction, cb: &!MliCodeBuf) -> i64 with Mut, Panic {
-    var n: i64 = 0
-
-    // The commitment check outranks shape checks: a Knowledge/CD/QD arg must
-    // fire ITS code even when the arity is also outside the golden surface.
     var ai: i64 = 0
     while ai < f.arg_count {
         if kind_is_unexpanded_structure(f.arg_kinds[ai]) {
             cb_fail(cb, MLI_L_KNOWLEDGE_UNEXPANDED, 0 - 1, ai)
             return 0
         }
-        ai = ai + 1
-    }
-    // Args (surface: exactly one f64 arg, measured; anything else refuses).
-    if f.arg_count != 1 {
-        cb_fail(cb, MLI_L_UNSUPPORTED_SHAPE, 0 - 1, 0 - 1)
-        return 0
-    }
-    if !kind_is_scalar_f64(f.arg_kinds[0]) {
-        cb_fail(cb, MLI_L_UNSUPPORTED_SHAPE, 0 - 1, 0 - 1)
-        return 0
-    }
-    n = 1
-
-    // Body walk mirrors the emission logic below: every f64 immediate claims
-    // a slot; every first dst definition claims a slot.
-    var seen: [i64; 128] = [0; 128]
-    seen[0] = 1
-
-    var j: i64 = 0
-    while j < f.blk_instr_count[0] {
-        let slot = mli_slot(0, j)
-        let op = mli_slot_opcode(f, slot)
-        let d = mli_slot_dst(f, slot)
-        let s1 = mli_slot_src1(f, slot)
-        let s2 = mli_slot_src2(f, slot)
-
-        if kind_is_unexpanded_structure(d.kind) || kind_is_unexpanded_structure(s1.kind) || kind_is_unexpanded_structure(s2.kind) {
-            cb_fail(cb, MLI_L_KNOWLEDGE_UNEXPANDED, 0, j)
+        if !kind_is_emittable(f.arg_kinds[ai]) {
+            cb_fail(cb, MLI_L_UNSUPPORTED_SHAPE, 0 - 1, ai)
             return 0
         }
-
-        if op == MLI_OP_NOP || op == MLI_OP_KEEP_ALIVE {
-            j = j + 1
-            continue
-        }
-
-        if op == MLI_OP_MOV || op == MLI_OP_COPY {
-            if s1.tag == MLI_OPD_IMM { n = n + 1 }
-            if d.tag == MLI_OPD_VREG && seen[d.id] == 0 {
-                seen[d.id] = 1
-                n = n + 1
-            }
-            j = j + 1
-            continue
-        }
-
-        if fadd_family_opbyte(op) > 0 {
-            if s1.tag == MLI_OPD_IMM { n = n + 1 }
-            if s2.tag == MLI_OPD_IMM { n = n + 1 }
-            if d.tag == MLI_OPD_VREG && seen[d.id] == 0 {
-                seen[d.id] = 1
-                n = n + 1
-            }
-            j = j + 1
-            continue
-        }
-
-        cb_fail(cb, MLI_L_UNSUPPORTED_OP, 0, j)
+        ai = ai + 1
+    }
+    if f.arg_count < 1 || f.arg_count > 6 {
+        cb_fail(cb, MLI_L_UNSUPPORTED_SHAPE, 0 - 1, 0 - 1)
         return 0
+    }
+
+    var n = f.arg_count
+    var seen: [i64; 128] = [0; 128]
+    var s: i64 = 0
+    while s < f.arg_count {
+        seen[s] = 1
+        s = s + 1
+    }
+
+    var b: i64 = 0
+    while b < f.block_count {
+        var j: i64 = 0
+        while j < f.blk_instr_count[b] {
+            let slot = mli_slot(b, j)
+            let op = mli_slot_opcode(f, slot)
+            let d = mli_slot_dst(f, slot)
+            let s1 = mli_slot_src1(f, slot)
+            let s2 = mli_slot_src2(f, slot)
+
+            if kind_is_unexpanded_structure(d.kind) || kind_is_unexpanded_structure(s1.kind) || kind_is_unexpanded_structure(s2.kind) {
+                cb_fail(cb, MLI_L_KNOWLEDGE_UNEXPANDED, b, j)
+                return 0
+            }
+
+            if op == MLI_OP_NOP || op == MLI_OP_KEEP_ALIVE {
+                j = j + 1
+                continue
+            }
+
+            var known = false
+            if op == MLI_OP_MOV || op == MLI_OP_COPY { known = true }
+            if fadd_family_opbyte(op) > 0 { known = true }
+            if op == MLI_OP_ADD || op == MLI_OP_MUL || op == MLI_OP_DIV { known = true }
+            if op == MLI_OP_ICMP { known = true }
+            if !known {
+                cb_fail(cb, MLI_L_UNSUPPORTED_OP, b, j)
+                return 0
+            }
+
+            if s1.tag == MLI_OPD_IMM { n = n + 1 }
+            if s2.tag == MLI_OPD_IMM && !(op == MLI_OP_MOV || op == MLI_OP_COPY) { n = n + 1 }
+            if d.tag == MLI_OPD_VREG && seen[d.id] == 0 {
+                seen[d.id] = 1
+                n = n + 1
+            }
+            j = j + 1
+        }
+        b = b + 1
     }
     n
 }
 
+// Emit one int binop through the measured push/pop shape. lhs slot pushed,
+// rhs loaded to rax, pop rbx, op.
+fn emit_int_binop(cb: &!MliCodeBuf, op: i64, cc: i64, lhs_slot: i64, rhs_slot: i64, b: i64, j: i64) with Mut, Panic {
+    if op == MLI_OP_DIV {
+        // Measured idiv shape: rhs -> rcx, lhs -> rax, cqto, idiv rcx.
+        emit_load_rax(cb, slot_disp(rhs_slot))
+        emit_mov_rcx_rax(cb)
+        emit_load_rax(cb, slot_disp(lhs_slot))
+        emit_cqto_idiv_rcx(cb)
+        return
+    }
+    emit_load_rax(cb, slot_disp(lhs_slot))
+    emit_push_rax(cb)
+    emit_load_rax(cb, slot_disp(rhs_slot))
+    emit_pop_rbx(cb)
+    if op == MLI_OP_ADD {
+        emit_add_rbx_rax(cb)
+        return
+    }
+    if op == MLI_OP_MUL {
+        emit_imul_rbx_rax(cb)
+        return
+    }
+    if op == MLI_OP_ICMP {
+        let scb = icmp_setcc_byte(cc)
+        if scb < 0 {
+            cb_fail(cb, MLI_L_UNSUPPORTED_OP, b, j)
+            return
+        }
+        emit_cmp_rbx_rax(cb)
+        emit_setcc_movzbq(cb, scb)
+        return
+    }
+    cb_fail(cb, MLI_L_UNSUPPORTED_OP, b, j)
+}
+
 // ---------------------------------------------------------------------------
-// Entry point: legalize + encode one MLI function into x86-64 bytes,
-// mimicking the pinned emitter. Straight-line single-block functions only —
-// branches are the next mimicry tranche (MLI_L_BRANCH_UNSUPPORTED).
+// Entry point: legalize + encode one MLI function (full CFG) into x86-64
+// bytes, mimicking the pinned emitter. Blocks are laid out in id order;
+// br emits test+je(false edge) with fallthrough or jmp for the true edge.
 // ---------------------------------------------------------------------------
 
 pub fn mli_legalize_x86(f: &MliFunction, cb: &!MliCodeBuf) -> bool with Mut, Panic, Div {
-    if f.block_count != 1 {
-        cb_fail(cb, MLI_L_BRANCH_UNSUPPORTED, 0 - 1, 0 - 1)
+    if f.block_count < 1 || f.block_count > MLI_MAX_BLOCKS {
+        cb_fail(cb, MLI_L_UNSUPPORTED_SHAPE, 0 - 1, 0 - 1)
         return false
     }
-    if f.blk_has_term[0] != 1 {
-        cb_fail(cb, MLI_L_UNSUPPORTED_SHAPE, 0, 0 - 1)
-        return false
-    }
-    if !kind_is_scalar_f64(f.ret) {
+    if !kind_is_emittable(f.ret) {
         if kind_is_unexpanded_structure(f.ret) {
             cb_fail(cb, MLI_L_KNOWLEDGE_UNEXPANDED, 0 - 1, 0 - 1)
         } else {
@@ -509,7 +674,6 @@ pub fn mli_legalize_x86(f: &MliFunction, cb: &!MliCodeBuf) -> bool with Mut, Pan
     let nslots = count_slots(f, cb)
     if !cb.ok { return false }
 
-    // Frame: slots*8 rounded up to 16 (measured: 3 slots -> 0x20).
     var frame = nslots * 8
     if frame % 16 != 0 { frame = frame + (16 - frame % 16) }
 
@@ -517,107 +681,182 @@ pub fn mli_legalize_x86(f: &MliFunction, cb: &!MliCodeBuf) -> bool with Mut, Pan
 
     emit_prologue(cb, frame)
 
-    // Arg 0 arrives in RDI as raw f64 bits (measured convention).
-    let a0 = slot_for_def(&!sm, 0)
-    emit_store_rdi(cb, slot_disp(a0))
+    var a: i64 = 0
+    while a < f.arg_count {
+        let s = slot_for_def(&!sm, a)
+        emit_store_argreg(cb, a, slot_disp(s))
+        a = a + 1
+    }
 
-    var j: i64 = 0
-    while j < f.blk_instr_count[0] {
-        let slot = mli_slot(0, j)
-        let op = mli_slot_opcode(f, slot)
-        let d = mli_slot_dst(f, slot)
-        let s1 = mli_slot_src1(f, slot)
-        let s2 = mli_slot_src2(f, slot)
-
-        if op == MLI_OP_NOP || op == MLI_OP_KEEP_ALIVE {
-            j = j + 1
-            continue
+    var b: i64 = 0
+    while b < f.block_count {
+        if f.blk_has_term[b] != 1 {
+            cb_fail(cb, MLI_L_UNSUPPORTED_SHAPE, b, 0 - 1)
+            return false
         }
+        cb.block_off[b] = cb.len
 
-        if op == MLI_OP_MOV || op == MLI_OP_COPY {
+        var j: i64 = 0
+        while j < f.blk_instr_count[b] {
+            let slot = mli_slot(b, j)
+            let op = mli_slot_opcode(f, slot)
+            let d = mli_slot_dst(f, slot)
+            let s1 = mli_slot_src1(f, slot)
+            let s2 = mli_slot_src2(f, slot)
+
+            if op == MLI_OP_NOP || op == MLI_OP_KEEP_ALIVE {
+                j = j + 1
+                continue
+            }
+
             if d.tag != MLI_OPD_VREG {
-                cb_fail(cb, MLI_L_OPERAND, 0, j)
+                cb_fail(cb, MLI_L_OPERAND, b, j)
                 return false
             }
-            if s1.tag == MLI_OPD_IMM {
-                // Pinned constant strategy: movabs + store into the CONST's
-                // own slot, then the dst slot is written from rax reload.
-                // For a direct `mov vreg, imm` the pinned emitter writes the
-                // constant straight into the dst slot (measured: 1.0 lands
-                // in its slot with a single movabs+store pair).
-                if kind_is_unexpanded_structure(s1.kind) || !kind_is_scalar_f64(s1.kind) {
-                    if kind_is_unexpanded_structure(s1.kind) {
-                        cb_fail(cb, MLI_L_KNOWLEDGE_UNEXPANDED, 0, j)
-                    } else {
-                        cb_fail(cb, MLI_L_UNSUPPORTED_SHAPE, 0, j)
+
+            if op == MLI_OP_MOV || op == MLI_OP_COPY {
+                if s1.tag == MLI_OPD_IMM {
+                    if kind_is_scalar_f64(s1.kind) {
+                        let fb = mli_f64_bits(s1.fimm)
+                        if !fb.ok {
+                            cb_fail(cb, MLI_L_CONST_UNSUPPORTED, b, j)
+                            return false
+                        }
+                        let ds = slot_for_def(&!sm, d.id)
+                        emit_movabs_rax(cb, fb.bits)
+                        emit_store_rax(cb, slot_disp(ds))
+                        j = j + 1
+                        continue
                     }
+                    if kind_is_scalar_int(s1.kind) {
+                        let ds = slot_for_def(&!sm, d.id)
+                        emit_int_imm_to_rax(cb, s1.aux)
+                        emit_store_rax(cb, slot_disp(ds))
+                        j = j + 1
+                        continue
+                    }
+                    cb_fail(cb, MLI_L_UNSUPPORTED_SHAPE, b, j)
                     return false
                 }
-                let fb = mli_f64_bits(s1.fimm)
-                if !fb.ok {
-                    cb_fail(cb, MLI_L_CONST_UNSUPPORTED, 0, j)
-                    return false
-                }
+                let ss = ensure_src_slot(cb, &!sm, s1, b, j)
+                if !cb.ok { return false }
                 let ds = slot_for_def(&!sm, d.id)
-                emit_movabs_rax(cb, fb.bits)
+                emit_load_rax(cb, slot_disp(ss))
                 emit_store_rax(cb, slot_disp(ds))
                 j = j + 1
                 continue
             }
-            // vreg -> vreg move through rax (store/load idiom).
-            let ss = ensure_src_slot(cb, &!sm, s1, 0, j)
-            if !cb.ok { return false }
-            let ds = slot_for_def(&!sm, d.id)
-            emit_load_rax(cb, slot_disp(ss))
-            emit_store_rax(cb, slot_disp(ds))
-            j = j + 1
-            continue
+
+            let opbyte = fadd_family_opbyte(op)
+            if opbyte > 0 {
+                let s1s = ensure_src_slot(cb, &!sm, s1, b, j)
+                if !cb.ok { return false }
+                let s2s = ensure_src_slot(cb, &!sm, s2, b, j)
+                if !cb.ok { return false }
+                emit_load_rax(cb, slot_disp(s1s))
+                emit_movq_xmm0_rax(cb)
+                emit_load_rax(cb, slot_disp(s2s))
+                emit_movq_xmm1_rax(cb)
+                emit_f64_binop_xmm(cb, opbyte)
+                emit_movq_rax_xmm0(cb)
+                let ds = slot_for_def(&!sm, d.id)
+                emit_store_rax(cb, slot_disp(ds))
+                j = j + 1
+                continue
+            }
+
+            if op == MLI_OP_ADD || op == MLI_OP_MUL || op == MLI_OP_DIV || op == MLI_OP_ICMP {
+                let s1s = ensure_src_slot(cb, &!sm, s1, b, j)
+                if !cb.ok { return false }
+                let s2s = ensure_src_slot(cb, &!sm, s2, b, j)
+                if !cb.ok { return false }
+                emit_int_binop(cb, op, mli_slot_cc(f, slot), s1s, s2s, b, j)
+                if !cb.ok { return false }
+                let ds = slot_for_def(&!sm, d.id)
+                emit_store_rax(cb, slot_disp(ds))
+                j = j + 1
+                continue
+            }
+
+            cb_fail(cb, MLI_L_UNSUPPORTED_OP, b, j)
+            return false
         }
 
-        let opbyte = fadd_family_opbyte(op)
-        if opbyte > 0 {
-            if d.tag != MLI_OPD_VREG {
-                cb_fail(cb, MLI_L_OPERAND, 0, j)
+        // Terminator.
+        let ts = mli_term_slot(b)
+        let top = mli_slot_opcode(f, ts)
+
+        if top == MLI_OP_RET {
+            let rv = mli_slot_src1(f, ts)
+            if f.ret.tag == MLI_KIND_VOID {
+                cb_fail(cb, MLI_L_UNSUPPORTED_SHAPE, b, 0 - 1)
                 return false
             }
-            let s1s = ensure_src_slot(cb, &!sm, s1, 0, j)
-            if !cb.ok { return false }
-            let s2s = ensure_src_slot(cb, &!sm, s2, 0, j)
-            if !cb.ok { return false }
-            emit_load_rax(cb, slot_disp(s1s))
-            emit_movq_xmm0_rax(cb)
-            emit_load_rax(cb, slot_disp(s2s))
-            emit_movq_xmm1_rax(cb)
-            emit_f64_binop_xmm(cb, opbyte)
-            emit_movq_rax_xmm0(cb)
-            let ds = slot_for_def(&!sm, d.id)
-            emit_store_rax(cb, slot_disp(ds))
-            j = j + 1
+            if rv.tag != MLI_OPD_VREG {
+                cb_fail(cb, MLI_L_OPERAND, b, 0 - 1)
+                return false
+            }
+            let rs = sm.slot_of_vreg[rv.id]
+            if rs == 0 {
+                cb_fail(cb, MLI_L_OPERAND, b, 0 - 1)
+                return false
+            }
+            emit_load_rax(cb, slot_disp(rs))
+            emit_epilogue(cb)
+            b = b + 1
             continue
         }
 
-        cb_fail(cb, MLI_L_UNSUPPORTED_OP, 0, j)
+        if top == MLI_OP_JMP {
+            let tgt = mli_slot_src1(f, ts)
+            if tgt.id != b + 1 {
+                emit_jmp_block(cb, tgt.id)
+            }
+            // Fallthrough elision when the target is the next block.
+            b = b + 1
+            continue
+        }
+
+        if top == MLI_OP_BR {
+            let c = mli_slot_src1(f, ts)
+            let tthen = mli_slot_src2(f, ts)
+            let telse = mli_slot_src3(f, ts)
+            if c.tag != MLI_OPD_VREG {
+                cb_fail(cb, MLI_L_OPERAND, b, 0 - 1)
+                return false
+            }
+            let cs = sm.slot_of_vreg[c.id]
+            if cs == 0 {
+                cb_fail(cb, MLI_L_OPERAND, b, 0 - 1)
+                return false
+            }
+            emit_load_rax(cb, slot_disp(cs))
+            emit_test_rax(cb)
+            emit_je_block(cb, telse.id)
+            if tthen.id != b + 1 {
+                emit_jmp_block(cb, tthen.id)
+            }
+            b = b + 1
+            continue
+        }
+
+        cb_fail(cb, MLI_L_UNSUPPORTED_OP, b, 0 - 1)
         return false
     }
 
-    // Terminator: ret <f64 vreg> only on this surface.
-    let ts = mli_term_slot(0)
-    let top = mli_slot_opcode(f, ts)
-    if top != MLI_OP_RET {
-        cb_fail(cb, MLI_L_BRANCH_UNSUPPORTED, 0, 0 - 1)
-        return false
+    if !cb.ok { return false }
+
+    // Resolve rel32 fixups now that all block offsets are known.
+    var k: i64 = 0
+    while k < cb.fix_count {
+        let site = cb.fix_site[k]
+        let tb = cb.fix_block[k]
+        if tb < 0 || tb >= f.block_count {
+            cb_fail(cb, MLI_L_OPERAND, tb, 0 - 1)
+            return false
+        }
+        cb_patch_i32le(cb, site, cb.block_off[tb] - (site + 4))
+        k = k + 1
     }
-    let rv = mli_slot_src1(f, ts)
-    if rv.tag != MLI_OPD_VREG || !kind_is_scalar_f64(rv.kind) {
-        cb_fail(cb, MLI_L_UNSUPPORTED_SHAPE, 0, 0 - 1)
-        return false
-    }
-    let rs = sm.slot_of_vreg[rv.id]
-    if rs == 0 {
-        cb_fail(cb, MLI_L_OPERAND, 0, 0 - 1)
-        return false
-    }
-    emit_load_rax(cb, slot_disp(rs))
-    emit_epilogue(cb)
     cb.ok
 }

--- a/self-hosted/mli/s2a_gate_runner.sio
+++ b/self-hosted/mli/s2a_gate_runner.sio
@@ -324,8 +324,9 @@ fn case_interp_div_zero() -> i64 with IO, Mut, Panic, Div {
     report_pass("I1 i64 div-by-zero REFUSED by interp")
 }
 
-// I2: the interp refuses a legal-but-unimplemented MLI op (cd_mul, verified
-// OK by V-struct) instead of guessing a semantics. Refuse, don't pick.
+// I2: a verified cd_mul must refuse AT THE OPCODE, not at arg-load and
+// not by writing a zero product. CD args have no value model — they are
+// not loaded as zeros (#1788); the body opcode is what must refuse.
 fn case_interp_refuses_cd() -> i64 with IO, Mut, Panic, Div {
     var m = mli_func_new("octmul", mli_kind_void())
     let ck = mli_kind_cd(8, 64)
@@ -346,11 +347,14 @@ fn case_interp_refuses_cd() -> i64 with IO, Mut, Panic, Div {
 
     var args = mli_interp_args_empty()
     let res = mli_interp_run(&m, &args)
-    if res.ok { return report_fail("I2 cd", "interp-accepted", MLI_I_OK, MLI_I_ARG_KIND) }
-    // CD args have no value model in the S2a interp: refusal fires at
-    // argument loading, before the op is even reached.
-    if res.code != MLI_I_ARG_KIND { return report_fail("I2 cd", "interp-code", res.code, MLI_I_ARG_KIND) }
-    report_pass("I2 CD function REFUSED by interp (no value model)")
+    if res.ok { return report_fail("I2 cd", "interp-accepted", MLI_I_OK, MLI_I_UNSUPPORTED_OP) }
+    if res.code != MLI_I_UNSUPPORTED_OP {
+        return report_fail("I2 cd", "interp-code", res.code, MLI_I_UNSUPPORTED_OP)
+    }
+    if res.block != 0 || res.index != 0 {
+        return report_fail("I2 cd", "refused-before-opcode", res.block, 0)
+    }
+    report_pass("I2 CD cd_mul REFUSED by interp at the opcode (no product, no arg-zero)")
 }
 
 // Tiny icmp so we can poke the SoA cc/op columns after a green verify.
@@ -423,6 +427,18 @@ fn case_interp_refuses_unknown_opcode() -> i64 with IO, Mut, Panic, Div {
     report_pass("I5 unknown opcode REFUSED by interp (no default-zero)")
 }
 
+// I6: CALL is a named opcode with no ABI. Verify must refuse it — stamping
+// OK was the same default-guess as E219 / #1784 / the char* printer.
+fn case_verify_refuses_call() -> i64 with IO, Mut, Panic, Div {
+    var f = build_add_i64()
+    f.i_op[mli_slot(0, 0)] = MLI_OP_CALL
+    let vs = mli_verify_function(&f)
+    if vs.code != MLI_VERR_CALL_UNSPECIFIED {
+        return report_fail("I6 call verify", "code", vs.code, MLI_VERR_CALL_UNSPECIFIED)
+    }
+    report_pass("I6 CALL is a VERIFY error (ABI unpinned, not a silent OK)")
+}
+
 fn main() -> i64 with IO, Mut, Panic, Div {
     println("=== MLI S2a gate: ir_to_mli (straight-line i64/f64) + minimal interp ===")
     if ir_instr_arena_init() != IR_ARENA_OK {
@@ -452,6 +468,7 @@ fn main() -> i64 with IO, Mut, Panic, Div {
     failures = failures + case_verify_refuses_unknown_cc()
     failures = failures + case_interp_refuses_unknown_cc()
     failures = failures + case_interp_refuses_unknown_opcode()
+    failures = failures + case_verify_refuses_call()
 
     if failures == 0 {
         println("=== MLI S2a: ALL CASES PASS ===")

--- a/self-hosted/mli/s2a_gate_runner.sio
+++ b/self-hosted/mli/s2a_gate_runner.sio
@@ -113,6 +113,7 @@ fn run_case_f64(name: string, src: &IrFunction, a0: f64, a1: f64, expect: f64) -
     args.af[1] = a1
     let res = mli_interp_run(&m, &args)
     if !res.ok { return report_fail(name, "interp", res.code, MLI_I_OK) }
+    if !res.has_value { return report_fail(name, "no-value", 0, 1) }
     if !res.ret_is_float { return report_fail(name, "ret-kind", 0, 1) }
     if res.ret_f != expect { return report_fail(name, "value", 0, 1) }
     report_pass(name)
@@ -129,6 +130,7 @@ fn run_case_i64(name: string, src: &IrFunction, a0: i64, a1: i64, expect: i64) -
     args.ai[1] = a1
     let res = mli_interp_run(&m, &args)
     if !res.ok { return report_fail(name, "interp", res.code, MLI_I_OK) }
+    if !res.has_value { return report_fail(name, "no-value", 0, 1) }
     if res.ret_is_float { return report_fail(name, "ret-kind", 1, 0) }
     if res.ret_i != expect { return report_fail(name, "value", res.ret_i, expect) }
     report_pass(name)
@@ -439,6 +441,45 @@ fn case_verify_refuses_call() -> i64 with IO, Mut, Panic, Div {
     report_pass("I6 CALL is a VERIFY error (ABI unpinned, not a silent OK)")
 }
 
+// I7: a never-written vreg must refuse, not return the register-file zero.
+// Same class as #1801 (empty stub / caller reads rax) and #1788 (no
+// fabricated zero). Poke is a scalar SoA column only — rewriting a whole
+// MliOperand in i_src1[] is the #1678/#1749 miscompile surface.
+// NOP the add after a green verify: dest is never defined, ret dest
+// must be UNDEF, not 0.
+fn case_interp_refuses_undef_vreg() -> i64 with IO, Mut, Panic, Div {
+    var f = build_add_i64()
+    let vs = mli_verify_function(&f)
+    if vs.code != MLI_VERR_OK { return report_fail("I7 undef", "pre-verify", vs.code, 0) }
+    f.i_op[mli_slot(0, 0)] = MLI_OP_NOP
+    var args = mli_interp_args_empty()
+    args.ai[0] = 3
+    args.ai[1] = 4
+    let res = mli_interp_run(&f, &args)
+    if res.ok { return report_fail("I7 undef", "guessed-zero", MLI_I_OK, MLI_I_UNDEF_VREG) }
+    if res.has_value { return report_fail("I7 undef", "value-after-refuse", 1, 0) }
+    if res.code != MLI_I_UNDEF_VREG {
+        return report_fail("I7 undef", "code", res.code, MLI_I_UNDEF_VREG)
+    }
+    report_pass("I7 unread vreg REFUSED by interp (no fabricated zero)")
+}
+
+// I8: void success is not integer 0. #1801's empty stub was prologue+ret
+// with the caller reading rax; has_value is the bit that forbids that.
+fn case_void_ret_has_no_value() -> i64 with IO, Mut, Panic, Div {
+    var f = mli_func_new("empty", mli_kind_void())
+    let b0 = mli_new_block(&!f)
+    if b0 < 0 { return report_fail("I8 void", "block", 0, 1) }
+    if !mli_set_term(&!f, b0, mli_term_ret_void()) { return report_fail("I8 void", "term", 0, 1) }
+    let vs = mli_verify_function(&f)
+    if vs.code != MLI_VERR_OK { return report_fail("I8 void", "verify", vs.code, 0) }
+    var args = mli_interp_args_empty()
+    let res = mli_interp_run(&f, &args)
+    if !res.ok { return report_fail("I8 void", "interp", res.code, MLI_I_OK) }
+    if res.has_value { return report_fail("I8 void", "claimed-int-zero", 1, 0) }
+    report_pass("I8 void return has no value (not a fabricated integer 0)")
+}
+
 fn main() -> i64 with IO, Mut, Panic, Div {
     println("=== MLI S2a gate: ir_to_mli (straight-line i64/f64) + minimal interp ===")
     if ir_instr_arena_init() != IR_ARENA_OK {
@@ -469,6 +510,8 @@ fn main() -> i64 with IO, Mut, Panic, Div {
     failures = failures + case_interp_refuses_unknown_cc()
     failures = failures + case_interp_refuses_unknown_opcode()
     failures = failures + case_verify_refuses_call()
+    failures = failures + case_interp_refuses_undef_vreg()
+    failures = failures + case_void_ret_has_no_value()
 
     if failures == 0 {
         println("=== MLI S2a: ALL CASES PASS ===")

--- a/self-hosted/mli/s2a_gate_runner.sio
+++ b/self-hosted/mli/s2a_gate_runner.sio
@@ -353,6 +353,76 @@ fn case_interp_refuses_cd() -> i64 with IO, Mut, Panic, Div {
     report_pass("I2 CD function REFUSED by interp (no value model)")
 }
 
+// Tiny icmp so we can poke the SoA cc/op columns after a green verify.
+// Writing i_cc / i_op is the sanctioned SoA path — do not land a MliInst.
+fn build_icmp_lt() -> MliFunction with Mut, Panic {
+    var f = mli_func_new("icmp_lt", mli_kind_bool())
+    let a = mli_add_arg(&!f, mli_kind_int(64, 1))
+    let b = mli_add_arg(&!f, mli_kind_int(64, 1))
+    let b0 = mli_new_block(&!f)
+    let d = mli_new_vreg(&!f, mli_kind_bool())
+    if a < 0 || b < 0 || b0 < 0 || d < 0 { return f }
+    var ok = mli_emit(&!f, b0, mli_inst_icmp(MLI_CC_LT, mli_opd_vreg(d, mli_kind_bool()), mli_opd_vreg(a, mli_kind_int(64, 1)), mli_opd_vreg(b, mli_kind_int(64, 1))))
+    ok = ok && mli_set_term(&!f, b0, mli_term_ret(mli_opd_vreg(d, mli_kind_bool())))
+    f
+}
+
+fn build_add_i64() -> MliFunction with Mut, Panic {
+    var f = mli_func_new("add2", mli_kind_int(64, 1))
+    let a = mli_add_arg(&!f, mli_kind_int(64, 1))
+    let b = mli_add_arg(&!f, mli_kind_int(64, 1))
+    let b0 = mli_new_block(&!f)
+    let d = mli_new_vreg(&!f, mli_kind_int(64, 1))
+    if a < 0 || b < 0 || b0 < 0 || d < 0 { return f }
+    var ok = mli_emit(&!f, b0, mli_inst3(MLI_OP_ADD, mli_opd_vreg(d, mli_kind_int(64, 1)), mli_opd_vreg(a, mli_kind_int(64, 1)), mli_opd_vreg(b, mli_kind_int(64, 1))))
+    ok = ok && mli_set_term(&!f, b0, mli_term_ret(mli_opd_vreg(d, mli_kind_int(64, 1))))
+    f
+}
+
+// I3: V-struct refuses an unclassified compare-code. cc=7 is not "false".
+fn case_verify_refuses_unknown_cc() -> i64 with IO, Mut, Panic, Div {
+    var f = build_icmp_lt()
+    f.i_cc[mli_slot(0, 0)] = 7
+    let vs = mli_verify_function(&f)
+    if vs.code != MLI_VERR_OPERAND_RULE {
+        return report_fail("I3 unknown cc verify", "code", vs.code, MLI_VERR_OPERAND_RULE)
+    }
+    report_pass("I3 unclassified icmp cc is a VERIFY error (not a silent false)")
+}
+
+// I4: interp refuses the same poke even if verify ran first on the clean fn.
+// The defect class: hold stayed false and the interp returned OK.
+fn case_interp_refuses_unknown_cc() -> i64 with IO, Mut, Panic, Div {
+    var f = build_icmp_lt()
+    let vs = mli_verify_function(&f)
+    if vs.code != MLI_VERR_OK { return report_fail("I4 unknown cc interp", "pre-verify", vs.code, 0) }
+    f.i_cc[mli_slot(0, 0)] = 7
+    var args = mli_interp_args_empty()
+    args.ai[0] = 1
+    args.ai[1] = 2
+    let res = mli_interp_run(&f, &args)
+    if res.ok { return report_fail("I4 unknown cc interp", "guessed-false", MLI_I_OK, MLI_I_BAD_CC) }
+    if res.code != MLI_I_BAD_CC { return report_fail("I4 unknown cc interp", "code", res.code, MLI_I_BAD_CC) }
+    report_pass("I4 unclassified icmp cc REFUSED by interp (not evaluated as false)")
+}
+
+// I5: an opcode with no case must refuse, not fall through to r=0 / OK.
+fn case_interp_refuses_unknown_opcode() -> i64 with IO, Mut, Panic, Div {
+    var f = build_add_i64()
+    let vs = mli_verify_function(&f)
+    if vs.code != MLI_VERR_OK { return report_fail("I5 unknown op interp", "pre-verify", vs.code, 0) }
+    f.i_op[mli_slot(0, 0)] = 77
+    var args = mli_interp_args_empty()
+    args.ai[0] = 3
+    args.ai[1] = 4
+    let res = mli_interp_run(&f, &args)
+    if res.ok { return report_fail("I5 unknown op interp", "guessed-zero", MLI_I_OK, MLI_I_UNSUPPORTED_OP) }
+    if res.code != MLI_I_UNSUPPORTED_OP {
+        return report_fail("I5 unknown op interp", "code", res.code, MLI_I_UNSUPPORTED_OP)
+    }
+    report_pass("I5 unknown opcode REFUSED by interp (no default-zero)")
+}
+
 fn main() -> i64 with IO, Mut, Panic, Div {
     println("=== MLI S2a gate: ir_to_mli (straight-line i64/f64) + minimal interp ===")
     if ir_instr_arena_init() != IR_ARENA_OK {
@@ -379,6 +449,9 @@ fn main() -> i64 with IO, Mut, Panic, Div {
     failures = failures + case_refuse_shift()
     failures = failures + case_interp_div_zero()
     failures = failures + case_interp_refuses_cd()
+    failures = failures + case_verify_refuses_unknown_cc()
+    failures = failures + case_interp_refuses_unknown_cc()
+    failures = failures + case_interp_refuses_unknown_opcode()
 
     if failures == 0 {
         println("=== MLI S2a: ALL CASES PASS ===")

--- a/self-hosted/mli/s2b_gate_runner.sio
+++ b/self-hosted/mli/s2b_gate_runner.sio
@@ -108,6 +108,7 @@ fn run_case_i64(name: string, src: &IrFunction, a0: i64, a1: i64, expect: i64) -
     args.ai[1] = a1
     let res = mli_interp_run(&m, &args)
     if !res.ok { return report_fail(name, "interp", res.code, MLI_I_OK) }
+    if !res.has_value { return report_fail(name, "no-value", 0, 1) }
     if res.ret_is_float { return report_fail(name, "ret-kind", 1, 0) }
     if res.ret_i != expect { return report_fail(name, "value", res.ret_i, expect) }
     report_pass(name)
@@ -124,6 +125,7 @@ fn run_case_f64(name: string, src: &IrFunction, a0: f64, a1: f64, expect: f64) -
     args.af[1] = a1
     let res = mli_interp_run(&m, &args)
     if !res.ok { return report_fail(name, "interp", res.code, MLI_I_OK) }
+    if !res.has_value { return report_fail(name, "no-value", 0, 1) }
     if !res.ret_is_float { return report_fail(name, "ret-kind", 0, 1) }
     if res.ret_f != expect { return report_fail(name, "value", 0, 1) }
     report_pass(name)

--- a/self-hosted/mli/s3_gate_runner.sio
+++ b/self-hosted/mli/s3_gate_runner.sio
@@ -13,13 +13,15 @@
 //   X6     a Knowledge operand reaching legalize UNEXPANDED is refused with
 //          the DEDICATED code — the erasure guard, the single control that
 //          distinguishes a first-class kind from decoration.
-//   X7     the EXPANDED function is refused by the S3 legaliser because the
-//          conf lane forced branch diamonds and branch encoding is the next
-//          mimicry tranche — the named, honest cost of non-erasure today.
+//   X7     S3b: the EXPANDED function LEGALIZES. The byte stream contains
+//          TWO addsd (val + var). The second addsd is the named point
+//          where every production backend erases. We kept it.
 //   X8     the golden pipeline (IR -> MLI -> verify -> legalize) emits a
 //          non-empty, deterministic byte body ending in ret.
 //   X9     two k_adds overflow the S1 block walls fail-closed — the
 //          measured trigger for the deferred module-arena decision.
+//   X10-12 k_mul GUM delta method (ep_mul oracle) through expand→interp.
+//   X13    expanded k_mul LEGALIZES with ≥5 mulsd (1 val + 4 var).
 
 use ir::ir::*
 use mli::ir::*
@@ -58,7 +60,7 @@ fn report_fail(name: string, detail: string, got: i64, want: i64) -> i64 with IO
 fn build_kfn(lane: i64) -> MliFunction with Mut, Panic {
     let kk = mli_kind_knowledge(MLI_KIND_FLOAT, 64, MLI_KSHAPE_MIN3)
     var ret_kind = mli_kind_float(64)
-    if lane == 2 { ret_kind = mli_kind_int(64, 1) }
+    if lane == 2 || lane == 12 { ret_kind = mli_kind_int(64, 1) }
     var f = mli_func_new("kfn", ret_kind)
     let ka = mli_add_arg(&!f, kk)
     let kb = mli_add_arg(&!f, kk)
@@ -69,7 +71,13 @@ fn build_kfn(lane: i64) -> MliFunction with Mut, Panic {
     let kco = mli_opd_vreg(kc, kk)
     let kao = mli_opd_vreg(ka, kk)
     let kbo = mli_opd_vreg(kb, kk)
-    var ok = mli_emit(&!f, b0, mli_inst3(MLI_OP_K_ADD, kco, kao, kbo))
+    var kop = MLI_OP_K_ADD
+    var elane = lane
+    if lane >= 10 {
+        kop = MLI_OP_K_MUL
+        elane = lane - 10
+    }
+    var ok = mli_emit(&!f, b0, mli_inst3(kop, kco, kao, kbo))
 
     if lane == 4 {
         let kd = mli_new_vreg(&!f, kk)
@@ -84,8 +92,8 @@ fn build_kfn(lane: i64) -> MliFunction with Mut, Panic {
     }
 
     var op = MLI_OP_K_DISCHARGE
-    if lane == 1 { op = MLI_OP_K_EXTRACT_VAR }
-    if lane == 2 { op = MLI_OP_K_EXTRACT_CONF }
+    if elane == 1 { op = MLI_OP_K_EXTRACT_VAR }
+    if elane == 2 { op = MLI_OP_K_EXTRACT_CONF }
     let d = mli_new_vreg(&!f, ret_kind)
     if d < 0 { return f }
     ok = ok && mli_emit(&!f, b0, mli_inst2(op, mli_opd_vreg(d, ret_kind), kco))
@@ -182,20 +190,36 @@ fn case_legalize_refuses_unexpanded() -> i64 with IO, Mut, Panic, Div {
     report_pass("X6 unexpanded Knowledge at codegen REFUSED with dedicated code")
 }
 
-// X7 — the honest cost: the expanded function carries branch diamonds (conf
-// lane), and branch encoding is not in the golden mimicry surface yet.
-fn case_legalize_refuses_expanded_branches() -> i64 with IO, Mut, Panic, Div {
+// Count the measured xmm binop encoding f2 0f <opbyte> c1.
+fn count_f64_op(cb: &MliCodeBuf, opbyte: i64) -> i64 with Panic {
+    var n: i64 = 0
+    var i: i64 = 0
+    while i + 3 < cb.len {
+        if cb.bytes[i] == 242 && cb.bytes[i + 1] == 15 && cb.bytes[i + 2] == opbyte && cb.bytes[i + 3] == 193 {
+            n = n + 1
+        }
+        i = i + 1
+    }
+    n
+}
+
+// X7 — S3b: expanded k_add LEGALIZES. Two addsd in the stream: val, then
+// THE variance addsd. Returning extract_var still emits the val addsd
+// (and vice versa) — unused-lane DCE of variance would be erasure.
+fn case_legalize_expanded_variance_in_stream() -> i64 with IO, Mut, Panic, Div {
     var src = build_kfn(1)
     var ex = mli_func_empty()
     let xs = mli_expand_min3(&src, &!ex)
-    if !xs.ok { return report_fail("X7 branch cost", "expand", xs.code, 0) }
+    if !xs.ok { return report_fail("X7 variance-in-stream", "expand", xs.code, 0) }
     var cb = mli_codebuf_empty()
-    let ok = mli_legalize_x86(&ex, &!cb)
-    if ok { return report_fail("X7 branch cost", "legalized-anyway", MLI_L_OK, MLI_L_BRANCH_UNSUPPORTED) }
-    if cb.code != MLI_L_BRANCH_UNSUPPORTED {
-        return report_fail("X7 branch cost", "code", cb.code, MLI_L_BRANCH_UNSUPPORTED)
+    if !mli_legalize_x86(&ex, &!cb) {
+        return report_fail("X7 variance-in-stream", "legalize", cb.code, 0)
     }
-    report_pass("X7 expanded conf diamonds block bytes today (named: BRANCH_UNSUPPORTED)")
+    if cb.len < 40 { return report_fail("X7 variance-in-stream", "len", cb.len, 40) }
+    if cb.bytes[cb.len - 1] != 195 { return report_fail("X7 variance-in-stream", "ret", cb.bytes[cb.len - 1], 195) }
+    let nadd = count_f64_op(&cb, 88)
+    if nadd < 2 { return report_fail("X7 variance-in-stream", "addsd-count", nadd, 2) }
+    report_pass("X7 expanded k_add LEGALIZES with 2 addsd — variance in the instruction stream")
 }
 
 // X8 — golden pipeline emits deterministically.
@@ -264,8 +288,45 @@ fn case_two_kadds_hit_wall() -> i64 with IO, Mut, Panic, Div {
     report_pass("X9 second k_add overflows block wall FAIL-CLOSED (arena trigger measured)")
 }
 
+fn case_kmul_val() -> i64 with IO, Mut, Panic, Div {
+    let r = run_kfn(10, 2.0, 0.5, 900, 3.0, 0.25, 800)
+    if !r.ok { return report_fail("X10 k_mul val", "stage", r.stage_code, 0) }
+    if !r.ret_is_float || r.ret_f != 6.0 { return report_fail("X10 k_mul val", "value", 0, 1) }
+    report_pass("X10 k_mul val lane == 6.0 (2*3, expand->verify->interp)")
+}
+
+fn case_kmul_var() -> i64 with IO, Mut, Panic, Div {
+    // GUM: Var(XY) ≈ Y² Var(X) + X² Var(Y) = 9*0.5 + 4*0.25 = 5.5
+    let r = run_kfn(11, 2.0, 0.5, 900, 3.0, 0.25, 800)
+    if !r.ok { return report_fail("X11 k_mul VAR", "stage", r.stage_code, 0) }
+    if !r.ret_is_float || r.ret_f != 5.5 { return report_fail("X11 k_mul VAR", "value", 0, 1) }
+    report_pass("X11 k_mul VARIANCE lane == 5.5 — GUM product in the result")
+}
+
+fn case_kmul_conf() -> i64 with IO, Mut, Panic, Div {
+    // min(900,800)*98/100 = 784 (ep_mul decay, not the add *99)
+    let r = run_kfn(12, 2.0, 0.5, 900, 3.0, 0.25, 800)
+    if !r.ok { return report_fail("X12 k_mul conf", "stage", r.stage_code, 0) }
+    if r.ret_is_float || r.ret_i != 784 { return report_fail("X12 k_mul conf", "value", r.ret_i, 784) }
+    report_pass("X12 k_mul conf lane == 784 (min*98/100, ep_mul oracle)")
+}
+
+fn case_kmul_bytes() -> i64 with IO, Mut, Panic, Div {
+    var src = build_kfn(11)
+    var ex = mli_func_empty()
+    let xs = mli_expand_min3(&src, &!ex)
+    if !xs.ok { return report_fail("X13 k_mul bytes", "expand", xs.code, 0) }
+    var cb = mli_codebuf_empty()
+    if !mli_legalize_x86(&ex, &!cb) { return report_fail("X13 k_mul bytes", "legalize", cb.code, 0) }
+    let nmul = count_f64_op(&cb, 89)
+    if nmul < 5 { return report_fail("X13 k_mul bytes", "mulsd-count", nmul, 5) }
+    let nadd = count_f64_op(&cb, 88)
+    if nadd < 1 { return report_fail("X13 k_mul bytes", "addsd-count", nadd, 1) }
+    report_pass("X13 expanded k_mul LEGALIZES with 5 mulsd + 1 addsd — product GUM in the stream")
+}
+
 fn main() -> i64 with IO, Mut, Panic, Div {
-    println("=== MLI S3 gate: expand_k lanes + erasure guard + golden emission ===")
+    println("=== MLI S3 gate: GUM in the instruction stream + erasure guard ===")
     if ir_instr_arena_init() != IR_ARENA_OK {
         println("FAIL: arena init")
         return 1
@@ -278,9 +339,13 @@ fn main() -> i64 with IO, Mut, Panic, Div {
     failures = failures + case_conf_clamp_low()
     failures = failures + case_conf_clamp_high()
     failures = failures + case_legalize_refuses_unexpanded()
-    failures = failures + case_legalize_refuses_expanded_branches()
+    failures = failures + case_legalize_expanded_variance_in_stream()
     failures = failures + case_golden_bytes()
     failures = failures + case_two_kadds_hit_wall()
+    failures = failures + case_kmul_val()
+    failures = failures + case_kmul_var()
+    failures = failures + case_kmul_conf()
+    failures = failures + case_kmul_bytes()
 
     if failures == 0 {
         println("=== MLI S3: ALL CASES PASS ===")

--- a/self-hosted/mli/s3b_gate_runner.sio
+++ b/self-hosted/mli/s3b_gate_runner.sio
@@ -94,16 +94,16 @@ fn run_cd_mul(dim: i64, lane: i64, args_f: &MliInterpArgs) -> MliInterpResult wi
     var src = build_cd_mul(dim, lane)
     let vs = mli_verify_function(&src)
     if vs.code != MLI_VERR_OK {
-        return MliInterpResult { ok: false, code: 1000 + vs.code, block: 0 - 1, index: 0 - 1, ret_is_float: false, ret_i: 0, ret_f: 0.0 }
+        return MliInterpResult { ok: false, code: 1000 + vs.code, block: 0 - 1, index: 0 - 1, has_value: false, ret_is_float: false, ret_i: 0, ret_f: 0.0 }
     }
     var ex = mli_func_empty()
     let xs = mli_expand_cd(&src, &!ex)
     if !xs.ok {
-        return MliInterpResult { ok: false, code: 2000 + xs.code, block: 0 - 1, index: 0 - 1, ret_is_float: false, ret_i: 0, ret_f: 0.0 }
+        return MliInterpResult { ok: false, code: 2000 + xs.code, block: 0 - 1, index: 0 - 1, has_value: false, ret_is_float: false, ret_i: 0, ret_f: 0.0 }
     }
     let ve = mli_verify_function(&ex)
     if ve.code != MLI_VERR_OK {
-        return MliInterpResult { ok: false, code: 3000 + ve.code, block: 0 - 1, index: 0 - 1, ret_is_float: false, ret_i: 0, ret_f: 0.0 }
+        return MliInterpResult { ok: false, code: 3000 + ve.code, block: 0 - 1, index: 0 - 1, has_value: false, ret_is_float: false, ret_i: 0, ret_f: 0.0 }
     }
     mli_interp_run(&ex, args_f)
 }

--- a/self-hosted/mli/s3b_gate_runner.sio
+++ b/self-hosted/mli/s3b_gate_runner.sio
@@ -1,0 +1,250 @@
+// MLI S3b research gate — Cayley-Dickson lowering and the named walls.
+//
+// Run: ./bin/souc run self-hosted/mli/s3b_gate_runner.sio
+//
+// What this gate proves:
+//   C1  complex cd_mul (1+2i)(3+4i) = −5+10i, real component through
+//       expand → verify → interp.
+//   C2  imag component == 10.0 (the three extra muls were not dropped).
+//   C3  expanded complex mul LEGALIZES with 4 mulsd + 1 addsd + 1 subsd.
+//       The first mulsd is a0*b0 — the named temptation. We kept the rest.
+//   C4  unexpanded CD at legalize is refused (erasure guard, same family
+//       as Knowledge).
+//   C5  octonion cd_mul REFUSES with OCTONION_WALL (16 args / ~120 ops).
+//   C6  complex associator is a VERIFY error (dim<8): the kind model
+//       refuses an identically-zero associator as an instruction.
+//   C7  octonion associator REFUSES with ASSOCIATOR_WALL — emitting zero
+//       here would be a semantic miscompile of a positive graded invariant.
+//   C8  quaternion i*j = k (component 3 == 1.0) through expand → interp.
+//       legalize then refuses 8 args (measured GPR convention is 6) — the
+//       next named wall, not a silent real-part multiply.
+
+use mli::ir::*
+use mli::builder::*
+use mli::verify::*
+use mli::interp::*
+use mli::expand_cd::*
+use mli::legalize_x86::*
+
+fn report_pass(name: string) -> i64 with IO {
+    print("PASS: ")
+    print(name)
+    print("\n")
+    0
+}
+
+fn report_fail(name: string, detail: string, got: i64, want: i64) -> i64 with IO {
+    print("FAIL: ")
+    print(name)
+    print(" [")
+    print(detail)
+    print("] got=")
+    print_int(got)
+    print(" want=")
+    print_int(want)
+    print("\n")
+    1
+}
+
+fn count_f64_op(cb: &MliCodeBuf, opbyte: i64) -> i64 with Panic {
+    var n: i64 = 0
+    var i: i64 = 0
+    while i + 3 < cb.len {
+        if cb.bytes[i] == 242 && cb.bytes[i + 1] == 15 && cb.bytes[i + 2] == opbyte && cb.bytes[i + 3] == 193 {
+            n = n + 1
+        }
+        i = i + 1
+    }
+    n
+}
+
+// cd_mul of two dim-d values, extract `lane`.
+fn build_cd_mul(dim: i64, lane: i64) -> MliFunction with Mut, Panic {
+    let ck = mli_kind_cd(dim, 64)
+    var f = mli_func_new("cdmul", mli_kind_float(64))
+    let a = mli_add_arg(&!f, ck)
+    let b = mli_add_arg(&!f, ck)
+    let b0 = mli_new_block(&!f)
+    let p = mli_new_vreg(&!f, ck)
+    let d = mli_new_vreg(&!f, mli_kind_float(64))
+    if a < 0 || b < 0 || b0 < 0 || p < 0 || d < 0 { return f }
+    var ok = mli_emit(&!f, b0, mli_inst_cd_mul(mli_opd_vreg(p, ck), mli_opd_vreg(a, ck), mli_opd_vreg(b, ck), MLI_ASSOC_STRICT, MLI_ZD_FLAG))
+    ok = ok && mli_emit(&!f, b0, mli_inst_cd_extract(mli_opd_vreg(d, mli_kind_float(64)), mli_opd_vreg(p, ck), lane))
+    ok = ok && mli_set_term(&!f, b0, mli_term_ret(mli_opd_vreg(d, mli_kind_float(64))))
+    f
+}
+
+fn build_cd_associator(dim: i64) -> MliFunction with Mut, Panic {
+    let ck = mli_kind_cd(dim, 64)
+    var f = mli_func_new("cdassoc", mli_kind_float(64))
+    let a = mli_add_arg(&!f, ck)
+    let b = mli_add_arg(&!f, ck)
+    let c = mli_add_arg(&!f, ck)
+    let b0 = mli_new_block(&!f)
+    let p = mli_new_vreg(&!f, ck)
+    let d = mli_new_vreg(&!f, mli_kind_float(64))
+    if a < 0 || b < 0 || c < 0 || b0 < 0 || p < 0 || d < 0 { return f }
+    var ok = mli_emit(&!f, b0, mli_inst_cd_associator(mli_opd_vreg(p, ck), mli_opd_vreg(a, ck), mli_opd_vreg(b, ck), mli_opd_vreg(c, ck), MLI_ASSOC_STRICT, MLI_ZD_FLAG))
+    ok = ok && mli_emit(&!f, b0, mli_inst_cd_extract(mli_opd_vreg(d, mli_kind_float(64)), mli_opd_vreg(p, ck), 0))
+    ok = ok && mli_set_term(&!f, b0, mli_term_ret(mli_opd_vreg(d, mli_kind_float(64))))
+    f
+}
+
+fn run_cd_mul(dim: i64, lane: i64, args_f: &MliInterpArgs) -> MliInterpResult with Mut, Panic, Div {
+    var src = build_cd_mul(dim, lane)
+    let vs = mli_verify_function(&src)
+    if vs.code != MLI_VERR_OK {
+        return MliInterpResult { ok: false, code: 1000 + vs.code, block: 0 - 1, index: 0 - 1, ret_is_float: false, ret_i: 0, ret_f: 0.0 }
+    }
+    var ex = mli_func_empty()
+    let xs = mli_expand_cd(&src, &!ex)
+    if !xs.ok {
+        return MliInterpResult { ok: false, code: 2000 + xs.code, block: 0 - 1, index: 0 - 1, ret_is_float: false, ret_i: 0, ret_f: 0.0 }
+    }
+    let ve = mli_verify_function(&ex)
+    if ve.code != MLI_VERR_OK {
+        return MliInterpResult { ok: false, code: 3000 + ve.code, block: 0 - 1, index: 0 - 1, ret_is_float: false, ret_i: 0, ret_f: 0.0 }
+    }
+    mli_interp_run(&ex, args_f)
+}
+
+fn case_complex_real() -> i64 with IO, Mut, Panic, Div {
+    var args = mli_interp_args_empty()
+    args.af[0] = 1.0
+    args.af[1] = 2.0
+    args.af[2] = 3.0
+    args.af[3] = 4.0
+    let r = run_cd_mul(2, 0, &args)
+    if !r.ok { return report_fail("C1 complex real", "stage", r.code, 0) }
+    if !r.ret_is_float || r.ret_f != (0.0 - 5.0) { return report_fail("C1 complex real", "value", 0, 1) }
+    report_pass("C1 complex (1+2i)(3+4i) real == -5")
+}
+
+fn case_complex_imag() -> i64 with IO, Mut, Panic, Div {
+    var args = mli_interp_args_empty()
+    args.af[0] = 1.0
+    args.af[1] = 2.0
+    args.af[2] = 3.0
+    args.af[3] = 4.0
+    let r = run_cd_mul(2, 1, &args)
+    if !r.ok { return report_fail("C2 complex imag", "stage", r.code, 0) }
+    if !r.ret_is_float || r.ret_f != 10.0 { return report_fail("C2 complex imag", "value", 0, 1) }
+    report_pass("C2 complex (1+2i)(3+4i) imag == 10 — cross terms kept")
+}
+
+fn case_complex_bytes() -> i64 with IO, Mut, Panic, Div {
+    var src = build_cd_mul(2, 0)
+    var ex = mli_func_empty()
+    let xs = mli_expand_cd(&src, &!ex)
+    if !xs.ok { return report_fail("C3 complex bytes", "expand", xs.code, 0) }
+    var cb = mli_codebuf_empty()
+    if !mli_legalize_x86(&ex, &!cb) { return report_fail("C3 complex bytes", "legalize", cb.code, 0) }
+    let nmul = count_f64_op(&cb, 89)
+    let nadd = count_f64_op(&cb, 88)
+    let nsub = count_f64_op(&cb, 92)
+    if nmul < 4 { return report_fail("C3 complex bytes", "mulsd", nmul, 4) }
+    if nadd < 1 { return report_fail("C3 complex bytes", "addsd", nadd, 1) }
+    if nsub < 1 { return report_fail("C3 complex bytes", "subsd", nsub, 1) }
+    report_pass("C3 complex cd_mul LEGALIZES with 4 mulsd+1 addsd+1 subsd — first mulsd is a0*b0, the rest were kept")
+}
+
+fn case_unexpanded_cd_refused() -> i64 with IO, Mut, Panic, Div {
+    var src = build_cd_mul(2, 0)
+    let vs = mli_verify_function(&src)
+    if vs.code != MLI_VERR_OK { return report_fail("C4 cd erasure guard", "src-verify", vs.code, 0) }
+    var cb = mli_codebuf_empty()
+    let ok = mli_legalize_x86(&src, &!cb)
+    if ok { return report_fail("C4 cd erasure guard", "legalized-anyway", MLI_L_OK, MLI_L_KNOWLEDGE_UNEXPANDED) }
+    if cb.code != MLI_L_KNOWLEDGE_UNEXPANDED {
+        return report_fail("C4 cd erasure guard", "code", cb.code, MLI_L_KNOWLEDGE_UNEXPANDED)
+    }
+    report_pass("C4 unexpanded CD at codegen REFUSED with dedicated code")
+}
+
+fn case_octonion_wall() -> i64 with IO, Mut, Panic, Div {
+    var src = build_cd_mul(8, 0)
+    let vs = mli_verify_function(&src)
+    if vs.code != MLI_VERR_OK { return report_fail("C5 octonion wall", "src-verify", vs.code, 0) }
+    var ex = mli_func_empty()
+    let xs = mli_expand_cd(&src, &!ex)
+    if xs.ok { return report_fail("C5 octonion wall", "expanded-anyway", MLI_XC_OK, MLI_XC_OCTONION_WALL) }
+    if xs.code != MLI_XC_OCTONION_WALL {
+        return report_fail("C5 octonion wall", "code", xs.code, MLI_XC_OCTONION_WALL)
+    }
+    report_pass("C5 octonion cd_mul REFUSES with OCTONION_WALL (16 args / ~120 ops)")
+}
+
+fn case_complex_associator_illegal() -> i64 with IO, Mut, Panic, Div {
+    // S1 kind-model: associator is only an instruction where it can be
+    // nonzero (dim>=8). dim<8 is a verify error, not a zero-emitting op —
+    // that is the associator-aware fact for associative algebras.
+    var src = build_cd_associator(2)
+    let vs = mli_verify_function(&src)
+    if vs.code != MLI_VERR_OPERAND_RULE {
+        return report_fail("C6 assoc dim<8", "code", vs.code, MLI_VERR_OPERAND_RULE)
+    }
+    report_pass("C6 complex associator is a VERIFY error — identically-zero ops are not instructions")
+}
+
+fn case_octonion_associator_wall() -> i64 with IO, Mut, Panic, Div {
+    var src = build_cd_associator(8)
+    let vs = mli_verify_function(&src)
+    if vs.code != MLI_VERR_OK { return report_fail("C7 assoc wall", "src-verify", vs.code, 0) }
+    var ex = mli_func_empty()
+    let xs = mli_expand_cd(&src, &!ex)
+    if xs.ok { return report_fail("C7 assoc wall", "expanded-anyway", MLI_XC_OK, MLI_XC_ASSOCIATOR_WALL) }
+    if xs.code != MLI_XC_ASSOCIATOR_WALL {
+        return report_fail("C7 assoc wall", "code", xs.code, MLI_XC_ASSOCIATOR_WALL)
+    }
+    report_pass("C7 octonion associator REFUSES with ASSOCIATOR_WALL — zero would be a miscompile")
+}
+
+fn case_quat_ij_k() -> i64 with IO, Mut, Panic, Div {
+    // i*j = k. args: (0,1,0,0) * (0,0,1,0) → (0,0,0,1)
+    var args = mli_interp_args_empty()
+    args.af[0] = 0.0
+    args.af[1] = 1.0
+    args.af[2] = 0.0
+    args.af[3] = 0.0
+    args.af[4] = 0.0
+    args.af[5] = 0.0
+    args.af[6] = 1.0
+    args.af[7] = 0.0
+    let r = run_cd_mul(4, 3, &args)
+    if !r.ok { return report_fail("C8 quat i*j=k", "stage", r.code, 0) }
+    if !r.ret_is_float || r.ret_f != 1.0 { return report_fail("C8 quat i*j=k", "value", 0, 1) }
+
+    var src = build_cd_mul(4, 3)
+    var ex = mli_func_empty()
+    let xs = mli_expand_cd(&src, &!ex)
+    if !xs.ok { return report_fail("C8 quat i*j=k", "expand", xs.code, 0) }
+    var cb = mli_codebuf_empty()
+    let ok = mli_legalize_x86(&ex, &!cb)
+    if ok { return report_fail("C8 quat i*j=k", "legalized-8args", MLI_L_OK, MLI_L_UNSUPPORTED_SHAPE) }
+    if cb.code != MLI_L_UNSUPPORTED_SHAPE {
+        return report_fail("C8 quat i*j=k", "legalize-code", cb.code, MLI_L_UNSUPPORTED_SHAPE)
+    }
+    report_pass("C8 quaternion i*j=k interp-true; legalize refuses 8-arg ABI (named GPR wall)")
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    println("=== MLI S3b gate: CD lowering + named walls ===")
+    var failures: i64 = 0
+    failures = failures + case_complex_real()
+    failures = failures + case_complex_imag()
+    failures = failures + case_complex_bytes()
+    failures = failures + case_unexpanded_cd_refused()
+    failures = failures + case_octonion_wall()
+    failures = failures + case_complex_associator_illegal()
+    failures = failures + case_octonion_associator_wall()
+    failures = failures + case_quat_ij_k()
+    if failures == 0 {
+        println("=== MLI S3b: ALL CASES PASS ===")
+        return 0
+    }
+    print("=== MLI S3b: FAILURES = ")
+    print_int(failures)
+    print(" ===")
+    print("\n")
+    1
+}

--- a/self-hosted/mli/self_test_runner.sio
+++ b/self-hosted/mli/self_test_runner.sio
@@ -354,6 +354,22 @@ fn fixture_overflow_fail_closed() -> i64 with IO, Mut, Panic {
     expect("L capacity overflow FIRES fail-closed", res, MLI_VERR_OVERFLOW)
 }
 
+// M. POSITIVE CONTROL — CALL has no ABI in R0. Stamping OK was a default
+//    guess (E219 / #1784 / #1788 class). Verify must refuse detectably.
+fn fixture_call_unspecified() -> i64 with IO, Mut, Panic {
+    var f = mli_func_new("callsite", mli_kind_int(64, 1))
+    let a = mli_add_arg(&!f, mli_kind_int(64, 1))
+    let b0 = mli_new_block(&!f)
+    let d = mli_new_vreg(&!f, mli_kind_int(64, 1))
+    if a < 0 || b0 < 0 || d < 0 { return build_fail("M call") }
+    let dst = mli_vreg_opd(&f, d)
+    let s1 = mli_vreg_opd(&f, a)
+    if !mli_emit(&!f, b0, mli_inst2(MLI_OP_CALL, dst, s1)) { return build_fail("M call") }
+    if !mli_set_term(&!f, b0, mli_term_ret(dst)) { return build_fail("M call") }
+    let res = mli_verify_function(&f)
+    expect("M CALL without ABI FIRES", res, MLI_VERR_CALL_UNSPECIFIED)
+}
+
 fn main() -> i64 with IO, Mut, Panic {
     println("=== MLI S1 self-test: kinds, builder, dump, V-struct verify ===")
     var failures: i64 = 0
@@ -372,6 +388,7 @@ fn main() -> i64 with IO, Mut, Panic {
     failures = failures + fixture_cd_mul_no_policy()
     failures = failures + fixture_control_in_body()
     failures = failures + fixture_overflow_fail_closed()
+    failures = failures + fixture_call_unspecified()
 
     if failures == 0 {
         println("=== MLI S1: ALL FIXTURES PASS ===")

--- a/self-hosted/mli/verify.sio
+++ b/self-hosted/mli/verify.sio
@@ -266,14 +266,14 @@ fn body_inst_code(op: i64, cc: i64, assoc: i64, zd: i64, d: MliOperand, s1: MliO
     }
 
     if op == MLI_OP_ICMP {
-        if cc == MLI_CC_NONE { return MLI_VERR_OPERAND_RULE }
+        if !mli_cc_known(cc) { return MLI_VERR_OPERAND_RULE }
         if !is_int_kind(s1.kind) || !is_int_kind(s2.kind) { return MLI_VERR_OPERAND_RULE }
         if !mli_kind_eq(s1.kind, s2.kind) { return MLI_VERR_OPERAND_RULE }
         if d.kind.tag != MLI_KIND_BOOL { return MLI_VERR_OPERAND_RULE }
         return MLI_VERR_OK
     }
     if op == MLI_OP_FCMP {
-        if cc == MLI_CC_NONE { return MLI_VERR_OPERAND_RULE }
+        if !mli_cc_known(cc) { return MLI_VERR_OPERAND_RULE }
         var g = scalar_guard_code(s1.kind)
         if g != MLI_VERR_OK { return g }
         g = scalar_guard_code(s2.kind)
@@ -372,6 +372,14 @@ fn body_inst_code(op: i64, cc: i64, assoc: i64, zd: i64, d: MliOperand, s1: MliO
     if op == MLI_OP_CD_ZD_PROBE {
         if !is_cd_kind(s1.kind) { return MLI_VERR_OPERAND_RULE }
         if d.kind.tag != MLI_KIND_BOOL && !is_float_kind(d.kind) { return MLI_VERR_OPERAND_RULE }
+        return MLI_VERR_OK
+    }
+    if op == MLI_OP_CD_EXTRACT {
+        // The ONLY legal CD → scalar path. Lane index lives in src2.aux.
+        if !is_cd_kind(s1.kind) || !is_float_kind(d.kind) { return MLI_VERR_OPERAND_RULE }
+        if d.kind.bits != s1.kind.bits { return MLI_VERR_OPERAND_RULE }
+        if s2.tag != MLI_OPD_IMM { return MLI_VERR_OPERAND_RULE }
+        if s2.aux < 0 || s2.aux >= s1.kind.dim { return MLI_VERR_OPERAND_RULE }
         return MLI_VERR_OK
     }
 

--- a/self-hosted/mli/verify.sio
+++ b/self-hosted/mli/verify.sio
@@ -56,6 +56,7 @@ pub let MLI_VERR_QD128_ARITH: i64 = 20
 pub let MLI_VERR_IMM_KIND: i64 = 21
 pub let MLI_VERR_BLOCK_ID: i64 = 22
 pub let MLI_VERR_ARG_PREFIX: i64 = 23
+pub let MLI_VERR_CALL_UNSPECIFIED: i64 = 24
 
 pub struct MliVerifyResult {
     pub ok: bool,
@@ -284,7 +285,10 @@ fn body_inst_code(op: i64, cc: i64, assoc: i64, zd: i64, d: MliOperand, s1: MliO
         return MLI_VERR_OK
     }
 
-    if op == MLI_OP_CALL { return MLI_VERR_OK }
+    // Calling convention is unpinned (no ABI, no arg-marshalling rule).
+    // Stamping OK here was the same default-guess as E219 / #1784 / #1788:
+    // a well-typed hole must refuse, not pretend the site is well-formed.
+    if op == MLI_OP_CALL { return MLI_VERR_CALL_UNSPECIFIED }
 
     if op == MLI_OP_ALLOCA {
         if d.kind.tag != MLI_KIND_PTR { return MLI_VERR_OPERAND_RULE }


### PR DESCRIPTION
## Summary

This lane started as MLI S1 (WS-D, Option C) and grew through S2a/S2b/S3 on the same branch. The S1 contract is still the load-bearing one: **Knowledge and Cayley–Dickson are first-class operand kinds from the first commit**, so S5 is not a breaking rewrite.

### What S1 covers

- Kind model in `self-hosted/mli/ir.sio`: Int/Ptr/Float/QD128/Bool/VecF64/Knowledge/CD/Bundle. QD128 is not IEEE f128. There is no Int{128}. There is no Flags kind — compares produce a Bool vreg; `br` consumes that Bool.
- Builder (`builder.sio`): fail-closed capacities, no phi, no block-params.
- Text dump (`dump.sio`).
- V-struct verifier (`verify.sio`): cross-kind move is an error; `k_add` is not `fadd`; `cd_mul` / associator require explicit assoc/zd policies; definite assignment as the no-phi dominance surrogate.
- Unit fixtures in `self_test_runner.sio` (already on main via #1754). This PR is the evolution after that squash.

Two standing constraints, both measured, both load-bearing:

1. **The instruction pool is SoA, not AoS.** Storing a nested `MliInst` into an array element miscompiles under native-v2 (#1678/#1749 family). Do not tidy the pool into structs. Dispatch: `docs/audit/MADAROS_NESTED_AGGREGATE_ELEMENT_STORE_DISPATCH_2026-08-16.md`.
2. **The interpreter is refuse-first.** An unimplemented opcode, an unpinned shift, a Knowledge/CD value, or an unclassified compare-code must refuse with a named code. A default branch that guesses is the same defect class as E229, #1784, and unclassified scalars routed to the `char*` printer.

### What S1 deliberately does not

- No `mir_to_mli` / EMIR feed (S2 is the side door `ir_to_mli` for scalar R0 only).
- No generic legaliser and no full compile of the language.
- No Int128, no Flags, no phi, no block-params, no silent `f128 := qd128`.
- No guessing a semantics for `k_*` / `cd_*` in the interpreter — those kinds exist so they can be *verified*, not so they can be quietly lowered to a real.

Later rungs on this same branch (not S1, not claimed as S1):

- S2a/S2b: `ir_to_mli` + refuse-first interp + CFG/branches.
- S3/S3b: `expand_k` / `expand_cd` + `legalize_x86` mimicry. Knowledge variance reaches the instruction stream as a second `addsd`; octonion `cd_mul` and the associator hit named walls. Write-up: `docs/audit/MLI_S3_UNCERTAINTY_TO_BYTES_2026-08-17.md`.

## Test plan

- [ ] `./bin/souc run self-hosted/mli/self_test_runner.sio` (S1 fixtures)
- [ ] `./bin/souc run self-hosted/mli/s2a_gate_runner.sio`
- [ ] `./bin/souc run self-hosted/mli/s2b_gate_runner.sio`
- [ ] `./bin/souc run self-hosted/mli/s3_gate_runner.sio`
- [ ] `./bin/souc run self-hosted/mli/s3b_gate_runner.sio`
- [ ] `bash scripts/ci/mli_s3_bit_identity_gate.sh` (golden `add1` only; Knowledge/CD sequences have no pinned-emitter twin)