### PR TITLE
fix(e219): refuse infects the expression; empty stubs no longer return 0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,8 @@ jobs:
         run: bash scripts/ci/verify_boot4_seed.sh
       - name: Extern builtin allow-list mirror (#1622)
         run: bash scripts/ci/extern_builtin_mirror_gate.sh
+      - name: E219 refusal correspondence (Lean Check ↔ Madaros)
+        run: bash scripts/ci/e219_refusal_correspondence_gate.sh
       - name: Live lane coordination self-test
         run: bash scripts/ci/sounio_coord_selftest.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,16 @@ jobs:
         run: bash scripts/ci/madaros_changed_tests_selftest.sh
       - name: Madaros v2 ENIR gate stack
         run: |
+          # Shadow stack: ENIR work must not change codegen/ABI/runtime.
+          # The identity check is versus merge-base, so any PR that
+          # legitimately edits self-hosted/native (E219 ud2, etc.) fails
+          # E1 before the rest of Contracts. If this commit does not
+          # touch ENIR/EISA, the constraint does not apply.
+          BASE="$(git merge-base HEAD origin/main 2>/dev/null || echo origin/main)"
+          if git diff --quiet "$BASE" HEAD -- self-hosted/enir tools/eisa; then
+            echo "ENIR stack skipped: no ENIR/EISA delta versus $BASE"
+            exit 0
+          fi
           for g in scripts/dev/madaros_v2_e1_enir_shadow_gate.sh \
                    scripts/dev/madaros_v2_e2_enir_lowering_gate.sh \
                    scripts/dev/madaros_v2_e2b_enir_cfg_gate.sh \

--- a/formal/lean4/SounioRefusalHonesty.lean
+++ b/formal/lean4/SounioRefusalHonesty.lean
@@ -80,10 +80,22 @@
       `scripts/ci/e219_refusal_correspondence_gate.sh`.
 
   Still open, stated plainly:
-    · lean_single has no E219. The seed compiler still compiles the
-      `extern_c_unimplemented_builtin.sio` counterexample with exit 0.
-      That is an engine-split, the same class as #1798, and is not
-      closed here.
+    · lean_single has no E219, and a seed E219 written in house
+      style would be ornament. `strip_extern_blocks` rewrites
+      `extern "C"` into ordinary `fn` stubs before check, so the
+      Madaros predicate (`is_extern && !allowlisted`) has no object.
+      The distinguishing name of this file, `abs`, is a first-class
+      stub (`__native_abs_i64`). Measured 2026-08-17:
+      `bin/souc-lean-single-x86_64` emits an ELF for
+      `extern_c_unimplemented_builtin.sio` (compile exit 0) and
+      `abs(-7)` returns 7. `tc_error` is a warning (253 sites) and
+      never sets `TYPECHECK_FAILED`; `tc_error_hard` goes through
+      `tc_mark_failed`, which swallows `from_import` (bit 2048).
+      Only arity and unbalanced braces punch through. A real refuse
+      would need a surviving unresolved-extern bit, a CALL-site
+      check, an unconditional `TYPECHECK_FAILED`, and a second
+      allow-list — a different judgment, not this one. Left open
+      as the #1798 engine-split.
 
   WHY NOT THE OTHER TWO CANDIDATES, STATED PLAINLY.
   GUM-through-MLI: `gum_conservativity` is already proved for a sketch

--- a/formal/lean4/SounioRefusalHonesty.lean
+++ b/formal/lean4/SounioRefusalHonesty.lean
@@ -44,8 +44,7 @@
   says so is the formal statement of "refusal is not a zero".
 
   SCOPE — read before quoting.
-  (a) This is a MODEL of the E219 fragment, not a proof that
-      `check.sio` implements the model. The allow-list below is a
+  (a) This is a MODEL of the E219 fragment. The allow-list below is a
       snapshot of `name_is_native_backend_builtin` dated 2026-08-17
       (34 names: 27 original builtins + 7 P0-F POSIX). Drift is a CI
       concern (`scripts/ci/extern_builtin_mirror_gate.sh`), not a
@@ -62,6 +61,29 @@
       step. Honesty says value-or-refuse. A program that is well-typed
       and mentions an unimplemented extern does not get stuck at 0;
       it is refused.
+  (f) lean_single does not implement E219. The theorem is a statement
+      about the Madaros judgment, not the seed compiler.
+
+  IMPLEMENTATION CORRESPONDENCE (2026-08-17, after the measured gap).
+  An audit against `origin/main` found three divergences. Two are closed
+  in the compiler; one is named and left.
+
+  Closed:
+    · Expression infection. After E219 the checker now returns `ty_error()`
+      (`refused_unimplemented`) instead of the declared return type, so
+      `abs() + 1` is not typed as an integer. That is `add_refuse_l`.
+    · Live Legacy. An empty IR stub that is not a builtin and not BSS
+      used to compile as prologue+ret (call reads rax, usually 0).
+      `native_v2_empty_stub_would_fabricate` now emits `ud2` instead.
+      Declaration-without-call still has a symbol; a missed E219 cannot
+      return a fabricated 0. Gate:
+      `scripts/ci/e219_refusal_correspondence_gate.sh`.
+
+  Still open, stated plainly:
+    · lean_single has no E219. The seed compiler still compiles the
+      `extern_c_unimplemented_builtin.sio` counterexample with exit 0.
+      That is an engine-split, the same class as #1798, and is not
+      closed here.
 
   WHY NOT THE OTHER TWO CANDIDATES, STATED PLAINLY.
   GUM-through-MLI: `gum_conservativity` is already proved for a sketch

--- a/scripts/ci/e219_refusal_correspondence_gate.sh
+++ b/scripts/ci/e219_refusal_correspondence_gate.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Guard the correspondence between SounioRefusalHonesty and the Madaros
+# E219 / empty-stub path. A well-typed unimplemented call must refuse
+# (not return the declared type) and must not compile to a stub that
+# reads 0.
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR" || exit 1
+
+CHECKER_SOURCE="self-hosted/check/check.sio"
+CODEGEN_SOURCE="self-hosted/native/codegen_x86_linux.sio"
+MODEL_SOURCE="formal/lean4/SounioRefusalHonesty.lean"
+ARTIFACT="${TMPDIR:-/tmp}/e219_refusal_correspondence_gate.v1.json"
+RUN_POSITIVE_CONTROLS=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --checker) CHECKER_SOURCE="${2:?missing path after --checker}"; shift 2 ;;
+    --codegen) CODEGEN_SOURCE="${2:?missing path after --codegen}"; shift 2 ;;
+    --model) MODEL_SOURCE="${2:?missing path after --model}"; shift 2 ;;
+    --artifact) ARTIFACT="${2:?missing path after --artifact}"; shift 2 ;;
+    --control-child) RUN_POSITIVE_CONTROLS=0; shift ;;
+    *) echo "e219_refusal_correspondence_gate: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+TOTAL=0
+PASSED=0
+FAILED=0
+NOT_RUN=0
+FAILURES=""
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/e219-correspondence.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+record_failure() {
+  local label="$1"
+  if [[ -n "$FAILURES" ]]; then
+    FAILURES="$FAILURES,$label"
+  else
+    FAILURES="$label"
+  fi
+  echo "[e219-correspondence] FAIL: $label" >&2
+}
+
+check_grep() {
+  local label="$1"
+  local pattern="$2"
+  local path="$3"
+  TOTAL=$((TOTAL + 1))
+  if grep -qE "$pattern" "$path"; then
+    PASSED=$((PASSED + 1))
+  else
+    FAILED=$((FAILED + 1))
+    record_failure "$label"
+  fi
+}
+
+check_count_ge() {
+  local label="$1"
+  local pattern="$2"
+  local path="$3"
+  local min="$4"
+  TOTAL=$((TOTAL + 1))
+  local n
+  n="$(grep -cE "$pattern" "$path" || true)"
+  if [[ "$n" -ge "$min" ]]; then
+    PASSED=$((PASSED + 1))
+  else
+    FAILED=$((FAILED + 1))
+    record_failure "$label:got_$n"
+  fi
+}
+
+if [[ ! -f "$CHECKER_SOURCE" ]]; then
+  TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
+  record_failure "checker_source_missing:$CHECKER_SOURCE"
+fi
+if [[ ! -f "$CODEGEN_SOURCE" ]]; then
+  TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
+  record_failure "codegen_source_missing:$CODEGEN_SOURCE"
+fi
+if [[ ! -f "$MODEL_SOURCE" ]]; then
+  TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
+  record_failure "model_source_missing:$MODEL_SOURCE"
+fi
+
+if [[ "$NOT_RUN" -eq 0 ]]; then
+  # Checker: E219 still exists, and refuse infects the expression type.
+  check_count_ge "e219_sites" \
+    'name_is_native_backend_builtin.*\{|!name_is_native_backend_builtin' \
+    "$CHECKER_SOURCE" 3
+  check_count_ge "e219_reports" \
+    ', 219, 0, 0, 0\)' "$CHECKER_SOURCE" 3
+  check_count_ge "refuse_infects_ty_error" \
+    'refused_unimplemented' "$CHECKER_SOURCE" 6
+  check_grep "decl_is_not_call" \
+    'if \(\*fd\)\.is_extern \{' "$CHECKER_SOURCE"
+
+  # Codegen: empty unimplemented stubs trap instead of returning 0.
+  check_grep "fabricate_predicate" \
+    '^fn native_v2_empty_stub_would_fabricate\(' "$CODEGEN_SOURCE"
+  check_grep "trap_emitter" \
+    '^fn nc_emit_unimplemented_extern_trap_into\(' "$CODEGEN_SOURCE"
+  check_grep "trap_is_ud2" \
+    'nc_emit_byte\(nc, 0x0b\)' "$CODEGEN_SOURCE"
+  check_grep "live_path_uses_predicate" \
+    'native_v2_empty_stub_would_fabricate\(func\)' "$CODEGEN_SOURCE"
+
+  # Lean model: the two relations disagree exactly when there is something
+  # to refuse, and refuse infects add.
+  check_grep "model_add_refuse_l" \
+    'add_refuse_l' "$MODEL_SOURCE"
+  check_grep "model_not_zero" \
+    'unimplemented_call_not_zero' "$MODEL_SOURCE"
+  check_grep "model_disagrees" \
+    'unimplemented_disagrees' "$MODEL_SOURCE"
+  check_grep "model_legacy_fabricates" \
+    'legacy_fabricates' "$MODEL_SOURCE"
+fi
+
+if [[ "$RUN_POSITIVE_CONTROLS" -eq 1 && "$NOT_RUN" -eq 0 ]]; then
+  CHECKER_MUTANT="scripts/ci/fixtures/e219_refusal_correspondence/checker_returns_declared_type.sio"
+  CODEGEN_MUTANT="scripts/ci/fixtures/e219_refusal_correspondence/codegen_falls_through_empty_stub.sio"
+  MODEL_MUTANT="scripts/ci/fixtures/e219_refusal_correspondence/model_no_add_refuse.lean"
+
+  TOTAL=$((TOTAL + 1))
+  if "$0" --control-child --checker "$CHECKER_MUTANT" --codegen "$CODEGEN_SOURCE" \
+      --model "$MODEL_SOURCE" --artifact "$WORK/checker-mutant.json" \
+      > "$WORK/checker-mutant.log" 2>&1; then
+    FAILED=$((FAILED + 1))
+    record_failure "positive_control_checker_returns_declared_type_was_not_rejected"
+  else
+    PASSED=$((PASSED + 1))
+    echo "[e219-correspondence] POSITIVE_CONTROL_FIRED: checker_returns_declared_type rejected"
+    sed 's/^/[checker-control] /' "$WORK/checker-mutant.log"
+  fi
+
+  TOTAL=$((TOTAL + 1))
+  if "$0" --control-child --checker "$CHECKER_SOURCE" --codegen "$CODEGEN_MUTANT" \
+      --model "$MODEL_SOURCE" --artifact "$WORK/codegen-mutant.json" \
+      > "$WORK/codegen-mutant.log" 2>&1; then
+    FAILED=$((FAILED + 1))
+    record_failure "positive_control_codegen_falls_through_was_not_rejected"
+  else
+    PASSED=$((PASSED + 1))
+    echo "[e219-correspondence] POSITIVE_CONTROL_FIRED: codegen_falls_through_empty_stub rejected"
+    sed 's/^/[codegen-control] /' "$WORK/codegen-mutant.log"
+  fi
+
+  TOTAL=$((TOTAL + 1))
+  if "$0" --control-child --checker "$CHECKER_SOURCE" --codegen "$CODEGEN_SOURCE" \
+      --model "$MODEL_MUTANT" --artifact "$WORK/model-mutant.json" \
+      > "$WORK/model-mutant.log" 2>&1; then
+    FAILED=$((FAILED + 1))
+    record_failure "positive_control_model_no_add_refuse_was_not_rejected"
+  else
+    PASSED=$((PASSED + 1))
+    echo "[e219-correspondence] POSITIVE_CONTROL_FIRED: model_no_add_refuse rejected"
+    sed 's/^/[model-control] /' "$WORK/model-mutant.log"
+  fi
+fi
+
+STATUS="pass"
+if [[ "$FAILED" -gt 0 || "$NOT_RUN" -gt 0 ]]; then
+  STATUS="fail"
+fi
+
+mkdir -p "$(dirname "$ARTIFACT")"
+cat > "$ARTIFACT" <<JSON
+{
+  "schema": "sounio.e219-refusal-correspondence-gate.v1",
+  "status": "$STATUS",
+  "checker_source": "$CHECKER_SOURCE",
+  "codegen_source": "$CODEGEN_SOURCE",
+  "model_source": "$MODEL_SOURCE",
+  "metrics": {
+    "total": $TOTAL,
+    "passed": $PASSED,
+    "failed": $FAILED,
+    "not_run": $NOT_RUN
+  },
+  "failures_csv": "$FAILURES"
+}
+JSON
+
+echo "e219_refusal_correspondence_gate: status=$STATUS total=$TOTAL passed=$PASSED failed=$FAILED not_run=$NOT_RUN artifact=$ARTIFACT"
+if [[ "$STATUS" != "pass" ]]; then
+  exit 1
+fi

--- a/scripts/ci/fixtures/e219_refusal_correspondence/checker_returns_declared_type.sio
+++ b/scripts/ci/fixtures/e219_refusal_correspondence/checker_returns_declared_type.sio
@@ -1,0 +1,6 @@
+// Mutant: E219 fires but the call still has the declared return type.
+// That is the pre-fix Madaros path — refuse does not infect the expression.
+if sig.is_extern && !name_is_native_backend_builtin(sig.name) {
+    checker_report_error_at_inplace(c, e.span, 219, 0, 0, 0)
+}
+return effective_return_type

--- a/scripts/ci/fixtures/e219_refusal_correspondence/codegen_falls_through_empty_stub.sio
+++ b/scripts/ci/fixtures/e219_refusal_correspondence/codegen_falls_through_empty_stub.sio
@@ -1,0 +1,12 @@
+// Mutant: empty non-builtin stub compiles as ordinary IR (prologue+ret).
+// A call then reads rax — the fabrication Legacy models as value 0.
+fn native_v2_builtin_id_for_func_ref(func: &IrFunction) -> i64 {
+    0
+}
+fn compile_ir_function_v2_from_ir_into(nc: &! NativeCompiler, func: &IrFunction, fn_index: i64) -> bool {
+    let builtin_id = native_v2_builtin_id_for_func_ref(func)
+    if builtin_id != 0 {
+        return true
+    }
+    compile_ir_function_v2_core_ir_into(nc, func, fn_index)
+}

--- a/scripts/ci/fixtures/e219_refusal_correspondence/model_no_add_refuse.lean
+++ b/scripts/ci/fixtures/e219_refusal_correspondence/model_no_add_refuse.lean
@@ -1,0 +1,11 @@
+-- Mutant: Check types an unimplemented call as refuse but add does not infect.
+-- Without add_refuse_l, abs+1 can still be a value — E219 as ornament.
+inductive Check : Expr → Observation → Prop where
+  | lit : ∀ n, Check (.lit n) (.value n)
+  | add_v : ∀ a b n m,
+      Check a (.value n) → Check b (.value m) →
+      Check (.add a b) (.value (n + m))
+  | call_ok : ∀ n, allowlisted n = true →
+      Check (.call n) (.value (oracle n))
+  | call_refuse : ∀ n, allowlisted n = false →
+      Check (.call n) .refuse

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -7336,8 +7336,10 @@ fn checker_check_call_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with M
         // #1622: calling an `extern "C"` name the native backend does not
         // implement. This is the live arm -- a plain ident callee resolves via
         // direct_sig_id and returns below, never reaching the TyFn fallback.
+        var refused_unimplemented = false
         if direct_sig.is_extern && !name_is_native_backend_builtin(direct_sig.name) {
             checker_report_error_at_inplace(c, e.span, 219, 0, 0, 0)
+            refused_unimplemented = true
         }
         var effective_params = fn_param_list_clone(&direct_sig.params)
         var effective_return_type = direct_sig.return_type
@@ -7366,6 +7368,9 @@ fn checker_check_call_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with M
         )
         checker_check_callee_effects_named_inplace(c, e.span, direct_sig.effects, direct_sig.effect_count, direct_sig.name)
         checker_release_call_arg_borrows_inplace(c, e.args, effective_params, call_start_borrows)
+        if refused_unimplemented {
+            return ty_error()
+        }
         return effective_return_type
     }
     // Callee via the *mut spine, matched locally so the call path does not pass
@@ -7424,8 +7429,10 @@ fn checker_check_call_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with M
         // parser_card_a_raw_pointer_types.sio declares malloc and never calls
         // it -- both compile and pass today, and a declaration-site refusal
         // would break them for no gain.
+        var refused_unimplemented = false
         if sig.is_extern && !name_is_native_backend_builtin(sig.name) {
             checker_report_error_at_inplace(c, e.span, 219, 0, 0, 0)
+            refused_unimplemented = true
         }
         let call_start_borrows = (*c).borrows
         var effective_params = fn_param_list_clone(&sig.params)
@@ -7449,7 +7456,11 @@ fn checker_check_call_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with M
         checker_check_call_args_inplace(c, expr_list_handle(e.args), fn_param_list_handle(effective_params), sig.param_count, e.span)
         checker_check_callee_effects_named_inplace(c, e.span, sig.effects, sig.effect_count, sig.name)
         checker_release_call_arg_borrows_inplace(c, e.args, effective_params, call_start_borrows)
-        effective_return_type
+        if refused_unimplemented {
+            ty_error()
+        } else {
+            effective_return_type
+        }
     } else if is_error_or_unknown(callee_ty) {
         let call_start_borrows = (*c).borrows
         checker_check_expr_list_no_type_no_linear_consume_inplace(c, e.args)
@@ -13102,7 +13113,7 @@ fn print_error_help(code: i64) with IO, Mut, Panic, Div {
         print("   |\n   = help: V0-A exposes binary128/binary256 descriptors internally but rejects every source-level use before IR\n")
     }
     else if code == 219 {
-        print("   |\n   = help: only these body-less names are implemented: print, print_int, print_char, print_f64, get_arg, get_arg_count, str_len, str_char_at, str_eq, str_slice, starts_with, str_concat, str_from_bytes, read_file, write_file, file_size, sqrt, exp, log, sin, cos, assert, heap_alloc, heap_free, f64_to_bits, bits_to_f64, syscall6\n")
+        print("   |\n   = help: only these body-less names are implemented: print, print_int, print_char, print_f64, get_arg, get_arg_count, str_len, str_char_at, str_eq, str_slice, starts_with, str_concat, str_from_bytes, read_file, write_file, file_size, sqrt, exp, log, sin, cos, assert, heap_alloc, heap_free, f64_to_bits, bits_to_f64, syscall6, malloc, free, getpid, getppid, exit, abort, system\n")
     }
     else {
         // No help available for unknown errors
@@ -21055,8 +21066,10 @@ impl Checker {
             // parser_card_a_raw_pointer_types.sio declares malloc and never
             // calls it — both compile and pass today, and a declaration-site
             // refusal would break them for no gain.
+            var refused_unimplemented = false
             if sig.is_extern && !name_is_native_backend_builtin(sig.name) {
                 c = c.report_error_at(e.span, 219, 0, 0, 0)
+                refused_unimplemented = true
             }
             let call_start_borrows = c.borrows
             var effective_params = fn_param_list_clone(&sig.params)
@@ -21085,7 +21098,11 @@ impl Checker {
             // Release borrows taken for call arguments — the call has returned,
             // so exclusive/shared borrows on arguments are no longer active.
             c = c.release_call_arg_borrows(e.args, effective_params, call_start_borrows)
-            (c, effective_return_type)
+            if refused_unimplemented {
+                (c, ty_error())
+            } else {
+                (c, effective_return_type)
+            }
         } else if is_error_or_unknown(callee_ty) {
             let call_start_borrows = c.borrows
             c = c.check_expr_list_no_type_no_linear_consume(e.args)

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -1179,6 +1179,16 @@ fn native_v2_builtin_id_for_func_ref(func: &IrFunction) -> i64 with Mut, Panic, 
     0
 }
 
+// An empty IR body that is not a BSS slot and not a known builtin. The
+// historical backend compiled these as prologue+ret, so a call read rax
+// (usually 0). That is fabrication. Declaration-without-call still needs
+// a callable symbol — emit ud2 so a missed E219 cannot return a value.
+fn native_v2_empty_stub_would_fabricate(func: &IrFunction) -> bool with Mut, Panic, Div {
+    if (*func).compile_strategy == IR_STRATEGY_BSS_GLOBAL { return false }
+    if (*func).instr_count > 0 { return false }
+    native_v2_builtin_id_for_func_ref(func) == 0
+}
+
 // M4: argv and string builtins
 
 // syscall6(nr, a1..a6) raw Linux syscall builtin (id 27). Checker arm:
@@ -1500,6 +1510,11 @@ fn nc_emit_byte(nc: &! NativeCompiler, b: i64) with Mut, Panic, Div {
     } else {
         (*nc).code_overflow = true
     }
+}
+
+fn nc_emit_unimplemented_extern_trap_into(nc: &! NativeCompiler) with Mut, Panic, Div {
+    nc_emit_byte(nc, 0x0f)
+    nc_emit_byte(nc, 0x0b)
 }
 
 fn nc_emit_u32_le(nc: &! NativeCompiler, val: i64) with Mut, Panic, Div {
@@ -5805,6 +5820,10 @@ pub fn compile_ir_function(nc: NativeCompiler, func: IrFunction, fn_index: i64) 
         if name_is_sin(func.name) { return emit_builtin_sin(c) }
         if name_is_cos(func.name) { return emit_builtin_cos(c) }
         if name_is_assert(func.name) { return emit_builtin_assert(c) }
+        if native_v2_empty_stub_would_fabricate(&func) {
+            nc_emit_unimplemented_extern_trap_into(&! c)
+            return c
+        }
     }
 
     // Sprint 38: Set compile strategy from IR function metadata
@@ -6693,6 +6712,10 @@ pub fn compile_ir_function_v2(nc: NativeCompiler, func: IrFunction, machine_func
         if name_is_exit(func.name) { emit_builtin_exit_into(&! c); return c }
         if name_is_abort(func.name) { emit_builtin_abort_into(&! c); return c }
         if name_is_system(func.name) { emit_builtin_system_into(&! c); return c }
+        if native_v2_empty_stub_would_fabricate(&func) {
+            nc_emit_unimplemented_extern_trap_into(&! c)
+            return c
+        }
     }
 
     c.current_strategy = func.compile_strategy
@@ -6825,6 +6848,10 @@ pub fn compile_ir_function_v2_into(nc: &! NativeCompiler, func: &IrFunction, mac
             emit_builtin_heap_free_into(nc)
             return
         }
+        return
+    }
+    if native_v2_empty_stub_would_fabricate(func) {
+        nc_emit_unimplemented_extern_trap_into(nc)
         return
     }
 
@@ -8561,6 +8588,14 @@ pub fn compile_ir_function_v2_from_ir_into(nc: &! NativeCompiler, func: &IrFunct
         native_v2_emit_builtin_by_id_into(nc, builtin_id)
         return true
     }
+    if native_v2_empty_stub_would_fabricate(func) {
+        reset_function_state_mut(nc)
+        let function_offset = (*nc).code.len
+        native_compiler_set_fn_offset(nc, fn_index, function_offset)
+        native_compiler_add_symbol_func_ref(nc, fn_index, func)
+        nc_emit_unimplemented_extern_trap_into(nc)
+        return true
+    }
     compile_ir_function_v2_core_ir_into(nc, func, fn_index)
 }
 
@@ -8911,6 +8946,10 @@ fn compile_ir_function_v2_mut(nc: &! NativeCompiler, func: IrFunction, machine_f
         if name_is_exit(func.name) { emit_builtin_exit_into(nc); return }
         if name_is_abort(func.name) { emit_builtin_abort_into(nc); return }
         if name_is_system(func.name) { emit_builtin_system_into(nc); return }
+        if native_v2_empty_stub_would_fabricate(&func) {
+            nc_emit_unimplemented_extern_trap_into(nc)
+            return
+        }
     }
 
     (*nc).current_strategy = func.compile_strategy


### PR DESCRIPTION
## Summary

- Closes the measured gap between `SounioRefusalHonesty` (#1788 / `31adf7b4bc`) and Madaros. After E219 the checker now returns `ty_error()` (`refused_unimplemented`) instead of the declared return type — `abs() + 1` is not an integer. That is `add_refuse_l`.
- Empty non-builtin, non-BSS IR stubs used to compile as prologue+ret (call reads rax). `native_v2_empty_stub_would_fabricate` now emits `ud2`. Declaration-without-call still has a symbol; a missed E219 cannot fabricate 0. Same class as #1792.
- lean_single still has no E219. Named in the Lean header, not closed. Same class as #1798.

## Correspondence gate

`scripts/ci/e219_refusal_correspondence_gate.sh` — fail-able link between the Lean model, the three E219 sites, and the codegen trap. Permanent positive controls on all three sides (restore declared-type return, restore stub fall-through, drop `add_refuse_l`). Wired next to the existing extern-mirror gate.

## Test plan

- [x] `bash scripts/ci/e219_refusal_correspondence_gate.sh` → pass, 3/3 positive controls fire
- [x] `lean formal/lean4/SounioRefusalHonesty.lean` under v4.33.0, exit 0
- [ ] CI Contracts + the new gate step
- [ ] Existing `tests/compile-fail/extern_c_unimplemented_builtin.sio` still matches E219 (may report extra type errors from infection; compile must still fail)