### PR TITLE
ci: wire epistemic_measure_correspondence_gate.sh (one forgotten orphan)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,14 @@ jobs:
         run: bash scripts/ci/e219_refusal_correspondence_gate.sh
       - name: E219 engine oracle (Madaros refuses; seed split is reported)
         run: bash scripts/ci/e219_engine_oracle_gate.sh
+      # #1780: first machine-checked link between EpistemicEffectsV2 t_kraw
+      # and Madaros measure/Knowledge typing. Grep correspondence, not a
+      # compile. Positive controls are the two mutants under
+      # scripts/ci/fixtures/epistemic_measure_correspondence/. One of the
+      # three named forgotten orphans from the 2026-08-18 census; the other
+      # two stay unwired (one gate per PR).
+      - name: Epistemic measure correspondence (Lean V2 ↔ Madaros Knowledge)
+        run: bash scripts/ci/epistemic_measure_correspondence_gate.sh
       - name: Live lane coordination self-test
         run: bash scripts/ci/sounio_coord_selftest.sh
 

--- a/scripts/dev/ci_gate_workflow_reachability.py
+++ b/scripts/dev/ci_gate_workflow_reachability.py
@@ -6,9 +6,10 @@ workflow execute this gate, at any call depth, by following real
 invocations (bash/sh/source), not comments and not inventory globs.
 
 Positive control (must be non-zero on this repo): at least one gate is
-reachable (ci.yml names several) AND at least one named orphan is not
-(epistemic_measure_correspondence_gate.sh). A census that reports 0
-orphans, or 0 reachable, has not measured.
+reachable (ci.yml names several) AND at least one named leftover is not
+(epistemic_fabrication_detect_gate.sh). A census that reports 0 leftovers,
+or 0 reachable, has not measured. Correspondence was the third named
+orphan; it is wired in ci.yml Contracts as of the 2026-08-18 one-gate PR.
 
 Usage:
   python3 scripts/dev/ci_gate_workflow_reachability.py
@@ -65,8 +66,10 @@ INVENTORY_MARKERS = (
     "rglob",
 )
 
+# Remaining named forgotten leftovers. Correspondence left this list when
+# it was wired in Contracts (one gate per PR). Do not add a newly wired
+# name back here — that would REFUTE the instrument.
 NAMED_DIRECT_ORPHANS = (
-    "epistemic_measure_correspondence_gate.sh",
     "epistemic_fabrication_detect_gate.sh",
     "madaros_ontology_enforcement_gate.sh",
 )
@@ -186,7 +189,11 @@ def classify_leftover(name: str, gate_path: Path, makefile_hit: bool, umbrella_h
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--tsv", default="docs/audit/CI_GATE_WORKFLOW_REACHABILITY_CENSUS_2026-08-18.tsv")
+    ap.add_argument(
+        "--tsv",
+        default="",
+        help="Write the per-gate table here. Default: do not overwrite the 2026-08-18 snapshot.",
+    )
     ap.add_argument("--json", default="")
     args = ap.parse_args()
 
@@ -319,29 +326,14 @@ def main() -> int:
         else:
             pass
     missing_named = [o for o in NAMED_DIRECT_ORPHANS if o in reach_names]
-    # The named three must stay unreachable for the instrument to match today's measurement.
+    # Remaining named leftovers must stay unreachable. Wiring one without
+    # removing it from NAMED_DIRECT_ORPHANS is a REFUTE, not a silent pass.
     if missing_named:
         print(
             f"REFUTE: named direct orphans resolved as reachable: {missing_named}",
             file=sys.stderr,
         )
         return 2
-
-    tsv_path = REPO / args.tsv
-    tsv_path.parent.mkdir(parents=True, exist_ok=True)
-    cols = [
-        "gate",
-        "reachable",
-        "class",
-        "depth",
-        "origin_workflow",
-        "via",
-        "direct_github_mention",
-    ]
-    with tsv_path.open("w") as f:
-        f.write("\t".join(cols) + "\n")
-        for r in rows:
-            f.write("\t".join(str(r[c]) for c in cols) + "\n")
 
     leftover = len(gates) - n_reach
     summary = {
@@ -363,8 +355,30 @@ def main() -> int:
                 o not in reach_names for o in NAMED_DIRECT_ORPHANS
             ),
         },
-        "tsv": str(tsv_path.relative_to(REPO)),
+        "tsv": "",
     }
+    if args.tsv:
+        tsv_path = Path(args.tsv)
+        if not tsv_path.is_absolute():
+            tsv_path = REPO / tsv_path
+        tsv_path.parent.mkdir(parents=True, exist_ok=True)
+        cols = [
+            "gate",
+            "reachable",
+            "class",
+            "depth",
+            "origin_workflow",
+            "via",
+            "direct_github_mention",
+        ]
+        with tsv_path.open("w") as f:
+            f.write("\t".join(cols) + "\n")
+            for r in rows:
+                f.write("\t".join(str(r[c]) for c in cols) + "\n")
+        try:
+            summary["tsv"] = str(tsv_path.relative_to(REPO))
+        except ValueError:
+            summary["tsv"] = str(tsv_path)
     if args.json:
         jp = REPO / args.json
         jp.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

- Wires **only** `scripts/ci/epistemic_measure_correspondence_gate.sh` in the Contracts job, next to the E219 correspondence gates.
- This is the first of the three named forgotten leftovers from the 2026-08-18 census (`docs/audit/CI_GATE_WORKFLOW_REACHABILITY_CENSUS_2026-08-18.md`). One gate per PR.
- Updates the reachability instrument so correspondence is no longer a named-orphan control (wiring it without that update would REFUTE the instrument). Bare instrument runs no longer overwrite the 2026-08-18 snapshot TSV.

Does **not** wire `epistemic_fabrication_detect_gate.sh` or `madaros_ontology_enforcement_gate.sh`. Those stay leftover.

**Collision:** #1836 already packs all three into one `ci.yml` edit and is Contracts-red + 10 commits behind `main`. This PR is the authorised split. Please drop the correspondence hunk from #1836 rather than merging the three-pack.

## Local measurement (this SHA)

```text
bash scripts/ci/epistemic_measure_correspondence_gate.sh
# status=pass total=15 passed=15 failed=0 not_run=0
# POSITIVE_CONTROL_FIRED: checker_fixed_f64 rejected
# POSITIVE_CONTROL_FIRED: model_fixed_treal rejected

python3 scripts/dev/ci_gate_workflow_reachability.py
# before (origin/main 44eb512510): reachable 85, leftover 383, forgotten 10
# after:                          reachable 86, leftover 382, forgotten 9
```

Deltas are exactly +1 / −1 / −1. Remaining named leftovers: fabrication detect, ontology enforcement.

Changing `.github/workflows/ci.yml` marks **full** impact. That is intended: the new Contracts step must actually run.

## Test plan

- [x] Gate green locally with both mutant controls firing
- [x] `check_workflow_script_refs.sh` passed (134 refs)
- [x] Instrument: reachable +1, leftover −1, forgotten −1; remaining two named leftovers still unreachable
- [ ] Contracts + CI Decision on this PR
- [ ] Do not merge while Contracts is red