### PR TITLE
feat(design-system): DiagnosticCodeBlock — E219 in full, never cut

### DIFF
--- a/website/src/components/epistemic/DiagnosticCodeBlock.css
+++ b/website/src/components/epistemic/DiagnosticCodeBlock.css
@@ -1,0 +1,253 @@
+/* DiagnosticCodeBlock — tokens only from website/src/styles/global.css */
+
+.dcb {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  border: 1px solid var(--color-epistemic-refused-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-primary);
+  overflow: hidden;
+}
+
+.dcb-header,
+.dcb-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.55rem 0.9rem;
+  min-width: 0;
+}
+
+.dcb-header {
+  border-bottom: 1px solid var(--color-border-hairline);
+  background: var(--color-surface-secondary);
+}
+
+.dcb-footer {
+  border-top: 1px solid var(--color-border-hairline);
+  background: var(--color-surface-secondary);
+}
+
+.dcb-file,
+.dcb-engine,
+.dcb-gutter,
+.dcb-src,
+.dcb-caret,
+.dcb-code-chip,
+.dcb-span,
+.dcb-diag-body,
+.dcb-help,
+.dcb-note,
+.dcb-meta,
+.dcb-effect {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.dcb-file {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dcb-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.dcb-engine,
+.dcb-effect,
+.dcb-code-chip,
+.dcb-verdict {
+  flex-shrink: 0;
+  border-radius: var(--radius-full);
+  padding: 0.15rem 0.5rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.dcb-engine {
+  border: 1px solid var(--color-border-subtle);
+  color: var(--color-text-tertiary);
+  background: transparent;
+}
+
+.dcb-effect {
+  border: 1px solid var(--color-effect-io);
+  color: var(--color-effect-io);
+  background: color-mix(in srgb, var(--color-effect-io) 10%, transparent);
+}
+
+.dcb-code-chip,
+.dcb-verdict {
+  border: 1px solid var(--color-epistemic-refused-border);
+  background: var(--color-epistemic-refused-surface);
+  color: var(--color-epistemic-refused-text);
+}
+
+.dcb-verdict {
+  font-family: var(--font-sans);
+}
+
+.dcb-body {
+  margin: 0;
+  padding: 0.75rem 0 0.35rem;
+  background: var(--color-surface-canvas);
+  overflow-x: auto;
+}
+
+.dcb-line {
+  display: grid;
+  grid-template-columns: 3rem 1fr;
+  column-gap: 0.85rem;
+  min-height: 1.35rem;
+}
+
+.dcb-line[data-hit='true'] {
+  background: var(--color-epistemic-refused-surface);
+}
+
+.dcb-gutter {
+  text-align: right;
+  font-size: 0.75rem;
+  color: var(--color-text-tertiary);
+  user-select: none;
+  padding-right: 0.15rem;
+}
+
+.dcb-src {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: var(--color-text-primary);
+  white-space: pre;
+}
+
+.dcb-hit {
+  color: var(--color-epistemic-refused-text);
+  background: color-mix(in srgb, var(--color-epistemic-refused) 16%, transparent);
+  box-shadow: inset 0 -2px 0 var(--color-epistemic-refused);
+}
+
+.dcb-caret-row .dcb-caret {
+  color: var(--color-epistemic-refused);
+  font-size: 0.8125rem;
+  line-height: 1.1;
+  white-space: pre;
+}
+
+.dcb-ribbon {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 0.75rem 0.9rem 0.9rem;
+  border-top: 1px solid var(--color-epistemic-refused-border);
+  background: var(--color-epistemic-refused-surface);
+}
+
+.dcb-ribbon-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.45rem 0.7rem;
+}
+
+.dcb-span {
+  font-size: 0.6875rem;
+  color: var(--color-text-tertiary);
+}
+
+.dcb-diag-body {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--color-epistemic-refused-text);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.dcb-help,
+.dcb-note {
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.dcb-help {
+  color: var(--color-text-secondary);
+}
+
+.dcb-note {
+  color: var(--color-text-tertiary);
+}
+
+.dcb-help-kept {
+  color: var(--color-text-secondary);
+}
+
+.dcb-help-dropped {
+  color: var(--color-epistemic-uncertain-text);
+  background: var(--color-epistemic-uncertain-surface);
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+
+.dcb-cut {
+  display: inline-flex;
+  align-items: center;
+  margin: 0 0.15rem;
+  vertical-align: middle;
+}
+
+.dcb-cut-rule {
+  width: 2px;
+  height: 1.05em;
+  background: var(--color-epistemic-uncertain);
+}
+
+.dcb-cut-label {
+  margin-left: 0.25rem;
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-epistemic-uncertain-text);
+  border: 1px solid var(--color-epistemic-uncertain-border);
+  background: var(--color-epistemic-uncertain-surface);
+  border-radius: var(--radius-sm);
+  padding: 0 0.28rem;
+  white-space: nowrap;
+}
+
+.dcb-meta {
+  font-size: 0.6875rem;
+  color: var(--color-text-tertiary);
+}
+
+.dcb-meta strong {
+  color: var(--color-epistemic-uncertain-text);
+  font-weight: 700;
+}
+
+@media (max-width: 640px) {
+  .dcb-header,
+  .dcb-footer {
+    flex-wrap: wrap;
+  }
+
+  .dcb-line {
+    grid-template-columns: 2.2rem 1fr;
+    column-gap: 0.5rem;
+  }
+}

--- a/website/src/components/epistemic/DiagnosticCodeBlock.tsx
+++ b/website/src/components/epistemic/DiagnosticCodeBlock.tsx
@@ -1,0 +1,214 @@
+import {
+  E219_HELP,
+  E219_MESSAGE,
+  E219_NOTE,
+  PRE_FIX_PRINT_CAP,
+  splitAtPrintCap,
+} from '../../lib/diagnosticHonesty';
+import './DiagnosticCodeBlock.css';
+
+export type DiagnosticSpan = {
+  file: string;
+  line: number;
+  column: number;
+  endColumn: number;
+};
+
+export type DiagnosticLine = {
+  number: number;
+  text: string;
+};
+
+export type DiagnosticCodeBlockProps = {
+  filename: string;
+  engine?: string;
+  effects?: string[];
+  lines: DiagnosticLine[];
+  span: DiagnosticSpan;
+  code?: string;
+  message: string;
+  help?: string;
+  note?: string;
+  /** Mark the pre-#1784 127-character print cap inside a long help literal. */
+  markPrintCap?: boolean;
+  className?: string;
+};
+
+function caretFor(line: string, column: number, endColumn: number): string {
+  const start = Math.min(line.length, Math.max(0, column - 1));
+  const end = Math.min(line.length, Math.max(start + 1, endColumn - 1));
+  return `${' '.repeat(start)}${'^'.repeat(Math.max(1, end - start))}`;
+}
+
+function renderLineText(
+  text: string,
+  hit: boolean,
+  column: number,
+  endColumn: number,
+) {
+  if (!hit) return text;
+  const start = Math.max(0, column - 1);
+  const end = Math.min(text.length, Math.max(start + 1, endColumn - 1));
+  return (
+    <>
+      {text.slice(0, start)}
+      <span className="dcb-hit">{text.slice(start, end)}</span>
+      {text.slice(end)}
+    </>
+  );
+}
+
+export function DiagnosticCodeBlock({
+  filename,
+  engine = 'Madaros',
+  effects = [],
+  lines,
+  span,
+  code = 'E219',
+  message,
+  help,
+  note,
+  markPrintCap = true,
+  className,
+}: DiagnosticCodeBlockProps) {
+  const helpSplit = help ? splitAtPrintCap(help) : null;
+  const showCut = Boolean(markPrintCap && helpSplit?.wouldTruncate);
+
+  return (
+    <article
+      className={['dcb', className].filter(Boolean).join(' ')}
+      data-code={code}
+      aria-label={`${code} ${message}`}
+    >
+      <header className="dcb-header">
+        <span className="dcb-file">{filename}</span>
+        <div className="dcb-meta-row">
+          <span className="dcb-engine">{engine}</span>
+          {effects.map((effect) => (
+            <span key={effect} className="dcb-effect">
+              {effect}
+            </span>
+          ))}
+          <span className="dcb-code-chip">{code}</span>
+          <span className="dcb-verdict">Refused</span>
+        </div>
+      </header>
+
+      <pre className="dcb-body">
+        {lines.map((line) => {
+          const hit = line.number === span.line;
+          return (
+            <div key={line.number}>
+              <div className="dcb-line" data-hit={hit}>
+                <span className="dcb-gutter">{line.number}</span>
+                <code className="dcb-src">
+                  {renderLineText(line.text, hit, span.column, span.endColumn)}
+                </code>
+              </div>
+              {hit ? (
+                <div className="dcb-line dcb-caret-row" aria-hidden="true">
+                  <span className="dcb-gutter" />
+                  <span className="dcb-caret">
+                    {caretFor(line.text, span.column, span.endColumn)}
+                  </span>
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </pre>
+
+      <section className="dcb-ribbon">
+        <div className="dcb-ribbon-head">
+          <span className="dcb-code-chip">{code}</span>
+          <span className="dcb-span">
+            {'--> '}
+            {span.file}:{span.line}:{span.column}
+          </span>
+        </div>
+        <p className="dcb-diag-body">
+          error[{code}]: {message}
+        </p>
+        {helpSplit ? (
+          <p className="dcb-help">
+            {showCut ? (
+              <>
+                <span className="dcb-help-kept">{helpSplit.kept}</span>
+                <span
+                  className="dcb-cut"
+                  title={`Pre-#1784 print cap: first ${PRE_FIX_PRINT_CAP} characters kept, ${helpSplit.droppedCount} dropped`}
+                >
+                  <span className="dcb-cut-rule" />
+                  <span className="dcb-cut-label">cut {PRE_FIX_PRINT_CAP}</span>
+                </span>
+                <span className="dcb-help-dropped">{helpSplit.dropped}</span>
+              </>
+            ) : (
+              help
+            )}
+          </p>
+        ) : null}
+        {note ? <p className="dcb-note">{note}</p> : null}
+      </section>
+
+      {helpSplit ? (
+        <footer className="dcb-footer">
+          <p className="dcb-meta">
+            Help literal {helpSplit.length} characters
+            {helpSplit.wouldTruncate ? (
+              <>
+                {' · '}
+                pre-#1784 would keep {PRE_FIX_PRINT_CAP} and drop{' '}
+                <strong>{helpSplit.droppedCount}</strong>
+              </>
+            ) : (
+              <> · under the old 127-character cap</>
+            )}
+          </p>
+        </footer>
+      ) : null}
+    </article>
+  );
+}
+
+export const E219_WITNESS_LINES: DiagnosticLine[] = [
+  { number: 19, text: 'extern "C" {' },
+  { number: 20, text: '    fn malloc(size: i64) -> i64;' },
+  { number: 21, text: '    fn abs(x: i64) -> i64;' },
+  { number: 22, text: '}' },
+  { number: 23, text: '' },
+  { number: 24, text: 'fn main() -> i64 with IO {' },
+  { number: 25, text: '    let p = malloc(64)' },
+  { number: 26, text: '    print_int(p)' },
+  { number: 27, text: '    print_int(abs(0 - 7))' },
+  { number: 28, text: '    0' },
+  { number: 29, text: '}' },
+];
+
+// P0-F allow-listed malloc. The live E219 in this fixture is abs — the
+// call that used to compile to a fabricated 0 (#1622) and that #1801
+// now infects as ty_error() rather than the declared i64.
+export const E219_WITNESS_SPAN: DiagnosticSpan = {
+  file: 'tests/compile-fail/extern_c_unimplemented_builtin.sio',
+  line: 27,
+  column: 15,
+  endColumn: 18,
+};
+
+export function E219DiagnosticCodeBlock(props: { className?: string }) {
+  return (
+    <DiagnosticCodeBlock
+      filename="tests/compile-fail/extern_c_unimplemented_builtin.sio"
+      engine="Madaros"
+      effects={['IO']}
+      lines={E219_WITNESS_LINES}
+      span={E219_WITNESS_SPAN}
+      code="E219"
+      message={E219_MESSAGE}
+      help={E219_HELP}
+      note={E219_NOTE}
+      markPrintCap
+      className={props.className}
+    />
+  );
+}

--- a/website/src/components/language/E219DiagnosticExhibit.astro
+++ b/website/src/components/language/E219DiagnosticExhibit.astro
@@ -1,0 +1,91 @@
+---
+import { E219DiagnosticCodeBlock } from '../epistemic/DiagnosticCodeBlock';
+import type { Locale } from '../../lib/i18n';
+
+interface Props {
+  locale?: Locale;
+}
+const { locale = 'en' } = Astro.props;
+
+const t: Record<string, { label: string; heading: string; body: string; after: string }> = {
+  en: {
+    label: 'DIAGNOSTIC, IN FULL',
+    heading: 'E219 refuses the call. The help text is 333 characters. None of it is cut.',
+    body: 'Before #1784 the print path kept 127 characters and dropped the rest without failing. #1794 counted 33 user-facing diagnostics over that cap — every one was cut — and the historical CI logs that quote them are incomplete in the tails. E219 was the longest casualty: 206 characters gone, mid-word, so the implemented names after st… never reached the user. The span, the code, and the tail are the diagnostic.',
+    after: 'The live span is abs, not malloc: P0-F allow-listed malloc. #1801 then closed two sites that still fabricated after a refusal — the checker used to keep the declared i64 so abs() + 1 type-checked, and an empty IR stub used to fall through and read 0. Refusal is the whole object: code, span, full text, infected type, no zero.',
+  },
+  pt: {
+    label: 'DIAGNÓSTICO, INTEIRO',
+    heading: 'E219 recusa a chamada. O texto de ajuda tem 333 caracteres. Nenhum é cortado.',
+    body: 'Antes de #1784 o caminho de impressão guardava 127 caracteres e deitava fora o resto sem falhar. O #1794 contou 33 diagnósticos acima desse tecto — todos cortados — e os logs históricos de CI que os citam estão incompletos nas caudas. O E219 foi a vítima mais longa: 206 caracteres a meio da palavra. O span, o código e a cauda são o diagnóstico.',
+    after: 'O span vivo é abs, não malloc: o P0-F já allow-listou malloc. O #1801 fechou dois sítios que ainda fabricavam depois de uma recusa — o checker mantinha o i64 declarado, e um stub IR vazio lia 0. A recusa é o objecto inteiro: código, span, texto completo, tipo infectado, nenhum zero.',
+  },
+  es: {
+    label: 'DIAGNÓSTICO, COMPLETO',
+    heading: 'E219 rechaza la llamada. El texto de ayuda tiene 333 caracteres. No se corta ninguno.',
+    body: 'Antes de #1784 la ruta de impresión conservaba 127 caracteres y descartaba el resto sin fallar. #1794 contó 33 diagnósticos por encima de ese tope — todos cortados — y los logs históricos de CI que los citan están incompletos en las colas. E219 fue la baja más larga: 206 caracteres a mitad de palabra.',
+    after: 'El span vivo es abs, no malloc: P0-F ya allow-listeó malloc. #1801 cerró dos sitios que aún fabricaban después de una negativa.',
+  },
+  el: {
+    label: 'ΔΙΑΓΝΩΣΤΙΚΟ, ΟΛΟΚΛΗΡΟ',
+    heading: 'Το E219 αρνείται την κλήση. Το κείμενο βοήθειας έχει 333 χαρακτήρες. Κανένας δεν κόβεται.',
+    body: 'Πριν το #1784 η εκτύπωση κρατούσε 127 χαρακτήρες. Το #1794 μέτρησε 33 διαγνωστικά πάνω από αυτό το όριο — όλα κομμένα — και τα ιστορικά CI logs είναι ελλιπή στις ουρές. Το E219 έχασε 206 χαρακτήρες στη μέση της λέξης.',
+    after: 'Το ζωντανό span είναι το abs, όχι η malloc. Το #1801 έκλεισε δύο σημεία που συνέχιζαν να κατασκευάζουν μετά την άρνηση.',
+  },
+  zh: {
+    label: '完整诊断',
+    heading: 'E219 拒绝这次调用。帮助文本 333 个字符，一个都不截。',
+    body: '在 #1784 之前，打印路径只保留 127 个字符。#1794 统计有 33 条用户可见诊断超限，全部被截，历史 CI 日志的尾巴不完整。E219 被切掉 206 个字符，从单词中间断开。',
+    after: '当前跨度是 abs，不是 malloc（P0-F 已放行 malloc）。#1801 关掉了两处拒绝之后仍在伪造零的位点。',
+  },
+  ja: {
+    label: '診断は、省略しない',
+    heading: 'E219 はその呼び出しを拒む。ヘルプは 333 文字。一切切らない。',
+    body: '#1784 以前は 127 文字だけ残した。#1794 は上限を超える診断 33 件を数え、いずれも切られ、それを引用する過去の CI ログは尾が欠けている。E219 は単語の途中で 206 文字を失った。',
+    after: '生きているスパンは abs であり malloc ではない（P0-F が malloc を許可済み）。#1801 は拒否のあとにもゼロを捏造していた二箇所を閉じた。',
+  },
+};
+
+const d = t[locale] ?? t.en;
+---
+
+<section class="dcb-exhibit">
+  <p class="dcb-exhibit-label">{d.label}</p>
+  <h3 class="dcb-exhibit-heading">{d.heading}</h3>
+  <p class="dcb-exhibit-body">{d.body}</p>
+  <E219DiagnosticCodeBlock />
+  <p class="dcb-exhibit-body">{d.after}</p>
+</section>
+
+<style>
+  .dcb-exhibit {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .dcb-exhibit-label {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--color-epistemic-refused-text);
+  }
+
+  .dcb-exhibit-heading {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(1.2rem, 2.4vw, 1.65rem);
+    font-weight: 400;
+    line-height: 1.3;
+    color: var(--color-text-primary);
+  }
+
+  .dcb-exhibit-body {
+    margin: 0;
+    max-width: 68ch;
+    font-size: 0.92rem;
+    line-height: 1.65;
+    color: var(--color-text-secondary);
+  }
+</style>

--- a/website/src/lib/diagnosticHonesty.ts
+++ b/website/src/lib/diagnosticHonesty.ts
@@ -1,0 +1,74 @@
+/**
+ * Honesty kernel for compiler diagnostics on the site.
+ *
+ * #1794 measured that 33 user-facing diagnostics had content length > 127
+ * and were silently cut to 127 characters on the pre-#1784 Madaros print
+ * path. Largest: 333 characters at check.sio help for code 219, cut by 206.
+ *
+ * A DiagnosticCodeBlock must render the whole literal. This module is the
+ * counterpart of that census: it measures, it can mark the old cap, and it
+ * refuses to return a shortened string as if it were the diagnostic.
+ */
+
+/** Pre-#1784 Madaros print cap (content length). Documented in the #1794 census. */
+export const PRE_FIX_PRINT_CAP = 127;
+
+/**
+ * E219 primary message — `self-hosted/check/check.sio` `code == 219` table.
+ * Length 70; would have printed in full even before the fix.
+ */
+export const E219_MESSAGE =
+  'call to an `extern "C"` function the native backend does not implement';
+
+/**
+ * E219 help literal, including the rustc-style prefix and trailing newline,
+ * exactly as printed by `print_error_help(219)`. Census length: 333.
+ */
+export const E219_HELP =
+  '   |\n   = help: only these body-less names are implemented: print, print_int, print_char, print_f64, get_arg, get_arg_count, str_len, str_char_at, str_eq, str_slice, starts_with, str_concat, str_from_bytes, read_file, write_file, file_size, sqrt, exp, log, sin, cos, assert, heap_alloc, heap_free, f64_to_bits, bits_to_f64, syscall6\n';
+
+/**
+ * E219 note literal from `print_error_note(219)`. Length 124 — under the cap.
+ */
+export const E219_NOTE =
+  '   = note: there is no dynamic linker in this backend; an unimplemented extern compiles to an empty stub whose calls read 0\n';
+
+export type TruncationSplit = {
+  length: number;
+  wouldTruncate: boolean;
+  kept: string;
+  dropped: string;
+  droppedCount: number;
+};
+
+export function measureLiteral(content: string): number {
+  return content.length;
+}
+
+export function splitAtPrintCap(
+  content: string,
+  cap: number = PRE_FIX_PRINT_CAP,
+): TruncationSplit {
+  const length = content.length;
+  if (length <= cap) {
+    return {
+      length,
+      wouldTruncate: false,
+      kept: content,
+      dropped: '',
+      droppedCount: 0,
+    };
+  }
+  return {
+    length,
+    wouldTruncate: true,
+    kept: content.slice(0, cap),
+    dropped: content.slice(cap),
+    droppedCount: length - cap,
+  };
+}
+
+/** Never return a silently shortened diagnostic. The dropped tail stays attached. */
+export function fullDiagnosticText(content: string): string {
+  return content;
+}

--- a/website/src/pages/language.astro
+++ b/website/src/pages/language.astro
@@ -4,6 +4,7 @@ import EpistemicTypeLadder from '../components/diagrams/EpistemicTypeLadder.astr
 import UncertaintyFlow from '../components/diagrams/UncertaintyFlow.astro';
 import RuntimeArchitecture from '../components/diagrams/RuntimeArchitecture.astro';
 import SounioCode from '../components/SounioCode.astro';
+import E219DiagnosticExhibit from '../components/language/E219DiagnosticExhibit.astro';
 import { getLocaleFromUrl, getLocalizedPath, loadTranslations } from '../lib/i18n';
 import { publicContract } from '../data/artifactStatus';
 import HonestStatusSection from '../components/status/HonestStatusSection.astro';
@@ -239,6 +240,8 @@ sha256sum gen2.elf gen3.elf`;
             </p>
             <SounioCode code={knowledgeExample} title="confidence_gate.sio" />
           </div>
+
+          <E219DiagnosticExhibit locale={locale} />
 
           {/* Algebra declarations */}
           <div class="glass rounded-[var(--radius-xl)] p-[1.1rem] grid gap-[0.6rem]">


### PR DESCRIPTION
## Summary

- `DiagnosticCodeBlock` on `/language`: a real compiler diagnostic with its E-code, span, caret, full message, help, and note. Refusal is the verdict, not error chrome.
- The witness is E219 from `tests/compile-fail/extern_c_unimplemented_builtin.sio`. The live span is `abs` at `27:15–18`, not `malloc` — P0-F already allow-listed `malloc`, so pointing the refusal there would be a fabricated diagnostic.
- Token names are taken only from `website/src/styles/global.css` on `main` (`--color-epistemic-refused-*`, `--color-epistemic-uncertain-*`, `--color-effect-io`, surfaces, text, borders). No new token names.

## What landed today, and why this control exists

1. **[#1794](https://github.com/Sounio-lang/sounio/pull/1794)** proved 33 user-facing compiler diagnostics were longer than 127 characters and were silently cut on the pre-#1784 print path. The longest was 333 characters — the E219 help listing implemented body-less names — cut by 206, mid-word (`st` | `r_len`). Historical CI logs that quote those messages are incomplete in the tails. This component is the visual argument against that cut: it renders the whole literal and marks the old cap so the dropped tail stays visible.

2. **[#1801](https://github.com/Sounio-lang/sounio/pull/1801)** closed two sites that still fabricated after a refusal: the checker used to keep the declared `i64` so `abs() + 1` type-checked, and an empty IR stub used to fall through and read 0. The exhibit states that. It does not invent extra compiler lines. Refusal is the whole object — code, span, full text, infected type, no zero.

3. **Gates actually run.** `check:astro` (0 errors / 0 warnings / 0 hints), `check:i18n`, and `check:nav` were run and passed. The full `check:quality` / `npm run build` path was **not** run. That path regenerates `website/src/data/artifactStatus.ts` and would mix an unrelated timestamp into this PR. An unrun gate is not a green gate. CI on this PR is the build evidence.

## Test plan

- [ ] `/language` shows the exhibit after the confidence-gate snippet.
- [ ] Default witness is E219 on `abs`, caret under columns 15–18, verdict `Refused`.
- [ ] Help literal is 333 characters; the cut mark sits after `st` and the restored tail includes `r_len` through `syscall6`.
- [ ] Footer reads `333` / keep `127` / drop `206`.
- [ ] Light and dark resolve from existing `--color-epistemic-*` tokens only.
- [ ] Let Vercel / Astro CI be the `build` evidence; do not treat this PR as having a local full-build receipt.