### PR TITLE
fix(mli): unwritten pool slots refuse — opcode 0 is not a silent NOP

### DIFF
--- a/self-hosted/mli/interp.sio
+++ b/self-hosted/mli/interp.sio
@@ -21,7 +21,9 @@
 //      Int≠64, Float≠64) refuse at load with MLI_I_ARG_KIND. Skipping
 //      them and continuing was #1801: the checker returned the declared
 //      type after a refuse, and the caller read a fabricated inhabitant.
-//      They are not loaded as zero.
+//      They are not loaded as zero. Unwritten pool slots refuse with
+//      MLI_I_UNWIRED_SLOT — i_op zero-inits to NOP, which is #1830
+//      (a field returning 0 with nobody writing it).
 //   2. Where behaviour IS defined, the interp delegates to the host — and
 //      the host is the claim oracle itself (Sounio under Madaros, ADR-008
 //      single semantic clock). i64 two's-complement arithmetic, IEEE f64
@@ -66,6 +68,7 @@ pub let MLI_I_FUEL: i64 = 11
 pub let MLI_I_BAD_TARGET: i64 = 12
 pub let MLI_I_UNDEF_VREG: i64 = 13
 pub let MLI_I_CALL_UNSPECIFIED: i64 = 14
+pub let MLI_I_UNWIRED_SLOT: i64 = 15
 
 // Execution budget: control flow means loops, and a non-terminating program
 // must fail LOUDLY rather than hang (refuse-first applied to termination).
@@ -151,6 +154,10 @@ fn rf_mark(rf: &!MliRegFile, id: i64) with Mut, Panic {
 // fields in some closures; see the landing hazard in mli::ir). Returns
 // MLI_I_OK or an error code; NOP/KEEP_ALIVE are OK no-ops.
 fn mli_exec_slot(rf: &!MliRegFile, f: &MliFunction, slot: i64) -> i64 with Mut, Panic, Div {
+    // Opcode 0 is NOP. An unwritten slot also reads as 0. Executing that
+    // as a successful no-op is #1830 (pin_count returned 0 with nobody
+    // writing it). Presence is the i_live column, not the opcode.
+    if mli_slot_live(f, slot) != 1 { return MLI_I_UNWIRED_SLOT }
     let op = mli_slot_opcode(f, slot)
     let cc = mli_slot_cc(f, slot)
     let d = mli_slot_dst(f, slot)
@@ -430,6 +437,7 @@ pub fn mli_interp_run(f: &MliFunction, args: &MliInterpArgs) -> MliInterpResult 
 
         fuel = fuel - 1
         let ts = mli_term_slot(cur)
+        if mli_slot_live(f, ts) != 1 { return i_err(MLI_I_UNWIRED_SLOT, cur, 0 - 1) }
         let top = mli_slot_opcode(f, ts)
 
         if top == MLI_OP_RET {

--- a/self-hosted/mli/ir.sio
+++ b/self-hosted/mli/ir.sio
@@ -455,6 +455,10 @@ pub struct MliFunction {
     pub overflowed: bool,
     pub overflow_detail: string,
     // Instruction pool (SoA columns; see storage layout note above).
+    // i_live is the #1830 bit: i_op zero-inits to NOP (0), so an unwritten
+    // slot is a plausible successful no-op unless presence is separate.
+    // 0 = nobody wrote this slot; 1 = mli_inst_put ran. Scalar column only.
+    pub i_live: [i64; 528],
     pub i_op: [i64; 528],
     pub i_cc: [i64; 528],
     pub i_assoc: [i64; 528],
@@ -481,6 +485,7 @@ pub fn mli_func_empty() -> MliFunction {
         vreg_count: 0,
         overflowed: false,
         overflow_detail: "",
+        i_live: [0; 528],
         i_op: [0; 528],
         i_cc: [0; 528],
         i_assoc: [0; 528],
@@ -496,6 +501,7 @@ pub fn mli_func_empty() -> MliFunction {
 // Store an instruction value into a pool slot (column-wise scalar and
 // MliOperand stores only — the verified-safe shapes).
 pub fn mli_inst_put(f: &!MliFunction, slot: i64, inst: MliInst) with Mut, Panic {
+    f.i_live[slot] = 1
     f.i_op[slot] = inst.opcode
     f.i_cc[slot] = inst.cc
     f.i_assoc[slot] = inst.assoc_policy
@@ -527,6 +533,10 @@ pub fn mli_inst_dst(inst: MliInst) -> MliOperand {
 // or a single MliOperand (88 B), whose local landings are S1-proven, and
 // never materialise a full MliInst (see the landing hazard below).
 // ---------------------------------------------------------------------------
+
+pub fn mli_slot_live(f: &MliFunction, slot: i64) -> i64 with Panic {
+    f.i_live[slot]
+}
 
 pub fn mli_slot_opcode(f: &MliFunction, slot: i64) -> i64 with Panic {
     f.i_op[slot]

--- a/self-hosted/mli/s2a_gate_runner.sio
+++ b/self-hosted/mli/s2a_gate_runner.sio
@@ -538,6 +538,39 @@ fn case_interp_refuses_call() -> i64 with IO, Mut, Panic, Div {
     report_pass("I11 CALL REFUSED by interp with named code (no rax after empty stub)")
 }
 
+// I12: #1830 class — opcode 0 is NOP. Bumping blk_instr_count after a
+// green verify walks a slot nobody wrote; that used to execute as a
+// successful no-op. Poke is the SoA count column only.
+fn case_interp_refuses_unwired_slot() -> i64 with IO, Mut, Panic, Div {
+    var f = build_add_i64()
+    let vs = mli_verify_function(&f)
+    if vs.code != MLI_VERR_OK { return report_fail("I12 unwired", "pre-verify", vs.code, 0) }
+    f.blk_instr_count[0] = f.blk_instr_count[0] + 1
+    var args = mli_interp_args_empty()
+    args.ai[0] = 3
+    args.ai[1] = 4
+    let res = mli_interp_run(&f, &args)
+    if res.ok { return report_fail("I12 unwired", "silent-nop", MLI_I_OK, MLI_I_UNWIRED_SLOT) }
+    if res.has_value { return report_fail("I12 unwired", "value-after-refuse", 1, 0) }
+    if res.code != MLI_I_UNWIRED_SLOT {
+        return report_fail("I12 unwired", "code", res.code, MLI_I_UNWIRED_SLOT)
+    }
+    if res.index != 1 { return report_fail("I12 unwired", "slot", res.index, 1) }
+    report_pass("I12 unwritten slot REFUSED by interp (not a silent NOP)")
+}
+
+// I13: verify must not stamp OK on the same ghost slot. #1801: returning
+// the declared well-formedness after reading a zero nobody wrote.
+fn case_verify_refuses_unwired_slot() -> i64 with IO, Mut, Panic, Div {
+    var f = build_add_i64()
+    f.blk_instr_count[0] = f.blk_instr_count[0] + 1
+    let vs = mli_verify_function(&f)
+    if vs.code != MLI_VERR_UNWIRED_SLOT {
+        return report_fail("I13 unwired verify", "code", vs.code, MLI_VERR_UNWIRED_SLOT)
+    }
+    report_pass("I13 unwritten slot is a VERIFY error (not a silent NOP)")
+}
+
 fn main() -> i64 with IO, Mut, Panic, Div {
     println("=== MLI S2a gate: ir_to_mli (straight-line i64/f64) + minimal interp ===")
     if ir_instr_arena_init() != IR_ARENA_OK {
@@ -573,6 +606,8 @@ fn main() -> i64 with IO, Mut, Panic, Div {
     failures = failures + case_interp_refuses_uninhabited_arg()
     failures = failures + case_interp_refuses_narrow_int_arg()
     failures = failures + case_interp_refuses_call()
+    failures = failures + case_interp_refuses_unwired_slot()
+    failures = failures + case_verify_refuses_unwired_slot()
 
     if failures == 0 {
         println("=== MLI S2a: ALL CASES PASS ===")

--- a/self-hosted/mli/verify.sio
+++ b/self-hosted/mli/verify.sio
@@ -57,6 +57,7 @@ pub let MLI_VERR_IMM_KIND: i64 = 21
 pub let MLI_VERR_BLOCK_ID: i64 = 22
 pub let MLI_VERR_ARG_PREFIX: i64 = 23
 pub let MLI_VERR_CALL_UNSPECIFIED: i64 = 24
+pub let MLI_VERR_UNWIRED_SLOT: i64 = 25
 
 pub struct MliVerifyResult {
     pub ok: bool,
@@ -633,6 +634,9 @@ pub fn mli_verify_function(f: &MliFunction) -> MliVerifyResult with Mut, Panic {
         var j: i64 = 0
         while j < f.blk_instr_count[b] {
             let slot = mli_slot(b, j)
+            // Unwritten pool slot reads as NOP (opcode 0). Stamping OK
+            // here is #1830: a field returning zero nobody wrote.
+            if mli_slot_live(f, slot) != 1 { return verr(MLI_VERR_UNWIRED_SLOT, b, j) }
             let d = mli_slot_dst(f, slot)
             let s1 = mli_slot_src1(f, slot)
             let s2 = mli_slot_src2(f, slot)
@@ -651,6 +655,7 @@ pub fn mli_verify_function(f: &MliFunction) -> MliVerifyResult with Mut, Panic {
         }
 
         let ts = mli_term_slot(b)
+        if mli_slot_live(f, ts) != 1 { return verr(MLI_VERR_UNWIRED_SLOT, b, 0 - 1) }
         let td = mli_slot_dst(f, ts)
         let ts1 = mli_slot_src1(f, ts)
         let ts2 = mli_slot_src2(f, ts)


### PR DESCRIPTION
## Summary
- `MLI_OP_NOP = 0` is also the zero-init of the SoA `i_op` column. A slot nobody wrote executed as a successful no-op — the same class as #1830 (`pin_count` returned 0 with nobody writing it) and #1801 (declared well-formedness after a refuse).
- Presence is a new SoA column `i_live`, set only by `mli_inst_put`. Interp returns `MLI_I_UNWIRED_SLOT` (15); verify returns `MLI_VERR_UNWIRED_SLOT` (25). Instruction pool stays SoA.
- I12 pokes `blk_instr_count` after a green verify (scalar column only). I13 is the verify twin. I7 still pokes a live slot to `NOP` and refuses UNDEF on the unread dest.

## Test plan
- [x] `./bin/souc run self-hosted/mli/s2a_gate_runner.sio` (I1–I13)
- [x] `./bin/souc run self-hosted/mli/self_test_runner.sio`
- [x] `./bin/souc run self-hosted/mli/s2b_gate_runner.sio`
- [x] `./bin/souc run self-hosted/mli/s3_gate_runner.sio`
- [x] `./bin/souc run self-hosted/mli/s3b_gate_runner.sio`