### PR TITLE
fix(ssm): preserve exponential negative tails (re-author #1058)

### DIFF
--- a/stdlib/ssm/README.md
+++ b/stdlib/ssm/README.md
@@ -81,6 +81,7 @@ fn demo() with IO, Mut, Div, Panic {
 | H-SSM no reset: ‖A_quat ⊗ (e6-e15)‖ ≈ 0.95 | PASS |
 | Gate ∈ (0, 1) | PASS |
 | Gate does not amplify | PASS |
+| Negative `exp` tail: `exp(-13.855)` and `exp(-16)` | PASS |
 | ker(A_sed) basis k=0 annihilated | PASS |
 | ker(A_sed) basis k=1 annihilated | PASS |
 | coker direction survives A_sed | PASS |
@@ -95,7 +96,7 @@ fn demo() with IO, Mut, Div, Panic {
 
 ```bash
 ./bin/souc run stdlib/ssm/lib.sio
-# expect: 13/13 PASS, ALL PASS
+# expect: 14/14 PASS, ALL PASS
 
 ./bin/souc run stdlib/ssm/fingerprint.sio
 # expect: 11/11 PASS, ALL PASS

--- a/stdlib/ssm/lib.sio
+++ b/stdlib/ssm/lib.sio
@@ -42,10 +42,17 @@ var SSM_RNG_B: i64 = 0
 // UTILITY MATH
 // ═══════════════════════════════════════════════════════════════════════════
 
-/// exp(x) via 20-term Taylor series; splits at ±15 to avoid overflow.
+/// exp(x) via a 20-term Taylor series after range reduction.
+///
+/// Reflect negative inputs before evaluating the series: the un-reduced Taylor
+/// polynomial suffers catastrophic cancellation for moderate negative values.
+/// Positive values are halved until the core runs on [0, 2].
 pub fn ssm_exp(x: f64) -> f64 with Mut, Div, Panic {
-    if x > 15.0 { return ssm_exp(7.5) * ssm_exp(x - 7.5) }
-    if x < 0.0 - 15.0 { return 0.0 }
+    if x < 0.0 { return 1.0 / ssm_exp(0.0 - x) }
+    if x > 2.0 {
+        let half = ssm_exp(x / 2.0)
+        return half * half
+    }
     var sum = 1.0; var term = 1.0; var i = 1
     while i <= 20 { term = term * x / (i as f64); sum = sum + term; i = i + 1 }
     sum
@@ -383,6 +390,19 @@ fn test_erase_input() with IO, Mut, Div, Panic {
     t_check(13, if abs_f(h[6] - 0.5) < 0.0001 && abs_f(h[15] - (0.0 - 0.5)) < 0.0001 { 1 } else { 0 })
 }
 
+fn test_exp_negative_tail() with IO, Mut, Div, Panic {
+    // Oracle: true exp(-13.855) ≈ 9.612801030980067e-7, exp(-16) ≈ 1.1253517471925912e-7.
+    // Old ssm_exp flushed |x| > 15 to 0.0 and cancelled moderate negative Taylor tails.
+    let expected_13855 = 9.612801030980067e-7
+    let expected_16 = 1.1253517471925912e-7
+    let tail_13855 = ssm_exp(0.0 - 13.855)
+    let tail_16 = ssm_exp(0.0 - 16.0)
+    let round_trip = tail_13855 * ssm_exp(13.855)
+    let rel_13855 = abs_f(tail_13855 - expected_13855) / expected_13855
+    let rel_16 = abs_f(tail_16 - expected_16) / expected_16
+    t_check(14, if rel_13855 < 1.0e-8 && rel_16 < 1.0e-8 && abs_f(round_trip - 1.0) < 1.0e-8 { 1 } else { 0 })
+}
+
 fn main() -> i32 with IO, Mut, Div, Panic {
     T_PASS = 0; T_FAIL = 0
     print("─── stdlib/ssm tests ───\n")
@@ -400,6 +420,7 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     test_sed_identity()
     test_sed_zd_pair()
     test_erase_input()
+    test_exp_negative_tail()
 
     print("─── "); print(T_PASS); print("/"); print(T_PASS + T_FAIL); print(" PASS ───\n")
     if T_FAIL == 0 {


### PR DESCRIPTION
## Summary

Re-author of **#1058** on current `main` (drain batch: July PR is **DIFFERENT ERA**, 1309 behind — do not mechanical-rebase).

`stdlib/ssm/lib.sio` on main still had:

```text
if x < 0.0 - 15.0 { return 0.0 }
```

which **flushes** negative exponential tails. Moderate negative Taylor evaluation also cancels. This PR:

1. Reflects `x < 0` as `1 / ssm_exp(-x)`
2. Reduces positive `x` to `[0, 2]` by successive halving
3. Adds `test_exp_negative_tail` (oracle `exp(-13.855)`, `exp(-16)`, round-trip)
4. Updates README 13/13 → **14/14**

## Verification

```text
./bin/souc run stdlib/ssm/lib.sio
# ─── 14/14 PASS ───
# ALL PASS
```

Also green under `SOUNIO_SOUC_ENGINE=lean_single` (same self-test).

## Relation to #1058

| | July #1058 | This PR |
|---|---|---|
| Base | ~Jul 17 | current `main` |
| Content | same numeric fix | same, re-applied |
| Action on #1058 | — | leave open until this lands; then close as superseded **with symbol evidence** (`ssm_exp` reciprocal path + `test_exp_negative_tail`) |

Does **not** merge or close #1058 from here (drain protocol: founder merges).

## Test plan

- [x] `bin/souc run stdlib/ssm/lib.sio` → 14/14 ALL PASS (Madaros default)
- [x] lean_single same self-test
- [ ] CI Full Suite / Contracts as selected