### PR TITLE
fix(ci): impact classifier refuses lost evidence instead of silently skipping the matrix

### DIFF
--- a/scripts/ci/classify_ci_impact.sh
+++ b/scripts/ci/classify_ci_impact.sh
@@ -36,7 +36,28 @@ else
     paths=("$@")
   else
     [[ -n "$BASE_SHA" ]] || { echo "error: CI_BASE_SHA is required for pull_request classification" >&2; exit 2; }
-    mapfile -t paths < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+    # The diff is this classifier's only evidence, and its failure used to be
+    # invisible: fed through process substitution, a failed `git diff` left
+    # paths=(), every output false, and the script exited 0 -- a run that
+    # downstream reads identically to "no jobs needed" and silently skips the
+    # whole matrix (CI_TRUST_CONTRACT: an instrument that did not answer is
+    # unavailable, not an empty selected set). Capture its status, and refuse
+    # an empty PR diff for the same reason.
+    diff_list="$(mktemp)"
+    diff_err="$(mktemp)"
+    if ! git diff --name-only "$BASE_SHA" "$HEAD_SHA" >"$diff_list" 2>"$diff_err"; then
+      echo "error: git diff --name-only $BASE_SHA $HEAD_SHA failed -- cannot classify impact:" >&2
+      sed 's/^/  git: /' "$diff_err" >&2
+      rm -f "$diff_list" "$diff_err"
+      exit 3
+    fi
+    if [[ ! -s "$diff_list" ]]; then
+      echo "error: git diff --name-only $BASE_SHA $HEAD_SHA is empty -- a pull request with no changed paths would silently skip every job" >&2
+      rm -f "$diff_list" "$diff_err"
+      exit 4
+    fi
+    mapfile -t paths <"$diff_list"
+    rm -f "$diff_list" "$diff_err"
   fi
 
   for path in "${paths[@]}"; do

--- a/scripts/ci/impact_ci_selftest.sh
+++ b/scripts/ci/impact_ci_selftest.sh
@@ -50,6 +50,29 @@ non_pr="$(CI_EVENT_NAME=push $CLASSIFIER)"
 expect "$non_pr" full true
 expect "$non_pr" compiler true
 
+# A failed `git diff` used to be invisible through process substitution:
+# paths=(), every output false, exit 0 -- a run downstream reads identically
+# to "no jobs needed" (silent skip of the whole matrix). Same for an empty
+# PR diff. Both must now refuse. Regression guards for the diff-status
+# capture in classify_ci_impact.sh.
+if (cd "$ROOT_DIR" && CI_EVENT_NAME=pull_request \
+      CI_BASE_SHA=0000000000000000000000000000000000000000 \
+      CI_HEAD_SHA=HEAD "$CLASSIFIER" >/dev/null 2>&1); then
+  echo "impact-ci-selftest: classifier accepted a failing git diff (all-false matrix, exit 0)" >&2
+  exit 1
+fi
+if (cd "$ROOT_DIR" && CI_EVENT_NAME=pull_request \
+      CI_BASE_SHA=HEAD CI_HEAD_SHA=HEAD "$CLASSIFIER" >/dev/null 2>&1); then
+  echo "impact-ci-selftest: classifier accepted an empty PR diff (every job would silently skip)" >&2
+  exit 1
+fi
+# Positive control: the guards must not over-fire -- a real, non-empty diff
+# still classifies through the guarded path.
+root_commit="$(cd "$ROOT_DIR" && git rev-list --max-parents=0 HEAD | tail -1)"
+live="$(cd "$ROOT_DIR" && CI_EVENT_NAME=pull_request \
+      CI_BASE_SHA="$root_commit" CI_HEAD_SHA=HEAD "$CLASSIFIER")"
+expect "$live" full true
+
 good_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"false","tests":"false","sio":"false","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"madaros-current-source-deref-f64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"madaros-witness-gate":{"result":"skipped"},"sounio-lint":{"result":"skipped"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
 NEEDS_JSON="$good_needs" python3 "$DECISION" | grep -Fq CI_DECISION_PASS
 


### PR DESCRIPTION
## What

F1 from the exit-status sweep of `scripts/ci` + `scripts/dev` (first of a 7-PR repair order).

`classify_ci_impact.sh` fed `git diff --name-only BASE HEAD` through process substitution — its exit status is visible to nothing. On a failed diff (bad/unreachable base SHA, e.g. a base-branch force-push race): `paths=()`, every output `false`, **exit 0**. Every output-gated job silently skips; the PR shows 3 green checks where 12 belong. Same defect class as #1720's "8 vs 12 checks", at the root of the matrix.

Measured pre-fix:

```
$ CI_EVENT_NAME=pull_request CI_BASE_SHA=0000…0 CI_HEAD_SHA=HEAD bash scripts/ci/classify_ci_impact.sh
docs=false  website=false  compiler=false  …  full=false      # + one "fatal: bad object" on stderr
classifier exit=0
```

`CI_TRUST_CONTRACT.md` already codifies the required behavior: *"CI-state readers must distinguish 'the instrument did not answer' from 'the answer was an empty selected set'"*. The classifier is link 1 of the trust chain; this makes it obey the contract.

## Change

- Failed `git diff` → **exit 3**, git's stderr surfaced in the log (impact job goes red; fail-closed).
- Empty PR diff → **exit 4** with the reason (now distinguishable from a failed diff because git succeeded; an empty PR diff would silently skip every job).
- Explicit-paths and non-PR modes unchanged.

## Assertion that proves it

`impact_ci_selftest.sh` gains three arms:

1. bogus `CI_BASE_SHA` → classifier must exit nonzero (was: all-false + exit 0)
2. `CI_BASE_SHA=HEAD CI_HEAD_SHA=HEAD` (empty diff) → must exit nonzero
3. **positive control**: root-commit→HEAD diff must still classify `full=true`, so the guards cannot over-fire and block all classification unnoticed

Verified locally: selftest green; all three transcripts behave as above; explicit-paths classification byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)