### PR TITLE
fix(governance): resync acceptance-report counts — main is currently red and every PR inherits it

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1345
-- Repo-backed topics: 1195
+- Total governed topics: 1347
+- Repo-backed topics: 1197
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 399
-- Authority count `repo_only`: 758
+- Authority count `repo_only`: 760
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 773 topics
+- A2: 775 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 37 topics


### PR DESCRIPTION
**origin/main is currently failing the docs-registry gate**, so every open PR
inherits a red `Contracts` and a failed `CI Decision` through no fault of its own.

Verified against a clean detached worktree of `origin/main` rather than a local
checkout: `docs/governance/DOCS_ACCEPTANCE_REPORT.md is stale`.

#1801 is the clearest case of the damage. It fails `Contracts` while touching
**no doc and no governance file at all**, with the entire compiler matrix green —
Native Self-Host on both architectures, Source-Bootstrap, Madaros Witness Gate,
f64 Lowering, Full Test Suite, Lean Proofs. The one red is inherited.

## The drift

Four derived counts, each off by exactly two:

```
- Total governed topics: 1345 -> 1347
- Repo-backed topics:    1195 -> 1197
- repo_only:              758 -> 760
- A2:                     773 -> 775
```

No content change. No provenance restamped — checked rather than assumed, since
the sync script has a standing bug that stamps a placeholder owner and date over
real headers.

## Cause is ordering, not error

The acceptance report carries counts derived from the *whole* doc set. Two of
today's merges each added a governed topic. Each synced correctly against its own
base; neither could account for the other landing beside it. **A doc-adding PR
can be green on its own and still leave main red once a second one lands.**

## Follow-up worth having

A gate that main itself cannot pass is indistinguishable, from a lane's point of
view, from a gate that its PR broke. That cost real attention today: this failure
was read as the author's three separate times before anyone checked main. Either
the report should stop carrying whole-corpus counts, or the gate should say
"main is also failing this" when it is.
