### PR TITLE
fix(harness): result completeness — the v2 suite must count what ran

### DIFF
--- a/scripts/dev/run_sio_test_suite_v2.sh
+++ b/scripts/dev/run_sio_test_suite_v2.sh
@@ -638,6 +638,20 @@ echo ""
 echo "Found ${#TEST_FILES[@]} test files"
 echo ""
 
+# Every test that passes the filter must produce exactly one result_*.json:
+# each path through run_test after the filter check writes one, and nothing
+# else in TEST_TMP does. Counting them here lets the collector prove below
+# that the summary is a measurement of this run -- a worker killed before its
+# write (OOM under the job cap is the realistic producer) otherwise vanishes
+# from the totals, and a dropped failing test is a silent green.
+EXPECTED_RESULTS=0
+for f in "${TEST_FILES[@]}"; do
+    basename="$(basename "$f")"
+    if test_matches_filter "$basename"; then
+        ((EXPECTED_RESULTS++))
+    fi
+done
+
 # Run tests in parallel with job limit
 job_count=0
 idx=0
@@ -653,8 +667,11 @@ done
 wait
 
 # Collect results
+RESULT_FILES=0
+UNPARSED=0
 for f in "$TEST_TMP"/result_*.json; do
     [[ -f "$f" ]] || continue
+    ((RESULT_FILES++))
     result=$(cat "$f")
     status=$(echo "$result" | grep -o '"status":"[^"]*"' | cut -d'"' -f4)
     category=$(echo "$result" | grep -o '"category":"[^"]*"' | cut -d'"' -f4)
@@ -710,6 +727,16 @@ for f in "$TEST_TMP"/result_*.json; do
                 echo "  SKIP  $name ($reason)"
             fi
             ;;
+        *)
+            # A result file whose status cannot be parsed -- truncated or
+            # malformed JSON, the realistic producer being a worker killed
+            # mid-write. Dropping it made the totals undercount: a failing
+            # test that vanishes is a silent green (the same reasoning as the
+            # vxfail comment above, applied to the parse-failure path).
+            # Count it and fail below instead of silently omitting it.
+            ((UNPARSED++))
+            echo "  UNPARSED  $f (status=[$status])" >&2
+            ;;
     esac
 done
 
@@ -723,6 +750,32 @@ echo "  Fail: $FAIL"
 [[ $FLAKY -gt 0 ]] && echo "  Flaky: $FLAKY"
 echo "  Skip: $SKIP"
 echo "  Total: $((PASS + FAIL + SKIP + KNOWN_FAILURE + VACUOUS_KNOWN))"
+[[ $UNPARSED -gt 0 ]] && echo "  Unparsed: $UNPARSED"
+
+# Completeness: the counts above must describe every filtered test exactly
+# once. Three ways to lose that, each previously silent:
+#   - a result file no parser branch recognizes (UNPARSED above);
+#   - a filtered test whose result file never appeared (worker died first);
+#   - a run that selected nothing at all (0 == 0 reading as "all tests
+#     passed" -- the vacuity failure mode; in CI an empty selection means the
+#     corpus or the glob broke, so it must fail, not report green).
+# CI-state readers must distinguish "the instrument did not answer" from "the
+# answer was an empty selected set" (docs/governance/CI_TRUST_CONTRACT.md).
+if [[ $UNPARSED -gt 0 ]]; then
+    echo "INCOMPLETE: $UNPARSED result file(s) had no readable status -- verdicts unknown, failing instead of dropping them" >&2
+    exit 1
+fi
+if [[ $RESULT_FILES -ne $EXPECTED_RESULTS ]]; then
+    echo "INCOMPLETE: $EXPECTED_RESULTS filtered test(s) ran but $RESULT_FILES result file(s) were found -- a worker exited before writing its result, so the totals above undercount" >&2
+    exit 1
+fi
+if [[ $EXPECTED_RESULTS -eq 0 ]]; then
+    if [[ -n "${CI:-}" ]]; then
+        echo "INCOMPLETE: zero test files matched (filter=${FILTER:-none}) -- this run measured nothing; refusing to report green on an empty suite" >&2
+        exit 1
+    fi
+    echo "WARNING: no test files matched the active filter -- this run measured nothing" >&2
+fi
 
 if [[ -n "$VACUOUS_STALE" ]]; then
     echo ""


### PR DESCRIPTION
## What

`scripts/dev/run_sio_test_suite_v2.sh` — the wired `full-test-suite` job on every PR — could silently drop a test from its own summary:

- The collect loop's `case` had **no default branch**. A `result_*.json` with no parseable status matched nothing and vanished from Pass/Fail/Skip/Total.
- Nothing tied the number of `result_*.json` files to the reported total. The suite spawns parallel background `run_test` subshells under a job cap; a worker killed before its write (OOM is the realistic producer) simply never appeared. A dropped **failing** test is a silent green.
- A run that selected zero tests printed `Total: 0` and "All tests passed!".

The authors already think in this vocabulary — the `vxfail` branch's comment says a tolerated failure that does not appear in the summary is indistinguishable from a test that never ran — but only the annotation-baseline path was guarded, not the parse-failure path.

## Fix

- `EXPECTED_RESULTS`: every filter-matching test must produce exactly one result file — each post-filter path through `run_test` writes one; the filter-mismatch return is the only no-write path, so the expected count is filter-matched files, not `${#TEST_FILES[@]}`.
- A `*)` case branch counts `UNPARSED` and names the offending file on stderr.
- After the summary: `UNPARSED > 0` or `RESULT_FILES != EXPECTED_RESULTS` → `INCOMPLETE` line + exit 1.
- Zero filtered tests: `WARNING` in dev runs, `INCOMPLETE` + exit 1 under `CI` — the trust-contract distinction between an empty selected set by choice and an instrument that measured nothing (`docs/governance/CI_TRUST_CONTRACT.md`).

## Verification (all measured, not asserted)

| Scenario | Result |
|---|---|
| Happy path: `--filter-prefix a14_` over 2997 files, 1 matched | `Total: 1`, exit 0 — no false fire |
| Zero-match, dev | `WARNING: … this run measured nothing`, exit 0 (unchanged dev semantics) |
| Zero-match, `CI=true` | `INCOMPLETE: … refusing to report green on an empty suite`, exit 1 |
| Truncated result file planted | `UNPARSED /tmp/…/result_999.json (status=[])`, `Unparsed: 1`, exit 1 |
| Matched test's write suppressed (simulated killed worker) | `INCOMPLETE: 1 filtered test(s) ran but 0 result file(s) were found`, exit 1 |

The last two run on copies differing from the committed script by **exactly one injected line** each (fixed `TEST_TMP` / conditional write); the first three run the committed file directly. `bash -n` and `sigpipe_hygiene_gate.sh` green.

## Observed, deliberately not touched

`FLAKY` is initialized (:146) and displayed (:723) but incremented nowhere — flaky tests carry `status:"fail"` into `FAIL`, so the `Flaky:` summary line can never print. Dead display, not a lost verdict; separate change if wanted.

## Relation to the census

Sweep finding **F3** (status axis) in `.scratch/EXIT_STATUS_SWEEP_2026-08-17.md` — complementary to `gate_vacuity_gate`'s value axis: no extraction is empty here; the evidence simply never got produced or read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
