### PR TITLE
ci: E219 live refuse against from-source Madaros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,8 @@ jobs:
         run: bash scripts/ci/extern_builtin_mirror_gate.sh
       - name: E219 refusal correspondence (Lean Check ↔ Madaros)
         run: bash scripts/ci/e219_refusal_correspondence_gate.sh
+      - name: E219 engine oracle (Madaros refuses; seed split is reported)
+        run: bash scripts/ci/e219_engine_oracle_gate.sh
       - name: Live lane coordination self-test
         run: bash scripts/ci/sounio_coord_selftest.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -631,6 +631,12 @@ jobs:
         env:
           MADAROS_RAW_BIN: /tmp/madaros-ci.elf
         run: bash scripts/ci/madaros_source_to_elf_gate.sh
+      # Grep correspondence lives in Contracts. This arm compiles the
+      # E219 fixture against the Madaros just built from this commit.
+      - name: E219 live refuse against the fresh build
+        env:
+          MADAROS_RAW_BIN: /tmp/madaros-ci.elf
+        run: bash scripts/ci/e219_madaros_live_refuse.sh
 
   sounio-lint:
     name: Sounio Lint

--- a/scripts/ci/e219_engine_oracle_gate.sh
+++ b/scripts/ci/e219_engine_oracle_gate.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Oracle for the E219 engine-split. The theorem is a Madaros judgment.
+# The default suite binary is lean_single and skips the fixture
+# (`requires: madaros`). Two greens that do not touch are not an oracle.
+#
+# This gate scores the DISAGREEMENT, the Lean `unimplemented_disagrees`
+# at CI: Madaros has the constructor and the suite skip is named; the
+# seed has no E219 constructor, implements abs, and emits an ELF for
+# the distinguishing program. A cosmetic `tc_error("E219")` on the seed
+# is a fail, not a close. A real seed refuse is also a fail — update
+# the theorem, do not silence the gate.
+#
+# Shape matches #1780 / e219_refusal_correspondence_gate: check_grep,
+# check_absent, not_run is fail, JSON metrics, --control-child mutants
+# that MUST be rejected.
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR" || exit 1
+
+CHECKER_SOURCE="self-hosted/check/check.sio"
+SEED_SOURCE="self-hosted/compiler/lean_single.sio"
+SUITE_SOURCE="scripts/dev/run_sio_test_suite.sh"
+FIXTURE="tests/compile-fail/extern_c_unimplemented_builtin.sio"
+LIVE_FIXTURE="tests/compile-fail/extern_c_unimplemented_builtin.sio"
+SEED_ELF="${E219_ORACLE_SEED_ELF:-$ROOT_DIR/bin/souc-lean-single-x86_64}"
+ARTIFACT="${TMPDIR:-/tmp}/e219_engine_oracle_gate.v1.json"
+RUN_POSITIVE_CONTROLS=1
+RUN_SEED_LIVE=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --checker) CHECKER_SOURCE="${2:?missing path after --checker}"; shift 2 ;;
+    --seed-source) SEED_SOURCE="${2:?missing path after --seed-source}"; shift 2 ;;
+    --suite) SUITE_SOURCE="${2:?missing path after --suite}"; shift 2 ;;
+    --fixture) FIXTURE="${2:?missing path after --fixture}"; shift 2 ;;
+    --live-fixture) LIVE_FIXTURE="${2:?missing path after --live-fixture}"; shift 2 ;;
+    --seed-elf) SEED_ELF="${2:?missing path after --seed-elf}"; shift 2 ;;
+    --artifact) ARTIFACT="${2:?missing path after --artifact}"; shift 2 ;;
+    --control-child) RUN_POSITIVE_CONTROLS=0; RUN_SEED_LIVE=0; shift ;;
+    *) echo "e219_engine_oracle_gate: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+TOTAL=0
+PASSED=0
+FAILED=0
+NOT_RUN=0
+FAILURES=""
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/e219-engine-oracle.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+record_failure() {
+  local label="$1"
+  if [[ -n "$FAILURES" ]]; then
+    FAILURES="$FAILURES,$label"
+  else
+    FAILURES="$label"
+  fi
+  echo "[e219-oracle] FAIL: $label" >&2
+}
+
+check_grep() {
+  local label="$1"
+  local pattern="$2"
+  local path="$3"
+  TOTAL=$((TOTAL + 1))
+  if grep -qE "$pattern" "$path"; then
+    PASSED=$((PASSED + 1))
+  else
+    FAILED=$((FAILED + 1))
+    record_failure "$label"
+  fi
+}
+
+check_absent() {
+  local label="$1"
+  local pattern="$2"
+  local path="$3"
+  TOTAL=$((TOTAL + 1))
+  if grep -qE "$pattern" "$path"; then
+    FAILED=$((FAILED + 1))
+    record_failure "$label"
+  else
+    PASSED=$((PASSED + 1))
+  fi
+}
+
+check_fixed() {
+  local label="$1"
+  local needle="$2"
+  local path="$3"
+  TOTAL=$((TOTAL + 1))
+  if grep -qF "$needle" "$path"; then
+    PASSED=$((PASSED + 1))
+  else
+    FAILED=$((FAILED + 1))
+    record_failure "$label"
+  fi
+}
+
+check_count_ge() {
+  local label="$1"
+  local pattern="$2"
+  local path="$3"
+  local min="$4"
+  TOTAL=$((TOTAL + 1))
+  local n
+  n="$(grep -cE "$pattern" "$path" || true)"
+  if [[ "$n" -ge "$min" ]]; then
+    PASSED=$((PASSED + 1))
+  else
+    FAILED=$((FAILED + 1))
+    record_failure "$label:got_$n"
+  fi
+}
+
+for req in \
+  "checker:$CHECKER_SOURCE" \
+  "seed:$SEED_SOURCE" \
+  "suite:$SUITE_SOURCE" \
+  "fixture:$FIXTURE"; do
+  kind="${req%%:*}"
+  path="${req#*:}"
+  if [[ ! -f "$path" ]]; then
+    TOTAL=$((TOTAL + 1))
+    NOT_RUN=$((NOT_RUN + 1))
+    record_failure "${kind}_source_missing:$path"
+  fi
+done
+
+if [[ "$NOT_RUN" -eq 0 ]]; then
+  # M — Madaros has the judgment (source). Live compile is the Witness arm.
+  check_count_ge "madaros_e219_reports" \
+    ', 219, 0, 0, 0\)' "$CHECKER_SOURCE" 3
+  check_count_ge "madaros_refuse_infects" \
+    'refused_unimplemented' "$CHECKER_SOURCE" 3
+  check_grep "madaros_allowlist_predicate" \
+    'fn name_is_native_backend_builtin\(' "$CHECKER_SOURCE"
+
+  # S — seed has no constructor and still implements the distinguishing name.
+  check_absent "seed_must_not_spell_e219" \
+    'E219|refused_unimplemented' "$SEED_SOURCE"
+  check_grep "seed_implements_abs" \
+    '__native_abs_i64' "$SEED_SOURCE"
+
+  # K — the suite skip is named, not coverage.
+  check_grep "fixture_requires_madaros_annotation" \
+    '^//@ requires: madaros' "$FIXTURE"
+  check_fixed "suite_skips_requires_madaros" \
+    'reason\":\"requires:madaros\"' "$SUITE_SOURCE"
+  check_grep "suite_madaros_skip_branch" \
+    'madaros\) \[\[ -z "\$\{SOUNIO_MADAROS_AVAILABLE:-\}" \]\]' "$SUITE_SOURCE"
+fi
+
+if [[ "$RUN_SEED_LIVE" -eq 1 && "$NOT_RUN" -eq 0 ]]; then
+  TOTAL=$((TOTAL + 1))
+  if [[ ! -x "$SEED_ELF" ]]; then
+    NOT_RUN=$((NOT_RUN + 1))
+    record_failure "seed_elf_missing:$SEED_ELF"
+  else
+    seed_out="$WORK/seed-live.elf"
+    rm -f "$seed_out"
+    "$SEED_ELF" "$LIVE_FIXTURE" "$seed_out" >"$WORK/seed-live.log" 2>&1
+    seed_rc=$?
+    if [[ "$seed_rc" -ne 0 ]]; then
+      FAILED=$((FAILED + 1))
+      record_failure "seed_live_refused_rc_${seed_rc}"
+      sed 's/^/[seed-live] /' "$WORK/seed-live.log" >&2
+    elif [[ ! -e "$seed_out" ]]; then
+      FAILED=$((FAILED + 1))
+      record_failure "seed_live_no_elf"
+    elif grep -qiE 'error\[E219\]|call to an `extern "C"` function the native backend does not implement' "$WORK/seed-live.log"; then
+      FAILED=$((FAILED + 1))
+      record_failure "seed_live_printed_e219"
+    else
+      PASSED=$((PASSED + 1))
+      echo "[e219-oracle] seed_live: compile_rc=0 elf_exists=1 (split reported)"
+    fi
+  fi
+fi
+
+if [[ "$RUN_POSITIVE_CONTROLS" -eq 1 && "$NOT_RUN" -eq 0 ]]; then
+  MADAROS_MUTANT="scripts/ci/fixtures/e219_engine_oracle/madaros_without_e219.sio"
+  SEED_MUTANT="scripts/ci/fixtures/e219_engine_oracle/seed_cosmetic_e219.sio"
+  FIXTURE_MUTANT="scripts/ci/fixtures/e219_engine_oracle/fixture_without_requires_madaros.sio"
+
+  TOTAL=$((TOTAL + 1))
+  if "$0" --control-child --checker "$MADAROS_MUTANT" --seed-source "$SEED_SOURCE" \
+      --suite "$SUITE_SOURCE" --fixture "$FIXTURE" \
+      --artifact "$WORK/madaros-mutant.json" \
+      >"$WORK/madaros-mutant.log" 2>&1; then
+    FAILED=$((FAILED + 1))
+    record_failure "positive_control_madaros_without_e219_was_not_rejected"
+  else
+    PASSED=$((PASSED + 1))
+    echo "[e219-oracle] POSITIVE_CONTROL_FIRED: madaros_without_e219 rejected"
+    sed 's/^/[madaros-control] /' "$WORK/madaros-mutant.log"
+  fi
+
+  TOTAL=$((TOTAL + 1))
+  if "$0" --control-child --checker "$CHECKER_SOURCE" --seed-source "$SEED_MUTANT" \
+      --suite "$SUITE_SOURCE" --fixture "$FIXTURE" \
+      --artifact "$WORK/seed-mutant.json" \
+      >"$WORK/seed-mutant.log" 2>&1; then
+    FAILED=$((FAILED + 1))
+    record_failure "positive_control_seed_cosmetic_e219_was_not_rejected"
+  else
+    PASSED=$((PASSED + 1))
+    echo "[e219-oracle] POSITIVE_CONTROL_FIRED: seed_cosmetic_e219 rejected"
+    sed 's/^/[seed-control] /' "$WORK/seed-mutant.log"
+  fi
+
+  TOTAL=$((TOTAL + 1))
+  if "$0" --control-child --checker "$CHECKER_SOURCE" --seed-source "$SEED_SOURCE" \
+      --suite "$SUITE_SOURCE" --fixture "$FIXTURE_MUTANT" \
+      --artifact "$WORK/fixture-mutant.json" \
+      >"$WORK/fixture-mutant.log" 2>&1; then
+    FAILED=$((FAILED + 1))
+    record_failure "positive_control_fixture_without_requires_was_not_rejected"
+  else
+    PASSED=$((PASSED + 1))
+    echo "[e219-oracle] POSITIVE_CONTROL_FIRED: fixture_without_requires_madaros rejected"
+    sed 's/^/[fixture-control] /' "$WORK/fixture-mutant.log"
+  fi
+fi
+
+STATUS="pass"
+if [[ "$FAILED" -gt 0 || "$NOT_RUN" -gt 0 ]]; then
+  STATUS="fail"
+fi
+
+mkdir -p "$(dirname "$ARTIFACT")"
+cat > "$ARTIFACT" <<JSON
+{
+  "schema": "sounio.e219-engine-oracle-gate.v1",
+  "status": "$STATUS",
+  "checker_source": "$CHECKER_SOURCE",
+  "seed_source": "$SEED_SOURCE",
+  "suite_source": "$SUITE_SOURCE",
+  "fixture": "$FIXTURE",
+  "metrics": {
+    "total": $TOTAL,
+    "passed": $PASSED,
+    "failed": $FAILED,
+    "not_run": $NOT_RUN
+  },
+  "failures_csv": "$FAILURES"
+}
+JSON
+
+echo "e219_engine_oracle_gate: status=$STATUS total=$TOTAL passed=$PASSED failed=$FAILED not_run=$NOT_RUN artifact=$ARTIFACT"
+if [[ "$STATUS" != "pass" ]]; then
+  exit 1
+fi

--- a/scripts/ci/e219_madaros_live_refuse.sh
+++ b/scripts/ci/e219_madaros_live_refuse.sh
@@ -109,17 +109,8 @@ else
   fi
 fi
 
-# Observation only — not a pass/fail arm.
-SEED="$ROOT_DIR/bin/souc-lean-single-x86_64"
-if [[ -x "$SEED" ]]; then
-  seed_elf="$WORK/seed.elf"
-  rm -f "$seed_elf"
-  "$SEED" "$FIXTURE" "$seed_elf" >"$WORK/seed.out" 2>&1
-  seed_rc=$?
-  seed_elf_exists=0
-  [[ -e "$seed_elf" ]] && seed_elf_exists=1
-  echo "[e219-live-refuse] seed_observation compile_rc=$seed_rc elf_exists=$seed_elf_exists (not scored)"
-fi
+# Seed disagreement is scored by e219_engine_oracle_gate.sh, not here.
+# Printing it without a verdict was the same hole as the suite skip.
 
 STATUS="pass"
 if [[ "$FAILED" -gt 0 || "$NOT_RUN" -gt 0 ]]; then

--- a/scripts/ci/e219_madaros_live_refuse.sh
+++ b/scripts/ci/e219_madaros_live_refuse.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Live Madaros arm of E219. The grep correspondence gate does not compile
+# anything. This script asks the engine that has the judgment: a well-typed
+# call to an unimplemented extern must refuse, and must not become an ELF.
+#
+# Do not point this at lean_single. The seed rewrites externs into stubs,
+# implements abs, and emits an ELF for the same fixture (measured 2026-08-17).
+# A pass that required the seed to keep compiling would freeze the #1798
+# split as a contract. The seed observation below is printed, not scored.
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR" || exit 1
+
+FIXTURE="${E219_LIVE_FIXTURE:-tests/compile-fail/extern_c_unimplemented_builtin.sio}"
+CONTROL="${E219_LIVE_CONTROL:-tests/run-pass/ffi_libm_call.sio}"
+SOUC="${E219_LIVE_SOUC:-$ROOT_DIR/bin/souc}"
+ARTIFACT="${TMPDIR:-/tmp}/e219_madaros_live_refuse.v1.json"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/e219-live-refuse.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+TOTAL=0
+PASSED=0
+FAILED=0
+NOT_RUN=0
+FAILURES=""
+
+record_failure() {
+  local label="$1"
+  if [[ -n "$FAILURES" ]]; then
+    FAILURES="$FAILURES,$label"
+  else
+    FAILURES="$label"
+  fi
+  echo "[e219-live-refuse] FAIL: $label" >&2
+}
+
+if [[ ! -x "$SOUC" ]]; then
+  echo "[e219-live-refuse] missing souc wrapper: $SOUC" >&2
+  exit 2
+fi
+if [[ ! -f "$FIXTURE" ]]; then
+  echo "[e219-live-refuse] missing fixture: $FIXTURE" >&2
+  exit 2
+fi
+if [[ ! -f "$CONTROL" ]]; then
+  echo "[e219-live-refuse] missing control: $CONTROL" >&2
+  exit 2
+fi
+
+if [[ ! -x "${MADAROS_RAW_BIN:-}" ]]; then
+  for cand in "${SOUNIO_MADAROS_BIN:-}" \
+              "$ROOT_DIR/artifacts/self-hosted/madaros" \
+              "$ROOT_DIR/bin/madaros-linux-x86_64"; do
+    if [[ -n "$cand" && -x "$cand" && "$(head -c2 "$cand" 2>/dev/null)" != '#!' ]]; then
+      MADAROS_RAW_BIN="$cand"
+      break
+    fi
+  done
+fi
+
+if [[ ! -x "${MADAROS_RAW_BIN:-}" ]]; then
+  TOTAL=$((TOTAL + 1))
+  NOT_RUN=$((NOT_RUN + 1))
+  record_failure "madaros_elf_missing"
+else
+  export MADAROS_RAW_BIN
+  export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+
+  # Positive control: declare unimplemented names, call only an allow-listed
+  # one. If this fails, the instrument is broken and a fixture refuse is
+  # unreadable.
+  TOTAL=$((TOTAL + 1))
+  "$SOUC" check "$CONTROL" >"$WORK/control.out" 2>&1
+  control_rc=$?
+  if [[ "$control_rc" -eq 0 ]] && grep -qF 'check: OK' "$WORK/control.out"; then
+    PASSED=$((PASSED + 1))
+    echo "[e219-live-refuse] POSITIVE_CONTROL_FIRED: ffi_libm_call checks clean"
+  else
+    FAILED=$((FAILED + 1))
+    record_failure "control_ffi_libm_check_rc_${control_rc}"
+    sed 's/^/[control] /' "$WORK/control.out" >&2
+  fi
+
+  # The distinguishing program. Never read rc through a pipe.
+  TOTAL=$((TOTAL + 1))
+  fixture_elf="$WORK/must-not-exist.elf"
+  rm -f "$fixture_elf"
+  "$SOUC" compile "$FIXTURE" -o "$fixture_elf" >"$WORK/fixture.out" 2>&1
+  fixture_rc=$?
+  if [[ "$fixture_rc" -eq 0 ]]; then
+    FAILED=$((FAILED + 1))
+    record_failure "fixture_compiled_exit_0"
+  elif [[ -e "$fixture_elf" ]]; then
+    FAILED=$((FAILED + 1))
+    record_failure "fixture_emitted_elf"
+  elif ! grep -qiF 'call to an `extern "C"` function the native backend does not implement' "$WORK/fixture.out"; then
+    FAILED=$((FAILED + 1))
+    record_failure "missing_e219_pattern"
+    sed 's/^/[fixture] /' "$WORK/fixture.out" >&2
+  elif ! grep -qiF 'no dynamic linker in this backend' "$WORK/fixture.out"; then
+    FAILED=$((FAILED + 1))
+    record_failure "missing_no_dynamic_linker_pattern"
+    sed 's/^/[fixture] /' "$WORK/fixture.out" >&2
+  else
+    PASSED=$((PASSED + 1))
+    echo "[e219-live-refuse] fixture refused: compile_rc=$fixture_rc no_elf=1"
+  fi
+fi
+
+# Observation only — not a pass/fail arm.
+SEED="$ROOT_DIR/bin/souc-lean-single-x86_64"
+if [[ -x "$SEED" ]]; then
+  seed_elf="$WORK/seed.elf"
+  rm -f "$seed_elf"
+  "$SEED" "$FIXTURE" "$seed_elf" >"$WORK/seed.out" 2>&1
+  seed_rc=$?
+  seed_elf_exists=0
+  [[ -e "$seed_elf" ]] && seed_elf_exists=1
+  echo "[e219-live-refuse] seed_observation compile_rc=$seed_rc elf_exists=$seed_elf_exists (not scored)"
+fi
+
+STATUS="pass"
+if [[ "$FAILED" -gt 0 || "$NOT_RUN" -gt 0 ]]; then
+  STATUS="fail"
+fi
+
+mkdir -p "$(dirname "$ARTIFACT")"
+cat > "$ARTIFACT" <<JSON
+{
+  "schema": "sounio.e219-madaros-live-refuse-gate.v1",
+  "status": "$STATUS",
+  "madaros_raw_bin": "${MADAROS_RAW_BIN:-}",
+  "fixture": "$FIXTURE",
+  "control": "$CONTROL",
+  "metrics": {
+    "total": $TOTAL,
+    "passed": $PASSED,
+    "failed": $FAILED,
+    "not_run": $NOT_RUN
+  },
+  "failures_csv": "$FAILURES"
+}
+JSON
+
+echo "e219_madaros_live_refuse: status=$STATUS total=$TOTAL passed=$PASSED failed=$FAILED not_run=$NOT_RUN artifact=$ARTIFACT"
+if [[ "$STATUS" != "pass" ]]; then
+  exit 1
+fi

--- a/scripts/ci/fixtures/e219_engine_oracle/fixture_without_requires_madaros.sio
+++ b/scripts/ci/fixtures/e219_engine_oracle/fixture_without_requires_madaros.sio
@@ -1,0 +1,18 @@
+//@ compile-fail
+//@ error-pattern: call to an `extern "C"` function the native backend does not implement
+//@ error-pattern: no dynamic linker in this backend
+// Mutant: the distinguishing program without `requires: madaros`.
+// The oracle must reject this. Deleting the annotation makes the default
+// suite a FALSE RED against lean_single, not coverage of the theorem.
+
+extern "C" {
+    fn malloc(size: i64) -> i64;
+    fn abs(x: i64) -> i64;
+}
+
+fn main() -> i64 with IO {
+    let p = malloc(64)
+    print_int(p)
+    print_int(abs(0 - 7))
+    0
+}

--- a/scripts/ci/fixtures/e219_engine_oracle/madaros_without_e219.sio
+++ b/scripts/ci/fixtures/e219_engine_oracle/madaros_without_e219.sio
@@ -1,0 +1,14 @@
+// Mutant for e219_engine_oracle_gate: a checker excerpt with no E219
+// constructor. The oracle must reject this as "Madaros has the judgment".
+// If the gate passes against this file, the M-arm greps are dead.
+
+fn name_is_native_backend_builtin(n: Name) -> bool {
+    false
+}
+
+fn check_call_no_refuse(sig: FnSig) {
+    if sig.is_extern {
+        return effective_return_type
+    }
+    return effective_return_type
+}

--- a/scripts/ci/fixtures/e219_engine_oracle/seed_cosmetic_e219.sio
+++ b/scripts/ci/fixtures/e219_engine_oracle/seed_cosmetic_e219.sio
@@ -1,0 +1,15 @@
+// Mutant for e219_engine_oracle_gate: a seed excerpt that grew a cosmetic
+// E219 warning. The oracle must reject this — house-style tc_error does
+// not refuse, and a grep that cannot see this string does not measure.
+
+fn tc_error(tok: i64, msg: string) -> i64 {
+    print("warning: ")
+    print(msg)
+    return 0
+}
+
+fn check_call_cosmetic(tok: i64) -> i64 {
+    tc_error(tok, "E219")
+    tc_error(tok, "refused_unimplemented")
+    0
+}


### PR DESCRIPTION
## Summary

- The correspondence gate (`e219_refusal_correspondence_gate.sh`) only greps. The compile-fail fixture is `requires: madaros` and the default suite binary is lean_single, so CI never asked the engine that has the judgment.
- This adds `scripts/ci/e219_madaros_live_refuse.sh` and runs it in the Madaros Witness Gate after the from-source build.
- Control: `ffi_libm_call.sio` must `check: OK` (declare unimplemented names, call only `sqrt`). Fixture: `souc compile` must exit non-zero, match both E219 patterns, and emit no ELF. The seed observation (`compile_rc=0 elf_exists=1`) is printed, not scored.

## Test plan

- [x] `bash scripts/ci/e219_madaros_live_refuse.sh` locally: `status=pass total=2 passed=2`; seed observation `compile_rc=0 elf_exists=1`
- [ ] Witness Gate on this PR (from-source Madaros, not the prebuilt)