### PR TITLE
fix(governance): resync acceptance-report counts — main is red again, second time today

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1365
-- Repo-backed topics: 1215
+- Total governed topics: 1370
+- Repo-backed topics: 1220
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 399
-- Authority count `repo_only`: 778
+- Authority count `repo_only`: 783
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 793 topics
+- A2: 798 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 37 topics


### PR DESCRIPTION
**main is red on the docs-registry gate again — second occurrence today.**

Verified against a clean detached worktree of `origin/main` at `9ebd8052e7`:
`DOCS_ACCEPTANCE_REPORT.md is stale`. Four derived counts. No content change, no
provenance restamped.

## Why this is not just a repeat

#1804 fixed the identical drift eight hours ago, and its body predicted this
exactly: the report carries counts derived from the **whole doc set**, so each
doc-adding PR is green against its own base and still leaves main red once a
second one lands beside it. Today's merge volume guaranteed a recurrence.

## The cost, measured

Every open PR inherits the red. Right now that includes **#1831** — the Box<T>
payload-layout fix, the first positive result on that defect after five refuted
causes and four reverted fixes, verified with a fresh from-source build on Slurm
10167 with `madaros_full_gate.sh` at rc=0, and independently confirmed by a
second lane reaching the same mechanism. It shows `Contracts FAILURE` and a
failed `CI Decision` for a reason with nothing to do with the compiler.

That is the **third** time today a lane's work was made to look defective by an
inherited registry red. The first two cost real investigation before anyone
thought to check main.

## This resync is a patch on a symptom

The structural fix is owed and already recorded in #1804: either the report stops
carrying whole-corpus counts, or the gate reports "main is also failing this"
when it is. A gate that main itself cannot pass is indistinguishable, from a
lane's point of view, from a gate that its own PR broke — and lanes cannot tell
the difference without doing what I did here, which is check out main in a clean
worktree and run the gate by hand.
