### PR TITLE
test(native-v2): pin handle reclamation acceptance wall

### DIFF
--- a/tests/native-v2/handle_reclamation_acceptance_gate.sh
+++ b/tests/native-v2/handle_reclamation_acceptance_gate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMPILER="${SOUNIO_HANDLE_RECLAIM_COMPILER:-}"
+OUT_DIR="${SOUNIO_HANDLE_RECLAIM_OUT_DIR:-${TMPDIR:-/tmp}/sounio-handle-reclamation-gate}"
+STATUS_JSON="$OUT_DIR/status.v1.json"
+CONTROL_SRC="$ROOT/tests/native-v2/handle_reclamation_below_capacity.sio"
+EXHAUST_SRC="$ROOT/tests/native-v2/handle_reclamation_exhaustion.sio"
+
+mkdir -p "$OUT_DIR"
+
+write_status() {
+    local status="$1" passed="$2" failed="$3" not_run="$4" reason="$5"
+    printf '{"status":"%s","metrics":{"total":2,"passed":%s,"failed":%s,"not_run":%s},"reason":"%s"}\n' \
+        "$status" "$passed" "$failed" "$not_run" "$reason" > "$STATUS_JSON"
+}
+
+if [[ -z "$COMPILER" || ! -x "$COMPILER" ]]; then
+    write_status "blocked" 0 0 2 "source_built_compiler_required"
+    echo "BLOCKED: set SOUNIO_HANDLE_RECLAIM_COMPILER to a source-built Madaros ELF" >&2
+    echo "status_json=$STATUS_JSON" >&2
+    exit 2
+fi
+
+ulimit -s 524288
+COMPILER_SHA="$(sha256sum "$COMPILER" | awk '{print $1}')"
+echo "compiler=$COMPILER"
+echo "compiler_sha256=$COMPILER_SHA"
+
+compile_fixture() {
+    local src="$1" out="$2" log="$3"
+    rm -f "$out"
+    "$ROOT/scripts/dev/souc-build-lock.sh" "$COMPILER" "$src" -o "$out" >"$log" 2>&1
+    local rc=$?
+    if [[ $rc -ne 0 || ! -s "$out" ]]; then
+        return 1
+    fi
+    chmod +x "$out"
+}
+
+CONTROL_ELF="$OUT_DIR/control.elf"
+EXHAUST_ELF="$OUT_DIR/exhaustion.elf"
+if ! compile_fixture "$CONTROL_SRC" "$CONTROL_ELF" "$OUT_DIR/control.compile.log"; then
+    write_status "blocked" 0 0 2 "control_compile_failed"
+    echo "BLOCKED: control fixture did not compile" >&2
+    exit 2
+fi
+if ! compile_fixture "$EXHAUST_SRC" "$EXHAUST_ELF" "$OUT_DIR/exhaustion.compile.log"; then
+    write_status "blocked" 0 0 2 "exhaustion_compile_failed"
+    echo "BLOCKED: exhaustion fixture did not compile" >&2
+    exit 2
+fi
+
+set +e
+timeout 180 "$CONTROL_ELF" >"$OUT_DIR/control.run.log" 2>&1
+CONTROL_RC=$?
+timeout 180 "$EXHAUST_ELF" >"$OUT_DIR/exhaustion.run.log" 2>&1
+EXHAUST_RC=$?
+set -e
+
+if [[ $CONTROL_RC -ne 0 ]] || ! grep -q '^HANDLE_CONTROL_OK count=1000000$' "$OUT_DIR/control.run.log"; then
+    write_status "fail" 0 2 0 "negative_control_failed"
+    echo "FAIL: below-capacity control rc=$CONTROL_RC" >&2
+    exit 1
+fi
+
+if [[ $EXHAUST_RC -eq 0 ]] && grep -q '^HANDLE_RECLAMATION_OK count=4194304$' "$OUT_DIR/exhaustion.run.log"; then
+    write_status "pass" 2 0 0 "reclamation_acceptance_met"
+    echo "PASS: managed allocations reclaimed before the lifetime wall"
+    echo "status_json=$STATUS_JSON"
+    exit 0
+fi
+
+write_status "fail" 1 1 0 "reclamation_acceptance_not_met"
+if [[ $EXHAUST_RC -eq 182 ]]; then
+    echo "POSITIVE_CONTROL_FIRED: exhaustion fixture failed closed with rc=182" >&2
+else
+    echo "FAIL: exhaustion fixture rc=$EXHAUST_RC, expected current-baseline rc=182 or repaired rc=0" >&2
+fi
+echo "status_json=$STATUS_JSON" >&2
+exit 1

--- a/tests/native-v2/handle_reclamation_below_capacity.sio
+++ b/tests/native-v2/handle_reclamation_below_capacity.sio
@@ -1,0 +1,31 @@
+//@ run-pass
+//@ expected-output: HANDLE_CONTROL_OK count=1000000
+
+// Negative control for managed-handle reclamation. TripleF64 is larger than
+// the native-v2 16-byte unboxed threshold, so every loop iteration allocates a
+// managed object. One million allocations must remain below the 2^22 table.
+
+struct TripleF64 {
+    a: f64,
+    b: f64,
+    c: f64,
+}
+
+fn main() -> i64 with IO, Mut, Alloc {
+    var acc = 0.0
+    var i: i64 = 0
+    while i < 1000000 {
+        let sample = TripleF64 { a: 1.0, b: 2.0, c: 3.0 }
+        acc = acc + sample.a
+        i = i + 1
+    }
+
+    if acc != 1000000.0 {
+        print("HANDLE_CONTROL_BAD_CHECKSUM\n")
+        return 3
+    }
+    print("HANDLE_CONTROL_OK count=")
+    print_int(i)
+    print("\n")
+    0
+}

--- a/tests/native-v2/handle_reclamation_exhaustion.sio
+++ b/tests/native-v2/handle_reclamation_exhaustion.sio
@@ -1,0 +1,29 @@
+// Acceptance witness for managed-handle reclamation.
+//
+// Before reclamation this program MUST fail closed with rc=182 at the 2^22
+// lifetime allocation wall. After reclamation it must reach the final marker.
+
+struct TripleF64 {
+    a: f64,
+    b: f64,
+    c: f64,
+}
+
+fn main() -> i64 with IO, Mut, Alloc {
+    var acc = 0.0
+    var i: i64 = 0
+    while i < 4194304 {
+        let sample = TripleF64 { a: 1.0, b: 2.0, c: 3.0 }
+        acc = acc + sample.a
+        i = i + 1
+    }
+
+    if acc != 4194304.0 {
+        print("HANDLE_RECLAMATION_BAD_CHECKSUM\n")
+        return 3
+    }
+    print("HANDLE_RECLAMATION_OK count=")
+    print_int(i)
+    print("\n")
+    0
+}


### PR DESCRIPTION
## Summary

- add a below-capacity managed-allocation control at 1,000,000 iterations
- add a reclamation acceptance witness at exactly 4,194,304 managed allocations
- add a tests-only gate that requires an explicitly supplied source-built Madaros ELF and publishes structured metrics

## Positive control demonstrated

Compiler SHA-256:
`2dcaf1594465e67f07858f4e178409b8c642fec2e02a000f095e8f7cf505745e`

Command:

```sh
SOUNIO_HANDLE_RECLAIM_COMPILER=/tmp/box-backend-sixth-madaros \
SOUNIO_HANDLE_RECLAIM_OUT_DIR=/tmp/handle-reclamation-acceptance-run \
  tests/native-v2/handle_reclamation_acceptance_gate.sh
```

Current baseline result, intentionally red:

```text
HANDLE_CONTROL_OK count=1000000
madaros: handles full
POSITIVE_CONTROL_FIRED: exhaustion fixture failed closed with rc=182
```

```json
{"status":"fail","metrics":{"total":2,"passed":1,"failed":1,"not_run":0},"reason":"reclamation_acceptance_not_met"}
```

This is the required before-state. A reclamation patch is accepted only when the same gate reaches `HANDLE_RECLAMATION_OK count=4194304`, returns zero, and reports 2 passed / 0 failed.

## Vacuity guard

With no explicit source-built compiler, the gate exits 2 and reports:

```json
{"status":"blocked","metrics":{"total":2,"passed":0,"failed":0,"not_run":2},"reason":"source_built_compiler_required"}
```

The gate is tests-only and is not wired into the ordinary green suite before a reclamation implementation exists.
