### PR TITLE
feat(website): FabricatedDatum — the fifth epistemic state

### DIFF
--- a/website/src/components/epistemic/FabricatedDatum.css
+++ b/website/src/components/epistemic/FabricatedDatum.css
@@ -1,0 +1,240 @@
+/* FabricatedDatum — tokens only from website/src/styles/global.css
+   Fabricated is not a fifth colour. It borrows refused for the tear and
+   text-primary for the face that looked given. */
+
+.fd {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.15rem;
+  border-radius: var(--radius-xl);
+  background: var(--color-surface-primary);
+  border: 1px solid var(--fd-border, var(--color-epistemic-refused-border));
+  color: var(--color-text-primary);
+  min-width: 0;
+}
+
+.fd[data-state='vacuous'] {
+  border-color: var(--color-epistemic-uncertain-border);
+}
+
+.fd-header,
+.fd-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.fd-signature,
+.fd-chip,
+.fd-face-kicker,
+.fd-face-label,
+.fd-numeral,
+.fd-tear-mark,
+.fd-sha,
+.fd-link {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.fd-signature {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fd-chip {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--fd-border, var(--color-epistemic-refused-border));
+  background: var(--fd-surface, var(--color-epistemic-refused-surface));
+  color: var(--fd-text, var(--color-epistemic-refused-text));
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.64rem;
+  font-weight: 700;
+  padding: 0.22rem 0.55rem;
+}
+
+.fd[data-state='vacuous'] .fd-chip {
+  border-color: var(--color-epistemic-uncertain-border);
+  background: var(--color-epistemic-uncertain-surface);
+  color: var(--color-epistemic-uncertain-text);
+}
+
+.fd-glyph {
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.fd-faces {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 0.55rem;
+  align-items: stretch;
+  min-width: 0;
+}
+
+@media (max-width: 640px) {
+  .fd-faces {
+    grid-template-columns: 1fr;
+  }
+
+  .fd-tear {
+    flex-direction: row;
+    min-height: 0;
+    padding: 0.15rem 0;
+  }
+
+  .fd-tear-rule {
+    width: 100%;
+    height: 1px;
+  }
+}
+
+.fd-face {
+  min-width: 0;
+  padding: 0.65rem 0.7rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-hairline);
+  background: var(--color-surface-secondary);
+}
+
+.fd-printed {
+  animation: fd-given 0.7s ease both;
+}
+
+.fd-actual {
+  animation: fd-reveal 0.9s ease 0.35s both;
+}
+
+.fd-face-kicker {
+  margin: 0 0 0.15rem;
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+}
+
+.fd-face-label {
+  margin: 0 0 0.45rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  color: var(--color-text-secondary);
+}
+
+.fd-numeral {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.35;
+  color: var(--color-text-primary);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.fd-numeral[data-long='true'] {
+  font-size: 0.68rem;
+  line-height: 1.45;
+  max-height: 8.5rem;
+  overflow: auto;
+}
+
+.fd-printed .fd-numeral {
+  text-decoration: line-through;
+  text-decoration-color: var(--color-epistemic-refused);
+  text-decoration-thickness: 1.5px;
+}
+
+.fd-actual .fd-numeral {
+  color: var(--color-epistemic-verified-text);
+}
+
+.fd-tear {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-width: 1.4rem;
+}
+
+.fd-tear-rule {
+  width: 1px;
+  flex: 1;
+  background: repeating-linear-gradient(
+    to bottom,
+    var(--color-epistemic-refused) 0 5px,
+    transparent 5px 8px
+  );
+  min-height: 2.4rem;
+}
+
+.fd-tear-mark {
+  font-size: 0.58rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-epistemic-refused-text);
+}
+
+.fd-reason {
+  margin: 0;
+  font-size: 0.84rem;
+  line-height: 1.55;
+  color: var(--color-text-secondary);
+}
+
+.fd-footer {
+  border-top: 1px solid var(--color-border-hairline);
+  padding-top: 0.55rem;
+}
+
+.fd-sha {
+  font-size: 0.68rem;
+  color: var(--color-text-tertiary);
+}
+
+.fd-link {
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  color: var(--color-accent-teal);
+}
+
+.fd-link:hover {
+  color: var(--color-accent-gold);
+}
+
+@keyframes fd-given {
+  from {
+    opacity: 0.35;
+    filter: none;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fd-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(0.25rem);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fd-printed,
+  .fd-actual {
+    animation: none;
+  }
+}

--- a/website/src/components/epistemic/FabricatedDatum.tsx
+++ b/website/src/components/epistemic/FabricatedDatum.tsx
@@ -1,0 +1,123 @@
+import type { CSSProperties } from 'react';
+import {
+  KIND_LABEL,
+  readFabrication,
+  type FabricationKind,
+} from '../../lib/fabricationHonesty';
+import './FabricatedDatum.css';
+
+export type FabricatedDatumProps = {
+  kind: FabricationKind;
+  signature: string;
+  printed: string;
+  actual: string;
+  printedLabel: string;
+  actualLabel: string;
+  reason: string;
+  sha: string;
+  href: string;
+  hrefLabel: string;
+  className?: string;
+};
+
+export function FabricatedDatum({
+  kind,
+  signature,
+  printed,
+  actual,
+  printedLabel,
+  actualLabel,
+  reason,
+  sha,
+  href,
+  hrefLabel,
+  className,
+}: FabricatedDatumProps) {
+  const reading = readFabrication(kind, printed, actual);
+  const classes = ['fd', className].filter(Boolean).join(' ');
+
+  if (reading.state === 'vacuous') {
+    return (
+      <article
+        className={classes}
+        data-state="vacuous"
+        data-kind={kind}
+        aria-label={`${signature}: not a fabrication witness`}
+      >
+        <header className="fd-header">
+          <span className="fd-signature">{signature}</span>
+          <span className="fd-chip">Vacuous</span>
+        </header>
+        <p className="fd-reason">
+          {reading.reason === 'faces-identical'
+            ? 'Printed and actual are the same string. That is not a fabrication witness — showing a tear here would fabricate one.'
+            : 'A fabrication witness needs both faces. One of them is empty.'}
+        </p>
+      </article>
+    );
+  }
+
+  const printedIsLong = reading.printed.length > 48;
+  const actualIsLong = reading.actual.length > 48;
+
+  return (
+    <article
+      className={classes}
+      data-state="fabricated"
+      data-kind={kind}
+      style={
+        {
+          '--fd-ink': 'var(--color-epistemic-refused)',
+          '--fd-surface': 'var(--color-epistemic-refused-surface)',
+          '--fd-border': 'var(--color-epistemic-refused-border)',
+          '--fd-text': 'var(--color-epistemic-refused-text)',
+        } as CSSProperties
+      }
+      aria-label={`${signature}: fabricated — ${KIND_LABEL[kind]}`}
+    >
+      <header className="fd-header">
+        <span className="fd-signature">{signature}</span>
+        <span className="fd-chip">
+          <span className="fd-glyph" aria-hidden="true">
+            ≠
+          </span>
+          Fabricated
+        </span>
+      </header>
+
+      <div className="fd-faces" data-kind={kind}>
+        <div className="fd-face fd-printed">
+          <p className="fd-face-kicker">{printedLabel}</p>
+          <p className="fd-face-label">Printed as given</p>
+          <pre className="fd-numeral" data-long={printedIsLong}>
+            {reading.printed}
+          </pre>
+        </div>
+
+        <div className="fd-tear" aria-hidden="true">
+          <span className="fd-tear-rule" />
+          <span className="fd-tear-mark">tear</span>
+        </div>
+
+        <div className="fd-face fd-actual">
+          <p className="fd-face-kicker">{actualLabel}</p>
+          <p className="fd-face-label">
+            {kind === 'truncated' ? 'Dropped after 127' : 'The other reading'}
+          </p>
+          <pre className="fd-numeral" data-long={actualIsLong}>
+            {reading.actual}
+          </pre>
+        </div>
+      </div>
+
+      <p className="fd-reason">{reason}</p>
+
+      <footer className="fd-footer">
+        <code className="fd-sha">{sha}</code>
+        <a className="fd-link" href={href} target="_blank" rel="noopener noreferrer">
+          {hrefLabel}
+        </a>
+      </footer>
+    </article>
+  );
+}

--- a/website/src/components/honesty/FabricatedDatumExhibit.astro
+++ b/website/src/components/honesty/FabricatedDatumExhibit.astro
@@ -1,0 +1,143 @@
+---
+import { FabricatedDatum } from '../epistemic/FabricatedDatum';
+import {
+  BIT_PATTERN_ACTUAL,
+  BIT_PATTERN_PRINTED,
+  SILENT_ZERO_ACTUAL,
+  SILENT_ZERO_PRINTED,
+  truncatedE219Help,
+} from '../../lib/fabricationHonesty';
+import { PRE_FIX_PRINT_CAP } from '../../lib/diagnosticHonesty';
+import type { Locale } from '../../lib/i18n';
+
+interface Props {
+  locale?: Locale;
+}
+
+const { locale = 'en' } = Astro.props;
+const cut = truncatedE219Help();
+const kept = cut.state === 'fabricated' ? cut.printed : '';
+const dropped = cut.state === 'fabricated' ? cut.actual : '';
+
+const t: Record<
+  string,
+  { kicker: string; heading: string; body: string }
+> = {
+  en: {
+    kicker: '04 · The fifth state',
+    heading: 'Fabricated looks like a given. That is why it is the dangerous one.',
+    body: 'Verified, uncertain, and refused already have a face. A diagnostic has a face. Fabricated was the state with no representation — a numeral that passed as data. The meter refuses to print it. This control shows both faces, and refuses to draw a tear when they are the same string. Three measured cases. #1792 is still open.',
+  },
+  pt: {
+    kicker: '04 · O quinto estado',
+    heading: 'Fabricado parece um dado. Por isso é o perigoso.',
+    body: 'Verificado, incerto e recusado já tinham cara. Um diagnóstico já tinha cara. Fabricado era o estado sem representação — um numeral que passava por dado. O medidor recusa imprimi-lo. Este controlo mostra as duas caras, e recusa rasgar quando são a mesma string. Três casos medidos. O #1792 continua aberto.',
+  },
+  es: {
+    kicker: '04 · El quinto estado',
+    heading: 'Fabricado parece un dato. Por eso engaña.',
+    body: 'Verificado, incierto y rechazado ya tenían cara. Fabricado no. Este control muestra las dos caras. Tres casos medidos. #1792 sigue abierto.',
+  },
+  el: {
+    kicker: '04 · Η πέμπτη κατάσταση',
+    heading: 'Το κατασκευασμένο μοιάζει με δεδομένο. Γι’ αυτό είναι επικίνδυνο.',
+    body: 'Τρεις μετρημένες περιπτώσεις. Το #1792 παραμένει ανοιχτό.',
+  },
+  zh: {
+    kicker: '04 · 第五态',
+    heading: '伪造看起来像给定值。所以它危险。',
+    body: '三个已测案例。#1792 仍开放。',
+  },
+  ja: {
+    kicker: '04 · 第五の状態',
+    heading: '捏造は与えられた値に見える。だから危ない。',
+    body: '実測は三つ。#1792 はまだ開いている。',
+  },
+};
+
+const d = t[locale] ?? (locale === 'zh-hk' ? t.zh : t.en);
+---
+
+<section class="honesty-act" id="fabricated" aria-labelledby="honesty-act4">
+  <p class="honesty-act-kicker" id="honesty-act4">{d.kicker}</p>
+  <h2 class="honesty-act-heading">{d.heading}</h2>
+  <p class="honesty-act-body">{d.body}</p>
+
+  <div class="fd-exhibit">
+    <FabricatedDatum
+      kind="silent-zero"
+      signature="var(blood): Knowledge<f64>"
+      printed={SILENT_ZERO_PRINTED}
+      actual={SILENT_ZERO_ACTUAL}
+      printedLabel="Madaros"
+      actualLabel="lean_single"
+      reason="rapamycin_epistemic_adaptive. Madaros printed var(blood/brain/periph)=0.000000. lean_single shows ~1e-5 / ~1e-9. A calibrated zero would be a measurement. This zero is the stub. #1792 is open: fail-closed detection, not a compiler ABI fix."
+      sha="4816902113"
+      href="https://github.com/Sounio-lang/sounio/pull/1792"
+      hrefLabel="PR #1792"
+    />
+    <FabricatedDatum
+      kind="bit-pattern"
+      signature="auc.ε: Knowledge<f64>"
+      printed={BIT_PATTERN_PRINTED}
+      actual={BIT_PATTERN_ACTUAL}
+      printedLabel="Madaros TEST 6"
+      actualLabel="lean_single ε"
+      reason="epistemic_pbpk28 TEST 6 printed AUC confidence 4604219396932172800.000000 — documented as the IEEE-bit-pattern-as-decimal of lean_single 0.671038. The integer exceeds JS 2^53; this control keeps it as text. It is not a unit-interval ε. #1792 remains open."
+      sha="4816902113"
+      href="https://github.com/Sounio-lang/sounio/blob/main/docs/dissertation/results/pbpk28_epistemic_v1.md"
+      hrefLabel="pbpk28_epistemic_v1.md"
+    />
+    <FabricatedDatum
+      kind="truncated"
+      signature={`E219 help · ${PRE_FIX_PRINT_CAP}-char cap`}
+      printed={kept}
+      actual={dropped}
+      printedLabel="Pre-#1784 print"
+      actualLabel={`Dropped · ${dropped.length} chars`}
+      reason="#1794 counted 33 user-facing diagnostics over the old 127-character print cap. Every one was cut. E219 help is 333 characters; 206 were dropped mid-word. The historical CI logs that quote them are incomplete in the tails. #1784 closed the path. This card is the census, not the fix."
+      sha="f6d2188d46"
+      href="https://github.com/Sounio-lang/sounio/pull/1794"
+      hrefLabel="PR #1794"
+    />
+  </div>
+</section>
+
+<style>
+  .honesty-act {
+    display: grid;
+    gap: 0.85rem;
+  }
+
+  .honesty-act-kicker {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--color-epistemic-refused-text);
+  }
+
+  .honesty-act-heading {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(1.35rem, 2.6vw, 1.85rem);
+    font-weight: 400;
+    line-height: 1.25;
+    color: var(--color-text-primary);
+  }
+
+  .honesty-act-body {
+    margin: 0;
+    max-width: 68ch;
+    font-size: 0.98rem;
+    line-height: 1.7;
+    color: var(--color-text-secondary);
+  }
+
+  .fd-exhibit {
+    display: grid;
+    gap: 1rem;
+    margin-top: 0.4rem;
+  }
+</style>

--- a/website/src/components/honesty/HonestyArgument.astro
+++ b/website/src/components/honesty/HonestyArgument.astro
@@ -3,6 +3,7 @@ import { KnowledgeRefusalMeter } from '../epistemic/KnowledgeRefusalMeter';
 import { E219DiagnosticCodeBlock } from '../epistemic/DiagnosticCodeBlock';
 import { EffectLatticeBadge } from '../epistemic/EffectLatticeBadge';
 import { EpistemicGateCard } from '../epistemic/EpistemicGateCard';
+import FabricatedDatumExhibit from './FabricatedDatumExhibit.astro';
 import { getLocalizedPath } from '../../lib/i18n';
 import type { Locale } from '../../lib/i18n';
 
@@ -37,11 +38,11 @@ const copy: Record<
   en: {
     kicker: 'The argument',
     heading: 'Types have content. Refusal is a result. Fabrication, when it happens, is visible.',
-    lede: 'Four instruments, one claim. Not a tour of the design system — the page that uses it.',
+    lede: 'Five states. The fifth is the one that used to look like a given.',
     spine: [
       'A signature carries effects and doubt, not just a return type.',
       'A well-typed program returns a value, or it refuses. It does not invent a zero.',
-      'When a backend still fabricates, the control prints the shape — not the fake numeral.',
+      'When a backend still fabricates, one control refuses the numeral; another shows both faces.',
     ],
     act1k: '01 · Types have content',
     act1h: 'The checker reads colour and ε before you read the name.',
@@ -52,7 +53,7 @@ const copy: Record<
     act3k: '03 · Fabrication is visible',
     act3h: 'Two sites closed. One case still measured in the open.',
     act3b: '#1801 made refusal infect the expression: abs() + 1 is ty_error(), not i64, and an empty IR stub emits ud2 instead of falling through to 0. lean_single still has no E219. #1792 is the remaining dissertation-surface case: Madaros printed var(blood)=0.000000 against lean_single ~1e-5, and printed AUC confidence 4604219396932172800 — the IEEE bits of 0.671038 as an integer. The meter refuses that integer as ε. The PR makes the shape fail-closed. It does not claim the compiler ABI is fixed.',
-    coda: 'The same four controls appear on /language, /compiler, /proof, and the home meter. This page is where they argue together.',
+    coda: 'The first four controls appear on /language, /compiler, /proof, and the home meter. FabricatedDatum is the fifth state — the one that used to have no face.',
     language: 'Language — types and E219',
     compiler: 'Compiler — effect lattice',
     proof: 'Proof — gate ladder',
@@ -60,11 +61,11 @@ const copy: Record<
   pt: {
     kicker: 'O argumento',
     heading: 'Os tipos têm conteúdo. A recusa é um resultado. A fabricação, quando acontece, é visível.',
-    lede: 'Quatro instrumentos, uma tese. Não é um tour do sistema de design — é a página que o usa.',
+    lede: 'Cinco estados. O quinto é o que parecia um dado.',
     spine: [
       'A assinatura carrega efeitos e dúvida, não só um tipo de retorno.',
       'Um programa bem tipado devolve um valor, ou recusa. Não inventa um zero.',
-      'Quando o backend ainda fabrica, o controlo imprime a forma — não o numeral falso.',
+      'Quando o backend ainda fabrica, um controlo recusa o numeral; outro mostra as duas caras.',
     ],
     act1k: '01 · Os tipos têm conteúdo',
     act1h: 'O checker lê a cor e o ε antes de leres o nome.',
@@ -75,7 +76,7 @@ const copy: Record<
     act3k: '03 · A fabricação é visível',
     act3h: 'Dois sítios fechados. Um caso ainda medido, em aberto.',
     act3b: 'O #1801 fez a recusa infectar a expressão: abs() + 1 é ty_error(), não i64, e um stub IR vazio emite ud2 em vez de cair para 0. O lean_single continua sem E219. O #1792 é o caso que resta na superfície da dissertação: o Madaros imprimiu var(blood)=0.000000 contra ~1e-5 no lean_single, e imprimiu confiança AUC 4604219396932172800 — os bits IEEE de 0.671038 como inteiro. O medidor recusa esse inteiro como ε. O PR torna a forma fail-closed. Não afirma que o ABI do compilador está corrigido.',
-    coda: 'Os mesmos quatro controlos aparecem em /language, /compiler, /proof e no medidor da entrada. Esta página é onde argumentam juntos.',
+    coda: 'Os primeiros quatro controlos aparecem em /language, /compiler, /proof e no medidor da entrada. FabricatedDatum é o quinto estado — o que não tinha cara.',
     language: 'Linguagem — tipos e E219',
     compiler: 'Compilador — reticulado de efeitos',
     proof: 'Prova — escada de portões',
@@ -83,7 +84,7 @@ const copy: Record<
   es: {
     kicker: 'El argumento',
     heading: 'Los tipos tienen contenido. La negativa es un resultado. La fabricación, cuando ocurre, se ve.',
-    lede: 'Cuatro instrumentos, una tesis.',
+    lede: 'Cinco estados. El quinto parecía un dato.',
     spine: [
       'La firma carga efectos y duda, no solo un tipo de retorno.',
       'Un programa bien tipado devuelve un valor, o se niega. No inventa un cero.',
@@ -98,7 +99,7 @@ const copy: Record<
     act3k: '03 · La fabricación es visible',
     act3h: 'Dos sitios cerrados. Un caso aún medido, abierto.',
     act3b: '#1801 infecta la expresión y emite ud2 en stubs vacíos. #1792 (abierto) midió var=0.000000 y la confianza 4604219396932172800. El medidor no imprime ese entero como ε.',
-    coda: 'Los mismos cuatro controles argumentan juntos aquí.',
+    coda: 'FabricatedDatum es el quinto estado — el que no tenía cara.',
     language: 'Lenguaje — tipos y E219',
     compiler: 'Compilador — retículo de efectos',
     proof: 'Prueba — escalera de puertas',
@@ -106,7 +107,7 @@ const copy: Record<
   el: {
     kicker: 'Το επιχείρημα',
     heading: 'Οι τύποι έχουν περιεχόμενο. Η άρνηση είναι αποτέλεσμα. Η κατασκευή, όταν συμβαίνει, φαίνεται.',
-    lede: 'Τέσσερα όργανα, μία θέση.',
+    lede: 'Πέντε καταστάσεις. Η πέμπτη έμοιαζε με δεδομένο.',
     spine: [
       'Η υπογραφή κουβαλά effects και αμφιβολία.',
       'Ένα καλά τυποποιημένο πρόγραμμα επιστρέφει τιμή, ή αρνείται.',
@@ -121,7 +122,7 @@ const copy: Record<
     act3k: '03 · Η κατασκευή είναι ορατή',
     act3h: 'Δύο σημεία κλειστά. Μία περίπτωση ακόμη ανοιχτή.',
     act3b: 'Το #1801 κλείνει δύο θέσεις κατασκευής. Το #1792 μέτρησε var=0.000000 και εμπιστοσύνη 4604219396932172800.',
-    coda: 'Τα ίδια τέσσερα controls συνθέτουν εδώ το επιχείρημα.',
+    coda: 'Το FabricatedDatum είναι η πέμπτη κατάσταση.',
     language: 'Γλώσσα — τύποι και E219',
     compiler: 'Μεταγλωττιστής — πλέγμα effects',
     proof: 'Απόδειξη — κλίμακα πυλών',
@@ -129,7 +130,7 @@ const copy: Record<
   zh: {
     kicker: '论点',
     heading: '类型有内容。拒绝是结果。伪造一旦发生，必须看得见。',
-    lede: '四件仪器，一个主张。',
+    lede: '五个状态。第五个曾经看起来像给定值。',
     spine: [
       '签名带着效应和怀疑，不只是返回类型。',
       '良类型程序给出值，或拒绝。它不伪造零。',
@@ -144,7 +145,7 @@ const copy: Record<
     act3k: '03 · 伪造看得见',
     act3h: '两处已关。一处仍在测量、仍开放。',
     act3b: '#1801 让拒绝感染表达式，空 stub 发 ud2。#1792 测到 var=0.000000 与置信度 4604219396932172800。',
-    coda: '同一套四个控件在此一起论证。',
+    coda: 'FabricatedDatum 是第五态。',
     language: '语言 — 类型与 E219',
     compiler: '编译器 — 效应格',
     proof: '证明 — 门阶梯',
@@ -152,7 +153,7 @@ const copy: Record<
   ja: {
     kicker: '論証',
     heading: '型には中身がある。拒否は結果である。捏造が起きれば、見える。',
-    lede: '四つの器具、一つの主張。',
+    lede: '五つの状態。五つ目は与えられた値に見えていた。',
     spine: [
       'シグネチャは効果と疑念を運ぶ。戻り値の型だけではない。',
       '正しく型付けされたプログラムは値を返すか、拒む。ゼロを捏造しない。',
@@ -167,7 +168,7 @@ const copy: Record<
     act3k: '03 · 捏造は見える',
     act3h: '二箇所は閉じた。一件はまだ測定され、開いている。',
     act3b: '#1801 は拒否を式に感染させ、空 stub は ud2 を出す。#1792 は var=0.000000 と信頼度 4604219396932172800 を測った。',
-    coda: '同じ四つのコントロールが、ここで一つの論証になる。',
+    coda: 'FabricatedDatum が第五の状態だ。',
     language: '言語 — 型と E219',
     compiler: 'コンパイラ — 効果格子',
     proof: '証明 — ゲートの梯子',
@@ -333,6 +334,8 @@ const FABRICATED_EPSILON_STAND_IN = 2;
       </div>
     </div>
   </section>
+
+  <FabricatedDatumExhibit locale={locale} />
 
   <footer class="honesty-coda">
     <p>{localeCopy.coda}</p>

--- a/website/src/lib/fabricationHonesty.ts
+++ b/website/src/lib/fabricationHonesty.ts
@@ -1,0 +1,75 @@
+/**
+ * Honesty kernel for the fifth epistemic state: FABRICATED.
+ *
+ * Verified, uncertain, and refused already have a face. A diagnostic has a
+ * face. Fabricated is the state that looks like a given and is not. The
+ * meter (#1797) refuses to print that numeral. This module is the other
+ * half: it will show the printed face only as a printed face, never as
+ * the actual.
+ *
+ * Witnesses are strings. The AUC integer 4604219396932172800 exceeds
+ * JS 2^53; Number() would fabricate a different integer. This file does
+ * not recover IEEE bits of 0.671038 in the browser — that conversion
+ * does not match the measured decimal, and claiming it would.
+ */
+
+import { E219_HELP, PRE_FIX_PRINT_CAP, splitAtPrintCap } from './diagnosticHonesty';
+
+export type FabricationKind = 'silent-zero' | 'bit-pattern' | 'truncated';
+
+export type FabricationReading =
+  | {
+      state: 'fabricated';
+      kind: FabricationKind;
+      printed: string;
+      actual: string;
+    }
+  | {
+      state: 'vacuous';
+      kind: FabricationKind;
+      reason: 'faces-identical' | 'empty-face';
+    };
+
+export function facesAreDistinct(printed: string, actual: string): boolean {
+  return printed.length > 0 && actual.length > 0 && printed !== actual;
+}
+
+export function readFabrication(
+  kind: FabricationKind,
+  printed: string,
+  actual: string,
+): FabricationReading {
+  if (printed.length === 0 || actual.length === 0) {
+    return { state: 'vacuous', kind, reason: 'empty-face' };
+  }
+  if (printed === actual) {
+    return { state: 'vacuous', kind, reason: 'faces-identical' };
+  }
+  return { state: 'fabricated', kind, printed, actual };
+}
+
+/** #1792 — Madaros printed var=0.000000; lean_single shows ~1e-5. */
+export const SILENT_ZERO_PRINTED = '0.000000';
+export const SILENT_ZERO_ACTUAL = '~1e-5';
+
+/**
+ * #1792 — Madaros printed this decimal as AUC confidence.
+ * Documented as IEEE-bit-pattern-as-decimal of lean_single 0.671038
+ * in PR #1792 / pbpk28_epistemic_v1.md. Stored as text.
+ */
+export const BIT_PATTERN_PRINTED = '4604219396932172800';
+export const BIT_PATTERN_ACTUAL = '0.671038';
+
+export function truncatedE219Help(): FabricationReading {
+  const split = splitAtPrintCap(E219_HELP, PRE_FIX_PRINT_CAP);
+  if (!split.wouldTruncate) {
+    return { state: 'vacuous', kind: 'truncated', reason: 'faces-identical' };
+  }
+  return readFabrication('truncated', split.kept, split.dropped);
+}
+
+export const KIND_LABEL: Record<FabricationKind, string> = {
+  'silent-zero': 'Silent zero',
+  'bit-pattern': 'Bit-pattern ε',
+  truncated: 'Truncated diagnostic',
+};


### PR DESCRIPTION
## Summary

The four landed instruments cover verified, uncertain, refused, and the diagnostic. The dangerous state had no face: **FABRICATED** — a value that looks like a given and is not.

`FabricatedDatum` is that face. It is not a fifth colour token (none exists in `global.css`). The printed face uses `--color-text-primary` so it looks like data; the tear uses the refused triad; the other reading uses verified text. The kernel (`fabricationHonesty.ts`) stores the AUC integer as text — it exceeds JS 2^53 — and **refuses to draw a tear when printed === actual** (a vacuous witness would itself be a fabrication).

Three measured cases on `/honesty` §04:

| Kind | Printed as given | Other reading | Source |
|---|---|---|---|
| Silent zero | `var=0.000000` | lean_single `~1e-5` | #1792 OPEN |
| Bit-pattern ε | `4604219396932172800` | `0.671038` | #1792 OPEN · `pbpk28_epistemic_v1.md` |
| Truncated diagnostic | first 127 of E219 help | 206 chars dropped mid-word | #1794 · #1784 closed the path |

The meter still refuses to print the fake numeral. This control exhibits the lie. They are complementary, not duplicates.

Tokens only from `website/src/styles/global.css`.

## Test plan

- [x] `npm run check:astro` (0 / 0 / 0)
- [x] `npm run check:i18n`
- [x] E219 help length 333, drop 206, wouldTruncate true (positive control for `truncated`)
- [x] `readFabrication("silent-zero", "0", "0")` is vacuous (positive control for the anti-fabrication guard)
- [ ] CI Website job (do not run `check:quality` / `build` locally)
- [ ] Confirm `/honesty#fabricated` shows three torn faces, none of them a clean given