### PR TITLE
docs(audit): 468 CI gates — 390 is the mention bound, not the leftover

### DIFF
--- a/docs/audit/CI_GATE_WORKFLOW_REACHABILITY_CENSUS_2026-08-18.md
+++ b/docs/audit/CI_GATE_WORKFLOW_REACHABILITY_CENSUS_2026-08-18.md
@@ -1,0 +1,136 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.ci-gate-workflow-reachability-census-2026-08-18
+authority: repo_only
+audience: users
+last_validated: 2026-08-18
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.ci-gate-workflow-reachability-census-2026-08-18
+-->
+
+# CI gate workflow reachability census
+
+**Date:** 2026-08-18  
+**SHA measured:** `465008a76b` (`origin/main` at census)  
+**Instrument:** `python3 scripts/dev/ci_gate_workflow_reachability.py`  
+**Table:** [`CI_GATE_WORKFLOW_REACHABILITY_CENSUS_2026-08-18.tsv`](CI_GATE_WORKFLOW_REACHABILITY_CENSUS_2026-08-18.tsv)
+
+This is a **census**, not a cleanup. Nothing was wired. Wiring the leftover set in one pull request would break CI and would repeat the #1778 failure mode in reverse: a green tick that does not mean the intended surface ran.
+
+## Why 390 is not a fact
+
+A basename grep of `.github/` finds **78** of **468** `scripts/ci/*_gate.sh` files and therefore **390** unmentioned names. That 390 is an **upper bound on direct orphans**, not a count of gates the CI never runs:
+
+- a workflow can invoke a gate only through another script (umbrella, `madaros_full_gate.sh`, `package_pbpk_gum_gate.sh`);
+- `scripts/ci/gate_vacuity_gate.sh` **lists** every `*_gate.sh` via `git ls-files` and does **not** execute them — treating that list as reachability would zero the leftover set and invent a green;
+- a name can appear in a comment (`madaros_corpus_regression_gate.sh` is named in `ci.yml` as *deliberately NOT wired*).
+
+Saying “390 orphans” as a fact is the same class of error the day spent closing: a plausible number where an absence should have been declared.
+
+## Instrument (validated before the count)
+
+| Control | What would refute the instrument | Result |
+|---|---|---|
+| Reachable set non-empty | `workflow_reachable_transitive = 0` | **85** |
+| Named direct orphans stay unreachable | any of the three #1780-family gates appears in the invoke graph | all three **unreachable** |
+| Vacuity lister is not an invoker | leftover collapses toward 0 because `gate_vacuity_gate.sh` is in `ci.yml` | leftover stays **383** |
+
+Regenerate:
+
+```text
+python3 scripts/dev/ci_gate_workflow_reachability.py
+```
+
+Roots are `.github/workflows/*.yml` only. Edges are real invocations (`bash`/`sh`/`source`, YAML `run:`, `for g in scripts/ci/…_gate.sh` continuation lines, and `make <target>` recipes when a workflow actually runs that target). Comments and `git ls-files` / `find` inventories are not edges.
+
+The only `make` a workflow runs today is `make build-madaros` (`madaros-prebuilt-refresh.yml`). That target does not pull the `make check` gate forest. Makefile-only gates are therefore **not** workflow-reachable.
+
+## Measured totals
+
+| Quantity | N | What it is |
+|---:|---:|---|
+| `scripts/ci/*_gate.sh` | 468 | population |
+| Named in `.github/` (any file, including comments) | 78 | the grep that produced 390 |
+| Mention-only leftover upper bound (468−78) | 390 | **not** the leftover |
+| Workflow-reachable after transitive invoke | **85** | includes 8 gates never named in `.github/` |
+| Named in `.github/` but not invoked | 1 | `madaros_corpus_regression_gate.sh` (comment only) |
+| Leftover (468−85) | **383** | not reachable from any workflow at any depth |
+
+Eight gates are reachable **only** transitively (not named in `.github/`):
+
+| Gate | Via |
+|---|---|
+| `generated_ontology_gate.sh` | `run_ontology_validation.sh` |
+| `madaros_blocker_contract_gate.sh` | `claude_operational_contract_gate.sh` |
+| `madaros_global_capacity_gate.sh` | `madaros_current_source_f64_lowering_gate.sh` |
+| `madaros_global_f64_scratch_gate.sh` | same |
+| `madaros_imported_call_arity_13_gate.sh` | same |
+| `madaros_imported_capacity_gate.sh` | same |
+| `madaros_imported_deref_f64_array_gate.sh` | f64-lowering + `madaros_full_gate.sh` |
+| `package_import_science_gate.sh` | `package_pbpk_gum_gate.sh`, `sounio_package_support_gate.sh` |
+
+## Leftover classification (383)
+
+Buckets are **evidence-only**. A leftover without a header or an operator entry point stays `unclassified`. Forcing 317 names into “obsolete” would be another fabricated zero.
+
+| Class | N | Rule |
+|---|---:|---|
+| `forgotten` | 10 | intended as a CI measurement (named orphan, or header `GATE_CONTRACT` / “positive control”) and no operator entry (Makefile / umbrella / dissertation / Slurm) |
+| `manual-by-design` | 56 | dissertation_* , `bootstrap_chain_gate.sh`, or invoked from Makefile / `native_v2_cpu_compiler_umbrella_gate.sh` (operator / Slurm / `make check`) |
+| `obsolete` | 0 | header comment says obsolete / superseded / do not use — **none matched** after excluding code-token hits |
+| `unclassified` | 317 | leftover, no evidence for the three buckets above |
+
+### Forgotten (10) — #1778 shape
+
+A gate that can fail its own positive control, and that no workflow runs, is indistinguishable from a gate that passes. That is the #1778 contract.
+
+| Gate | Why forgotten, not manual |
+|---|---|
+| `epistemic_measure_correspondence_gate.sh` | #1780 Lean↔checker correspondence; positive controls in-file; **not** in any workflow |
+| `epistemic_fabrication_detect_gate.sh` | silent zero-variance / out-of-range confidence; `GATE_CONTRACT`; **not** in any workflow |
+| `madaros_ontology_enforcement_gate.sh` | inverse-role witnesses + valid control; **not** in any workflow |
+| `f64_bitcast_sitofp_boundary_gate.sh` | F2 confidence fabrication; `GATE_CONTRACT` |
+| `madaros_f128_f256_ladder_gate.sh` | V0-B must FAIL under V0-A; positive control named |
+| `madaros_f128_f256_v0c_wire_gate.sh` | same ladder family, `GATE_CONTRACT` in header |
+| `madaros_f128_f256_v0d_softfloat_gate.sh` | same |
+| `madaros_print_f64_negative_gate.sh` | residual #890; positive control `+2.0` |
+| `mli_s3_bit_identity_gate.sh` | S3 O5 bit-identity; positive control on IEEE 1.0 / `ret` |
+| `stdlib_source_byte_ceiling_gate.sh` | E229 wall; must FAIL if a file exceeds CAP |
+
+Adjacent, not auto-bucketed: `ci.yml` line 515 says `madaros_corpus_regression_gate.sh` is **deliberately NOT wired**. That is a declared absence, not a silent one. It remains leftover.
+
+### Manual-by-design (56) — includes the six dissertation gates and bootstrap
+
+All six dissertation gates are leftover:
+
+- `dissertation_confidence_gate_gate.sh`
+- `dissertation_dossier_gate.sh`
+- `dissertation_frontend_parity_gate.sh`
+- `dissertation_pbpk28_parity_gate.sh`
+- `dissertation_pbpk_hessian_gate.sh`
+- `dissertation_pbpk_suite_gate.sh`
+
+`dissertation_pbpk_suite_gate.sh` **is** called by `native_v2_cpu_compiler_umbrella_gate.sh`. The umbrella is **not** in any workflow (handoff / Slurm / operator). So the suite is operator-reachable and workflow-unreachable. That is manual-by-design, not forgotten.
+
+`bootstrap_chain_gate.sh` is the same shape: local bootstrap proof, no workflow edge.
+
+The rest of the 56 are Makefile `check` / ontology / knowledge-runtime / suffering-aware / umbrella children. They have an operator entry. They do not have a GitHub Actions entry.
+
+### Unclassified (317)
+
+Largest name-prefixes: `madaros_*` (43), `native_*` (34), `fo_*` (29), `kretikos_*` (24), then semantic / mercyful / particle / moonshot / proof-carrying. This census does **not** call them obsolete. A second pass can split them once each header is read; doing that from the filename would fabricate a class.
+
+## What this does not authorise
+
+- Wiring the 383 leftovers.
+- Wiring even the 10 forgotten gates in this change-set — each needs its own cost, skip rules, and a demonstrated positive control in CI, not a bulk `for g in scripts/ci/*_gate.sh`.
+- Treating `make check` as CI. It is not, until a workflow runs that target.
+
+## Next-Command (if a later lane wires)
+
+Start with the three already shown to fire their positive controls and to be absent from every workflow:
+
+1. `epistemic_measure_correspondence_gate.sh`
+2. `epistemic_fabrication_detect_gate.sh`
+3. `madaros_ontology_enforcement_gate.sh`
+
+One gate per pull request. Re-run this instrument after each wire; the forgotten count must fall by exactly one, and the reachable count must rise by exactly one.

--- a/docs/audit/CI_GATE_WORKFLOW_REACHABILITY_CENSUS_2026-08-18.tsv
+++ b/docs/audit/CI_GATE_WORKFLOW_REACHABILITY_CENSUS_2026-08-18.tsv
@@ -1,0 +1,469 @@
+gate	reachable	class	depth	origin_workflow	via	direct_github_mention
+168_biology_validation_gate.sh	no	unclassified	0			no
+ade_wildgen_mckay_gate.sh	no	unclassified	0			no
+arm64_nested_store_witness_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+associator_gum_variance_gate.sh	no	unclassified	0			no
+bootstrap_chain_gate.sh	no	manual-by-design	0			no
+brain_ossm_sigmoid_polarity_gate.sh	no	unclassified	0			no
+canonical_compiler_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+cd_tower_nullity_histogram_law_gate.sh	no	unclassified	0			no
+cd_tower_seam_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+cd_zd_graph_invariants_gate.sh	no	unclassified	0			no
+chingon_zd_gate.sh	no	unclassified	0			no
+claim_ast_gate.sh	no	unclassified	0			no
+claim_native_gate.sh	no	unclassified	0			no
+claude_operational_contract_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+compiler_lane_status_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+compiler_stage_contract_gate.sh	no	unclassified	0			no
+cpc2026_yale_evidence_gate.sh	no	unclassified	0			no
+deep_four_lane_gate.sh	no	unclassified	0			no
+dissertation_confidence_gate_gate.sh	no	manual-by-design	0			no
+dissertation_dossier_gate.sh	no	manual-by-design	0			no
+dissertation_frontend_parity_gate.sh	no	manual-by-design	0			no
+dissertation_pbpk28_parity_gate.sh	no	manual-by-design	0			no
+dissertation_pbpk_hessian_gate.sh	no	manual-by-design	0			no
+dissertation_pbpk_suite_gate.sh	no	manual-by-design	0		umbrella	no
+dyadic_non_reduction_gate.sh	no	unclassified	0			no
+dyadic_relational_associator_gate.sh	no	unclassified	0			no
+e219_engine_oracle_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+e219_refusal_correspondence_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+e_series_semantic_germ_gate.sh	no	unclassified	0			no
+effects_handler_interaction_lean_gate.sh	no	unclassified	0			no
+eisa_bridge_conformance_gate.sh	no	unclassified	0			no
+eisa_h_zd_reference_gate.sh	no	unclassified	0			no
+ekan_native_core_gate.sh	no	unclassified	0			no
+engine_parity_gate.sh	no	unclassified	0			no
+epistemic_egraph_rewrite_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+epistemic_fabrication_detect_gate.sh	no	forgotten	0			no
+epistemic_measure_correspondence_gate.sh	no	forgotten	0			no
+epistemic_monotonicity_gate.sh	no	unclassified	0			no
+epistemic_multidrug_gate.sh	no	unclassified	0			no
+epistemic_pbpk_gate.sh	no	unclassified	0			no
+epistemic_witness_gate.sh	no	unclassified	0			no
+exact_bitwise_rebracket_authority_gate.sh	no	unclassified	0			no
+exact_bitwise_rebracket_source_ir_gate.sh	no	unclassified	0			no
+extern_builtin_mirror_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+f64_bitcast_sitofp_boundary_gate.sh	no	forgotten	0			no
+falsification_ledger_gate.sh	no	unclassified	0			no
+federated_san_gate.sh	no	manual-by-design	0			no
+ffi_posix_builtin_gate.sh	no	unclassified	0			no
+float_slot_capacity_coherence_gate.sh	no	unclassified	0			no
+fo_bytecode_fragment_gate.sh	no	unclassified	0			no
+fo_css_surface_parity_gate.sh	no	unclassified	0			no
+fo_emit_pure_gate.sh	no	unclassified	0			no
+fo_engine_install_fragment_gate.sh	no	unclassified	0			no
+fo_method_xfer_fragment_gate.sh	no	unclassified	0			no
+fo_multimod_fragment_gate.sh	no	unclassified	0			no
+fo_pk_import_auc_thalf_driver_gate.sh	no	unclassified	0			no
+fo_pk_import_auct_driver_gate.sh	no	unclassified	0			no
+fo_pk_import_cmax_driver_gate.sh	no	unclassified	0			no
+fo_pk_import_fss_driver_gate.sh	no	unclassified	0			no
+fo_pk_import_ld_driver_gate.sh	no	unclassified	0			no
+fo_pk_import_method_driver_gate.sh	no	unclassified	0			no
+fo_pk_import_mrt_driver_gate.sh	no	unclassified	0			no
+fo_pk_import_ptr_driver_gate.sh	no	unclassified	0			no
+fo_pk_import_rac_driver_gate.sh	no	unclassified	0			no
+fo_pk_struct_auc_thalf_driver_gate.sh	no	unclassified	0			no
+fo_pk_struct_auct_driver_gate.sh	no	unclassified	0			no
+fo_pk_struct_cmax_driver_gate.sh	no	unclassified	0			no
+fo_pk_struct_fss_driver_gate.sh	no	unclassified	0			no
+fo_pk_struct_ld_driver_gate.sh	no	unclassified	0			no
+fo_pk_struct_method_driver_gate.sh	no	unclassified	0			no
+fo_pk_struct_mrt_driver_gate.sh	no	unclassified	0			no
+fo_pk_struct_multidose_driver_gate.sh	no	unclassified	0			no
+fo_pk_struct_ptr_driver_gate.sh	no	unclassified	0			no
+fo_pk_struct_rac_driver_gate.sh	no	unclassified	0			no
+fo_pk_struct_rho_tau_driver_gate.sh	no	unclassified	0			no
+fo_registration_fragment_gate.sh	no	unclassified	0			no
+fo_residual4_stack_gate.sh	no	unclassified	0			no
+fo_surface_transfer_gate.sh	no	unclassified	0			no
+founder_intent_contract_gate.sh	no	unclassified	0			no
+fpga_catastrophe_scan_gate.sh	no	unclassified	0			no
+fpga_receipt_staleness_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+functor_f_g2_covariance_gate.sh	no	unclassified	0			no
+furey_charge_g2_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+furey_octonion_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+g1_expr_recursion_gate.sh	no	unclassified	0			no
+g2_zd_fibers_gate.sh	no	unclassified	0			no
+garden_to_claim_gate.sh	no	unclassified	0			no
+gate_vacuity_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+gb10_wmma_receipt_gate.sh	yes	workflow-reachable	1	gb10-wmma-receipt.yml	.github/workflows/gb10-wmma-receipt.yml,scripts/ci/gb10_wmma_receipt_gate.sh	yes
+generated_ontology_gate.sh	yes	workflow-reachable	2	ci.yml	scripts/ci/generated_ontology_gate.sh,scripts/ci/run_ontology_validation.sh	no
+generated_ontology_manifest_gate.sh	no	manual-by-design	0		makefile	no
+global_aggregate_store_gate.sh	no	unclassified	0			no
+gpu_knowledge_vecmat_evidence_gate.sh	no	unclassified	0			no
+graphics_companion_gate.sh	no	unclassified	0			no
+graphics_scaffold_gate.sh	no	unclassified	0			no
+gresnigt_family_s3_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+gresnigt_g2s3_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+gri30_full_workspace_allocation_gate.sh	no	unclassified	0			no
+heuristic_firewall_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+ir_instr_arena_gate.sh	no	unclassified	0			no
+ir_module_arena_v2_soir_v5_bridge_gate.sh	no	unclassified	0			no
+ir_nop_marker_gate.sh	no	unclassified	0			no
+irfunction_instr_capacity_coherence_gate.sh	no	unclassified	0			no
+journal_submission_gate.sh	no	unclassified	0			no
+kaxi_ptx_golden_gate.sh	no	unclassified	0			no
+knowledge_context_composite_gate.sh	no	manual-by-design	0		makefile	no
+knowledge_context_numeric_gate.sh	no	manual-by-design	0		makefile	no
+knowledge_context_phase2_ontology_gate.sh	no	manual-by-design	0		makefile	no
+knowledge_context_runtime_obligation_gate.sh	no	manual-by-design	0		makefile	no
+knowledge_context_static_gate.sh	no	manual-by-design	0		makefile	no
+knowledge_context_static_value_gate.sh	no	manual-by-design	0		makefile	no
+knowledge_context_unit_gate.sh	no	manual-by-design	0		makefile	no
+knowledge_runtime_guard_directive_native_scan_gate.sh	no	manual-by-design	0		makefile	no
+knowledge_runtime_guard_expansion_gate.sh	no	manual-by-design	0		makefile	no
+knowledge_runtime_guard_lowering_plan_gate.sh	no	manual-by-design	0		makefile	no
+knowledge_runtime_guard_native_lowering_gate.sh	no	manual-by-design	0		makefile	no
+kretikos_associator_emit_gate.sh	no	unclassified	0			no
+kretikos_cross_backend_cuda_benchmark_gate.sh	no	unclassified	0			no
+kretikos_cross_backend_cuda_runtime_gate.sh	no	unclassified	0			no
+kretikos_cross_backend_semantic_gate.sh	no	unclassified	0			no
+kretikos_cubin_evidence_gate.sh	no	unclassified	0			no
+kretikos_cubin_evidence_matrix_gate.sh	no	unclassified	0			no
+kretikos_f64_runtime_gate.sh	no	unclassified	0			no
+kretikos_hpc_slurm_runtime_gate.sh	no	unclassified	0			no
+kretikos_hpc_source_lowering_gate.sh	no	unclassified	0			no
+kretikos_kaxi_fmad_invariance_gate.sh	no	unclassified	0			no
+kretikos_kaxi_gate.sh	no	manual-by-design	0		umbrella	no
+kretikos_kaxi_iso_budget_gate.sh	no	manual-by-design	0		umbrella	no
+kretikos_kaxi_l4_launch_gate.sh	no	unclassified	0			no
+kretikos_kaxi_lowering_gate.sh	no	unclassified	0			no
+kretikos_kaxi_lse8_gate.sh	no	unclassified	0			no
+kretikos_kaxi_phase_j_aggregate_gate.sh	no	unclassified	0			no
+kretikos_kaxi_phase_j_gate.sh	no	manual-by-design	0		umbrella	no
+kretikos_kaxi_phase_w2_gate.sh	no	unclassified	0			no
+kretikos_kaxi_phase_w_gate.sh	no	unclassified	0			no
+kretikos_kaxi_phase_x_gate.sh	no	unclassified	0			no
+kretikos_kaxi_phase_y_gate.sh	no	manual-by-design	0		umbrella	no
+kretikos_kaxi_phase_z_assoc_gate.sh	no	unclassified	0			no
+kretikos_kaxi_round_mode_gate.sh	no	unclassified	0			no
+kretikos_kaxi_sinkhorn16_epistemic_slurm_gate.sh	no	unclassified	0			no
+kretikos_kaxi_sinkhorn16_gate.sh	no	unclassified	0			no
+kretikos_kaxi_sinkhorn16_slurm_gate.sh	no	unclassified	0			no
+kretikos_spirv_vulkan_storage_semantic_baseline_gate.sh	no	unclassified	0			no
+kretikos_spirv_vulkan_storage_vec_add_gate.sh	no	unclassified	0			no
+l8_zd_census_gate.sh	no	unclassified	0			no
+l9_nullity_histogram_law_gate.sh	no	unclassified	0			no
+l9_zd_census_gate.sh	no	unclassified	0			no
+lean_falsification_ledger_gate.sh	no	unclassified	0			no
+lean_single_fixed_point_gate.sh	no	manual-by-design	0		umbrella	no
+lean_single_pub_use_reexport_gate.sh	no	unclassified	0			no
+local_cuda_device_admission_gate.sh	no	unclassified	0			no
+lora_assets_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+lsp_smoke_gate.sh	yes	workflow-reachable	1	release-gate.yml	.github/workflows/release-gate.yml	yes
+madaros_862_import_print_gate.sh	no	unclassified	0			no
+madaros_blocker_contract_gate.sh	yes	workflow-reachable	2	ci.yml	scripts/ci/claude_operational_contract_gate.sh	no
+madaros_changed_tests_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml,scripts/ci/madaros_changed_tests_selftest.sh	yes
+madaros_contest_callsite_box_gate.sh	no	unclassified	0			no
+madaros_contest_ir_authority_gate.sh	no	unclassified	0			no
+madaros_corpus_regression_gate.sh	no	unclassified	0			yes
+madaros_correlated_eq_gate.sh	no	unclassified	0			no
+madaros_current_source_f64_lowering_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+madaros_d3_exclref_shipped_gate.sh	no	unclassified	0			no
+madaros_d3_openslice_len_gate.sh	no	unclassified	0			no
+madaros_d6_const_nonmain_gate.sh	no	unclassified	0			no
+madaros_dce_reachability_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml,scripts/ci/madaros_ir_capacity_probe.sh	yes
+madaros_enum_gate.sh	yes	workflow-reachable	1	madaros-prebuilt-refresh.yml	.github/workflows/madaros-prebuilt-refresh.yml	yes
+madaros_ep_gate_imported_gate.sh	no	unclassified	0			no
+madaros_f128_f256_format_identity_gate.sh	no	unclassified	0			no
+madaros_f128_f256_ladder_gate.sh	no	forgotten	0			no
+madaros_f128_f256_numeric_payload_gate.sh	no	unclassified	0			no
+madaros_f128_f256_numeric_wire_gate.sh	no	unclassified	0			no
+madaros_f128_f256_v0c_wire_gate.sh	no	forgotten	0			no
+madaros_f128_f256_v0d_softfloat_gate.sh	no	forgotten	0			no
+madaros_field_if_i64_gate.sh	no	unclassified	0			no
+madaros_fixed_array_call_boundary_alias_gate.sh	no	unclassified	0			no
+madaros_fixed_point_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+madaros_full_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml,.github/workflows/madaros-prebuilt-refresh.yml	yes
+madaros_global_array_ref_gate.sh	no	unclassified	0			no
+madaros_global_capacity_gate.sh	yes	workflow-reachable	2	ci.yml	scripts/ci/madaros_current_source_f64_lowering_gate.sh	no
+madaros_global_f64_scratch_gate.sh	yes	workflow-reachable	2	ci.yml	scripts/ci/madaros_current_source_f64_lowering_gate.sh	no
+madaros_global_string_init_gate.sh	no	unclassified	0			no
+madaros_gum_cross_function_gate.sh	no	unclassified	0			no
+madaros_gum_fo_trust_gate.sh	no	unclassified	0			no
+madaros_gum_semantic_suite_gate.sh	no	unclassified	0			no
+madaros_high_arity_ref_gate.sh	no	unclassified	0			no
+madaros_imported_array_byvalue_gate.sh	no	unclassified	0			no
+madaros_imported_call_arity_13_gate.sh	yes	workflow-reachable	2	ci.yml	scripts/ci/madaros_current_source_f64_lowering_gate.sh	no
+madaros_imported_capacity_gate.sh	yes	workflow-reachable	2	ci.yml	scripts/ci/madaros_current_source_f64_lowering_gate.sh	no
+madaros_imported_deref_f64_array_gate.sh	yes	workflow-reachable	2	ci.yml	scripts/ci/madaros_current_source_f64_lowering_gate.sh,scripts/ci/madaros_full_gate.sh	no
+madaros_imported_ep_var_preserve_gate.sh	no	unclassified	0			no
+madaros_imported_f64_const_gate.sh	no	unclassified	0			no
+madaros_imported_f64_mul_gate.sh	no	unclassified	0			no
+madaros_launcher_exit_status_gate.sh	no	unclassified	0			no
+madaros_local_known_extent_word_array_copy_gate.sh	no	unclassified	0			no
+madaros_loop_gate.sh	yes	workflow-reachable	1	madaros-prebuilt-refresh.yml	.github/workflows/madaros-prebuilt-refresh.yml	yes
+madaros_metal_gate.sh	no	unclassified	0			no
+madaros_method_receiver_gate.sh	no	unclassified	0			no
+madaros_monolithic_public_lower_call_gate.sh	no	unclassified	0			no
+madaros_ols_fixed_e2e_gate.sh	no	unclassified	0			no
+madaros_ontology_enforcement_gate.sh	no	forgotten	0			no
+madaros_operational_contract_gate.sh	no	unclassified	0			no
+madaros_print_f64_negative_gate.sh	no	forgotten	0			no
+madaros_propagate_monte_carlo_fnptr_failclosed_gate.sh	no	unclassified	0			no
+madaros_ptx_gate.sh	no	unclassified	0			no
+madaros_qd128_core_native_v2_gate.sh	no	unclassified	0			no
+madaros_qd128_mul_native_v2_gate.sh	no	unclassified	0			no
+madaros_receipt_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml,scripts/ci/madaros_write_receipt.sh	yes
+madaros_sedenion_native_v2_gate.sh	no	unclassified	0			no
+madaros_self_parse_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml,.github/workflows/madaros-prebuilt-refresh.yml	yes
+madaros_source_to_elf_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml,.github/workflows/madaros-prebuilt-refresh.yml	yes
+madaros_syscall6_gate.sh	no	unclassified	0			no
+madaros_thinlink_bool_cmp_field_gate.sh	no	unclassified	0			no
+madaros_trait_i64_cd_exact_gate.sh	no	unclassified	0			no
+madaros_validation_import_gate.sh	no	unclassified	0			no
+madaros_visibility_context_gate.sh	no	unclassified	0			no
+madaros_wide_int_gate.sh	no	manual-by-design	0		makefile	no
+madaros_xoshiro_imported_gate.sh	no	unclassified	0			no
+madaros_zero_provenance_failclosed_gate.sh	no	unclassified	0			no
+madaros_zero_provenance_native_v2_gate.sh	no	unclassified	0			no
+mercyful_chemo_sequencing_gate.sh	no	unclassified	0			no
+mercyful_clinical_sequencing_gate.sh	no	unclassified	0			no
+mercyful_continuous_control_gate.sh	no	unclassified	0			no
+mercyful_expanded_ethics_gate.sh	no	manual-by-design	0			no
+mercyful_independent_tdm_gate.sh	no	unclassified	0			no
+mercyful_lean_gate.sh	no	unclassified	0			no
+mercyful_learned_field_gate.sh	no	manual-by-design	0			no
+mercyful_machine_channel_gate.sh	no	unclassified	0			no
+mercyful_mimic_iv_gate.sh	no	unclassified	0			no
+mercyful_mimic_iv_sensitivity_gate.sh	no	unclassified	0			no
+mercyful_mimic_iv_subgroup_gate.sh	no	unclassified	0			no
+mercyful_pontryagin_control_gate.sh	no	unclassified	0			no
+mercyful_preprint_gate.sh	no	unclassified	0			no
+mercyful_runtime_gate.sh	no	unclassified	0			no
+mercyful_sounio_gate.sh	no	unclassified	0			no
+mir_instr_capacity_coherence_gate.sh	no	unclassified	0			no
+mli_s3_bit_identity_gate.sh	no	forgotten	0			no
+moonshot_a_abide_claim_discipline_gate.sh	no	unclassified	0			no
+moonshot_a_abide_cohort_manifest_gate.sh	no	unclassified	0			no
+moonshot_a_abide_epistemic_cohort_slurm_gate.sh	no	unclassified	0			no
+moonshot_a_abide_epistemic_orc_slice_gate.sh	no	unclassified	0			no
+moonshot_a_abide_f32_cohort_analysis_gate.sh	no	unclassified	0			no
+moonshot_a_abide_transport_conditioned_orc_gate.sh	no	unclassified	0			no
+moonshot_a_phase_status_gate.sh	no	unclassified	0			no
+moonshot_a_slurm_blocker_handoff_gate.sh	no	unclassified	0			no
+moonshot_a_transport_168_curvature_gate.sh	no	unclassified	0			no
+moonshot_a_transport_168_linearity_gate.sh	no	unclassified	0			no
+moonshot_a_transport_168_manifest_gate.sh	no	unclassified	0			no
+moonshot_a_transport_168_modulation_gate.sh	no	unclassified	0			no
+native_capacity_tiers_gate.sh	no	unclassified	0			no
+native_v2_albert_gate.sh	no	unclassified	0			no
+native_v2_algebra_law_gate.sh	no	unclassified	0			no
+native_v2_array_gate.sh	no	unclassified	0			no
+native_v2_associator_gate.sh	no	unclassified	0			no
+native_v2_capturing_closure_unsupported_gate.sh	no	unclassified	0			no
+native_v2_clifford_grade_gate.sh	no	unclassified	0			no
+native_v2_cpu_compiler_umbrella_gate.sh	no	unclassified	0			no
+native_v2_dissertation_rapamycin_gate.sh	no	unclassified	0			no
+native_v2_driver_self_compile_gate.sh	no	manual-by-design	0		umbrella	no
+native_v2_e2e_codegen_suite_gate.sh	no	manual-by-design	0		umbrella	no
+native_v2_e2e_exit_code_gate.sh	no	unclassified	0			no
+native_v2_enum_match_gate.sh	no	unclassified	0			no
+native_v2_epistemic_accel_spine_gate.sh	no	unclassified	0			no
+native_v2_epistemic_gpu_runtime_parity_gate.sh	no	unclassified	0			no
+native_v2_epistemic_science_spine_gate.sh	no	manual-by-design	0		umbrella	no
+native_v2_f64_ladder_gate.sh	no	manual-by-design	0		umbrella	no
+native_v2_fractal_gate.sh	no	unclassified	0			no
+native_v2_frontend_convergence_gate.sh	no	unclassified	0			no
+native_v2_gum_primitives_gate.sh	no	manual-by-design	0		umbrella	no
+native_v2_hof_closure_gate.sh	no	unclassified	0			no
+native_v2_imported_body_lowering_gate.sh	no	unclassified	0			no
+native_v2_imported_captured_closure_boundary_gate.sh	no	manual-by-design	0		umbrella	no
+native_v2_imported_closure_boundary_gate.sh	no	manual-by-design	0		umbrella	no
+native_v2_imported_core_abi_gate.sh	no	unclassified	0			no
+native_v2_imported_hof_abi_gate.sh	no	unclassified	0			no
+native_v2_logical_gate.sh	no	unclassified	0			no
+native_v2_metal_algebra_gate.sh	no	unclassified	0			no
+native_v2_muraki_pentagon_gate.sh	no	unclassified	0			no
+native_v2_nested_field_gate.sh	no	unclassified	0			no
+native_v2_nvidia_bare_metal_gate.sh	no	unclassified	0			no
+native_v2_out_param_boundary_gate.sh	no	unclassified	0			no
+native_v2_prebundle_gate.sh	no	unclassified	0			no
+native_v2_q_deform_gate.sh	no	unclassified	0			no
+native_v2_q_deform_octonion_gate.sh	no	unclassified	0			no
+native_v2_sed_zd_gate.sh	no	unclassified	0			no
+native_v2_semantic_hardening_gate.sh	no	manual-by-design	0		umbrella	no
+native_v2_serious_track_gate.sh	no	unclassified	0			no
+native_v2_struct_gate.sh	no	manual-by-design	0		umbrella	no
+native_v2_struct_mutation_gate.sh	no	unclassified	0			no
+native_v2_struct_param_gate.sh	no	unclassified	0			no
+native_v2_struct_return_gate.sh	no	unclassified	0			no
+native_v2_wasserstein_orc_gate.sh	no	unclassified	0			no
+nullity_histogram_law_gate.sh	no	unclassified	0			no
+nunwa_lean_gate.sh	no	unclassified	0			no
+ontology_bundle_directive_gate.sh	no	manual-by-design	0		makefile	no
+ontology_bundle_directive_native_scan_gate.sh	no	manual-by-design	0		makefile	no
+ontology_cache_compile_gate.sh	no	unclassified	0			no
+ontology_cache_frontend_composition_gate.sh	no	manual-by-design	0		makefile	no
+ontology_cli_smoke_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+ontology_model_compile_gate.sh	no	unclassified	0			no
+ontology_query_compile_gate.sh	no	unclassified	0			no
+ontology_reasoner_compile_gate.sh	no	unclassified	0			no
+ontology_typed_bridge_gate.sh	no	unclassified	0			no
+ontology_unit_metadata_gate.sh	no	manual-by-design	0		makefile	no
+oopsla2027_paper_gate.sh	no	unclassified	0			no
+ordered_path_provenance_source_ir_gate.sh	no	unclassified	0			no
+package_boundary_release_gate.sh	no	unclassified	0			no
+package_import_science_gate.sh	yes	workflow-reachable	2	ci.yml	scripts/ci/package_pbpk_gum_gate.sh,scripts/ci/sounio_package_support_gate.sh	no
+package_pbpk_gum_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+paper168_cocycle_subspace_gate.sh	no	unclassified	0			no
+paper_168_theorem_claims_gate.sh	no	unclassified	0			no
+parser_contextual_ident_routing_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+parser_keyword_classification_gate.sh	no	unclassified	0			no
+parser_module_path_gate.sh	no	unclassified	0			no
+particle_broken_structure_dual_gate.sh	no	unclassified	0			no
+particle_exp10_approx_algebra_gate.sh	no	unclassified	0			no
+particle_exp11_scheme_approx_gate.sh	no	unclassified	0			no
+particle_exp123_gate.sh	no	unclassified	0			no
+particle_exp123_oracle_gate.sh	no	unclassified	0			no
+particle_exp12_residual_closure_gate.sh	no	unclassified	0			no
+particle_exp13_amplitude_honesty_gate.sh	no	unclassified	0			no
+particle_exp17_zwh_ledger_gate.sh	no	unclassified	0			no
+particle_exp6_universal_xi_gate.sh	no	unclassified	0			no
+particle_exp7_gum_transfer_gate.sh	no	unclassified	0			no
+particle_exp8_collapse_gate.sh	no	unclassified	0			no
+particle_exp9_engine_joint_gate.sh	no	unclassified	0			no
+particle_unstable_effect_gate.sh	no	unclassified	0			no
+pediatric_pbpk_gate.sh	no	unclassified	0			no
+physical_extraction_canonical_cutover_approval_gate.sh	no	unclassified	0			no
+physical_extraction_canonical_cutover_execution_gate.sh	no	unclassified	0			no
+physical_extraction_canonical_production_gap_gate.sh	no	unclassified	0			no
+physical_extraction_canonical_production_mapping_decision_gate.sh	no	unclassified	0			no
+physical_extraction_inventory_gate.sh	no	unclassified	0			no
+physical_extraction_materialization_gate.sh	no	unclassified	0			no
+physical_extraction_source_removal_authorization_gate.sh	no	unclassified	0			no
+physical_extraction_source_removal_execution_gate.sh	no	unclassified	0			no
+pin_registry_honesty_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+plan_big_gate.sh	no	unclassified	0			no
+poseidon_gate.sh	no	unclassified	0			no
+precise_stack_maps_honesty_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+project_spine_gate.sh	no	manual-by-design	0		makefile	no
+proof_carrying_deployment_validity_revocable_authority_gate.sh	no	unclassified	0			no
+proof_carrying_endogenous_observability_gate.sh	no	unclassified	0			no
+proof_carrying_model_contest_gate.sh	no	unclassified	0			no
+proof_carrying_path_conditioned_identification_gate.sh	no	unclassified	0			no
+proof_carrying_policy_observation_associator_gate.sh	no	unclassified	0			no
+proof_carrying_policy_state_feedback_gate.sh	no	unclassified	0			no
+proof_carrying_rebracketing_protocol_gate.sh	no	unclassified	0			no
+proof_carrying_reflexive_inquiry_gate.sh	no	unclassified	0			no
+proof_carrying_shift_robust_risk_transport_gate.sh	no	unclassified	0			no
+proof_carrying_statistical_coverage_empirical_binding_gate.sh	no	unclassified	0			no
+r2_continuous_law_theorem_gate.sh	no	unclassified	0			no
+real_language_runner_gate.sh	no	manual-by-design	0		makefile	no
+refinement_gate.sh	no	unclassified	0			no
+registry_attestation_spec_gate.sh	no	unclassified	0			no
+routon_zd_gate.sh	no	unclassified	0			no
+run_pass_output_gate.sh	no	unclassified	0			no
+rupture_abcd_contracts_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+sac_llm_gate.sh	no	manual-by-design	0			no
+san_imagenet_fpga_dl380_gate.sh	no	unclassified	0			no
+san_real_patient_data_gate.sh	no	manual-by-design	0			no
+science_boundary_gate.sh	no	unclassified	0			no
+sedenion_associator_1848_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+sedenion_cd_qbig_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+sedenion_clifford8_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+sedenion_dynamics_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+sedenion_e8_boundary_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+sedenion_gresnigt_octonions_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+sedenion_ladder_extension_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+sedenion_octonion_census_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+sedenion_phi_injectivity_gate.sh	no	unclassified	0			no
+sedenion_quartet_fiber_incidence_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+sedenion_seam_bridge_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+sedenion_spectra_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+sedenion_zd168_crosscheck_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+sedenion_zd_fiber_identity_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+sedenion_zd_fibers_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+sedenion_zd_quartets_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_gate.sh	no	unclassified	0			no
+self_falsifying_compilation_line_r10_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r11_gate.sh	no	unclassified	0			no
+self_falsifying_compilation_line_r12_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r13_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r14_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r15_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r16_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r17_gate.sh	no	unclassified	0			no
+self_falsifying_compilation_line_r19_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r1_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r20_gate.sh	no	unclassified	0			no
+self_falsifying_compilation_line_r21_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r22_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r23_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r24_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r25_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r26_gate.sh	no	unclassified	0			no
+self_falsifying_compilation_line_r27_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r28_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r29_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r2_gate.sh	no	unclassified	0			no
+self_falsifying_compilation_line_r3_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r4_gate.sh	no	unclassified	0			no
+self_falsifying_compilation_line_r5_gate.sh	no	unclassified	0			no
+self_falsifying_compilation_line_r6_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r7_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r8_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compilation_line_r9_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+self_falsifying_compiler_gate.sh	no	unclassified	0			no
+selfhost_driver_output_gate.sh	no	unclassified	0			no
+selfhost_host_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml,.github/workflows/release-gate.yml	yes
+semantic_coordination_gate.sh	no	unclassified	0			no
+semantic_knowledge_spine_gate.sh	no	manual-by-design	0		makefile	no
+semantic_orc_depression_orc_gate.sh	no	unclassified	0			no
+semantic_orc_sinkhorn_lse_gate.sh	no	unclassified	0			no
+semantic_orc_swow16_fixture_gate.sh	no	unclassified	0			no
+semantic_orc_swow16_graph_degree_shuffle_fixture_gate.sh	no	unclassified	0			no
+semantic_orc_swow16_graph_edge_kaxi_pack_gate.sh	no	unclassified	0			no
+semantic_orc_swow16_graph_edge_multifixture_gate.sh	no	unclassified	0			no
+semantic_orc_swow16_graph_edge_tile_gate.sh	no	unclassified	0			no
+semantic_orc_swow16_graph_edge_tile_matrix_gate.sh	no	unclassified	0			no
+semantic_orc_swow16_graph_edge_tile_matrix_parameter_sweep_gate.sh	no	unclassified	0			no
+semantic_orc_swow16_graph_edge_tile_matrix_reducer_gate.sh	no	unclassified	0			no
+semantic_orc_swow16_kaxi_pack_gate.sh	no	unclassified	0			no
+semantic_orc_swow16_kaxi_runtime_gate.sh	no	unclassified	0			no
+semantic_orc_swow16_kaxi_slurm_gate.sh	no	unclassified	0			no
+semantic_orc_swow16_multisupport_gate.sh	no	unclassified	0			no
+semantic_orc_swow16_permutation_fixture_gate.sh	no	unclassified	0			no
+serious_language_claim_closure_gate.sh	no	unclassified	0			no
+serious_language_conformance_gate.sh	no	unclassified	0			no
+serious_language_spec_drift_gate.sh	no	unclassified	0			no
+sigpipe_hygiene_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+soir_v5_empty_reader_gate.sh	no	unclassified	0			no
+soir_v6_bss_layout_gate.sh	no	unclassified	0			no
+souc_launcher_portability_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+souc_v2_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml,.github/workflows/release-gate.yml	yes
+sounio_direct_driver_support_gate.sh	no	unclassified	0			no
+sounio_editor_tooling_support_gate.sh	no	unclassified	0			no
+sounio_install_support_gate.sh	no	unclassified	0			no
+sounio_package_support_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+sounio_release_production_readiness_gate.sh	no	unclassified	0			no
+sounio_science_flex_gate.sh	no	unclassified	0			no
+sounio_stdlib_surface_support_gate.sh	no	unclassified	0			no
+sounio_website_docs_support_gate.sh	yes	workflow-reachable	1	ci.yml	.github/workflows/ci.yml	yes
+stdlib_evolution_gate.sh	no	unclassified	0			no
+stdlib_science_pipeline_gate.sh	no	unclassified	0			no
+stdlib_source_byte_ceiling_gate.sh	no	forgotten	0			no
+suffering_aware_architecture_gate.sh	no	manual-by-design	0			no
+suffering_aware_deep_architecture_gate.sh	no	manual-by-design	0			no
+suffering_aware_game_theory_gate.sh	no	manual-by-design	0			no
+suffering_aware_large_architecture_gate.sh	no	manual-by-design	0			no
+suffering_aware_multi_agent_gate.sh	no	manual-by-design	0			no
+suffering_aware_multi_agent_scale_gate.sh	no	manual-by-design	0			no
+suffering_aware_multi_agent_sophisticated_gate.sh	no	manual-by-design	0			no
+trigintaduonion_zd_gate.sh	no	unclassified	0			no
+ui_type_backlog_quality_gate.sh	no	unclassified	0			no
+unit_types_clinical_current_source_gate.sh	no	manual-by-design	0		makefile	no
+unit_types_derived_gate.sh	no	manual-by-design	0		makefile	no
+unit_types_phase1_gate.sh	no	manual-by-design	0		makefile	no
+windows_pe_smoke_gate.sh	no	unclassified	0			no
+witness_based_compilation_paper_gate.sh	no	unclassified	0			no
+zd_deep_dive_gate.sh	no	unclassified	0			no
+zd_fiber_spectra_witness_gate.sh	no	unclassified	0			no
+zd_fiber_spectra_witness_perturbed_gate.sh	no	unclassified	0			no
+zd_orbit_equivalence_gate.sh	no	unclassified	0			no
+zd_qec_prediction_gate.sh	no	unclassified	0			no
+zero_event_gate.sh	no	unclassified	0			no
+zero_event_native_compile_privacy_gate.sh	no	unclassified	0			no
+zero_provenance_claims_gate.sh	no	unclassified	0			no
+zero_provenance_witness_gate.sh	no	unclassified	0			no

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1363
-- Repo-backed topics: 1213
+- Total governed topics: 1365
+- Repo-backed topics: 1215
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 399
-- Authority count `repo_only`: 776
+- Authority count `repo_only`: 778
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 791 topics
+- A2: 793 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 37 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -85,6 +85,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.bucket-d-script-hardening-2026-06-21 | repo_only | docs/audit/BUCKET_D_SCRIPT_HARDENING_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.checker-guard-wiring-dispatch-2026-07-11 | repo_only | docs/audit/CHECKER_GUARD_WIRING_DISPATCH_2026-07-11.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.chi5-real-axiom-audit-2026-05-30 | repo_only | docs/audit/CHI5_REAL_AXIOM_AUDIT_2026-05-30.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.ci-gate-workflow-reachability-census-2026-08-18 | repo_only | docs/audit/CI_GATE_WORKFLOW_REACHABILITY_CENSUS_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.clinical-drug-switch-vanco-validation-2026-07-19 | repo_only | docs/audit/CLINICAL_DRUG_SWITCH_VANCO_VALIDATION_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.clinical-midazolam-ddi-e2e-vertical-2026-07-19 | repo_only | docs/audit/CLINICAL_MIDAZOLAM_DDI_E2E_VERTICAL_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.clinical-vanco-tdm-e2e-vertical-2026-07-19 | repo_only | docs/audit/CLINICAL_VANCO_TDM_E2E_VERTICAL_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1419,6 +1419,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.ci-gate-workflow-reachability-census-2026-08-18",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/CI_GATE_WORKFLOW_REACHABILITY_CENSUS_2026-08-18.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.clinical-drug-switch-vanco-validation-2026-07-19",
       "collection": "repo",
       "repo_doc_path": "docs/audit/CLINICAL_DRUG_SWITCH_VANCO_VALIDATION_2026-07-19.md",

--- a/scripts/dev/ci_gate_workflow_reachability.py
+++ b/scripts/dev/ci_gate_workflow_reachability.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Transitive workflow reachability of scripts/ci/*_gate.sh.
+
+This is a CENSUS instrument, not a wirer. It answers: can a GitHub
+workflow execute this gate, at any call depth, by following real
+invocations (bash/sh/source), not comments and not inventory globs.
+
+Positive control (must be non-zero on this repo): at least one gate is
+reachable (ci.yml names several) AND at least one named orphan is not
+(epistemic_measure_correspondence_gate.sh). A census that reports 0
+orphans, or 0 reachable, has not measured.
+
+Usage:
+  python3 scripts/dev/ci_gate_workflow_reachability.py
+  python3 scripts/dev/ci_gate_workflow_reachability.py --tsv PATH --json PATH
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict, deque
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+# Conservative invoke: a shell actually runs the path.
+INVOKE_RE = re.compile(
+    r"""(?x)
+    (?:^|&&|\|\||;|`|\(|\s)
+    (?:bash|sh|source|\.)
+    \s+
+    (?:[A-Za-z0-9_]+=\S+\s+)*          # env assignments
+    (?P<q>["']?)
+    (?:\$\{?(?:ROOT_DIR|ROOT|PWD|GITHUB_WORKSPACE)\}?/? )?
+    (?P<path>scripts/(?:ci|dev)/[A-Za-z0-9_./-]+\.sh)
+    (?P=q)
+    """
+)
+
+# YAML `run:` sometimes has the script as the only token after bash.
+YAML_RUN_RE = re.compile(
+    r"""(?x)
+    run:\s*(?:\|)?\s*
+    (?:bash|sh)
+    \s+
+    (?P<path>scripts/(?:ci|dev)/[A-Za-z0-9_./-]+\.sh)
+    """
+)
+
+# for-loop bodies list paths on their own continuation lines, then
+# `bash "$g"`. A listed *_gate.sh on a non-comment line is an invoke.
+BARE_GATE_RE = re.compile(
+    r"(?P<path>scripts/(?:ci|dev)/[A-Za-z0-9_./-]+_gate\.sh)"
+)
+
+MAKE_RE = re.compile(r"""(?x)(?:^|&&|\s)make\s+(?P<target>[A-Za-z0-9_.-]+)""")
+
+# Inventory, not invoke — gate_vacuity_gate.sh lists every gate.
+INVENTORY_MARKERS = (
+    "git ls-files",
+    "mapfile",
+    "find ",
+    "rglob",
+)
+
+NAMED_DIRECT_ORPHANS = (
+    "epistemic_measure_correspondence_gate.sh",
+    "epistemic_fabrication_detect_gate.sh",
+    "madaros_ontology_enforcement_gate.sh",
+)
+
+DISSERTATION_GATES = (
+    "dissertation_confidence_gate_gate.sh",
+    "dissertation_dossier_gate.sh",
+    "dissertation_frontend_parity_gate.sh",
+    "dissertation_pbpk28_parity_gate.sh",
+    "dissertation_pbpk_hessian_gate.sh",
+    "dissertation_pbpk_suite_gate.sh",
+)
+
+
+def is_comment_line(path: Path, line: str) -> bool:
+    s = line.lstrip()
+    if not s or s.startswith("#!"):
+        return False
+    if path.suffix in {".yml", ".yaml"}:
+        return s.startswith("#")
+    if path.suffix == ".sh" or path.name in {"Makefile", "makefile"}:
+        return s.startswith("#")
+    if path.suffix == ".py":
+        return s.startswith("#")
+    return s.startswith("#")
+
+
+def extract_invokes(path: Path, text: str) -> set[str]:
+    found: set[str] = set()
+    for i, line in enumerate(text.splitlines(), 1):
+        if is_comment_line(path, line):
+            continue
+        if any(m in line for m in INVENTORY_MARKERS) and "_gate.sh" in line:
+            # Listing gates is not running them (gate_vacuity_gate.sh).
+            continue
+        for rx in (INVOKE_RE, YAML_RUN_RE, BARE_GATE_RE):
+            for m in rx.finditer(line):
+                found.add(m.group("path"))
+    return found
+
+
+def extract_make_targets(path: Path, text: str) -> set[str]:
+    found: set[str] = set()
+    for line in text.splitlines():
+        if is_comment_line(path, line):
+            continue
+        for m in MAKE_RE.finditer(line):
+            tgt = m.group("target")
+            if tgt not in {"-C", "-f", "-j", "build", "clean"}:
+                found.add(tgt)
+    return found
+
+
+def parse_makefile(makefile: Path) -> dict[str, set[str]]:
+    """target -> invoked script paths (best-effort, no $(fn) expansion)."""
+    if not makefile.is_file():
+        return {}
+    text = makefile.read_text(errors="replace")
+    recipes: dict[str, set[str]] = defaultdict(set)
+    current: list[str] = []
+    for line in text.splitlines():
+        if line.startswith("\t"):
+            for t in current:
+                recipes[t] |= extract_invokes(makefile, line)
+            continue
+        if "=" in line and not line.startswith(".") and ":" not in line.split("=")[0]:
+            continue
+        if ":" in line and not line.startswith("\t"):
+            left = line.split(":", 1)[0]
+            current = [x.strip() for x in left.split() if x.strip()]
+    return recipes
+
+
+def header_blob(path: Path, n: int = 40) -> str:
+    try:
+        lines = path.read_text(errors="replace").splitlines()[:n]
+    except OSError:
+        return ""
+    return "\n".join(lines)
+
+
+def classify_leftover(name: str, gate_path: Path, makefile_hit: bool, umbrella_hit: bool) -> str:
+    """Classify a workflow-unreachable gate. Evidence-only buckets."""
+    if name in NAMED_DIRECT_ORPHANS:
+        return "forgotten"
+    if name in DISSERTATION_GATES or name.startswith("dissertation_"):
+        return "manual-by-design"
+    if name == "bootstrap_chain_gate.sh":
+        return "manual-by-design"
+    comments = "\n".join(
+        ln for ln in header_blob(gate_path).splitlines() if ln.lstrip().startswith("#")
+    ).lower()
+    head = comments
+    if any(k in head for k in ("obsolete", "superseded", "deprecated", "do not use", "historical only")):
+        return "obsolete"
+    if any(
+        k in head
+        for k in (
+            "not wired",
+            "not in ci",
+            "not in github",
+            "operator-run",
+            "run on slurm",
+            "slurm-only",
+            "manual gate",
+            "run by hand",
+            "not a ci job",
+        )
+    ):
+        return "manual-by-design"
+    if makefile_hit or umbrella_hit:
+        return "manual-by-design"
+    if "positive control" in head or "GATE_CONTRACT" in header_blob(gate_path):
+        return "forgotten"
+    return "unclassified"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tsv", default="docs/audit/CI_GATE_WORKFLOW_REACHABILITY_CENSUS_2026-08-18.tsv")
+    ap.add_argument("--json", default="")
+    args = ap.parse_args()
+
+    gates = sorted((REPO / "scripts/ci").glob("*_gate.sh"))
+    if len(gates) < 400:
+        print(f"REFUTE: expected >=400 scripts/ci/*_gate.sh, got {len(gates)}", file=sys.stderr)
+        return 2
+
+    workflows = sorted((REPO / ".github/workflows").glob("*.yml")) + sorted(
+        (REPO / ".github/workflows").glob("*.yaml")
+    )
+    if not workflows:
+        print("REFUTE: no workflows", file=sys.stderr)
+        return 2
+
+    makefile_recipes = parse_makefile(REPO / "Makefile")
+
+    # BFS over invoked scripts, starting at workflow files.
+    invoked_by: dict[str, set[str]] = defaultdict(set)
+    queue: deque[Path] = deque(workflows)
+    seen: set[Path] = set()
+    root_of: dict[str, str] = {}
+    depth_of: dict[str, int] = {}
+
+    for wf in workflows:
+        rel = str(wf.relative_to(REPO))
+        depth_of[rel] = 0
+        root_of[rel] = wf.name
+
+    while queue:
+        cur = queue.popleft()
+        if cur in seen or not cur.is_file():
+            continue
+        seen.add(cur)
+        try:
+            text = cur.read_text(errors="replace")
+        except OSError:
+            continue
+        cur_rel = str(cur.relative_to(REPO))
+        d = depth_of.get(cur_rel, 0)
+        origin = root_of.get(cur_rel, cur.name)
+
+        for inv in extract_invokes(cur, text):
+            child = REPO / inv
+            invoked_by[inv].add(cur_rel)
+            if inv not in depth_of:
+                depth_of[inv] = d + 1
+                root_of[inv] = origin
+            if child.is_file() and child not in seen:
+                queue.append(child)
+
+        for tgt in extract_make_targets(cur, text):
+            for inv in makefile_recipes.get(tgt, ()):
+                child = REPO / inv
+                invoked_by[inv].add(f"{cur_rel}:make:{tgt}")
+                if inv not in depth_of:
+                    depth_of[inv] = d + 1
+                    root_of[inv] = origin
+                if child.is_file() and child not in seen:
+                    queue.append(child)
+
+    # Makefile-only (operator) and umbrella-only (operator) — not workflow roots.
+    makefile_names = set()
+    for scripts in makefile_recipes.values():
+        for p in scripts:
+            makefile_names.add(Path(p).name)
+
+    umbrella = REPO / "scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh"
+    umbrella_names: set[str] = set()
+    if umbrella.is_file():
+        for inv in extract_invokes(umbrella, umbrella.read_text(errors="replace")):
+            umbrella_names.add(Path(inv).name)
+
+    # Direct basename mention in .github (the 78-number, including comments).
+    gh_text = ""
+    for p in (REPO / ".github").rglob("*"):
+        if p.is_file() and p.suffix in {".yml", ".yaml", ".md"}:
+            try:
+                gh_text += p.read_text(errors="replace") + "\n"
+            except OSError:
+                pass
+    direct_mention = {g.name for g in gates if g.name in gh_text}
+
+    rows = []
+    n_reach = 0
+    classes = defaultdict(int)
+    for g in gates:
+        rel = f"scripts/ci/{g.name}"
+        reachable = rel in invoked_by or rel in depth_of and depth_of.get(rel, 0) > 0
+        # depth_of includes workflows at 0; a gate must have been invoked.
+        reachable = rel in invoked_by
+        if reachable:
+            n_reach += 1
+            klass = "workflow-reachable"
+            how = ",".join(sorted(invoked_by[rel])[:6])
+            depth = depth_of.get(rel, 0)
+            origin = root_of.get(rel, "")
+        else:
+            klass = classify_leftover(
+                g.name, g, g.name in makefile_names, g.name in umbrella_names
+            )
+            how = ""
+            if g.name in makefile_names:
+                how = "makefile"
+            if g.name in umbrella_names:
+                how = (how + "+umbrella") if how else "umbrella"
+            depth = 0
+            origin = ""
+        classes[klass] += 1
+        rows.append(
+            {
+                "gate": g.name,
+                "reachable": "yes" if reachable else "no",
+                "class": klass,
+                "depth": depth,
+                "origin_workflow": origin,
+                "via": how,
+                "direct_github_mention": "yes" if g.name in direct_mention else "no",
+            }
+        )
+
+    # Instrument checks.
+    reach_names = {r["gate"] for r in rows if r["reachable"] == "yes"}
+    if not reach_names:
+        print("REFUTE: 0 reachable gates — instrument is dead", file=sys.stderr)
+        return 2
+    for orphan in NAMED_DIRECT_ORPHANS:
+        if orphan in reach_names:
+            print(f"NOTE: named orphan {orphan} is reachable under invoke-trace", file=sys.stderr)
+        else:
+            pass
+    missing_named = [o for o in NAMED_DIRECT_ORPHANS if o in reach_names]
+    # The named three must stay unreachable for the instrument to match today's measurement.
+    if missing_named:
+        print(
+            f"REFUTE: named direct orphans resolved as reachable: {missing_named}",
+            file=sys.stderr,
+        )
+        return 2
+
+    tsv_path = REPO / args.tsv
+    tsv_path.parent.mkdir(parents=True, exist_ok=True)
+    cols = [
+        "gate",
+        "reachable",
+        "class",
+        "depth",
+        "origin_workflow",
+        "via",
+        "direct_github_mention",
+    ]
+    with tsv_path.open("w") as f:
+        f.write("\t".join(cols) + "\n")
+        for r in rows:
+            f.write("\t".join(str(r[c]) for c in cols) + "\n")
+
+    leftover = len(gates) - n_reach
+    summary = {
+        "gates_total": len(gates),
+        "workflows": [w.name for w in workflows],
+        "direct_github_mention": len(direct_mention),
+        "direct_mention_orphan_upper_bound": len(gates) - len(direct_mention),
+        "workflow_reachable_transitive": n_reach,
+        "leftover": leftover,
+        "class_counts": dict(classes),
+        "named_direct_orphans_unreachable": list(NAMED_DIRECT_ORPHANS),
+        "dissertation_leftover": [
+            n for n in DISSERTATION_GATES if n not in reach_names
+        ],
+        "bootstrap_chain_reachable": "bootstrap_chain_gate.sh" in reach_names,
+        "positive_control": {
+            "reachable_nonzero": n_reach > 0,
+            "named_orphans_still_unreachable": all(
+                o not in reach_names for o in NAMED_DIRECT_ORPHANS
+            ),
+        },
+        "tsv": str(tsv_path.relative_to(REPO)),
+    }
+    if args.json:
+        jp = REPO / args.json
+        jp.parent.mkdir(parents=True, exist_ok=True)
+        jp.write_text(json.dumps(summary, indent=2) + "\n")
+
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- A `.github/` basename grep finds 78 of 468 `scripts/ci/*_gate.sh` names (390 unmentioned). That 390 is an **upper bound**, not a count of gates CI never runs.
- Transitive invoke-trace from `.github/workflows/` reaches **85** gates and leaves **383**. Eight of the 85 are never named in `.github/` (called from `madaros_full_gate.sh`, the f64-lowering gate, ontology validation, package support). `gate_vacuity_gate.sh` lists every gate and executes none of them — counting that list as reachability would invent a green.
- Leftover classification is evidence-only: **10 forgotten** (including the three named today), **56 manual-by-design** (all six dissertation gates + `bootstrap_chain_gate.sh` + Makefile/umbrella), **0 obsolete**, **317 unclassified**. Nothing was wired.

## Test plan
- [x] `python3 scripts/dev/ci_gate_workflow_reachability.py` — reachable=85, named orphans still unreachable, leftover=383
- [ ] Do **not** wire the leftover set in this PR