### PR TITLE
feat(design-system): EffectLatticeBadge — nine effects readable by colour

### DIFF
--- a/website/src/components/compiler/EffectLatticeExhibit.astro
+++ b/website/src/components/compiler/EffectLatticeExhibit.astro
@@ -1,0 +1,230 @@
+---
+import { EffectLatticeBadge, ALGEBRAIC_EFFECTS } from '../epistemic/EffectLatticeBadge';
+import { getLocalizedPath } from '../../lib/i18n';
+import type { Locale } from '../../lib/i18n';
+
+interface Props {
+  locale?: Locale;
+}
+
+const { locale = 'en' } = Astro.props;
+const languageEffects = getLocalizedPath('/language', locale) + '#effects';
+---
+
+<section id="effects" class="elb-section">
+  <div class="elb-section-inner">
+    <p class="elb-section-label">Effects live in the signature</p>
+    <h2 class="elb-section-heading">The checker reads colour before you read the name.</h2>
+    <p class="elb-section-annotation">
+      Nine algebraic effects, plus linear as a type qualifier. A solid border is written in
+      <code>with</code>. A dashed border is recovered from a callee. A struck badge is no longer
+      live in this frame. A function without <code>with IO</code> cannot call one that has it.
+    </p>
+
+    <figure class="elb-card">
+      <figcaption class="elb-card-label">Declared in the signature</figcaption>
+      <p class="elb-sig" aria-label="fn read_sensor returns Knowledge of f64 with IO and Observe">
+        <span class="elb-sig-kw">fn</span>
+        <span class="elb-sig-name">read_sensor</span>
+        <span class="elb-sig-plain">() -&gt; Knowledge&lt;f64&gt;</span>
+        <span class="elb-sig-kw">with</span>
+        <EffectLatticeBadge effect="IO" purityLevel="Declared" size="md" />
+        <EffectLatticeBadge effect="Observe" purityLevel="Declared" size="md" />
+      </p>
+      <p class="elb-card-source">
+        website/src/pages/language.astro · effectsExample · subset rule, not a handler
+      </p>
+    </figure>
+
+    <figure class="elb-card">
+      <figcaption class="elb-card-label">Three purity states · Mut</figcaption>
+      <p class="elb-sig" aria-label="fn calibrate takes exclusive Sensor and f64 with Mut">
+        <span class="elb-sig-kw">fn</span>
+        <span class="elb-sig-name">calibrate</span>
+        <span class="elb-sig-plain">(sensor: &amp;!Sensor, bias: f64)</span>
+        <span class="elb-sig-kw">with</span>
+        <EffectLatticeBadge effect="Mut" purityLevel="Declared" size="md" />
+      </p>
+      <div class="elb-purity" role="list">
+        <div class="elb-purity-item" role="listitem">
+          <EffectLatticeBadge effect="Mut" purityLevel="Declared" size="sm" />
+          <span class="elb-purity-cap">Declared · solid · written in <code>with</code></span>
+        </div>
+        <div class="elb-purity-item" role="listitem">
+          <EffectLatticeBadge effect="Mut" purityLevel="Inferred" size="sm" />
+          <span class="elb-purity-cap">Inferred · dashed · recovered from a callee</span>
+        </div>
+        <div class="elb-purity-item" role="listitem">
+          <EffectLatticeBadge effect="Mut" purityLevel="Handled" size="sm" />
+          <span class="elb-purity-cap">Handled · struck · no longer live here</span>
+        </div>
+      </div>
+      <p class="elb-card-source">
+        <code>&amp;!</code> is exclusive mutation, not Rust <code>&amp;mut</code>. The three
+        renderings are the badge vocabulary. This page does not claim Sounio has effect handlers.
+      </p>
+    </figure>
+
+    <figure class="elb-card">
+      <figcaption class="elb-card-label">The lattice</figcaption>
+      <div class="elb-lattice" role="list">
+        {ALGEBRAIC_EFFECTS.map((effect) => (
+          <div class="elb-lattice-item" role="listitem">
+            <EffectLatticeBadge effect={effect} purityLevel="Declared" size="md" />
+          </div>
+        ))}
+        <div class="elb-lattice-item" role="listitem">
+          <EffectLatticeBadge effect="Linear" purityLevel="Declared" size="md" />
+        </div>
+      </div>
+      <p class="elb-card-source">
+        Tokens: <code>--color-effect-{'{io,mut,div,panic,alloc,async,gpu,prob,observe}'}</code> and
+        <code>--color-type-linear</code>. Linear is a type qualifier, not a tenth effect.
+      </p>
+    </figure>
+
+    <a href={languageEffects} class="elb-section-link">Read the subset rule on /language →</a>
+  </div>
+</section>
+
+<style>
+  .elb-section {
+    position: relative;
+    padding: clamp(3.5rem, 7vw, 6rem) 1.5rem;
+  }
+
+  .elb-section-inner {
+    max-width: 760px;
+    margin: 0 auto;
+    display: grid;
+    gap: 1.1rem;
+  }
+
+  .elb-section-label {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-accent-teal);
+    opacity: 0.85;
+  }
+
+  .elb-section-heading {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(1.5rem, 3vw, 2.2rem);
+    font-weight: 400;
+    line-height: 1.25;
+    color: var(--color-text-primary);
+  }
+
+  .elb-section-annotation {
+    margin: 0;
+    max-width: 68ch;
+    font-size: 0.95rem;
+    line-height: 1.7;
+    color: var(--color-text-secondary);
+  }
+
+  .elb-section-annotation code,
+  .elb-purity-cap code,
+  .elb-card-source code {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    background: var(--color-surface-frost);
+    padding: 0.1em 0.3em;
+    border-radius: var(--radius-sm);
+  }
+
+  .elb-card {
+    margin: 0;
+    display: grid;
+    gap: 0.7rem;
+    padding: 1.1rem 1.2rem;
+    border-radius: var(--radius-xl);
+    background: var(--color-surface-primary);
+    border: 1px solid var(--color-border-subtle);
+  }
+
+  .elb-card-label {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--color-text-tertiary);
+  }
+
+  .elb-sig {
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem 0.45rem;
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    line-height: 1.5;
+    color: var(--color-text-primary);
+  }
+
+  .elb-sig-kw {
+    color: var(--color-text-tertiary);
+  }
+
+  .elb-sig-name {
+    color: var(--color-text-primary);
+    font-weight: 600;
+  }
+
+  .elb-sig-plain {
+    color: var(--color-text-secondary);
+  }
+
+  .elb-card-source {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    line-height: 1.55;
+    color: var(--color-text-tertiary);
+  }
+
+  .elb-purity,
+  .elb-lattice {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem 0.55rem;
+  }
+
+  .elb-purity {
+    display: grid;
+    gap: 0.4rem;
+  }
+
+  .elb-purity-item {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.55rem;
+  }
+
+  .elb-purity-cap {
+    font-size: 0.78rem;
+    line-height: 1.4;
+    color: var(--color-text-secondary);
+  }
+
+  .elb-lattice-item {
+    display: inline-flex;
+  }
+
+  .elb-section-link {
+    font-size: 0.84rem;
+    color: var(--color-accent-gold-soft);
+    width: fit-content;
+  }
+
+  .elb-section-link:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/website/src/components/epistemic/EffectLatticeBadge.css
+++ b/website/src/components/epistemic/EffectLatticeBadge.css
@@ -1,0 +1,61 @@
+/* EffectLatticeBadge — consumes only --color-effect-* and --color-type-linear */
+
+.elb {
+  --elb-ink: var(--color-effect-io);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  height: 24px;
+  padding: 0 0.55rem;
+  border: 1px solid var(--elb-ink);
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--elb-ink) 10%, transparent);
+  color: var(--elb-ink);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  line-height: 1;
+  text-transform: uppercase;
+  white-space: nowrap;
+  vertical-align: middle;
+  box-sizing: border-box;
+}
+
+.elb[data-size='sm'] {
+  height: 18px;
+  padding: 0 0.4rem;
+  font-size: 0.625rem;
+}
+
+.elb[data-purity='Inferred'] {
+  border-style: dashed;
+}
+
+.elb[data-purity='Handled'] {
+  opacity: 0.5;
+}
+
+.elb[data-purity='Handled'] .elb-label {
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.12em;
+}
+
+.elb[data-kind='linear'] {
+  border-radius: var(--radius-sm);
+}
+
+.elb-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0.85em;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.elb-label {
+  display: inline-block;
+}

--- a/website/src/components/epistemic/EffectLatticeBadge.tsx
+++ b/website/src/components/epistemic/EffectLatticeBadge.tsx
@@ -1,0 +1,81 @@
+import type { CSSProperties } from 'react';
+import './EffectLatticeBadge.css';
+
+export const ALGEBRAIC_EFFECTS = [
+  'IO',
+  'Mut',
+  'Div',
+  'Panic',
+  'Alloc',
+  'Async',
+  'GPU',
+  'Prob',
+  'Observe',
+] as const;
+
+export type AlgebraicEffect = (typeof ALGEBRAIC_EFFECTS)[number];
+export type LatticeMark = AlgebraicEffect | 'Linear';
+export type PurityLevel = 'Declared' | 'Inferred' | 'Handled';
+export type EffectLatticeSize = 'sm' | 'md';
+
+export type EffectLatticeBadgeProps = {
+  effect: LatticeMark;
+  purityLevel?: PurityLevel;
+  size?: EffectLatticeSize;
+  className?: string;
+};
+
+const TOKEN: Record<LatticeMark, string> = {
+  IO: 'var(--color-effect-io)',
+  Mut: 'var(--color-effect-mut)',
+  Div: 'var(--color-effect-div)',
+  Panic: 'var(--color-effect-panic)',
+  Alloc: 'var(--color-effect-alloc)',
+  Async: 'var(--color-effect-async)',
+  GPU: 'var(--color-effect-gpu)',
+  Prob: 'var(--color-effect-prob)',
+  Observe: 'var(--color-effect-observe)',
+  Linear: 'var(--color-type-linear)',
+};
+
+const GLYPH: Record<LatticeMark, string> = {
+  IO: '⌁',
+  Mut: '&!',
+  Div: '÷',
+  Panic: '⊥',
+  Alloc: '⊞',
+  Async: '∿',
+  GPU: '∇',
+  Prob: '∼',
+  Observe: '◐',
+  Linear: '1',
+};
+
+export function EffectLatticeBadge({
+  effect,
+  purityLevel = 'Declared',
+  size = 'md',
+  className,
+}: EffectLatticeBadgeProps) {
+  const ink = TOKEN[effect];
+  const kind = effect === 'Linear' ? 'linear' : 'effect';
+  const classes = ['elb', className].filter(Boolean).join(' ');
+
+  return (
+    <span
+      className={classes}
+      data-effect={effect}
+      data-kind={kind}
+      data-purity={purityLevel}
+      data-size={size}
+      style={{ '--elb-ink': ink } as CSSProperties}
+      title={`${effect} · ${purityLevel}`}
+      aria-label={`${effect}, ${purityLevel.toLowerCase()}`}
+    >
+      <span className="elb-glyph" aria-hidden="true">
+        {GLYPH[effect]}
+      </span>
+      <span className="elb-label">{effect}</span>
+    </span>
+  );
+}

--- a/website/src/pages/compiler.astro
+++ b/website/src/pages/compiler.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import EffectLatticeExhibit from '../components/compiler/EffectLatticeExhibit.astro';
 import { getLocaleFromUrl, getLocalizedPath, loadTranslations } from '../lib/i18n';
 
 const locale = getLocaleFromUrl(Astro.url);
@@ -46,6 +47,10 @@ const compilerBreadcrumbSchema = {
       </p>
     </div>
   </section>
+
+  <div class="border-t border-[var(--glass-border)]"></div>
+
+  <EffectLatticeExhibit locale={locale} />
 
   <div class="border-t border-[var(--glass-border)]"></div>
 


### PR DESCRIPTION
## Summary

- `EffectLatticeBadge` on `/compiler`: the nine algebraic effects plus linear, readable by colour before they are read as text. A function without `with IO` cannot call one that has it — the lattice is the demonstration, not a table of names.
- Three purity states are the badge vocabulary, not a claim that Sounio has effect handlers. **Declared** is a solid border (written in `with`). **Inferred** is dashed (recovered from a callee). **Handled** is struck at 50% (no longer live in this frame). The live signature `fn read_sensor() -> Knowledge<f64> with IO, Observe` uses Declared only; it is the existing `effectsExample` on `/language`.
- Token names are taken only from `website/src/styles/global.css` on `main`: `--color-effect-{io,mut,div,panic,alloc,async,gpu,prob,observe}` and `--color-type-linear`. Linear is a type qualifier (squared radius), not a tenth effect. No invented token names.
- Does **not** touch `website/src/pages/language.astro`. That file is still owned by #1805. This exhibit mounts after the `/compiler` hero and links to `/language#effects` for the subset-rule prose. `/language` §B remains the narrative home after #1805 lands.

## Test plan

- [x] `npm run check:astro` — 0 errors / 0 warnings / 0 hints
- [x] `npm run check:i18n`
- [x] `npm run check:routes`
- [x] `npm run check:nav`
- [ ] Website CI build (this PR does **not** run `npm run build` / `check:quality` locally — that regenerates `website/src/data/artifactStatus.ts`. An unrun gate is not a green gate. CI is the build evidence.)
- [ ] Visual: light and `prefers-color-scheme: dark` / `.dark` — nine effect inks + linear, solid / dashed / struck Mut
- [ ] Confirm no conflict with #1805 (`language.astro` untouched)