### PR TITLE
fix(madaros): preserve Box payload layout through lowering

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -38,6 +38,9 @@ struct LowerLocalStack {
     // -1 = not a capturing closure; otherwise the synthetic closure fn_id whose captures
     // must be injected when this local is called (closures step 2).
     closure_fn_id: [i64; 4096],
+    // Layout-table index of T for a local or parameter whose runtime value is Box<T>.
+    // struct_types remains "Box" because explicit deref relies on that tag.
+    box_inner_layout: [i64; 4096],
     count: i64,
 }
 
@@ -60,6 +63,7 @@ fn empty_lower_local_stack() -> LowerLocalStack {
         tuple_float_mask: [0; 4096],
         variance_regs: [-1; 4096],
         closure_fn_id: [-1; 4096],
+        box_inner_layout: [-1; 4096],
         count: 0,
     }
 }
@@ -2341,7 +2345,7 @@ fn lowerer_preseed_external_struct_items_mut(
                                                 // instead of a direct load, corrupting the value. Compute
                                                 // the real class from the field type, matching
                                                 // ir_fast_summary_register_struct_fields_owned.
-                                                is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_integer(&(*flist).head.ty) { 3 } else if lower_type_expr_is_bool(&(*flist).head.ty) { 3 } else { 0 },
+                                                is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_integer(&(*flist).head.ty) { 3 } else if lower_type_expr_is_bool(&(*flist).head.ty) { 3 } else if lower_type_expr_is_box(&(*flist).head.ty) { 4 } else { 0 },
                                                 elem_type_name_id: ir_intern_name(lower_type_expr_array_elem_name(&(*flist).head.ty)),
                                                 word_scalar_array_len: lower_type_expr_word_scalar_array_len(&(*flist).head.ty),
                                                 named_type_name_id: ir_intern_name(lower_type_expr_named_type_name(&(*flist).head.ty)),
@@ -2527,7 +2531,7 @@ fn lowerer_preseed_external_items_into_acc_mut(
                                             entry.fields[fc as usize] = StructFieldEntry {
                                                 name_id: ir_intern_name((*flist).head.name),
                                                 index: fc,
-                                                is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_integer(&(*flist).head.ty) { 3 } else if lower_type_expr_is_bool(&(*flist).head.ty) { 3 } else { 0 },
+                                                is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_integer(&(*flist).head.ty) { 3 } else if lower_type_expr_is_bool(&(*flist).head.ty) { 3 } else if lower_type_expr_is_box(&(*flist).head.ty) { 4 } else { 0 },
                                                 elem_type_name_id: ir_intern_name(ir_empty_name()),
                                                 word_scalar_array_len: lower_type_expr_word_scalar_array_len(&(*flist).head.ty),
                                                 named_type_name_id: ir_intern_name(lower_type_expr_named_type_name(&(*flist).head.ty)),
@@ -2619,7 +2623,7 @@ fn lowerer_register_struct_fields_direct_mut(
                     // over the same struct_layouts table; a mismatch here would leave the
                     // FIRST-registered field entry — the one actually found by name lookup —
                     // without the i64 marker).
-                    is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_integer(&(*flist).head.ty) { 3 } else if lower_type_expr_is_bool(&(*flist).head.ty) { 3 } else { 0 },
+                    is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_integer(&(*flist).head.ty) { 3 } else if lower_type_expr_is_bool(&(*flist).head.ty) { 3 } else if lower_type_expr_is_box(&(*flist).head.ty) { 4 } else { 0 },
                     elem_type_name_id: ir_intern_name(lower_type_expr_array_elem_name(&(*flist).head.ty)),
                     word_scalar_array_len: lower_type_expr_word_scalar_array_len(&(*flist).head.ty),
                     named_type_name_id: ir_intern_name(lower_type_expr_named_type_name(&(*flist).head.ty)),
@@ -2676,7 +2680,7 @@ fn lowerer_register_struct_fields_mut(
                         name_id: ir_intern_name((*list).head.name),
                         index: field_idx,
                         // println i64-segfault fix: see note in lowerer_register_struct_fields_direct_mut.
-                        is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_integer(&(*list).head.ty) { 3 } else if lower_type_expr_is_bool(&(*list).head.ty) { 3 } else { 0 },
+                        is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_integer(&(*list).head.ty) { 3 } else if lower_type_expr_is_bool(&(*list).head.ty) { 3 } else if lower_type_expr_is_box(&(*list).head.ty) { 4 } else { 0 },
                         elem_type_name_id: ir_intern_name(lower_type_expr_array_elem_name(&(*list).head.ty)),
                         word_scalar_array_len: lower_type_expr_word_scalar_array_len(&(*list).head.ty),
                         named_type_name_id: ir_intern_name(lower_type_expr_named_type_name(&(*list).head.ty)),
@@ -3493,7 +3497,7 @@ fn ir_fast_summary_register_struct_fields_owned(
                     name_id: ir_intern_name((*list).head.name),
                     index: idx,
                     // println i64-segfault fix: see note in lowerer_register_struct_fields_direct_mut.
-                    is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_integer(&(*list).head.ty) { 3 } else if lower_type_expr_is_bool(&(*list).head.ty) { 3 } else { 0 },
+                    is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_integer(&(*list).head.ty) { 3 } else if lower_type_expr_is_bool(&(*list).head.ty) { 3 } else if lower_type_expr_is_box(&(*list).head.ty) { 4 } else { 0 },
                     elem_type_name_id: ir_intern_name(lower_type_expr_array_elem_name(&(*list).head.ty)),
                     word_scalar_array_len: lower_type_expr_word_scalar_array_len(&(*list).head.ty),
                     named_type_name_id: ir_intern_name(lower_type_expr_named_type_name(&(*list).head.ty)),
@@ -3818,10 +3822,25 @@ fn lowerer_bind_local_mut(
         (*locals_box).is_ref[idx as usize] = 0
         (*locals_box).scalar_kind[idx as usize] = 0
         (*locals_box).variance_regs[idx as usize] = -1
+        (*locals_box).box_inner_layout[idx as usize] = -1
         (*locals_box).count = idx + 1
         (*lo).locals = locals_box
     } else {
         lowerer_mark_error(lo)
+    }
+}
+
+fn lowerer_bind_local_box_inner_mut(lo: &! Lowerer, name: Name, layout_idx: i64) with Mut, Alloc, Panic, Div {
+    if layout_idx < 0 { return }
+    var locals_box = (*lo).locals
+    var i = (*locals_box).count - 1
+    while i >= 0 {
+        if (*locals_box).depths[i as usize] <= (*lo).scope_depth && ir_name_eq((*locals_box).names[i as usize], name) {
+            (*locals_box).box_inner_layout[i as usize] = layout_idx
+            (*lo).locals = locals_box
+            return
+        }
+        i = i - 1
     }
 }
 
@@ -4068,6 +4087,10 @@ fn lowerer_lower_fn_params_mut(
                 }
                 if lower_type_expr_is_ref_like(&(*list).head.ty) {
                     lowerer_mark_local_ref_mut(lo, (*list).head.name)
+                }
+                if lower_type_expr_is_box(&(*list).head.ty) {
+                    let inner_layout = lower_struct_layout_index_of(&(*(*lo).struct_layouts), lower_box_inner_type_name(&(*list).head.ty))
+                    lowerer_bind_local_box_inner_mut(lo, (*list).head.name, inner_layout)
                 }
                 if lower_type_expr_is_array_of_f64(&(*list).head.ty) {
                     lowerer_mark_local_array_elem_float_mut(lo, (*list).head.name)
@@ -4988,6 +5011,55 @@ fn lower_call_first_arg_is_int_literal(args: &Option<Box<ExprList>>) -> bool wit
         Some(list) => (*list).head.kind == ExprKind::ExprIntLit,
         _ => false,
     }
+}
+
+// expr_to_callee_name_ref deliberately mangles `Type::method` into `Type_method`.
+// Recognize the Box allocator from its original path so both binding metadata and
+// call lowering make the same decision without treating other `Box::*` methods as new.
+fn lower_callee_is_box_new(callee: &Option<Box<Expr>>, callee_name: Name) -> bool with Mut, Panic, Div, Alloc {
+    match *callee {
+        Some(expr) => {
+            if (*expr).kind == ExprKind::ExprPath {
+                return ir_name_is_box(ir_path_first_name((*expr).path)) &&
+                    ir_name_eq(ir_path_last_name((*expr).path), make_name("new"))
+            }
+            ir_name_is_box(callee_name)
+        }
+        None => false,
+    }
+}
+
+fn lower_type_expr_is_box(ty: &TypeExpr) -> bool with Mut, Panic, Div {
+    (*ty).kind == TypeExprKind::TypeNamed && ir_name_is_box(ir_path_first_name((*ty).path))
+}
+
+fn lower_box_inner_type_name(ty: &TypeExpr) -> Name with Mut, Panic, Div {
+    match (*ty).type_args {
+        Some(list) => ir_path_first_name((*list).head.path),
+        None => ir_empty_name(),
+    }
+}
+
+fn lower_struct_layout_index_of(table: &StructLayoutTable, type_name: Name) -> i64 with Mut, Panic, Div {
+    var i: i64 = 0
+    while i < (*table).count {
+        if ir_name_eq((*table).entries[i as usize].type_name, type_name) { return i }
+        i = i + 1
+    }
+    0 - 1
+}
+
+// This deliberately takes the boxed local stack, not Lowerer by value. A by-value
+// lookup here copied the compiler's largest hot aggregate and broke four prior fixes.
+fn lower_lookup_box_inner_layout(locals: Box<LowerLocalStack>, scope_depth: i64, name: Name) -> i64 with Mut, Panic, Div {
+    var i = (*locals).count - 1
+    while i >= 0 {
+        if (*locals).depths[i as usize] <= scope_depth && ir_name_eq((*locals).names[i as usize], name) {
+            return (*locals).box_inner_layout[i as usize]
+        }
+        i = i - 1
+    }
+    0 - 1
 }
 
 fn lower_opt_type_named_name(opt: &Option<Box<TypeExpr>>) -> Name with Mut, Panic, Div {
@@ -7201,6 +7273,7 @@ impl Lowerer {
                 (*stk).scalar_kind[idx as usize] = 0
                 (*stk).tuple_float_mask[idx as usize] = 0
                 (*stk).variance_regs[idx as usize] = -1
+                (*stk).box_inner_layout[idx as usize] = -1
                 (*stk).count = idx + 1
             lo.locals = stk
         } else {
@@ -7296,6 +7369,38 @@ impl Lowerer {
             i = i - 1
         }
         lo
+    }
+
+    fn bind_local_box_inner_layout(self, name: Name, layout_idx: i64) -> Lowerer with Mut, Alloc, Panic, Div {
+        if layout_idx < 0 { return self }
+        var lo = self
+        var stk = lo.locals
+        var i = (*stk).count - 1
+        while i >= 0 {
+            if (*stk).depths[i as usize] <= lo.scope_depth && ir_name_eq((*stk).names[i as usize], name) {
+                (*stk).box_inner_layout[i as usize] = layout_idx
+                lo.locals = stk
+                return lo
+            }
+            i = i - 1
+        }
+        lo
+    }
+
+    fn expr_first_arg_struct_name_ref(self, call_expr: &Expr) -> Name with Mut, Panic, Div, Alloc {
+        match (*call_expr).args {
+            Some(args) => {
+                let first = &(*args).head
+                if (*first).kind == ExprKind::ExprCall {
+                    return self.expr_call_return_struct_name_ref(first)
+                }
+                if (*first).kind == ExprKind::ExprStructLit {
+                    return ir_path_first_name((*first).path)
+                }
+                ir_empty_name()
+            }
+            None => ir_empty_name(),
+        }
     }
 
     // Mark a local as a capturing closure bound to synthetic fn `fn_id` (closures step 2).
@@ -10228,6 +10333,36 @@ impl Lowerer {
         }
     }
 
+    fn field_is_pointer_for_struct(self, type_name: Name, field_name: Name) -> bool with Mut, Panic, Div {
+        var si: i64 = 0
+        while si < (*self.struct_layouts).count {
+            if ir_name_eq((*self.struct_layouts).entries[si as usize].type_name, type_name) {
+                var fi: i64 = 0
+                while fi < (*self.struct_layouts).entries[si as usize].field_count {
+                    let field = (*self.struct_layouts).entries[si as usize].fields[fi as usize]
+                    if ir_name_eq(ir_name_at(field.name_id), field_name) {
+                        return field.is_float == 4
+                    }
+                    fi = fi + 1
+                }
+            }
+            si = si + 1
+        }
+        false
+    }
+
+    fn field_is_pointer_for_base_ref(self, base_opt: &Option<Box<Expr>>, field_name: Name) -> bool with Mut, Panic, Div, Alloc {
+        match *base_opt {
+            Some(base_expr) => {
+                if (*base_expr).kind == ExprKind::ExprIdent {
+                    return self.field_is_pointer_for_struct(self.lookup_local_struct_type((*base_expr).name), field_name)
+                }
+                false
+            }
+            None => false,
+        }
+    }
+
     fn field_idx_for_base_ref(self, base_opt: &Option<Box<Expr>>, field_name: Name) -> i64 with Mut, Panic, Div, Alloc {
         match *base_opt {
             Some(base_expr) => {
@@ -10918,7 +11053,7 @@ impl Lowerer {
                             // that would strlen the bool value 1 as a pointer (SIGSEGV).
                             // Marker 3 is consumed only by field_is_int_* (println
                             // dispatch), so this is inert for float/array/store paths.
-                            is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_integer(&(*list).head.ty) { 3 } else if lower_type_expr_is_bool(&(*list).head.ty) { 3 } else { 0 },
+                            is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_integer(&(*list).head.ty) { 3 } else if lower_type_expr_is_bool(&(*list).head.ty) { 3 } else if lower_type_expr_is_box(&(*list).head.ty) { 4 } else { 0 },
                             elem_type_name_id: ir_intern_name(lower_type_expr_array_elem_name(&(*list).head.ty)),
                             word_scalar_array_len: lower_type_expr_word_scalar_array_len(&(*list).head.ty),
                             named_type_name_id: ir_intern_name(lower_type_expr_named_type_name(&(*list).head.ty)),
@@ -11656,6 +11791,11 @@ impl Lowerer {
                         (*locals).wide_bits[idx as usize] = 0
                         (*locals).wide_signed[idx as usize] = 0
                         (*locals).is_ref[idx as usize] = if lower_type_expr_is_ref_like(&(*list).head.ty) { 1 } else { 0 }
+                        (*locals).box_inner_layout[idx as usize] = if lower_type_expr_is_box(&(*list).head.ty) {
+                            lower_struct_layout_index_of(&(*lo.struct_layouts), lower_box_inner_type_name(&(*list).head.ty))
+                        } else {
+                            0 - 1
+                        }
                         // D5+D1 (#986+#983): f64 params → kind 2 (cast + float-print);
                         // word-size integer params (i8..i64/u8..u64/isize/usize) → kind 1
                         // (println safety). Bare int `as i64` stays identity because only
@@ -12842,11 +12982,12 @@ impl Lowerer {
                         Some(c) => lo.expr_to_callee_name_ref(&(*c)),
                         None => ir_empty_name(),
                     }
+                    let callee_is_box_new = lower_callee_is_box_new(callee_opt_struct_ref, callee_struct_name)
                     // measure(...) → Knowledge (return-name lookup often misses builtins)
                     if ir_name_is_measure(callee_struct_name) {
                         lo = lo.bind_local_struct_type(s.name, make_name("Knowledge"))
                     }
-                    if !ir_name_is_box(callee_struct_name) {
+                    if !callee_is_box_new {
                         let ret_name = lo.expr_call_return_struct_name_ref(&(*expr_box))
                         if ret_name.len > 0 {
                             lo = lo.bind_local_struct_type(s.name, ret_name)
@@ -12855,7 +12996,10 @@ impl Lowerer {
                         // `let b = Box::new(...)`: tag the local's struct-type slot with
                         // "Box" so `*b` lowers to a field-0 read (box deref through the
                         // handle) rather than a raw IrUnaryOp(OpDeref) pointer load.
-                        lo = lo.bind_local_struct_type(s.name, callee_struct_name)
+                        lo = lo.bind_local_struct_type(s.name, make_name("Box"))
+                        let inner_name = lo.expr_first_arg_struct_name_ref(&(*expr_box))
+                        let inner_layout = lower_struct_layout_index_of(&(*lo.struct_layouts), inner_name)
+                        lo = lo.bind_local_box_inner_layout(s.name, inner_layout)
                     }
                 } else if (*expr_box).kind == ExprKind::ExprMethodCall {
                     // `let s = a.add(&b)`: bind s to the method's return struct so
@@ -14864,7 +15008,7 @@ impl Lowerer {
         if ir_name_is_some(callee_name) {
             return self.lower_expr_args_first(&e.args)
         }
-        if ir_name_is_box(callee_name) {
+        if lower_callee_is_box_new(callee_opt_ref, callee_name) {
             return self.lower_box_new(&e.args)
         }
         if ir_name_is_prove_robust(callee_name) {
@@ -15250,10 +15394,39 @@ impl Lowerer {
             lo_t = lo_t.emit(ir_load_imm(dst_t, 0))
             return (lo_t, dst_t)
         }
+        let base_field_is_box = match e.left {
+            Some(base_expr) => {
+                if (*base_expr).kind == ExprKind::ExprFieldAccess {
+                    self.field_is_pointer_for_base_ref(&(*base_expr).left, (*base_expr).name)
+                } else {
+                    false
+                }
+            }
+            None => false,
+        }
         let pair_b = self.lower_opt_expr_ref(&e.left)
-        let lo1 = pair_b.0
-        let base = pair_b.1
-        let fidx = lo1.field_idx_for_base_ref(&e.left, e.name)
+        var lo1 = pair_b.0
+        var base = pair_b.1
+        let box_inner_layout = match e.left {
+            Some(base_expr) => {
+                if (*base_expr).kind == ExprKind::ExprIdent {
+                    lower_lookup_box_inner_layout(lo1.locals, lo1.scope_depth, (*base_expr).name)
+                } else {
+                    0 - 1
+                }
+            }
+            None => 0 - 1,
+        }
+        if box_inner_layout >= 0 || base_field_is_box {
+            let pair_box_value = lo1.fresh_reg()
+            lo1 = pair_box_value.0.emit(ir_field_get(pair_box_value.1, base, 0, ir_empty_name()))
+            base = pair_box_value.1
+        }
+        let fidx = if box_inner_layout >= 0 {
+            lo1.field_idx_from_name((*lo1.struct_layouts).entries[box_inner_layout as usize].type_name, e.name)
+        } else {
+            lo1.field_idx_for_base_ref(&e.left, e.name)
+        }
         // Tuple desugar: let __tup = f(); let a = __tup.0 — float-element base
         // means .0/.1 are f64 even without a struct layout entry.
         var field_is_float = lo1.field_is_float_for_base_ref(&e.left, e.name) || lo1.field_is_float_by_name_simple(e.name)


### PR DESCRIPTION
## What changed

- recognize `Box::new` from the original `Box::new` AST path before call-name mangling turns it into `Box_new`
- preserve the boxed payload layout for parameters and locals in a side table while retaining the existing `Box` tag used by explicit dereference
- mark `Box<T>` struct fields as pointer-bearing and emit the missing payload dereference before auto-deref field access
- read the side table through the boxed local stack, avoiding the by-value `Lowerer` copy that invalidated four earlier attempts

## Measured evidence

Source-built Madaros on Slurm job `10166` (`gpuorangefs-r770-proxmox`):

- build rc 0, ELF sha256 `2489a51f20a0c89565e59ce768b0d31ba53587df76099531161178546119c192`
- explicit Box deref witness: rc 0, `RESULT: box return deref boundary stable`
- full `box_all_read_forms.sio`: rc 0, `BOXMATRIX OK`
- nested type-hash control: rc 0, `type-hash 3-level PASS`

Fresh source build plus full gate on Slurm job `10167`:

- build rc 0 with the same ELF sha256
- `madaros_full_gate.sh`: rc 0
- imported dereferenced f64-array current-source gate: PASS

This independently confirms the two-stage upstream mechanism reported by empryo-1: Box allocation recognition was dead after name mangling, and payload layout metadata was absent at field lowering. No backend change is required.