### PR TITLE
fix(mli): refuse unimplemented arg kinds at load — #1801 class

### DIFF
--- a/self-hosted/mli/interp.sio
+++ b/self-hosted/mli/interp.sio
@@ -16,8 +16,11 @@
 //      f128/f256/qd128/Knowledge/CD/vec/ptr VALUES, phys/stack/reloc
 //      operands, unclassified compare-codes (not "false"), i64 div-by-zero
 //      and INT_MIN/-1. Control flow is implemented (S2b) with a fuel cap.
-//      Unimplemented argument kinds are skipped (no register write) so the
-//      first consuming opcode can refuse; they are not loaded as zero.
+//      Argument kinds with no interp model (Knowledge/CD/ptr/vec/qd128,
+//      Int≠64, Float≠64) refuse at load with MLI_I_ARG_KIND. Skipping
+//      them and continuing was #1801: the checker returned the declared
+//      type after a refuse, and the caller read a fabricated inhabitant.
+//      They are not loaded as zero.
 //   2. Where behaviour IS defined, the interp delegates to the host — and
 //      the host is the claim oracle itself (Sounio under Madaros, ADR-008
 //      single semantic clock). i64 two's-complement arithmetic, IEEE f64
@@ -377,8 +380,12 @@ pub fn mli_interp_run(f: &MliFunction, args: &MliInterpArgs) -> MliInterpResult 
     }
 
     // Arguments: arg a is vreg a (MLI invariant).
+    // Runnable kinds only. A declared Knowledge/CD/i32/ptr/… with no
+    // model here must refuse — not skip, not write 0, not run the body
+    // as if the type were inhabited (#1801 declared-type-after-refuse).
     var a: i64 = 0
     while a < f.arg_count {
+        if a < 0 || a >= 8 { return i_err(MLI_I_ARG_KIND, 0 - 1, a) }
         let ak = f.arg_kinds[a]
         if krun_int(ak.tag, ak.bits) {
             rf.vi[a] = args.ai[a]
@@ -387,11 +394,9 @@ pub fn mli_interp_run(f: &MliFunction, args: &MliInterpArgs) -> MliInterpResult 
             if krun_f64(ak.tag, ak.bits) {
                 rf.vf[a] = args.af[a]
                 rf_mark(&!rf, a)
+            } else {
+                return i_err(MLI_I_ARG_KIND, 0 - 1, a)
             }
-            // else: Knowledge/CD/ptr/vec/qd128 have no value model.
-            // Do not write a register and do not invent a zero payload
-            // (#1788 fabrication). def stays 0 so a later scalar read
-            // of this vreg is UNDEF, not a silent 0.
         }
         a = a + 1
     }

--- a/self-hosted/mli/s2a_gate_runner.sio
+++ b/self-hosted/mli/s2a_gate_runner.sio
@@ -326,39 +326,6 @@ fn case_interp_div_zero() -> i64 with IO, Mut, Panic, Div {
     report_pass("I1 i64 div-by-zero REFUSED by interp")
 }
 
-// I2: a verified cd_mul must refuse AT THE OPCODE, not at arg-load and
-// not by writing a zero product. CD args have no value model — they are
-// not loaded as zeros (#1788); the body opcode is what must refuse.
-fn case_interp_refuses_cd() -> i64 with IO, Mut, Panic, Div {
-    var m = mli_func_new("octmul", mli_kind_void())
-    let ck = mli_kind_cd(8, 64)
-    let a = mli_add_arg(&!m, ck)
-    let b = mli_add_arg(&!m, ck)
-    let b0 = mli_new_block(&!m)
-    let r = mli_new_vreg(&!m, ck)
-    if a < 0 || b < 0 || b0 < 0 || r < 0 { return report_fail("I2 cd", "build", 0, 1) }
-    let dst = mli_vreg_opd(&m, r)
-    let s1 = mli_vreg_opd(&m, a)
-    let s2 = mli_vreg_opd(&m, b)
-    if !mli_emit(&!m, b0, mli_inst_cd_mul(dst, s1, s2, MLI_ASSOC_STRICT, MLI_ZD_FLAG)) {
-        return report_fail("I2 cd", "emit", 0, 1)
-    }
-    if !mli_set_term(&!m, b0, mli_term_ret_void()) { return report_fail("I2 cd", "term", 0, 1) }
-    let vr = mli_verify_function(&m)
-    if vr.code != MLI_VERR_OK { return report_fail("I2 cd", "verify", vr.code, MLI_VERR_OK) }
-
-    var args = mli_interp_args_empty()
-    let res = mli_interp_run(&m, &args)
-    if res.ok { return report_fail("I2 cd", "interp-accepted", MLI_I_OK, MLI_I_UNSUPPORTED_OP) }
-    if res.code != MLI_I_UNSUPPORTED_OP {
-        return report_fail("I2 cd", "interp-code", res.code, MLI_I_UNSUPPORTED_OP)
-    }
-    if res.block != 0 || res.index != 0 {
-        return report_fail("I2 cd", "refused-before-opcode", res.block, 0)
-    }
-    report_pass("I2 CD cd_mul REFUSED by interp at the opcode (no product, no arg-zero)")
-}
-
 // Tiny icmp so we can poke the SoA cc/op columns after a green verify.
 // Writing i_cc / i_op is the sanctioned SoA path — do not land a MliInst.
 fn build_icmp_lt() -> MliFunction with Mut, Panic {
@@ -383,6 +350,30 @@ fn build_add_i64() -> MliFunction with Mut, Panic {
     var ok = mli_emit(&!f, b0, mli_inst3(MLI_OP_ADD, mli_opd_vreg(d, mli_kind_int(64, 1)), mli_opd_vreg(a, mli_kind_int(64, 1)), mli_opd_vreg(b, mli_kind_int(64, 1))))
     ok = ok && mli_set_term(&!f, b0, mli_term_ret(mli_opd_vreg(d, mli_kind_int(64, 1))))
     f
+}
+
+// I2: a named R1 opcode must refuse AT THE OPCODE, not by writing a
+// zero product. After #1801, unimplemented arg kinds refuse at load
+// (I9), so this witness pokes CD_MUL onto a green i64 add — SoA
+// i_op only, never a whole MliInst (#1678/#1749).
+fn case_interp_refuses_cd() -> i64 with IO, Mut, Panic, Div {
+    var f = build_add_i64()
+    let vr = mli_verify_function(&f)
+    if vr.code != MLI_VERR_OK { return report_fail("I2 cd", "pre-verify", vr.code, MLI_VERR_OK) }
+    f.i_op[mli_slot(0, 0)] = MLI_OP_CD_MUL
+    var args = mli_interp_args_empty()
+    args.ai[0] = 3
+    args.ai[1] = 4
+    let res = mli_interp_run(&f, &args)
+    if res.ok { return report_fail("I2 cd", "interp-accepted", MLI_I_OK, MLI_I_UNSUPPORTED_OP) }
+    if res.has_value { return report_fail("I2 cd", "value-after-refuse", 1, 0) }
+    if res.code != MLI_I_UNSUPPORTED_OP {
+        return report_fail("I2 cd", "interp-code", res.code, MLI_I_UNSUPPORTED_OP)
+    }
+    if res.block != 0 || res.index != 0 {
+        return report_fail("I2 cd", "refused-before-opcode", res.block, 0)
+    }
+    report_pass("I2 CD cd_mul REFUSED by interp at the opcode (no product)")
 }
 
 // I3: V-struct refuses an unclassified compare-code. cc=7 is not "false".
@@ -480,6 +471,72 @@ fn case_void_ret_has_no_value() -> i64 with IO, Mut, Panic, Div {
     report_pass("I8 void return has no value (not a fabricated integer 0)")
 }
 
+// I9: #1801 site 1 — declared type after refuse. Knowledge is a legal
+// S1 kind (verify OK) but the interp has no inhabitant. Skipping the
+// arg and returning void success would fabricate "I handled this".
+fn case_interp_refuses_uninhabited_arg() -> i64 with IO, Mut, Panic, Div {
+    var f = mli_func_new("kvoid", mli_kind_void())
+    let kk = mli_kind_knowledge(MLI_KIND_FLOAT, 64, MLI_KSHAPE_MIN3)
+    let ka = mli_add_arg(&!f, kk)
+    let b0 = mli_new_block(&!f)
+    if ka < 0 || b0 < 0 { return report_fail("I9 arg-kind", "build", 0, 1) }
+    if !mli_set_term(&!f, b0, mli_term_ret_void()) { return report_fail("I9 arg-kind", "term", 0, 1) }
+    let vs = mli_verify_function(&f)
+    if vs.code != MLI_VERR_OK { return report_fail("I9 arg-kind", "verify", vs.code, 0) }
+    var args = mli_interp_args_empty()
+    let res = mli_interp_run(&f, &args)
+    if res.ok { return report_fail("I9 arg-kind", "accepted-declared-type", MLI_I_OK, MLI_I_ARG_KIND) }
+    if res.has_value { return report_fail("I9 arg-kind", "value-after-refuse", 1, 0) }
+    if res.code != MLI_I_ARG_KIND {
+        return report_fail("I9 arg-kind", "code", res.code, MLI_I_ARG_KIND)
+    }
+    if res.index != 0 { return report_fail("I9 arg-kind", "arg-index", res.index, 0) }
+    report_pass("I9 unimplemented arg kind REFUSED at load (no declared-type inhabitant)")
+}
+
+// I10: same hole with a narrow int. Int{32} is a legal kind; only i64
+// is runnable. `fn f(x: i32) -> i64 { 1 }` used to succeed with 1.
+fn case_interp_refuses_narrow_int_arg() -> i64 with IO, Mut, Panic, Div {
+    var f = mli_func_new("i32arg", mli_kind_int(64, 1))
+    let a = mli_add_arg(&!f, mli_kind_int(32, 1))
+    let b0 = mli_new_block(&!f)
+    if a < 0 || b0 < 0 { return report_fail("I10 i32-arg", "build", 0, 1) }
+    if !mli_set_term(&!f, b0, mli_term_ret(mli_opd_imm_int(1, mli_kind_int(64, 1)))) {
+        return report_fail("I10 i32-arg", "term", 0, 1)
+    }
+    let vs = mli_verify_function(&f)
+    if vs.code != MLI_VERR_OK { return report_fail("I10 i32-arg", "verify", vs.code, 0) }
+    var args = mli_interp_args_empty()
+    args.ai[0] = 99
+    let res = mli_interp_run(&f, &args)
+    if res.ok { return report_fail("I10 i32-arg", "fabricated-one", MLI_I_OK, MLI_I_ARG_KIND) }
+    if res.has_value { return report_fail("I10 i32-arg", "value-after-refuse", 1, 0) }
+    if res.code != MLI_I_ARG_KIND {
+        return report_fail("I10 i32-arg", "code", res.code, MLI_I_ARG_KIND)
+    }
+    report_pass("I10 i32 arg REFUSED at load (not a silent i64 1)")
+}
+
+// I11: #1801 site 2 twin — CALL is a named hole. Poke after green
+// verify (SoA i_op only). Interp must refuse; has_value must stay false
+// so a caller cannot read rax as the dest.
+fn case_interp_refuses_call() -> i64 with IO, Mut, Panic, Div {
+    var f = build_add_i64()
+    let vs = mli_verify_function(&f)
+    if vs.code != MLI_VERR_OK { return report_fail("I11 call interp", "pre-verify", vs.code, 0) }
+    f.i_op[mli_slot(0, 0)] = MLI_OP_CALL
+    var args = mli_interp_args_empty()
+    args.ai[0] = 3
+    args.ai[1] = 4
+    let res = mli_interp_run(&f, &args)
+    if res.ok { return report_fail("I11 call interp", "guessed-rax", MLI_I_OK, MLI_I_UNSUPPORTED_OP) }
+    if res.has_value { return report_fail("I11 call interp", "value-after-refuse", 1, 0) }
+    if res.code != MLI_I_UNSUPPORTED_OP {
+        return report_fail("I11 call interp", "code", res.code, MLI_I_UNSUPPORTED_OP)
+    }
+    report_pass("I11 CALL REFUSED by interp (no rax after empty stub)")
+}
+
 fn main() -> i64 with IO, Mut, Panic, Div {
     println("=== MLI S2a gate: ir_to_mli (straight-line i64/f64) + minimal interp ===")
     if ir_instr_arena_init() != IR_ARENA_OK {
@@ -512,6 +569,9 @@ fn main() -> i64 with IO, Mut, Panic, Div {
     failures = failures + case_verify_refuses_call()
     failures = failures + case_interp_refuses_undef_vreg()
     failures = failures + case_void_ret_has_no_value()
+    failures = failures + case_interp_refuses_uninhabited_arg()
+    failures = failures + case_interp_refuses_narrow_int_arg()
+    failures = failures + case_interp_refuses_call()
 
     if failures == 0 {
         println("=== MLI S2a: ALL CASES PASS ===")


### PR DESCRIPTION
## Summary
- The interpreter defined `MLI_I_ARG_KIND` and never returned it. Knowledge/CD/i32/ptr/qd128 arguments were skipped and the body ran — the same default as #1801 (checker returned the declared type after a refuse; empty stub left rax for the caller).
- Load now refuses those kinds at the argument index. No write-zero, no continuation, `has_value=false`.
- S2a I9–I11 lock the two #1801 sites. I2 still refuses `cd_mul` at the opcode (SoA `i_op` poke on a green i64 add — the instruction pool stays SoA).

## Test plan
- [x] `./bin/souc run self-hosted/mli/s2a_gate_runner.sio` (I1–I11)
- [x] `./bin/souc run self-hosted/mli/self_test_runner.sio`
- [x] `./bin/souc run self-hosted/mli/s2b_gate_runner.sio`
- [x] `./bin/souc run self-hosted/mli/s3_gate_runner.sio`
- [x] `./bin/souc run self-hosted/mli/s3b_gate_runner.sio`