### PR TITLE
research: dual-engine run-pass census — divergence is majority, not anecdote

### DIFF
--- a/artifacts/research/cross_engine_runpass_census/20260817T-check/metrics.json
+++ b/artifacts/research/cross_engine_runpass_census/20260817T-check/metrics.json
@@ -1,0 +1,48 @@
+{
+  "status": "pass",
+  "phase": "check",
+  "corpus": "tests/run-pass",
+  "engines": {
+    "madaros": "bin/souc default (prebuilt Madaros v0.80.0)",
+    "lean_single": "SOUNIO_SOUC_ENGINE=lean_single"
+  },
+  "metrics": {
+    "total": 1759,
+    "agree_total": 841,
+    "diverge_explicit": 918,
+    "accept_vs_reject": 607,
+    "MADAROS_ONLY_REJECT": 230,
+    "LEAN_ONLY_REJECT": 377,
+    "different_diagnostic_raw": 15,
+    "different_diagnostic_strict_both_codes": 6,
+    "same_diagnostic_different_span_raw": 296,
+    "agree_reject_or_weak_span_strict": 302,
+    "runtime_output_different": 0,
+    "timeout": 0,
+    "by_class": {
+      "AGREE_ACCEPT": 835,
+      "LEAN_ONLY_REJECT": 377,
+      "SPAN_DIFF": 296,
+      "MADAROS_ONLY_REJECT": 230,
+      "DIAG_DIFF": 15,
+      "AGREE_REJECT": 6
+    }
+  },
+  "caveats": [
+    "SPAN_DIFF is inflated: fallback span extractor matched bare N:N pairs in non-diagnostic output; strict recount collapses almost all to AGREE_REJECT_or_weak_span.",
+    "LEAN_ONLY_REJECT often has lean_err=NONE (lean_single fails without error[E###] form).",
+    "Prebuilt Madaros ELF, not source-rebuilt from this tip — instrument is fleet surface as shipped.",
+    "Runtime phase (#1792 class) measured separately on AGREE_ACCEPT subset."
+  ],
+  "known_anecdotes_mapped": {
+    "E218_f128_f256": "present in check corpus (2 files with E218 on Madaros path in run-pass literals)",
+    "E219_extern": "0 hits in run-pass (lives in compile-fail / ffi_posix positive control)",
+    "E158_inverse": "0 hits in run-pass after #1798 close on main; positive control path is compile-fail ontology",
+    "var_zero_fabrication_1792": "requires runtime phase on AGREE_ACCEPT / dissertation surfaces"
+  },
+  "slurm": {
+    "job_partition": "cpu-ops",
+    "recipe": "scripts/dev/slurm_srun_minimal.sh / scrubbed srun",
+    "stage": "/orangefs/training/sounio/engine-census-20260817"
+  }
+}

--- a/artifacts/research/cross_engine_runpass_census/20260817T-check/summary.txt
+++ b/artifacts/research/cross_engine_runpass_census/20260817T-check/summary.txt
@@ -1,0 +1,46 @@
+# Cross-engine run-pass census — CHECK phase
+date: 2026-08-17
+corpus: tests/run-pass (1759 .sio files, git-tracked on origin/main tip c5754c0c84)
+host: cpuops-t560-proxmox via scrubbed srun (SLURM_CONF=/tmp/slurm-direct.conf)
+engines: Madaros default bin/souc vs SOUNIO_SOUC_ENGINE=lean_single
+positive controls: AGREE_ACCEPT (_diag_sobol), MADAROS_ONLY_REJECT (f256 E218) — fired before sweep
+
+## Counts
+
+| Bucket | N |
+|---|---:|
+| Total files | 1759 |
+| Agree (AGREE_ACCEPT + AGREE_REJECT) | 841 |
+| Diverge (explicit classes) | 918 |
+| accept-vs-reject | 607 |
+| — Madaros rejects, lean accepts | 230 |
+| — lean rejects, Madaros accepts | 377 |
+| different diagnostic (raw DIAG_DIFF) | 15 |
+| different diagnostic (strict, both E-codes) | 6 |
+| same diagnostic, different span (raw SPAN_DIFF) | 296 |
+| (strict: almost all collapse to AGREE_REJECT / weak span) | 302 weak |
+| runtime different (this phase) | 0 (check only) |
+| timeout | 0 |
+
+## Interpretation (bounded)
+
+This is a **measurement of disagreement**, not a defect rate. Intentional gaps
+(Madaros stricter on async/closures/Seq, lean_single missing E219 surface, etc.)
+mix with unintentional bugs. CI that pins lean_single is validating against a
+motor that **disagrees with the default engine on 918/1759 run-pass files (52%)**
+at check time under this instrument.
+
+SPAN_DIFF raw count is **not trustworthy** without .sio:line:col anchors; see
+strict recount.
+
+## Positive controls
+
+- agree_accept: OK
+- e218_f256: Madaros E218 reject, lean accept (MADAROS_ONLY_REJECT) — OK
+
+## Artifacts
+
+- OrangeFS: /orangefs/training/sounio/engine-census-20260817/
+- TSV: census_check.tsv (1760 lines incl header)
+- Script: scripts/research/cross_engine_runpass_census.sh
+- Sibling accept/reject tool restored: scripts/research/cross_engine_diagnostic_agreement.sh

--- a/artifacts/research/cross_engine_runpass_census/20260817T-run/runtime_reclass.txt
+++ b/artifacts/research/cross_engine_runpass_census/20260817T-run/runtime_reclass.txt
@@ -1,0 +1,8 @@
+n=835
+rc_same=752
+rc_diff=83
+empty_lean_stdout_among_rc_same=299
+empty_mad_stdout_among_rc_same=0
+both_nonempty_hash_diff_among_rc_same=453
+note=raw RUNTIME_DIFF=835 is instrument-inflated; cite rc_diff=83 and science samples
+orangefs=/orangefs/training/sounio/engine-census-20260817

--- a/artifacts/research/cross_engine_runpass_census/metrics_check_latest.json
+++ b/artifacts/research/cross_engine_runpass_census/metrics_check_latest.json
@@ -1,0 +1,48 @@
+{
+  "status": "pass",
+  "phase": "check",
+  "corpus": "tests/run-pass",
+  "engines": {
+    "madaros": "bin/souc default (prebuilt Madaros v0.80.0)",
+    "lean_single": "SOUNIO_SOUC_ENGINE=lean_single"
+  },
+  "metrics": {
+    "total": 1759,
+    "agree_total": 841,
+    "diverge_explicit": 918,
+    "accept_vs_reject": 607,
+    "MADAROS_ONLY_REJECT": 230,
+    "LEAN_ONLY_REJECT": 377,
+    "different_diagnostic_raw": 15,
+    "different_diagnostic_strict_both_codes": 6,
+    "same_diagnostic_different_span_raw": 296,
+    "agree_reject_or_weak_span_strict": 302,
+    "runtime_output_different": 0,
+    "timeout": 0,
+    "by_class": {
+      "AGREE_ACCEPT": 835,
+      "LEAN_ONLY_REJECT": 377,
+      "SPAN_DIFF": 296,
+      "MADAROS_ONLY_REJECT": 230,
+      "DIAG_DIFF": 15,
+      "AGREE_REJECT": 6
+    }
+  },
+  "caveats": [
+    "SPAN_DIFF is inflated: fallback span extractor matched bare N:N pairs in non-diagnostic output; strict recount collapses almost all to AGREE_REJECT_or_weak_span.",
+    "LEAN_ONLY_REJECT often has lean_err=NONE (lean_single fails without error[E###] form).",
+    "Prebuilt Madaros ELF, not source-rebuilt from this tip — instrument is fleet surface as shipped.",
+    "Runtime phase (#1792 class) measured separately on AGREE_ACCEPT subset."
+  ],
+  "known_anecdotes_mapped": {
+    "E218_f128_f256": "present in check corpus (2 files with E218 on Madaros path in run-pass literals)",
+    "E219_extern": "0 hits in run-pass (lives in compile-fail / ffi_posix positive control)",
+    "E158_inverse": "0 hits in run-pass after #1798 close on main; positive control path is compile-fail ontology",
+    "var_zero_fabrication_1792": "requires runtime phase on AGREE_ACCEPT / dissertation surfaces"
+  },
+  "slurm": {
+    "job_partition": "cpu-ops",
+    "recipe": "scripts/dev/slurm_srun_minimal.sh / scrubbed srun",
+    "stage": "/orangefs/training/sounio/engine-census-20260817"
+  }
+}

--- a/docs/audit/CROSS_ENGINE_RUNPASS_CENSUS_2026-08-17.md
+++ b/docs/audit/CROSS_ENGINE_RUNPASS_CENSUS_2026-08-17.md
@@ -1,0 +1,168 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.cross-engine-runpass-census-2026-08-17
+authority: repo_only
+audience: users
+last_validated: 2026-08-17
+validated_by: grok-cli1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.cross-engine-runpass-census-2026-08-17
+-->
+
+# Cross-engine run-pass census (2026-08-17)
+
+**Author:** grok-cli1  
+**Branch (local):** `lane/grok-cli1/engine-divergence-census-20260817`  
+**Base:** `origin/main` @ `c5754c0c84`  
+**Instrument:** `scripts/research/cross_engine_runpass_census.sh`  
+**Heavy path:** scrubbed `srun` / `scripts/dev/slurm_srun_minimal.sh` on `cpu-ops`  
+**Stage:** `/orangefs/training/sounio/engine-census-20260817/`  
+**Engines:** default Madaros (`bin/souc`) vs `SOUNIO_SOUC_ENGINE=lean_single`  
+**Binary class:** **prebuilt fleet surface** (not a source-rebuilt Madaros from this tip).
+
+## Why this exists
+
+On 2026-08-17 alone, three new dual-engine divergences landed as PRs/anecdotes:
+
+| ID | Madaros | lean_single | Note |
+|---|---|---|---|
+| #1798 | accepted forward `inverse_of` | **E158** | **CLOSED** — Madaros aligned |
+| #1792 | `var=0.000000` | ~1e-5 | **OPEN** — thesis fabrication |
+| #1801 | **E219** on non-allowlisted extern | no E219 surface | Madaros-only refuse |
+
+Plus earlier: **tilde** semantics differ; **E218** V0-A (Madaros refuses f128/f256 arithmetic, lean_single accepts).
+
+CI oracles often pin lean_single. That means the fleet was validating the **non-default** motor while the default disagrees with it in many places. This census turns that from anecdote into a corpus count on `tests/run-pass`.
+
+## Instrument validation (required)
+
+Positive controls **must fire** or the sweep aborts:
+
+1. **AGREE_ACCEPT** — `tests/run-pass/_diag_sobol.sio` (both check OK).
+2. **MADAROS_ONLY_REJECT** — `tests/compile-fail/f256_v0b_arithmetic_rejected.sio` (Madaros `error[E218]`, lean accepts).
+
+A zero-disagreement result after failed controls would measure nothing.
+
+## CHECK-phase results (full run-pass, 1759 files)
+
+| Bucket | N | Share of 1759 |
+|---|---:|---:|
+| **Total** | 1759 | 100% |
+| **Agree** (AGREE_ACCEPT + AGREE_REJECT) | 841 | 47.8% |
+| **Diverge (explicit)** | 918 | **52.2%** |
+| accept-vs-reject | 607 | 34.5% |
+| — Madaros-only reject | 230 | 13.1% |
+| — lean-only reject | 377 | 21.4% |
+| different diagnostic (raw `DIAG_DIFF`) | 15 | 0.9% |
+| different diagnostic (strict: both have E-codes) | 6 | 0.3% |
+| same diagnostic, different span (raw `SPAN_DIFF`) | 296 | 16.8% |
+| timeout | 0 | 0% |
+
+### Class histogram (raw)
+
+```
+AGREE_ACCEPT         835
+LEAN_ONLY_REJECT     377
+SPAN_DIFF            296
+MADAROS_ONLY_REJECT  230
+DIAG_DIFF             15
+AGREE_REJECT           6
+```
+
+### Caveat on `SPAN_DIFF`
+
+The first-pass span extractor accepted bare `N:N` pairs from non-diagnostic text (including noise such as `50272:24`). A **strict** recount requiring `.sio:line:col` collapses nearly all raw `SPAN_DIFF` into `AGREE_REJECT` / weak-span both-reject. **Do not cite 296 as true span disagreement.** Prefer:
+
+- accept-vs-reject **607**
+- strict dual-coded DIAG_DIFF **6**
+- raw DIAG_DIFF **15** (includes one-sided E-code)
+
+### Top Madaros-only error codes (among 230)
+
+| Count | Code | Sketch |
+|---:|---|---|
+| 91 | NONE | reject without `error[E…]` form |
+| 42 | E137 | unresolved name / import surface |
+| 13 | E009 | type / generic |
+| 13 | E175 | import / multi-module family |
+| 10 | E004 | parse / syntax family |
+| 10 | E035 | type |
+| 7 | E012 | async |
+| 7 | E036 | epistemic / measure family |
+
+lean-only rejects: **374/377** with `lean_err=NONE` — lean_single often fails without the Madaros-style `error[E###]` wire form (still a real accept-vs-reject).
+
+### Anecdote coverage inside run-pass
+
+| Anecdote | In run-pass check sweep? |
+|---|---|
+| E218 f128/f256 | **Yes** — 2 files carry E218 on Madaros (`f128_v0b_literal_smoke`, `f256_v0b_literal_forms` appear as DIAG_DIFF E218 vs E200) |
+| E219 | **No** in run-pass (positive control on compile-fail / ffi_posix) |
+| E158 / #1798 | **No** residual in run-pass after close on main |
+| #1792 var=0 | **Runtime phase** (both must accept at check first) |
+
+## Runtime phase (835 AGREE_ACCEPT files, dual `souc run`)
+
+Naive normalized-stdout hash called **every** file `RUNTIME_DIFF` (835/835). That is an
+**instrument failure**, not a scientific claim: Madaros `run` still emits compile banners
+(`Compilation successful!`, `/tmp/madaros-run…`) that lean_single does not, and 299 cases are
+lean empty-stdout vs Madaros non-empty after the weak normalizer. Reclassified on the TSV notes:
+
+| Runtime reclass | N | Meaning |
+|---|---:|---|
+| **rc_diff** | **83** | exit codes disagree (hard runtime divergence) |
+| rc_same | 752 | same exit code |
+| — lean stdout empty, Madaros not | 299 | mostly instrument / print-path noise |
+| — both non-empty, hash differs | 453 | mix of banner residue + real numeric drift |
+
+### Science-surface samples (both rc=0, content inspected)
+
+| File | Observation |
+|---|---|
+| `door1_dense1024_epistemic.sio` | Madaros: uncertainty `0.114585 -> 0.000000`; lean: `-> 2.756059e-17` — **same family as #1792 zero-vs-tiny** |
+| `dissertation_pbpk28_degenerate_parity_ref.sio` | trailing PARITY|ct/cavg scientific values differ (0 vs ~3e-7) |
+| `dissertation_pbpk_qss_analytical_ref.sio` | similar trailing float drift |
+| `beta10_product_cancel_variance.sio` | both print `var_…=0.000000` and PASS (agree on zeros here) |
+| `darwin_pbpk28_smoke.sio` | mass/step markers match |
+
+So runtime divergence is **real** (83 rc + multiple numeric content diffs), but the raw 835
+hash-diff count is **not** the number to cite. Prefer **rc_diff=83** and case-level science
+samples until the normalizer strips Madaros run banners completely.
+
+## How to re-run
+
+```bash
+# Login pod: stage is already on OrangeFS after first transfer, or re-tar + srun stdin.
+export SLURM_CONF=/tmp/slurm-direct.conf
+srun --partition=cpu-ops --nodes=1 --ntasks=1 --cpus-per-task=32 --time=02:00:00 \
+  --chdir=/tmp \
+  --export=NONE,PATH=/usr/bin:/bin:/usr/local/bin,TMPDIR=/tmp,HOME=/tmp \
+  /bin/bash -lc '
+    cd /orangefs/training/sounio/engine-census-20260817/tree
+    export SOUNIO_STDLIB_PATH=$PWD/stdlib
+    export CROSS_ENGINE_OUT_DIR=/orangefs/training/sounio/engine-census-20260817/out-check
+    export CROSS_ENGINE_JOBS=32 CROSS_ENGINE_TIMEOUT=20
+    export CROSS_ENGINE_FILE_LIST=/orangefs/training/sounio/engine-census-20260817/tree/file_list.txt
+    ulimit -S -s 524288
+    bash scripts/research/cross_engine_runpass_census.sh
+  '
+```
+
+Helper: `scripts/dev/slurm_srun_minimal.sh` (supported path today; **sbatch not repaired**).
+
+## Related tools
+
+- `scripts/research/cross_engine_diagnostic_agreement.sh` — whole-repo accept/reject only (restored into tree; was not on `main`).
+- `scripts/research/cross_engine_runpass_census.sh` — this census (check + optional run, classified).
+
+## Honest claims
+
+1. Dual-engine divergence on run-pass is a **majority event** under this instrument (918/1759 diverge at check).
+2. This is **not** a defect rate; it is a disagreement census.
+3. CI pinned to lean_single is **not** measuring default Madaros agreement; it measures lean_single.
+4. SPAN_DIFF raw counts are **instrument-limited**; use accept-vs-reject + strict DIAG_DIFF for argument.
+5. Prebuilt Madaros may lag source; rebuild before claiming source-current parity.
+
+## What this does not close
+
+- ABI fix for #1792 fabrication.
+- Making CI’s claim oracle dual-engine or Madaros-default.
+- Full source-current Madaros rebuild gate before the census.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1347
-- Repo-backed topics: 1197
+- Total governed topics: 1348
+- Repo-backed topics: 1198
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 399
-- Authority count `repo_only`: 760
+- Authority count `repo_only`: 761
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 775 topics
+- A2: 776 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 37 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -88,6 +88,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.clinical-drug-switch-vanco-validation-2026-07-19 | repo_only | docs/audit/CLINICAL_DRUG_SWITCH_VANCO_VALIDATION_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.clinical-midazolam-ddi-e2e-vertical-2026-07-19 | repo_only | docs/audit/CLINICAL_MIDAZOLAM_DDI_E2E_VERTICAL_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.clinical-vanco-tdm-e2e-vertical-2026-07-19 | repo_only | docs/audit/CLINICAL_VANCO_TDM_E2E_VERTICAL_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.cross-engine-runpass-census-2026-08-17 | repo_only | docs/audit/CROSS_ENGINE_RUNPASS_CENSUS_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.data-io-lane-compiler-blocker-2026-07-13 | repo_only | docs/audit/DATA_IO_LANE_COMPILER_BLOCKER_2026-07-13.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.data-io-trilha-b-builtin-bufptr-dispatch-2026-07-14 | repo_only | docs/audit/DATA_IO_TRILHA_B_BUILTIN_BUFPTR_DISPATCH_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.dissertation-dossier-resolution-dispatch-2026-08-16 | repo_only | docs/audit/DISSERTATION_DOSSIER_RESOLUTION_DISPATCH_2026-08-16.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1488,6 +1488,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.cross-engine-runpass-census-2026-08-17",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/CROSS_ENGINE_RUNPASS_CENSUS_2026-08-17.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.data-io-lane-compiler-blocker-2026-07-13",
       "collection": "repo",
       "repo_doc_path": "docs/audit/DATA_IO_LANE_COMPILER_BLOCKER_2026-07-13.md",

--- a/scripts/research/cross_engine_diagnostic_agreement.sh
+++ b/scripts/research/cross_engine_diagnostic_agreement.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Accept/reject diagnostic agreement between the two Sounio compilers.
+#
+# WHAT THIS MEASURES, AND WHY IT IS NOT SOMETHING ELSE
+#
+# lean_single (frozen bootstrap seed, single file, token-level recognition) and Madaros (modular
+# Lexer→Parser→AST→Check→HIR→SIR→HLIR(SSA)→ELF) are two implementations of one language sharing a
+# specification and differing in internal representation. For each versioned .sio file this script
+# records whether each engine ACCEPTS or REJECTS it, and classifies the pair:
+#
+#   AGREE_ACCEPT   both accept
+#   AGREE_REJECT   both reject
+#   MADAROS_ONLY   Madaros rejects, lean_single accepts
+#   LEAN_ONLY      lean_single rejects, Madaros accepts
+#
+# The last two are the signal. Sun, Le & Su (Epiphron, ICSE 2016) built the first randomised
+# differential tester whose oracle is cross-compiler diagnostic inconsistency, but restricted it to
+# WARNINGS on syntactically valid, compilable programs; the accept/reject configuration was left as
+# future work. Csmith (PLDI 2011) excludes the diagnostic surface by construction — every generated
+# program must pass the lexer, parser and typechecker before it is used.
+#
+# WHAT THIS IS NOT
+#
+# It is NOT a defect rate. A disagreement can be a defect in either engine OR an intentional
+# divergence (lean_single mutes ~35 diagnostic classes for imported functions and has no strict
+# mode; Madaros implements guarantees lean_single never had). Epiphron measured a false-positive
+# rate in [10%, 47%] on its own warning-inconsistency oracle and needed dedicated filters. Any
+# claim built on these counts MUST separate intentional from unintentional divergence by hand.
+#
+# It is also NOT calibration. Calibration needs a STATED confidence checked against an OBSERVED
+# correctness rate. This supplies only the observed half.
+#
+# Neither engine is ground truth. Where they disagree, this says so; it does not say who is right.
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+OUT_DIR="${CROSS_ENGINE_OUT_DIR:-$(mktemp -d /tmp/sounio-cross-engine.XXXXXX)}"
+mkdir -p "$OUT_DIR"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+
+# Both engines are invoked THROUGH bin/souc, not directly. lean_single's raw CLI is
+# `mini_native <source.sio> <output>` with no check-only mode, so calling it directly would compare
+# a full compile against a Madaros --check -- different amounts of work, and rc=1 on files that are
+# perfectly fine. The wrapper translates the verb for each engine. Measured while building this:
+# the direct form reported rc=1 for two files that both engines actually accept.
+MADAROS_BIN="${CROSS_ENGINE_MADAROS_BIN:-}"
+
+if [[ -z "$MADAROS_BIN" ]]; then
+  echo "[cross-engine] FAIL: set CROSS_ENGINE_MADAROS_BIN to a Madaros built from the source under test." >&2
+  echo "[cross-engine] A prebuilt bin/madaros is not a baseline -- it lags source (measured 127 commits on 2026-07-26)." >&2
+  exit 1
+fi
+
+[[ -x "$MADAROS_BIN" ]] || { echo "[cross-engine] FAIL: not executable: $MADAROS_BIN" >&2; exit 1; }
+[[ -x "$ROOT_DIR/bin/souc" ]] || { echo "[cross-engine] FAIL: bin/souc missing" >&2; exit 1; }
+
+# Madaros needs a large stack to run at all (its own build reports frames up to ~31 MB), so a
+# 16384 KiB CI default kills it on a three-line program. Same block as the Madaros gates.
+stack_kb="${CROSS_ENGINE_STACK_KB:-524288}"
+stack_before="$(ulimit -S -s 2>/dev/null)" || { echo "[cross-engine] FAIL: soft stack limit unavailable" >&2; exit 1; }
+if [[ "$stack_before" != "unlimited" ]] && ((stack_before < stack_kb)); then
+  ulimit -S -s "$stack_kb" 2>/dev/null || { echo "[cross-engine] FAIL: could not raise soft stack to ${stack_kb} KiB" >&2; exit 1; }
+fi
+printf '[cross-engine] stack_kb before=%s after=%s\n' "$stack_before" "$(ulimit -S -s)"
+printf '[cross-engine] lean=wrapper(SOUNIO_SOUC_ENGINE=lean_single)\n[cross-engine] madaros=%s\n[cross-engine] out=%s\n' \
+  "$MADAROS_BIN" "$OUT_DIR"
+
+# Positive control: the instrument must be able to REPORT a disagreement, or a clean sweep means
+# nothing. These three are verified by hand -- both accept, Madaros-only rejects, both reject.
+pc_fail=0
+pc() {
+  local f="$1" want="$2"
+  SOUNIO_SOUC_ENGINE=lean_single "$ROOT_DIR/bin/souc" check "$f" >/dev/null 2>&1; local l=$?
+  SOUNIO_SOUC_BIN="$MADAROS_BIN" "$ROOT_DIR/bin/souc" check "$f" >/dev/null 2>&1; local m=$?
+  local got="AGREE_ACCEPT"
+  if [[ $l -ne 0 && $m -ne 0 ]]; then got="AGREE_REJECT"
+  elif [[ $l -eq 0 && $m -ne 0 ]]; then got="MADAROS_ONLY"
+  elif [[ $l -ne 0 && $m -eq 0 ]]; then got="LEAN_ONLY"; fi
+  if [[ "$got" == "$want" ]]; then printf '[cross-engine] positive-control OK %s -> %s\n' "$(basename "$f")" "$got"
+  else printf '[cross-engine] positive-control FAIL %s: want %s got %s\n' "$(basename "$f")" "$want" "$got" >&2; pc_fail=1; fi
+}
+pc tests/run-pass/struct_name_8byte_collision_ref.sio AGREE_ACCEPT
+pc tests/run-pass/interval_outward_rounding_containment.sio MADAROS_ONLY
+pc stdlib/verify/interval.sio AGREE_REJECT
+if [[ $pc_fail -ne 0 ]]; then
+  echo "[cross-engine] ABORT: the instrument cannot reproduce a known disagreement; a sweep would be meaningless." >&2
+  exit 1
+fi
+
+TSV="$OUT_DIR/agreement.tsv"
+printf 'file\tlean_rc\tmadaros_rc\tverdict\n' > "$TSV"
+
+# Per-file timeout: a hung compile must not stall the sweep, and a timeout is NOT a rejection --
+# it is recorded distinctly so it cannot be silently counted as a disagreement.
+TMO="${CROSS_ENGINE_TIMEOUT:-25}"
+
+n=0
+while IFS= read -r f; do
+  n=$((n + 1))
+  lout="$OUT_DIR/l.$$"; mout="$OUT_DIR/m.$$"
+  SOUNIO_SOUC_ENGINE=lean_single timeout "$TMO" "$ROOT_DIR/bin/souc" check "$f" >"$lout" 2>&1; lrc=$?
+  SOUNIO_SOUC_BIN="$MADAROS_BIN" timeout "$TMO" "$ROOT_DIR/bin/souc" check "$f" >"$mout" 2>&1; mrc=$?
+
+  if [[ "$lrc" -eq 124 || "$mrc" -eq 124 ]]; then
+    verdict="TIMEOUT"
+  elif [[ "$lrc" -eq 0 && "$mrc" -eq 0 ]]; then
+    verdict="AGREE_ACCEPT"
+  elif [[ "$lrc" -ne 0 && "$mrc" -ne 0 ]]; then
+    verdict="AGREE_REJECT"
+  elif [[ "$lrc" -eq 0 && "$mrc" -ne 0 ]]; then
+    verdict="MADAROS_ONLY"
+    cp "$mout" "$OUT_DIR/madaros_only.$(echo "$f" | tr '/' '_').log" 2>/dev/null || true
+  else
+    verdict="LEAN_ONLY"
+    cp "$lout" "$OUT_DIR/lean_only.$(echo "$f" | tr '/' '_').log" 2>/dev/null || true
+  fi
+  printf '%s\t%s\t%s\t%s\n' "$f" "$lrc" "$mrc" "$verdict" >> "$TSV"
+  rm -f "$lout" "$mout"
+
+  if ((n % 250 == 0)); then printf '[cross-engine] %d files\n' "$n" >&2; fi
+done < <(git ls-files '*.sio' | grep -vE '^(archive|bootstrap)/')
+
+echo
+echo "=== verdicts over $n files ==="
+awk -F'\t' 'NR>1{c[$4]++} END{for (k in c) printf "%-14s %6d\n", k, c[k]}' "$TSV" | sort -k2 -rn
+echo
+echo "TSV: $TSV"
+echo "Disagreement logs: $OUT_DIR/{madaros_only,lean_only}.*.log"
+echo
+echo "REMINDER: these counts mix genuine defects with intentional divergence. Do not report a"
+echo "disagreement RATE as a defect rate without classifying the cases by hand."

--- a/scripts/research/cross_engine_runpass_census.sh
+++ b/scripts/research/cross_engine_runpass_census.sh
@@ -1,0 +1,527 @@
+#!/usr/bin/env bash
+# Cross-engine run-pass census: Madaros (default) vs lean_single.
+#
+# Turns dual-engine divergence from anecdote into a measured corpus count.
+# Known 2026-08-17 anecdotes this instrument is meant to absorb:
+#   #1798 E158 forward inverse_of (CLOSED — both should reject once source-aligned)
+#   #1792 var=0.000000 vs ~1e-5 (OPEN — runtime / fabricated variance)
+#   #1801 E219 Madaros-only (non-allowlisted extern)
+#   V0-A / E218 f128-f256 (Madaros rejects; lean_single accepts arithmetic)
+#   tilde operator semantics differ by engine (doc surface; not every fixture hits it)
+#
+# CI oracles often pin lean_single. This census reports how often the default
+# engine (Madaros) disagrees with that pin on the run-pass corpus.
+#
+# Classification (per file):
+#   AGREE_ACCEPT              both check accept
+#   AGREE_REJECT              both check reject, same primary error code + span
+#   DIAG_DIFF                 both reject, primary error codes differ
+#   SPAN_DIFF                 both reject, same primary code, different span
+#   MADAROS_ONLY_REJECT       Madaros rejects, lean_single accepts   (accept-vs-reject)
+#   LEAN_ONLY_REJECT          lean_single rejects, Madaros accepts   (accept-vs-reject)
+#   RUNTIME_DIFF              both accept check; run rc or stdout differs
+#   AGREE_RUNTIME             both accept check; run rc+stdout match (when --run)
+#   TIMEOUT                   either side hit the per-file timeout
+#   INSTRUMENT_ERROR          missing binary / setup failure
+#
+# Positive controls MUST fire or the sweep aborts (instrument validation).
+#
+# Usage:
+#   scripts/research/cross_engine_runpass_census.sh
+#   CROSS_ENGINE_OUT_DIR=... scripts/research/cross_engine_runpass_census.sh --run
+#   CROSS_ENGINE_GLOBS='tests/run-pass/med/*.sio' ...  # subset
+#   CROSS_ENGINE_JOBS=32 CROSS_ENGINE_TIMEOUT=20 ...
+#
+# Heavy runs: use scripts/dev/slurm_srun_minimal.sh on a node that can see
+# /orangefs (not /workspace). See docs/ops/SLURM_LAUNCH_REPAIR_2026-08-17.md.
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+DO_RUN=0
+GLOBS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run) DO_RUN=1; shift ;;
+    --glob=*) GLOBS+=("${1#*=}"); shift ;;
+    --) shift; break ;;
+    -h|--help)
+      sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+OUT_DIR="${CROSS_ENGINE_OUT_DIR:-$ROOT_DIR/artifacts/research/cross_engine_runpass_census/$(date -u +%Y%m%dT%H%M%SZ)}"
+mkdir -p "$OUT_DIR"/{logs,work}
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+
+STACK_KB="${CROSS_ENGINE_STACK_KB:-524288}"
+stack_before="$(ulimit -S -s 2>/dev/null || echo unknown)"
+if [[ "$stack_before" != "unlimited" && "$stack_before" != "unknown" ]]; then
+  if (( stack_before < STACK_KB )); then
+    ulimit -S -s "$STACK_KB" 2>/dev/null || true
+  fi
+fi
+
+TMO="${CROSS_ENGINE_TIMEOUT:-25}"
+JOBS="${CROSS_ENGINE_JOBS:-$(nproc 2>/dev/null || echo 8)}"
+SOUC="$ROOT_DIR/bin/souc"
+LEAN_ELF="${CROSS_ENGINE_LEAN_ELF:-$ROOT_DIR/bin/souc-lean-single-x86_64}"
+[[ -x "$LEAN_ELF" ]] || LEAN_ELF="$ROOT_DIR/bin/souc-linux-x86_64"
+
+if [[ ! -x "$SOUC" ]]; then
+  echo "[census] FAIL: bin/souc missing" >&2
+  exit 1
+fi
+if [[ ! -x "$LEAN_ELF" ]]; then
+  echo "[census] FAIL: lean_single ELF missing" >&2
+  exit 1
+fi
+
+# Resolve which Madaros ELF the default souc path will use (for the receipt).
+MADAROS_RESOLVED="$("$SOUC" info 2>/dev/null | head -5 || true)"
+
+printf '[census] root=%s\n' "$ROOT_DIR"
+printf '[census] out=%s\n' "$OUT_DIR"
+printf '[census] stack_before=%s stack_after=%s\n' "$stack_before" "$(ulimit -S -s 2>/dev/null || echo unknown)"
+printf '[census] jobs=%s timeout=%ss do_run=%s\n' "$JOBS" "$TMO" "$DO_RUN"
+printf '[census] madaros_via=bin/souc (default)\n'
+printf '[census] lean_via=SOUNIO_SOUC_ENGINE=lean_single bin/souc → %s\n' "$LEAN_ELF"
+{
+  echo "status=running"
+  echo "date_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "root=$ROOT_DIR"
+  echo "git_head=$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+  echo "git_describe=$(git describe --always --dirty 2>/dev/null || echo unknown)"
+  echo "do_run=$DO_RUN"
+  echo "jobs=$JOBS"
+  echo "timeout_s=$TMO"
+  echo "souc_version_madaros=$("$SOUC" --version 2>&1 | head -1)"
+  echo "lean_elf=$LEAN_ELF"
+} > "$OUT_DIR/receipt_meta.txt"
+
+# --- helpers -----------------------------------------------------------------
+
+# Extract primary error code like E158 / E218 / E219 from compiler stderr/stdout.
+primary_errcode() {
+  local f="$1"
+  local code
+  code="$(grep -oE 'error\[E[0-9]+\]' "$f" 2>/dev/null | head -1 | tr -d 'error[]' || true)"
+  if [[ -z "$code" ]]; then
+    code="$(grep -oE 'E[0-9]{3,4}' "$f" 2>/dev/null | head -1 || true)"
+  fi
+  printf '%s' "${code:-NONE}"
+}
+
+primary_span() {
+  local f="$1"
+  local span
+  span="$(grep -oE '[A-Za-z0-9_./-]+\.sio:[0-9]+:[0-9]+' "$f" 2>/dev/null | head -1 || true)"
+  if [[ -z "$span" ]]; then
+    span="$(grep -oE '[0-9]+:[0-9]+' "$f" 2>/dev/null | head -1 || true)"
+  fi
+  printf '%s' "${span:-NONE}"
+}
+
+# Check with one engine. Writes full log to $2. Prints rc on stdout.
+check_engine() {
+  local engine="$1" src="$2" log="$3"
+  local rc
+  if [[ "$engine" == "madaros" ]]; then
+    # Default souc → Madaros
+    ( cd "$ROOT_DIR" && timeout "$TMO" env SOUNIO_STDLIB_PATH="$SOUNIO_STDLIB_PATH" \
+        "$SOUC" check "$src" >"$log" 2>&1 )
+    rc=$?
+  else
+    ( cd "$ROOT_DIR" && timeout "$TMO" env SOUNIO_STDLIB_PATH="$SOUNIO_STDLIB_PATH" \
+        SOUNIO_SOUC_ENGINE=lean_single \
+        "$SOUC" check "$src" >"$log" 2>&1 )
+    rc=$?
+  fi
+  printf '%s' "$rc"
+}
+
+# Run with one engine (compile+execute via souc run). Writes log; prints rc.
+run_engine() {
+  local engine="$1" src="$2" log="$3"
+  local rc
+  if [[ "$engine" == "madaros" ]]; then
+    ( cd "$ROOT_DIR" && timeout "$TMO" env SOUNIO_STDLIB_PATH="$SOUNIO_STDLIB_PATH" \
+        "$SOUC" run "$src" >"$log" 2>&1 )
+    rc=$?
+  else
+    ( cd "$ROOT_DIR" && timeout "$TMO" env SOUNIO_STDLIB_PATH="$SOUNIO_STDLIB_PATH" \
+        SOUNIO_SOUC_ENGINE=lean_single \
+        "$SOUC" run "$src" >"$log" 2>&1 )
+    rc=$?
+  fi
+  printf '%s' "$rc"
+}
+
+# Normalize stdout for runtime comparison: drop absolute paths and souc banners.
+normalize_output() {
+  local f="$1"
+  # strip common noise lines; keep numeric/science payload
+  sed -E \
+    -e '/^Madaros v/d' \
+    -e '/^the bare highland/d' \
+    -e '/^Horizon /d' \
+    -e '/^science-boundary:/d' \
+    -e '/^check: OK/d' \
+    -e '/^compile:/d' \
+    -e '/^elf:/d' \
+    -e '/^epistemic_meas:/d' \
+    -e '/^knightian:/d' \
+    -e '/^knowledge_/d' \
+    -e '/^tier_dist:/d' \
+    -e '/^econf:/d' \
+    -e '/^Merged IR:/d' \
+    -e '/^Written to /d' \
+    -e '/^Compilation successful/d' \
+    -e '/^[[:space:]]*Output:/d' \
+    -e "s|$ROOT_DIR/||g" \
+    -e 's|/tmp/[^ ]+|/tmp/OUT|g' \
+    "$f" 2>/dev/null || true
+}
+
+# --- positive controls -------------------------------------------------------
+
+pc_fail=0
+pc() {
+  local label="$1" want="$2" src="$3"
+  if [[ ! -f "$src" ]]; then
+    printf '[census] positive-control SKIP %s (missing %s)\n' "$label" "$src" >&2
+    return 0
+  fi
+  local ml="$OUT_DIR/work/pc_${label}_m.log" ll="$OUT_DIR/work/pc_${label}_l.log"
+  local mrc lrc
+  mrc="$(check_engine madaros "$src" "$ml")"
+  lrc="$(check_engine lean "$src" "$ll")"
+  local got="AGREE_ACCEPT"
+  if [[ "$mrc" -eq 124 || "$lrc" -eq 124 ]]; then got="TIMEOUT"
+  elif [[ "$mrc" -eq 0 && "$lrc" -eq 0 ]]; then got="AGREE_ACCEPT"
+  elif [[ "$mrc" -ne 0 && "$lrc" -ne 0 ]]; then got="AGREE_REJECT"
+  elif [[ "$mrc" -ne 0 && "$lrc" -eq 0 ]]; then got="MADAROS_ONLY_REJECT"
+  else got="LEAN_ONLY_REJECT"; fi
+  if [[ "$got" == "$want" ]]; then
+    printf '[census] positive-control OK %s -> %s (mrc=%s lrc=%s)\n' "$label" "$got" "$mrc" "$lrc"
+  else
+    printf '[census] positive-control FAIL %s: want %s got %s (mrc=%s lrc=%s)\n' \
+      "$label" "$want" "$got" "$mrc" "$lrc" >&2
+    pc_fail=1
+  fi
+}
+
+# AGREE_ACCEPT control: tiny run-pass (must exist on main)
+if [[ -f tests/run-pass/_diag_sobol.sio ]]; then
+  pc agree_accept AGREE_ACCEPT tests/run-pass/_diag_sobol.sio
+elif [[ -f tests/run-pass/a13_crossmod_mainfirst_ok_ctrlE.sio ]]; then
+  pc agree_accept AGREE_ACCEPT tests/run-pass/a13_crossmod_mainfirst_ok_ctrlE.sio
+else
+  echo "[census] positive-control FAIL agree_accept: no candidate fixture" >&2
+  pc_fail=1
+fi
+
+# MADAROS_ONLY on f256 arithmetic reserved (E218) — compile-fail under Madaros,
+# may accept under lean_single (V0-A class).
+pc e218_f256 MADAROS_ONLY_REJECT tests/compile-fail/f256_v0b_arithmetic_rejected.sio
+
+# E219 Madaros-only on non-allowlisted extern (if fixture present)
+if [[ -f tests/compile-fail/extern_c_unimplemented_builtin.sio ]]; then
+  pc e219_extern MADAROS_ONLY_REJECT tests/compile-fail/extern_c_unimplemented_builtin.sio
+elif [[ -f tests/ffi_posix/arm_claim_unimplemented.sio ]]; then
+  pc e219_extern MADAROS_ONLY_REJECT tests/ffi_posix/arm_claim_unimplemented.sio
+fi
+
+# AGREE_REJECT on a known-bad library file if present
+if [[ -f stdlib/verify/interval.sio ]]; then
+  pc agree_reject AGREE_REJECT stdlib/verify/interval.sio
+fi
+
+if [[ "$pc_fail" -ne 0 ]]; then
+  echo "[census] ABORT: positive controls failed; a zero-disagreement sweep would be meaningless." >&2
+  echo "status=fail_positive_control" >> "$OUT_DIR/receipt_meta.txt"
+  exit 1
+fi
+
+# --- build file list ---------------------------------------------------------
+
+LIST="$OUT_DIR/file_list.txt"
+: > "$LIST"
+if [[ ${#GLOBS[@]} -eq 0 ]]; then
+  if [[ -n "${CROSS_ENGINE_GLOBS:-}" ]]; then
+    # shellcheck disable=SC2206
+    GLOBS=( $CROSS_ENGINE_GLOBS )
+  else
+    GLOBS=( 'tests/run-pass/**/*.sio' 'tests/run-pass/*.sio' )
+  fi
+fi
+
+# Prefer git-tracked run-pass files for reproducibility.
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git ls-files 'tests/run-pass/**/*.sio' 'tests/run-pass/*.sio' 2>/dev/null | sort -u > "$LIST"
+fi
+if [[ ! -s "$LIST" ]]; then
+  find tests/run-pass -type f -name '*.sio' | sort > "$LIST"
+fi
+
+if [[ -n "${CROSS_ENGINE_FILE_LIST:-}" && -f "${CROSS_ENGINE_FILE_LIST}" ]]; then
+  cp "${CROSS_ENGINE_FILE_LIST}" "$LIST"
+fi
+
+N_FILES="$(wc -l < "$LIST" | tr -d ' ')"
+printf '[census] corpus_files=%s\n' "$N_FILES"
+echo "corpus_files=$N_FILES" >> "$OUT_DIR/receipt_meta.txt"
+
+if [[ "$N_FILES" -eq 0 ]]; then
+  echo "[census] FAIL: empty corpus" >&2
+  exit 1
+fi
+
+# --- per-file worker ---------------------------------------------------------
+
+WORKER="$OUT_DIR/work/worker.sh"
+cat > "$WORKER" <<'WORKER_EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+src="$1"
+ROOT_DIR="$CENSUS_ROOT"
+OUT_DIR="$CENSUS_OUT"
+TMO="$CENSUS_TMO"
+DO_RUN="$CENSUS_DO_RUN"
+SOUC="$CENSUS_SOUC"
+SOUNIO_STDLIB_PATH="$CENSUS_STDLIB"
+
+safe="$(echo "$src" | tr '/' '_')"
+ml="$OUT_DIR/logs/${safe}.madaros.check.log"
+ll="$OUT_DIR/logs/${safe}.lean.check.log"
+mr="$OUT_DIR/logs/${safe}.madaros.run.log"
+lr="$OUT_DIR/logs/${safe}.lean.run.log"
+
+primary_errcode() {
+  local f="$1" code
+  code="$(grep -oE 'error\[E[0-9]+\]' "$f" 2>/dev/null | head -1 | tr -d 'error[]' || true)"
+  if [[ -z "$code" ]]; then
+    code="$(grep -oE 'E[0-9]{3,4}' "$f" 2>/dev/null | head -1 || true)"
+  fi
+  printf '%s' "${code:-NONE}"
+}
+primary_span() {
+  local f="$1" span
+  span="$(grep -oE '[A-Za-z0-9_./-]+\.sio:[0-9]+:[0-9]+' "$f" 2>/dev/null | head -1 || true)"
+  if [[ -z "$span" ]]; then
+    span="$(grep -oE '[0-9]+:[0-9]+' "$f" 2>/dev/null | head -1 || true)"
+  fi
+  printf '%s' "${span:-NONE}"
+}
+normalize_output() {
+  local f="$1"
+  sed -E \
+    -e '/^Madaros v/d' \
+    -e '/^the bare highland/d' \
+    -e '/^Horizon /d' \
+    -e '/^science-boundary:/d' \
+    -e '/^check: OK/d' \
+    -e '/^compile:/d' \
+    -e '/^elf:/d' \
+    -e '/^epistemic_meas:/d' \
+    -e '/^knightian:/d' \
+    -e '/^knowledge_/d' \
+    -e '/^tier_dist:/d' \
+    -e '/^econf:/d' \
+    -e '/^Merged IR:/d' \
+    -e '/^Written to /d' \
+    -e '/^Compilation successful/d' \
+    -e '/^[[:space:]]*Output:/d' \
+    -e "s|$ROOT_DIR/||g" \
+    -e 's|/tmp/[^ ]+|/tmp/OUT|g' \
+    "$f" 2>/dev/null || true
+}
+
+( cd "$ROOT_DIR" && timeout "$TMO" env SOUNIO_STDLIB_PATH="$SOUNIO_STDLIB_PATH" \
+    "$SOUC" check "$src" >"$ml" 2>&1 )
+mrc=$?
+( cd "$ROOT_DIR" && timeout "$TMO" env SOUNIO_STDLIB_PATH="$SOUNIO_STDLIB_PATH" \
+    SOUNIO_SOUC_ENGINE=lean_single \
+    "$SOUC" check "$src" >"$ll" 2>&1 )
+lrc=$?
+
+m_err="$(primary_errcode "$ml")"
+l_err="$(primary_errcode "$ll")"
+m_span="$(primary_span "$ml")"
+l_span="$(primary_span "$ll")"
+
+class=""
+run_mrc=""
+run_lrc=""
+run_note=""
+
+if [[ "$mrc" -eq 124 || "$lrc" -eq 124 ]]; then
+  class="TIMEOUT"
+elif [[ "$mrc" -eq 0 && "$lrc" -eq 0 ]]; then
+  class="AGREE_ACCEPT"
+  if [[ "$DO_RUN" == "1" ]]; then
+    ( cd "$ROOT_DIR" && timeout "$TMO" env SOUNIO_STDLIB_PATH="$SOUNIO_STDLIB_PATH" \
+        "$SOUC" run "$src" >"$mr" 2>&1 )
+    run_mrc=$?
+    ( cd "$ROOT_DIR" && timeout "$TMO" env SOUNIO_STDLIB_PATH="$SOUNIO_STDLIB_PATH" \
+        SOUNIO_SOUC_ENGINE=lean_single \
+        "$SOUC" run "$src" >"$lr" 2>&1 )
+    run_lrc=$?
+    if [[ "$run_mrc" -eq 124 || "$run_lrc" -eq 124 ]]; then
+      class="TIMEOUT"
+      run_note="run_timeout"
+    else
+      nm="$(normalize_output "$mr" | sha256sum | awk '{print $1}')"
+      nl="$(normalize_output "$lr" | sha256sum | awk '{print $1}')"
+      if [[ "$run_mrc" -eq "$run_lrc" && "$nm" == "$nl" ]]; then
+        class="AGREE_RUNTIME"
+      else
+        class="RUNTIME_DIFF"
+        run_note="mrc=${run_mrc};lrc=${run_lrc};mhash=${nm:0:12};lhash=${nl:0:12}"
+      fi
+    fi
+  fi
+elif [[ "$mrc" -ne 0 && "$lrc" -ne 0 ]]; then
+  if [[ "$m_err" != "$l_err" ]]; then
+    class="DIAG_DIFF"
+  elif [[ "$m_span" != "$l_span" ]]; then
+    class="SPAN_DIFF"
+  else
+    class="AGREE_REJECT"
+  fi
+elif [[ "$mrc" -ne 0 && "$lrc" -eq 0 ]]; then
+  class="MADAROS_ONLY_REJECT"
+else
+  class="LEAN_ONLY_REJECT"
+fi
+
+# TSV row (one line)
+printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+  "$src" "$mrc" "$lrc" "$m_err" "$l_err" "$m_span" "$l_span" \
+  "$class" "${run_mrc:-}" "${run_lrc:-}" "${run_note:-}"
+WORKER_EOF
+chmod +x "$WORKER"
+
+export CENSUS_ROOT="$ROOT_DIR"
+export CENSUS_OUT="$OUT_DIR"
+export CENSUS_TMO="$TMO"
+export CENSUS_DO_RUN="$DO_RUN"
+export CENSUS_SOUC="$SOUC"
+export CENSUS_STDLIB="$SOUNIO_STDLIB_PATH"
+
+TSV="$OUT_DIR/census.tsv"
+printf 'file\tmadaros_check_rc\tlean_check_rc\tmadaros_err\tlean_err\tmadaros_span\tlean_span\tclass\trun_mrc\trun_lrc\trun_note\n' > "$TSV"
+
+# Parallel sweep
+export -n  # nothing
+if command -v xargs >/dev/null 2>&1; then
+  # shellcheck disable=SC2016
+  <"$LIST" xargs -P "$JOBS" -I{} bash "$WORKER" {} >> "$TSV"
+else
+  while IFS= read -r f; do
+    bash "$WORKER" "$f" >> "$TSV"
+  done < "$LIST"
+fi
+
+# --- summarize ---------------------------------------------------------------
+
+SUMMARY="$OUT_DIR/summary.txt"
+python3 - <<'PY' "$TSV" "$SUMMARY" "$OUT_DIR"
+import sys, collections, pathlib
+tsv, summary, out_dir = sys.argv[1:4]
+rows = []
+with open(tsv, encoding='utf-8', errors='replace') as f:
+    header = f.readline().rstrip('\n').split('\t')
+    for line in f:
+        parts = line.rstrip('\n').split('\t')
+        if len(parts) < 8:
+            continue
+        row = dict(zip(header, parts + [''] * (len(header) - len(parts))))
+        rows.append(row)
+
+counts = collections.Counter(r['class'] for r in rows)
+n = len(rows)
+# taxonomy buckets requested by the founder
+accept_vs_reject = counts.get('MADAROS_ONLY_REJECT', 0) + counts.get('LEAN_ONLY_REJECT', 0)
+diag_diff = counts.get('DIAG_DIFF', 0)
+span_diff = counts.get('SPAN_DIFF', 0)
+runtime_diff = counts.get('RUNTIME_DIFF', 0)
+agree = (
+    counts.get('AGREE_ACCEPT', 0)
+    + counts.get('AGREE_REJECT', 0)
+    + counts.get('AGREE_RUNTIME', 0)
+)
+diverge = n - agree - counts.get('TIMEOUT', 0) - counts.get('INSTRUMENT_ERROR', 0)
+# more precise diverge = explicit disagreement classes
+diverge_explicit = accept_vs_reject + diag_diff + span_diff + runtime_diff
+
+lines = []
+lines.append(f'corpus_files={n}')
+lines.append(f'agree_total={agree}')
+lines.append(f'diverge_explicit={diverge_explicit}')
+lines.append(f'timeout={counts.get("TIMEOUT", 0)}')
+lines.append('')
+lines.append('## class counts')
+for k, v in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
+    lines.append(f'{k}={v}')
+lines.append('')
+lines.append('## taxonomy (founder request)')
+lines.append(f'accept_vs_reject={accept_vs_reject}  # MADAROS_ONLY_REJECT + LEAN_ONLY_REJECT')
+lines.append(f'different_diagnostic={diag_diff}  # DIAG_DIFF')
+lines.append(f'same_diagnostic_different_span={span_diff}  # SPAN_DIFF')
+lines.append(f'runtime_output_different={runtime_diff}  # RUNTIME_DIFF')
+lines.append('')
+lines.append('## disagreement files (first 200)')
+shown = 0
+for r in rows:
+    if r['class'] in {
+        'MADAROS_ONLY_REJECT', 'LEAN_ONLY_REJECT', 'DIAG_DIFF',
+        'SPAN_DIFF', 'RUNTIME_DIFF',
+    }:
+        lines.append(
+            f"{r['class']}\t{r['file']}\tm_err={r['madaros_err']}\tl_err={r['lean_err']}"
+            f"\tm_span={r['madaros_span']}\tl_span={r['lean_span']}\tnote={r.get('run_note','')}"
+        )
+        shown += 1
+        if shown >= 200:
+            lines.append(f'... truncated; see census.tsv for full list')
+            break
+
+text = '\n'.join(lines) + '\n'
+pathlib.Path(summary).write_text(text, encoding='utf-8')
+print(text)
+
+# compact JSON metrics
+import json
+metrics = {
+    'status': 'pass' if n > 0 else 'fail',
+    'metrics': {
+        'total': n,
+        'agree_total': agree,
+        'diverge_explicit': diverge_explicit,
+        'accept_vs_reject': accept_vs_reject,
+        'different_diagnostic': diag_diff,
+        'same_diagnostic_different_span': span_diff,
+        'runtime_output_different': runtime_diff,
+        'timeout': counts.get('TIMEOUT', 0),
+        'by_class': dict(counts),
+    },
+}
+pathlib.Path(out_dir, 'metrics.json').write_text(json.dumps(metrics, indent=2) + '\n', encoding='utf-8')
+PY
+
+{
+  echo "status=pass"
+  echo "date_utc_end=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "summary=$SUMMARY"
+  echo "tsv=$TSV"
+  echo "metrics=$OUT_DIR/metrics.json"
+} >> "$OUT_DIR/receipt_meta.txt"
+
+printf '[census] DONE summary=%s\n' "$SUMMARY"
+printf '[census] TSV=%s\n' "$TSV"
+printf '[census] metrics=%s\n' "$OUT_DIR/metrics.json"


### PR DESCRIPTION
## Summary

Turns Madaros vs lean_single divergence from anecdote into a **measured run-pass census**.

CI often pins **lean_single**. Default Madaros disagrees with that pin on **918/1759 (52%)** of `tests/run-pass` files at check time under this instrument.

Same honesty register as #1782 / #1786: state what is measured, what is instrument noise, what is still open.

## Numbers (check phase, 1759 files, scrubbed srun on cpu-ops)

| Bucket | N |
|---|---:|
| Agree (AGREE_ACCEPT + AGREE_REJECT) | **841** |
| Diverge (explicit) | **918** |
| accept-vs-reject | **607** (Madaros-only reject 230 · lean-only reject 377) |
| different diagnostic (raw / strict both E-codes) | 15 / **6** |
| same diagnostic, different span (raw) | 296 — **do not cite** (span extractor inflated) |
| timeout | 0 |

Positive controls fired: AGREE_ACCEPT (`_diag_sobol`); MADAROS_ONLY_REJECT (f256 → Madaros **E218**, lean accepts).

## Runtime phase (835 AGREE_ACCEPT)

Raw stdout-hash said 835/835 differ — **instrument failure** (Madaros run banners). Reclass:

| Reclass | N |
|---|---:|
| **rc_diff** | **83** ← cite this |
| rc_same | 752 |
| Science sample | `door1_dense1024_epistemic`: Madaros `-> 0.000000` vs lean `-> 2.756059e-17` (#1792 family) |

## What ships

- `scripts/research/cross_engine_runpass_census.sh` — classified census + positive controls
- `scripts/research/cross_engine_diagnostic_agreement.sh` — restored accept/reject helper
- `docs/audit/CROSS_ENGINE_RUNPASS_CENSUS_2026-08-17.md`
- Compact metrics under `artifacts/research/cross_engine_runpass_census/`
- Full TSVs on OrangeFS: `/orangefs/training/sounio/engine-census-20260817/`

## Test plan

- [x] Positive controls fire before sweep
- [x] Full run-pass check census on Slurm (not login pod)
- [x] Runtime reclass (rc_diff vs banner noise)
- [x] Local `check_docs_registry.mjs` after rebase + acceptance refresh
- [ ] CI Contracts green when Actions healthy