### PR TITLE
fix(mli): name the CALL refuse — empty stub is not an unknown opcode

### DIFF
--- a/self-hosted/mli/interp.sio
+++ b/self-hosted/mli/interp.sio
@@ -12,7 +12,8 @@
 //      REFUSES with a named code instead of picking — so the ambiguity fails
 //      loudly rather than getting frozen by accident. Refused today: shifts
 //      (width/mask semantics unpinned), memory ops (no MLI memory model yet:
-//      load/store/lea/alloca), calls, fcast, every k_* and cd_* op, f32/
+//      load/store/lea/alloca), calls (MLI_I_CALL_UNSPECIFIED — named, not
+//      the unknown-op catch-all), fcast, every k_* and cd_* op, f32/
 //      f128/f256/qd128/Knowledge/CD/vec/ptr VALUES, phys/stack/reloc
 //      operands, unclassified compare-codes (not "false"), i64 div-by-zero
 //      and INT_MIN/-1. Control flow is implemented (S2b) with a fuel cap.
@@ -64,6 +65,7 @@ pub let MLI_I_BAD_CC: i64 = 10
 pub let MLI_I_FUEL: i64 = 11
 pub let MLI_I_BAD_TARGET: i64 = 12
 pub let MLI_I_UNDEF_VREG: i64 = 13
+pub let MLI_I_CALL_UNSPECIFIED: i64 = 14
 
 // Execution budget: control flow means loops, and a non-terminating program
 // must fail LOUDLY rather than hang (refuse-first applied to termination).
@@ -365,7 +367,13 @@ fn mli_exec_slot(rf: &!MliRegFile, f: &MliFunction, slot: i64) -> i64 with Mut, 
         return MLI_I_OK
     }
 
-    // Everything else — memory ops, calls, fcast, every k_* and cd_* — is
+    // CALL is a named hole (verify: MLI_VERR_CALL_UNSPECIFIED). Falling
+    // through to UNSUPPORTED_OP made a specified-but-unpinned ABI look
+    // like an unknown opcode — the empty-stub class (#1801): dest stays
+    // unread and a caller can treat "unknown" as "no dest".
+    if op == MLI_OP_CALL { return MLI_I_CALL_UNSPECIFIED }
+
+    // Everything else — memory ops, fcast, every k_* and cd_* — is
     // refused loudly. See the header: refuse, don't pick.
     MLI_I_UNSUPPORTED_OP
 }

--- a/self-hosted/mli/s2a_gate_runner.sio
+++ b/self-hosted/mli/s2a_gate_runner.sio
@@ -518,8 +518,9 @@ fn case_interp_refuses_narrow_int_arg() -> i64 with IO, Mut, Panic, Div {
 }
 
 // I11: #1801 site 2 twin — CALL is a named hole. Poke after green
-// verify (SoA i_op only). Interp must refuse; has_value must stay false
-// so a caller cannot read rax as the dest.
+// verify (SoA i_op only). Interp must refuse with the named code, not
+// the unknown-op catch-all; has_value must stay false so a caller
+// cannot read rax as the dest.
 fn case_interp_refuses_call() -> i64 with IO, Mut, Panic, Div {
     var f = build_add_i64()
     let vs = mli_verify_function(&f)
@@ -529,12 +530,12 @@ fn case_interp_refuses_call() -> i64 with IO, Mut, Panic, Div {
     args.ai[0] = 3
     args.ai[1] = 4
     let res = mli_interp_run(&f, &args)
-    if res.ok { return report_fail("I11 call interp", "guessed-rax", MLI_I_OK, MLI_I_UNSUPPORTED_OP) }
+    if res.ok { return report_fail("I11 call interp", "guessed-rax", MLI_I_OK, MLI_I_CALL_UNSPECIFIED) }
     if res.has_value { return report_fail("I11 call interp", "value-after-refuse", 1, 0) }
-    if res.code != MLI_I_UNSUPPORTED_OP {
-        return report_fail("I11 call interp", "code", res.code, MLI_I_UNSUPPORTED_OP)
+    if res.code != MLI_I_CALL_UNSPECIFIED {
+        return report_fail("I11 call interp", "code", res.code, MLI_I_CALL_UNSPECIFIED)
     }
-    report_pass("I11 CALL REFUSED by interp (no rax after empty stub)")
+    report_pass("I11 CALL REFUSED by interp with named code (no rax after empty stub)")
 }
 
 fn main() -> i64 with IO, Mut, Panic, Div {


### PR DESCRIPTION
## Summary
- Builds on #1821. CALL was refused only by the unknown-op catch-all, so a specified-but-unpinned ABI looked like a missing case — the #1801 empty-stub class (dest unread, caller can treat that as rax).
- Interp now returns `MLI_I_CALL_UNSPECIFIED` (14), matching `MLI_VERR_CALL_UNSPECIFIED`. I11 requires the named code and `has_value=false`.
- Instruction pool stays SoA. I5 still covers a genuinely unknown opcode (77).

## Test plan
- [x] `./bin/souc run self-hosted/mli/s2a_gate_runner.sio` (I1–I11, I11 named)