### PR TITLE
feat(design-system): KnowledgeRefusalMeter — TDM band as clinical refusal

### DIFF
--- a/website/src/components/epistemic/KnowledgeRefusalMeter.css
+++ b/website/src/components/epistemic/KnowledgeRefusalMeter.css
@@ -1,0 +1,256 @@
+/* KnowledgeRefusalMeter — consumes only tokens from website/src/styles/global.css */
+
+.krm {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-xl);
+  background: var(--color-surface-primary);
+  border: 1px solid var(--krm-border);
+  color: var(--color-text-primary);
+  min-width: 0;
+}
+
+.krm[data-density='compact'] {
+  gap: 0.55rem;
+  padding: 0.75rem 0.95rem;
+}
+
+.krm-header,
+.krm-readout,
+.krm-banner-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.krm-header {
+  min-height: 1.5rem;
+}
+
+.krm-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.krm-signature,
+.krm-provenance,
+.krm-unit,
+.krm-scale,
+.krm-epsilon,
+.krm-verdict,
+.krm-banner-title,
+.krm-nominal {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.krm-signature {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.krm-provenance {
+  font-size: 0.6875rem;
+  font-weight: 400;
+  color: var(--color-text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 28ch;
+}
+
+.krm-epsilon,
+.krm-verdict {
+  flex-shrink: 0;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--krm-border);
+  background: var(--krm-surface);
+  color: var(--krm-text);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.krm-epsilon {
+  padding: 0.125rem 0.5rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+}
+
+.krm-verdict {
+  padding: 0.25rem 0.625rem;
+  font-family: var(--font-sans);
+  font-size: 0.6875rem;
+  font-weight: 700;
+}
+
+.krm-readout {
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.krm-nominal {
+  font-size: clamp(1.55rem, 3.4vw, 2rem);
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--color-text-primary);
+  letter-spacing: -0.03em;
+}
+
+.krm-nominal[data-empty='true'] {
+  color: var(--krm-text);
+  letter-spacing: 0.04em;
+}
+
+.krm-unit {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+}
+
+.krm[data-state='refused'] .krm-unit {
+  color: var(--color-epistemic-refused-text);
+}
+
+.krm-spacer {
+  flex: 1;
+}
+
+.krm-ribbon {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.krm-gauge {
+  position: relative;
+  height: 2rem;
+  width: 100%;
+}
+
+.krm-axis {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 1px;
+  background: var(--color-border-hairline);
+  transform: translateY(-50%);
+}
+
+.krm-window {
+  position: absolute;
+  top: 50%;
+  height: 1.25rem;
+  border: 1px dashed var(--color-border-subtle);
+  border-radius: 2px;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.krm-envelope {
+  position: absolute;
+  top: 50%;
+  height: 0.875rem;
+  border-radius: 999px;
+  transform: translateY(-50%);
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--krm-ink) 15%, transparent),
+    var(--krm-ink) 42%,
+    var(--krm-ink) 58%,
+    color-mix(in srgb, var(--krm-ink) 15%, transparent)
+  );
+  opacity: 0.85;
+}
+
+.krm-needle {
+  position: absolute;
+  top: 50%;
+  width: 2px;
+  height: 1.25rem;
+  background: var(--krm-ink);
+  transform: translate(-50%, -50%);
+}
+
+.krm-scale {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.625rem;
+  font-weight: 400;
+  color: var(--color-text-tertiary);
+}
+
+.krm-scale-mid {
+  font-weight: 600;
+}
+
+.krm-absent {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--color-text-tertiary);
+}
+
+.krm-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.625rem 0.875rem;
+  border-radius: var(--radius-md);
+  background: var(--krm-surface);
+  border: 1px solid var(--krm-border);
+}
+
+.krm-banner-title {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--krm-text);
+}
+
+.krm-glyph {
+  display: inline-flex;
+  width: 1rem;
+  justify-content: center;
+}
+
+.krm-banner-body {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1.45;
+  color: var(--color-text-secondary);
+}
+
+@media (max-width: 640px) {
+  .krm-header,
+  .krm-readout {
+    flex-wrap: wrap;
+  }
+
+  .krm-provenance {
+    max-width: 100%;
+  }
+
+  .krm-nominal {
+    font-size: 1.45rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .krm-envelope,
+  .krm-needle {
+    transition: none;
+  }
+}

--- a/website/src/components/epistemic/KnowledgeRefusalMeter.tsx
+++ b/website/src/components/epistemic/KnowledgeRefusalMeter.tsx
@@ -1,0 +1,291 @@
+import type { CSSProperties } from 'react';
+import {
+  formatFixed,
+  readKnowledge,
+  type EpistemicState,
+  type KnowledgeInput,
+} from '../../lib/epistemicHonesty';
+import './KnowledgeRefusalMeter.css';
+
+export type KnowledgeRefusalMeterProps = KnowledgeInput & {
+  signature: string;
+  unit?: string;
+  provenance?: string;
+  coverageK?: number;
+  windowLow?: number | null;
+  windowHigh?: number | null;
+  guard?: string;
+  diagnostic?: string;
+  density?: 'full' | 'compact';
+  className?: string;
+};
+
+const TOKEN: Record<
+  EpistemicState,
+  { ink: string; surface: string; border: string; text: string; glyph: string; label: string }
+> = {
+  verified: {
+    ink: 'var(--color-epistemic-verified)',
+    surface: 'var(--color-epistemic-verified-surface)',
+    border: 'var(--color-epistemic-verified-border)',
+    text: 'var(--color-epistemic-verified-text)',
+    glyph: '◈',
+    label: 'Verified',
+  },
+  uncertain: {
+    ink: 'var(--color-epistemic-uncertain)',
+    surface: 'var(--color-epistemic-uncertain-surface)',
+    border: 'var(--color-epistemic-uncertain-border)',
+    text: 'var(--color-epistemic-uncertain-text)',
+    glyph: '△',
+    label: 'Uncertain',
+  },
+  refused: {
+    ink: 'var(--color-epistemic-refused)',
+    surface: 'var(--color-epistemic-refused-surface)',
+    border: 'var(--color-epistemic-refused-border)',
+    text: 'var(--color-epistemic-refused-text)',
+    glyph: '⊘',
+    label: 'Refused',
+  },
+};
+
+function pct(value: number, lo: number, hi: number): number {
+  if (hi <= lo) return 50;
+  return Math.min(100, Math.max(0, ((value - lo) / (hi - lo)) * 100));
+}
+
+function domainOf(values: Array<number | null | undefined>): [number, number] | null {
+  const xs = values.filter((v): v is number => v !== null && v !== undefined && Number.isFinite(v));
+  if (xs.length === 0) return null;
+  const lo = Math.min(...xs);
+  const hi = Math.max(...xs);
+  if (lo === hi) return [lo - 1, hi + 1];
+  const pad = (hi - lo) * 0.12;
+  return [lo - pad, hi + pad];
+}
+
+function epsilonLabel(
+  status: ReturnType<typeof readKnowledge>['epsilonStatus'],
+  epsilon: number | null,
+): string {
+  if (status === 'readable' && epsilon !== null) return `ε = ${formatFixed(epsilon, 2)}`;
+  if (status === 'missing') return 'ε absent';
+  return 'ε unreadable';
+}
+
+function varianceLabel(
+  status: ReturnType<typeof readKnowledge>['varianceStatus'],
+  variance: number | null,
+  expandedU: number | null,
+  unit: string,
+  coverageK: number,
+): string | null {
+  if (status === 'calibrated' && variance !== null) {
+    const uPart =
+      expandedU !== null
+        ? ` ± ${formatFixed(expandedU, 3)} (k=${coverageK}, GUM)`
+        : ` var = ${formatFixed(variance, 6)}`;
+    return `${unit}${uPart}`.trim();
+  }
+  if (status === 'uncalibrated') return 'var uncalibrated';
+  if (status === 'invalid') return 'var unreadable';
+  return null;
+}
+
+function defaultBanner(
+  state: EpistemicState,
+  reason: ReturnType<typeof readKnowledge>['reason'],
+  guard?: string,
+): { title: string; body: string } {
+  if (reason === 'fabrication-shape') {
+    return {
+      title: `${TOKEN.refused.glyph} Refusal — fabrication refused`,
+      body: 'A stub zero paired with a non-unit confidence is not a Knowledge value. The control prints no numeral.',
+    };
+  }
+  if (reason === 'unreadable-epsilon') {
+    return {
+      title: `${TOKEN.refused.glyph} Refusal — ε is not a unit interval`,
+      body: 'Confidence outside [0, 1] is not rendered as ε. A raw integer is a bit pattern, not a degree of belief.',
+    };
+  }
+  if (reason === 'guard-failed') {
+    return {
+      title: `${TOKEN.refused.glyph} Refusal — guard`,
+      body: guard
+        ? `The static constraint ${guard} does not hold. The program does not produce a downstream value.`
+        : 'The confidence guard does not hold. The program does not produce a downstream value.',
+    };
+  }
+  if (state === 'verified') {
+    return {
+      title: `${TOKEN.verified.glyph} Verified`,
+      body: guard
+        ? `Support sits inside the gate ${guard}. Variance, if uncalibrated, is still not printed as zero.`
+        : 'The payload is readable and the caller claims verification.',
+    };
+  }
+  return {
+    title: `${TOKEN.uncertain.glyph} Uncertain`,
+    body: 'The measurement stands, with its doubt attached. This is not an error state.',
+  };
+}
+
+export function KnowledgeRefusalMeter({
+  signature,
+  unit = '',
+  provenance,
+  coverageK = 2,
+  windowLow,
+  windowHigh,
+  guard,
+  diagnostic,
+  density = 'full',
+  className,
+  ...input
+}: KnowledgeRefusalMeterProps) {
+  const reading = readKnowledge(input, coverageK);
+  const tone = TOKEN[reading.state];
+  const banner = diagnostic
+    ? {
+        title: `${tone.glyph} ${tone.label}${reading.reason === 'fabrication-shape' ? ' — fabrication' : ''}`,
+        body: diagnostic,
+      }
+    : defaultBanner(reading.state, reading.reason, guard);
+
+  const hasInterval = reading.boundLow !== null && reading.boundHigh !== null;
+  const scale = domainOf([
+    reading.value,
+    reading.boundLow,
+    reading.boundHigh,
+    windowLow,
+    windowHigh,
+    reading.value !== null && reading.expandedU !== null ? reading.value - reading.expandedU : null,
+    reading.value !== null && reading.expandedU !== null ? reading.value + reading.expandedU : null,
+  ]);
+
+  const envelopeLow =
+    reading.boundLow ??
+    (reading.value !== null && reading.expandedU !== null ? reading.value - reading.expandedU : null);
+  const envelopeHigh =
+    reading.boundHigh ??
+    (reading.value !== null && reading.expandedU !== null ? reading.value + reading.expandedU : null);
+  const showRibbon =
+    scale !== null && envelopeLow !== null && envelopeHigh !== null && envelopeLow <= envelopeHigh;
+
+  const primary = hasInterval
+    ? `[${formatFixed(reading.boundLow as number, 2)}, ${formatFixed(reading.boundHigh as number, 2)}]`
+    : reading.value !== null
+      ? formatFixed(reading.value, reading.value >= 10 ? 2 : 3)
+      : `${tone.glyph}`;
+
+  const unitLine = varianceLabel(
+    reading.varianceStatus,
+    reading.variance,
+    reading.expandedU,
+    unit,
+    coverageK,
+  );
+  const unitFallback = unit && !unitLine ? unit : null;
+
+  const [domainLo, domainHi] = scale ?? [0, 1];
+  const envLeft = showRibbon ? pct(envelopeLow as number, domainLo, domainHi) : 0;
+  const envRight = showRibbon ? pct(envelopeHigh as number, domainLo, domainHi) : 0;
+  const needle =
+    showRibbon && reading.value !== null ? pct(reading.value, domainLo, domainHi) : null;
+  const windowLeft =
+    showRibbon && windowLow != null && windowHigh != null
+      ? pct(windowLow, domainLo, domainHi)
+      : null;
+  const windowRight =
+    showRibbon && windowLow != null && windowHigh != null
+      ? pct(windowHigh, domainLo, domainHi)
+      : null;
+
+  return (
+    <article
+      className={['krm', className].filter(Boolean).join(' ')}
+      data-state={reading.state}
+      data-density={density}
+      data-reason={reading.reason}
+      style={
+        {
+          '--krm-ink': tone.ink,
+          '--krm-surface': tone.surface,
+          '--krm-border': tone.border,
+          '--krm-text': tone.text,
+        } as CSSProperties
+      }
+      aria-label={`${signature}: ${tone.label}`}
+    >
+      <header className="krm-header">
+        <span className="krm-signature">{signature}</span>
+        <div className="krm-meta">
+          {provenance ? <span className="krm-provenance">{provenance}</span> : null}
+          <span className="krm-epsilon">{epsilonLabel(reading.epsilonStatus, reading.epsilon)}</span>
+        </div>
+      </header>
+
+      <div className="krm-readout">
+        <span className="krm-nominal" data-empty={reading.value === null && !hasInterval}>
+          {primary}
+        </span>
+        {unitLine ? <span className="krm-unit">{unitLine}</span> : null}
+        {!unitLine && unitFallback ? <span className="krm-unit">{unitFallback}</span> : null}
+        <span className="krm-spacer" />
+        <span className="krm-verdict">{tone.label}</span>
+      </div>
+
+      {showRibbon ? (
+        <div className="krm-ribbon" aria-hidden="true">
+          <div className="krm-gauge">
+            <div className="krm-axis" />
+            {windowLeft !== null && windowRight !== null ? (
+              <div
+                className="krm-window"
+                style={{ left: `${windowLeft}%`, width: `${Math.max(0, windowRight - windowLeft)}%` }}
+              />
+            ) : null}
+            <div
+              className="krm-envelope"
+              style={{ left: `${envLeft}%`, width: `${Math.max(1.5, envRight - envLeft)}%` }}
+            />
+            {needle !== null ? <div className="krm-needle" style={{ left: `${needle}%` }} /> : null}
+          </div>
+          <div className="krm-scale">
+            <span>{formatFixed(envelopeLow as number, 2)}</span>
+            {windowLow != null && windowHigh != null ? (
+              <span className="krm-scale-mid">
+                window [{formatFixed(windowLow, 0)}, {formatFixed(windowHigh, 0)}]
+              </span>
+            ) : (
+              <span />
+            )}
+            <span>{formatFixed(envelopeHigh as number, 2)}</span>
+          </div>
+        </div>
+      ) : (
+        <p className="krm-absent">
+          {reading.varianceStatus === 'uncalibrated'
+            ? 'No GUM ribbon — variance left uncalibrated rather than printed as 0.000.'
+            : 'No GUM ribbon — no calibrated dispersion was supplied.'}
+        </p>
+      )}
+
+      {density === 'full' ? (
+        <footer className="krm-banner">
+          <div className="krm-banner-head">
+            <span className="krm-banner-title">
+              <span className="krm-glyph" aria-hidden="true">
+                {tone.glyph}
+              </span>
+              {banner.title.replace(/^[◈△⊘]\s/, '')}
+            </span>
+          </div>
+          <p className="krm-banner-body">{banner.body}</p>
+        </footer>
+      ) : null}
+    </article>
+  );
+}

--- a/website/src/components/home/KnowledgeRefusalExhibit.astro
+++ b/website/src/components/home/KnowledgeRefusalExhibit.astro
@@ -1,0 +1,177 @@
+---
+import { KnowledgeRefusalPlayground } from './KnowledgeRefusalPlayground';
+import { getLocalizedPath } from '../../lib/i18n';
+import type { Locale } from '../../lib/i18n';
+
+interface Props {
+  locale?: Locale;
+}
+const { locale = 'en' } = Astro.props;
+
+const t: Record<
+  string,
+  { label: string; heading: string; annotation: string; link: string }
+> = {
+  en: {
+    label: 'KNOWLEDGE ARRIVES WITH ITS DOUBT',
+    heading: 'A well-typed program returns a value, or it refuses.',
+    annotation:
+      'It does not invent a zero. The pre-TDM vancomycin Cmin is a support band, not a point. Variance is left uncalibrated rather than printed as var=0.000. Refusal is the successful outcome.',
+    link: 'Read the vancomycin example →',
+  },
+  pt: {
+    label: 'O CONHECIMENTO CHEGA COM A SUA DÚVIDA',
+    heading: 'Um programa bem tipado devolve um valor, ou recusa.',
+    annotation:
+      'Não inventa um zero. O Cmin pré-TDM da vancomicina é uma banda de suporte, não um ponto. A variância fica por calibrar em vez de se imprimir var=0.000. A recusa é o resultado bem-sucedido.',
+    link: 'Ler o exemplo da vancomicina →',
+  },
+  es: {
+    label: 'EL CONOCIMIENTO LLEGA CON SU DUDA',
+    heading: 'Un programa bien tipado devuelve un valor, o se niega.',
+    annotation:
+      'No inventa un cero. El Cmin pre-TDM de vancomicina es una banda de soporte, no un punto. La varianza queda sin calibrar en lugar de imprimirse como var=0.000. La negativa es el resultado correcto.',
+    link: 'Lea el ejemplo de vancomicina →',
+  },
+  el: {
+    label: 'Η ΓΝΩΣΗ ΕΡΧΕΤΑΙ ΜΕ ΤΗΝ ΑΜΦΙΒΟΛΙΑ ΤΗΣ',
+    heading: 'Ένα καλά τυποποιημένο πρόγραμμα επιστρέφει τιμή, ή αρνείται.',
+    annotation:
+      'Δεν επινοεί μηδέν. Το pre-TDM Cmin της βανκομυκίνης είναι ζώνη στήριξης, όχι σημείο. Η διασπορά μένει αβαθμονόμητη αντί να τυπωθεί var=0.000. Η άρνηση είναι το επιτυχές αποτέλεσμα.',
+    link: 'Διαβάστε το παράδειγμα βανκομυκίνης →',
+  },
+  zh: {
+    label: '知识带着它的怀疑到来',
+    heading: '良类型程序给出值，或拒绝给出。',
+    annotation:
+      '它不会伪造一个零。万古霉素治疗前 Cmin 是支撑区间，不是一个点。方差保持未校准，而不是印成 var=0.000。拒绝是成功的结果。',
+    link: '阅读万古霉素示例 →',
+  },
+  ja: {
+    label: '知は、その疑念とともに届く',
+    heading: '正しく型付けされたプログラムは値を返すか、拒む。',
+    annotation:
+      'ゼロを捏造しない。TDM前のバンコマイシンCminは点ではなく支持帯域だ。分散は var=0.000 と印刷せず、未校正のまま残す。拒否は成功した結果である。',
+    link: 'バンコマイシンの例を読む →',
+  },
+};
+
+const d = t[locale] ?? t.en;
+---
+
+<section class="krm-section">
+  <div class="krm-section-inner">
+    <p class="krm-section-label">{d.label}</p>
+    <h2 class="krm-section-heading">{d.heading}</h2>
+    <p class="krm-section-annotation">{d.annotation}</p>
+    <KnowledgeRefusalPlayground client:visible />
+    <a href={getLocalizedPath('/learn/vancomycin-uncertainty', locale)} class="krm-section-link">
+      {d.link}
+    </a>
+  </div>
+</section>
+
+<style>
+  .krm-section {
+    position: relative;
+    padding: clamp(3.5rem, 7vw, 6rem) 1.5rem;
+  }
+
+  .krm-section-inner {
+    max-width: 760px;
+    margin: 0 auto;
+    display: grid;
+    gap: 1.1rem;
+  }
+
+  .krm-section-label {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-accent-teal);
+    opacity: 0.85;
+  }
+
+  .krm-section-heading {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(1.5rem, 3vw, 2.2rem);
+    font-weight: 400;
+    line-height: 1.25;
+    color: var(--color-text-primary);
+  }
+
+  .krm-section-annotation {
+    margin: 0;
+    max-width: 68ch;
+    font-size: 0.95rem;
+    line-height: 1.7;
+    color: var(--color-text-secondary);
+  }
+
+  .krm-section-link {
+    font-size: 0.84rem;
+    color: var(--color-accent-gold-soft);
+    width: fit-content;
+  }
+
+  .krm-section-link:hover {
+    text-decoration: underline;
+  }
+
+  :global(.krm-play) {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  :global(.krm-play-toggle) {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  :global(.krm-play-btn) {
+    border-radius: var(--radius-full);
+    border: 1px solid var(--color-border-subtle);
+    background: var(--color-surface-frost);
+    color: var(--color-text-secondary);
+    font-family: var(--font-sans);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 0.35rem 0.7rem;
+    cursor: pointer;
+  }
+
+  :global(.krm-play-btn:hover) {
+    color: var(--color-text-primary);
+  }
+
+  :global(.krm-play-btn[data-active='true'][data-state='refused']) {
+    border-color: var(--color-epistemic-refused-border);
+    background: var(--color-epistemic-refused-surface);
+    color: var(--color-epistemic-refused-text);
+  }
+
+  :global(.krm-play-btn[data-active='true'][data-state='verified']) {
+    border-color: var(--color-epistemic-verified-border);
+    background: var(--color-epistemic-verified-surface);
+    color: var(--color-epistemic-verified-text);
+  }
+
+  :global(.krm-play-btn[data-active='true'][data-state='uncertain']) {
+    border-color: var(--color-epistemic-uncertain-border);
+    background: var(--color-epistemic-uncertain-surface);
+    color: var(--color-epistemic-uncertain-text);
+  }
+
+  :global(.krm-play-source) {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    color: var(--color-text-tertiary);
+  }
+</style>

--- a/website/src/components/home/KnowledgeRefusalPlayground.tsx
+++ b/website/src/components/home/KnowledgeRefusalPlayground.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import {
+  KnowledgeRefusalMeter,
+  type KnowledgeRefusalMeterProps,
+} from '../epistemic/KnowledgeRefusalMeter';
+
+type WitnessId = 'refused' | 'verified' | 'uncertain';
+
+type Witness = {
+  id: WitnessId;
+  label: string;
+  source: string;
+  meter: KnowledgeRefusalMeterProps;
+};
+
+const WITNESSES: Witness[] = [
+  {
+    id: 'refused',
+    label: 'Refused',
+    source: 'docs/audit/MADAROS_MULTIMODULE_FALLBACK_SEGFAULT_2026-06-30.md · pre-TDM',
+    meter: {
+      signature: 'cmin: Knowledge<mg/L>',
+      boundLow: 9.052178,
+      boundHigh: 24.298861,
+      variance: 0,
+      varianceCalibrated: false,
+      unit: 'mg/L',
+      provenance: 'pre-TDM · 78.5 kg · CrCl 65 · 1000 mg q12h',
+      state: 'refused',
+      windowLow: 10,
+      windowHigh: 20,
+      guard: 'where band ⊂ [10, 20] mg/L',
+      diagnostic:
+        'PRE_REFUSE. Fréchet support [9.05, 24.30] is not inside the therapeutic window. The stdlib leaves variance uncalibrated (v = 0.0 in source); this control will not print var=0.000.',
+    },
+  },
+  {
+    id: 'verified',
+    label: 'Verified',
+    source: 'docs/audit/MADAROS_MULTIMODULE_FALLBACK_SEGFAULT_2026-06-30.md · post-TDM',
+    meter: {
+      signature: 'cmin: Knowledge<mg/L>',
+      boundLow: 12.820636,
+      boundHigh: 17.358234,
+      variance: 0,
+      varianceCalibrated: false,
+      unit: 'mg/L',
+      provenance: 'post-TDM · 3 samples · same patient',
+      state: 'verified',
+      windowLow: 10,
+      windowHigh: 20,
+      guard: 'where band ⊂ [10, 20] mg/L',
+      diagnostic:
+        'POST_PRESCRIBE. Support [12.82, 17.36] ⊂ [10, 20]. Same uncalibrated variance field as the refused witness — still not rendered as a zero.',
+    },
+  },
+  {
+    id: 'uncertain',
+    label: 'Uncertain',
+    source: 'tests/run-pass/med/vancomycin_full_propagation.sio',
+    meter: {
+      signature: 'crcl: Knowledge<mL/min>',
+      value: 65.0,
+      epsilon: 0.72,
+      unit: 'mL/min',
+      provenance: 'Cockcroft_Gault_2025',
+      state: 'uncertain',
+      diagnostic:
+        'The measurement stands. ε = 0.72 is a unit-interval confidence, not a bit pattern. This is not a dosing decision and not an error.',
+    },
+  },
+];
+
+export function KnowledgeRefusalPlayground() {
+  const [id, setId] = useState<WitnessId>('refused');
+  const witness = WITNESSES.find((w) => w.id === id) ?? WITNESSES[0];
+
+  return (
+    <div className="krm-play">
+      <div className="krm-play-toggle" role="radiogroup" aria-label="Epistemic witness">
+        {WITNESSES.map((w) => (
+          <button
+            key={w.id}
+            type="button"
+            role="radio"
+            aria-checked={w.id === id}
+            className="krm-play-btn"
+            data-active={w.id === id}
+            data-state={w.id}
+            onClick={() => setId(w.id)}
+          >
+            {w.label}
+          </button>
+        ))}
+      </div>
+      <KnowledgeRefusalMeter {...witness.meter} />
+      <p className="krm-play-source">{witness.source}</p>
+    </div>
+  );
+}

--- a/website/src/lib/epistemicHonesty.ts
+++ b/website/src/lib/epistemicHonesty.ts
@@ -1,0 +1,192 @@
+/**
+ * Honesty kernel for Knowledge<T> display.
+ *
+ * A well-typed program produces a value or refuses. It does not invent a
+ * zero. That is the Lean thesis of SounioRefusalHonesty
+ * (`refusal_is_not_zero`, `well_typed_value_or_refuse`) — a model of the
+ * E219 fragment, not a proof that today's backend implements it.
+ *
+ * This module is the visual counterpart: it decides what a control may
+ * print. It will not render an uncalibrated variance as `var=0.000`, and
+ * it will not render a non-unit-interval bit pattern as ε.
+ */
+
+export type EpistemicState = 'verified' | 'uncertain' | 'refused';
+
+export type VarianceStatus = 'calibrated' | 'uncalibrated' | 'missing' | 'invalid';
+
+export type EpsilonStatus = 'readable' | 'missing' | 'unreadable';
+
+export type KnowledgeInput = {
+  value?: number | null;
+  variance?: number | null;
+  /** When false, a stored 0 is "uncalibrated", not "exact". Default: treat 0 as uncalibrated. */
+  varianceCalibrated?: boolean;
+  epsilon?: number | null;
+  /** Guard of the form `where x.ε >= threshold`. Missing threshold does not refuse. */
+  threshold?: number | null;
+  /** Caller-claimed triad state. Honesty failures override a verified/uncertain claim. */
+  state?: EpistemicState;
+  boundLow?: number | null;
+  boundHigh?: number | null;
+};
+
+export type KnowledgeReading = {
+  state: EpistemicState;
+  /** Null means: print no numeral. A refused fabrication has no value slot. */
+  value: number | null;
+  /** Null means: print no `var=…`. Uncalibrated zero is not a variance. */
+  variance: number | null;
+  varianceStatus: VarianceStatus;
+  epsilon: number | null;
+  epsilonStatus: EpsilonStatus;
+  expandedU: number | null;
+  boundLow: number | null;
+  boundHigh: number | null;
+  reason:
+    | 'caller-state'
+    | 'guard-failed'
+    | 'unreadable-epsilon'
+    | 'fabrication-shape'
+    | 'invalid-bounds';
+};
+
+export function isUnitInterval(value: number): boolean {
+  return Number.isFinite(value) && value >= 0 && value <= 1;
+}
+
+export function isFiniteNumber(value: number): boolean {
+  return Number.isFinite(value);
+}
+
+export function isNonNegativeFinite(value: number): boolean {
+  return Number.isFinite(value) && value >= 0;
+}
+
+function asOptionalNumber(value: number | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  return Number.isFinite(value) ? value : null;
+}
+
+export function classifyVariance(
+  variance: number | null | undefined,
+  calibrated?: boolean,
+): { status: VarianceStatus; variance: number | null } {
+  if (variance === null || variance === undefined) {
+    return { status: 'missing', variance: null };
+  }
+  if (!isNonNegativeFinite(variance)) {
+    return { status: 'invalid', variance: null };
+  }
+  if (variance === 0 && calibrated !== true) {
+    // stdlib/clinical/vancomycin_pbpk.sio leaves v = 0.0 when the joint
+    // is unknown: "Leave variance uncalibrated instead of inventing
+    // pseudo-statistics". Printing that as var=0.000 would be a lie.
+    return { status: 'uncalibrated', variance: null };
+  }
+  return { status: 'calibrated', variance };
+}
+
+export function classifyEpsilon(
+  epsilon: number | null | undefined,
+): { status: EpsilonStatus; epsilon: number | null } {
+  if (epsilon === null || epsilon === undefined) {
+    return { status: 'missing', epsilon: null };
+  }
+  if (!isUnitInterval(epsilon)) {
+    return { status: 'unreadable', epsilon: null };
+  }
+  return { status: 'readable', epsilon };
+}
+
+/**
+ * Detect the dissertation-suite fabrication shape: a stub zero variance
+ * paired with a confidence that is not a unit interval (the observed
+ * raw integer 4604219396932172800 is the witness, not a display value).
+ */
+export function isFabricationShape(
+  variance: number | null | undefined,
+  epsilon: number | null | undefined,
+): boolean {
+  const epsilonGiven = epsilon !== null && epsilon !== undefined;
+  if (!epsilonGiven || isUnitInterval(epsilon)) return false;
+  if (variance === null || variance === undefined) return true;
+  return variance === 0 || !isNonNegativeFinite(variance);
+}
+
+export function readKnowledge(
+  input: KnowledgeInput,
+  coverageK = 2,
+): KnowledgeReading {
+  const fabrication = isFabricationShape(input.variance, input.epsilon);
+  const { status: varianceStatus, variance } = classifyVariance(
+    input.variance,
+    input.varianceCalibrated,
+  );
+  const { status: epsilonStatus, epsilon } = classifyEpsilon(input.epsilon);
+
+  const rawValue = asOptionalNumber(input.value);
+  const boundLow = asOptionalNumber(input.boundLow);
+  const boundHigh = asOptionalNumber(input.boundHigh);
+  const boundsValid =
+    boundLow !== null && boundHigh !== null && boundLow <= boundHigh;
+
+  let state: EpistemicState = input.state ?? 'uncertain';
+  let reason: KnowledgeReading['reason'] = 'caller-state';
+
+  if (fabrication) {
+    state = 'refused';
+    reason = 'fabrication-shape';
+  } else if (epsilonStatus === 'unreadable') {
+    state = 'refused';
+    reason = 'unreadable-epsilon';
+  } else if (
+    epsilonStatus === 'readable' &&
+    epsilon !== null &&
+    input.threshold !== null &&
+    input.threshold !== undefined &&
+    isUnitInterval(input.threshold) &&
+    epsilon < input.threshold
+  ) {
+    state = 'refused';
+    reason = 'guard-failed';
+  } else if (input.boundLow != null && input.boundHigh != null && !boundsValid) {
+    state = 'refused';
+    reason = 'invalid-bounds';
+  } else if (input.state) {
+    state = input.state;
+    reason = 'caller-state';
+  }
+
+  const hideNumeral = reason === 'fabrication-shape';
+
+  const expandedU =
+    varianceStatus === 'calibrated' &&
+    variance !== null &&
+    Number.isFinite(coverageK) &&
+    coverageK > 0
+      ? coverageK * Math.sqrt(variance)
+      : null;
+
+  return {
+    state,
+    value: hideNumeral ? null : rawValue,
+    variance: hideNumeral ? null : variance,
+    varianceStatus: hideNumeral ? 'invalid' : varianceStatus,
+    epsilon: hideNumeral ? null : epsilon,
+    epsilonStatus: hideNumeral ? 'unreadable' : epsilonStatus,
+    expandedU: hideNumeral ? null : expandedU,
+    boundLow: hideNumeral ? null : boundsValid ? boundLow : null,
+    boundHigh: hideNumeral ? null : boundsValid ? boundHigh : null,
+    reason,
+  };
+}
+
+export function formatFixed(value: number, digits: number): string {
+  if (!Number.isFinite(value)) return '—';
+  return value.toLocaleString('en-GB', {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+    useGrouping: false,
+  });
+}

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Hero from '../components/home/Hero.astro';
 import ManifestoPulse from '../components/home/ManifestoPulse.astro';
+import KnowledgeRefusalExhibit from '../components/home/KnowledgeRefusalExhibit.astro';
 import LivingLanguagePulse from '../components/home/LivingLanguagePulse.astro';
 import ProofMoment from '../components/home/ProofMoment.astro';
 import NumberAnchor from '../components/home/NumberAnchor.astro';
@@ -62,28 +63,31 @@ const d = cta[locale] ?? cta.en;
   {/* 2 — MANIFESTO */}
   <ManifestoPulse locale={locale} />
 
-  {/* 3 — LIVING LANGUAGE PULSE */}
+  {/* 3 — KNOWLEDGE REFUSAL METER */}
+  <KnowledgeRefusalExhibit locale={locale} />
+
+  {/* 4 — LIVING LANGUAGE PULSE */}
   <LivingLanguagePulse locale={locale} />
 
-  {/* 4 — PROOF MOMENT */}
+  {/* 5 — PROOF MOMENT */}
   <ProofMoment locale={locale} />
 
-  {/* 5 — THE NUMBER */}
+  {/* 6 — THE NUMBER */}
   <NumberAnchor locale={locale} />
 
-  {/* 6 — DOMAIN GLIMPSES */}
+  {/* 7 — DOMAIN GLIMPSES */}
   <DomainGlimpses locale={locale} />
 
-  {/* 7 — FLAGSHIP APPLICATIONS */}
+  {/* 8 — FLAGSHIP APPLICATIONS */}
   <FlagshipApplications locale={locale} />
 
-  {/* 8 — COMPILER DEPTH */}
+  {/* 9 — COMPILER DEPTH */}
   <CompilerDepth locale={locale} />
 
-  {/* 9 — HONEST STATUS */}
+  {/* 10 — HONEST STATUS */}
   <HonestStatusSection variant="clinical" />
 
-  {/* 10 — ENTER */}
+  {/* 11 — ENTER */}
   <section class="section-shell relative overflow-hidden">
     <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
       <div class="absolute inset-0 bg-[radial-gradient(ellipse_80%_60%_at_50%_120%,color-mix(in_srgb,var(--color-accent-gold)_15%,transparent),transparent)]"></div>


### PR DESCRIPTION
## Summary

- Landing-page `KnowledgeRefusalMeter`: one control shows a `Knowledge` payload with its GUM / support band, its ε, and its verdict. Refusal is the default state, not an error chrome.
- The three witnesses are from the dissertation TDM domain, not placeholders. Pre-TDM Cmin `[9.05, 24.30]` **overflows** the therapeutic window `[10, 20]`, so prescribing would be unsafe and the control **refuses** (`PRE_REFUSE`). Post-TDM `[12.82, 17.36]` sits inside the window and prescribes (`POST_PRESCRIBE`). CrCl `65.0`, ε `= 0.72` is the uncertain measurement that stands. Refusal is a clinical safety property, demonstrated rather than asserted.
- Token names are taken only from `website/src/styles/global.css` on `origin/main` (the `#1764` triad: `--color-epistemic-{verified,uncertain,refused}` plus `surface` / `border` / `text`). No new token names.

## What landed today, and why this control exists

1. **[#1788](https://github.com/Sounio-lang/sounio/pull/1788)** proves formally that a well-typed program produces a value or refuses and never fabricates a zero (`refusal_is_not_zero`, `well_typed_value_or_refuse`). **[#1792](https://github.com/Sounio-lang/sounio/pull/1792)** caught the compiler printing `var=0.000000` and a confidence as the raw integer `4604219396932172800`. This component is the visual argument for the exact property Lean proves and the compiler was violating this morning. `readKnowledge` will not print an uncalibrated `v = 0.0` as `var=0.000`, and it will not print a non-unit-interval bit pattern as ε — the value slot goes empty (`⊘`), not `0`.

2. **Still no zero, on purpose.** Both the refused pre-TDM band and the verified post-TDM band carry the same uncalibrated variance field (`v = 0.0` in `stdlib/clinical/vancomycin_pbpk.sio`: "Leave variance uncalibrated instead of inventing pseudo-statistics"). The meter prints `var uncalibrated` in **both** states. That is a deliberate contrast with the fabricated zero `#1792` caught — verification does not earn a fake `var=0.000` any more than refusal does.

3. **Gates actually run.** `check:astro` (0 errors), `check:i18n`, `check:routes`, and `check:nav` were run and passed. The full `check:quality` / `npm run build` path was **not** run. That path regenerates `website/src/data/artifactStatus.ts` (a data file, not a stylesheet) and would have mixed an unrelated timestamp into this PR, as it did on `#1764`. An unrun gate is not a green gate. CI on this PR is the build evidence.

## Test plan

- [ ] Confirm the home exhibit sits after the manifesto and defaults to **Refused** (pre-TDM overflow of `[10, 20]`).
- [ ] Toggle **Verified**: post-TDM band inside the window; variance still reads uncalibrated, not `0.000`.
- [ ] Toggle **Uncertain**: CrCl `65.0` / ε `= 0.72` has no ribbon and is not styled as an error.
- [ ] Light and dark: triad colours resolve from the existing `--color-epistemic-*` tokens, no new names.
- [ ] Feed the honesty kernel a stub zero + non-unit ε (`4604219396932172800`): no numeral, no `var=0.000`, state `refused`.
- [ ] Let Vercel / Astro CI be the `build` evidence; do not treat this PR as having a local full-build receipt.