### PR TITLE
ci(octonion): re-author O-SSM probes gate off main (#1063)

### DIFF
--- a/scripts/ci/classify_ci_impact.sh
+++ b/scripts/ci/classify_ci_impact.sh
@@ -89,7 +89,7 @@ else
     case "$path" in tests/*|check_sounio.sh) mark tests; recognized=true ;; esac
     case "$path" in formal/lean4/*) mark lean; recognized=true ;; esac
     case "$path" in
-      formal/lean4/*|scripts/ci/sedenion_*|scripts/ci/cd_tower_*|scripts/ci/gresnigt_*|scripts/ci/furey_*|scripts/research/sedenion_*|scripts/research/cd_tower_*|scripts/ci/ade_wildgen_*|scripts/research/ade_wildgen_*)
+      formal/lean4/*|scripts/ci/sedenion_*|scripts/ci/cd_tower_*|scripts/ci/gresnigt_*|scripts/ci/furey_*|scripts/ci/octonion_probes_gate.sh|scripts/research/sedenion_*|scripts/research/cd_tower_*|scripts/research/oct_*|scripts/research/ossm_*|scripts/ci/ade_wildgen_*|scripts/research/ade_wildgen_*)
         mark math
         recognized=true
         ;;

--- a/scripts/ci/octonion_probes_gate.sh
+++ b/scripts/ci/octonion_probes_gate.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Octonion / O-SSM research probes — keep them live (math-bearing .sio rots if
+# nothing runs it). Each probe is self-validating; this gate asserts scientific
+# invariants in stdout, not just compile success.
+#
+# Engine: lean_single (committed ELF). Exact sentinels were re-measured
+# 2026-08-18 on origin/main; if the seed is rebuilt, re-pin from a fresh run.
+#
+# GATE_CONTRACT: v0
+# GATE_ID: octonion_probes
+# GATE_CLAIMS: octonion algebra + O-SSM separation/recover + correlated RK4 sd
+# GATE_ENGINE: lean_single
+# GATE_RESULT_ON_SKIP: fail
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+export MADAROS_STACK_KB="${MADAROS_STACK_KB:-524288}"
+SOUC="${SOUC_BIN:-$ROOT_DIR/bin/souc}"
+OUT="$(mktemp -d /tmp/sounio-octonion-probes.XXXXXX)"
+trap 'rm -rf "$OUT"' EXIT
+
+fail=0
+fail() { echo "[octonion-probes] FAIL: $*" >&2; fail=1; }
+pass() { echo "[octonion-probes] PASS: $*"; }
+
+[[ -x "$SOUC" ]] || { echo "[octonion-probes] FAIL: souc missing: $SOUC" >&2; exit 1; }
+
+run() {
+  local f="$1"; shift
+  echo "[octonion-probes] == $f =="
+  if [[ ! -f "$f" ]]; then
+    fail "missing fixture $f"
+    return
+  fi
+  local log="$OUT/$(basename "$f").log"
+  set +e
+  timeout 90 env SOUNIO_SOUC_ENGINE=lean_single SOUNIO_STDLIB_PATH="$SOUNIO_STDLIB_PATH" \
+    MADAROS_STACK_KB="$MADAROS_STACK_KB" \
+    "$SOUC" run "$f" >"$log" 2>&1
+  local rc=$?
+  set -e
+  if [[ "$rc" -ne 0 ]]; then
+    fail "run rc=$rc $f (log $log)"
+    tail -20 "$log" >&2 || true
+    return
+  fi
+  local s
+  for s in "$@"; do
+    if ! grep -qF -- "$s" "$log"; then
+      fail "invariant missing in $f: «$s»"
+      return
+    fi
+  done
+  pass "$f"
+}
+
+# Positive control: a string that must appear so an empty-log green is impossible.
+run scripts/research/oct_truth.sio \
+  "alternative (x,x,y) ||.||^2 (*1e6): 0" \
+  "norm-mult |xy|^2-|x|^2|y|^2 (*1e6): 0"
+
+run scripts/research/oct_algebra.sio \
+  "antisymmetry violations = 0" \
+  "alternative violations = 0" \
+  "flexible ||.||^2 (*1e6) = 0"
+
+run scripts/research/ossm_separation.sio \
+  "permil): 500"
+
+# Recover curve: alpha=400 reaches 987 permil under lean_single (measured 2026-08-18).
+run scripts/research/ossm_recover.sio \
+  "cc     987"
+
+run examples/epistemic/rk4_correlated_uncertainty.sio \
+  "sd = 3.279153"
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "[octonion-probes] GATE_RECEIPT id=octonion_probes result=fail"
+  exit 1
+fi
+echo "[octonion-probes] GATE_RECEIPT id=octonion_probes result=pass measured=1 inputs=5 assertions=5"
+echo "OCTONION_PROBES_GATE_OK"
+exit 0

--- a/scripts/research/HYPERCOMPLEX_SSM_LANE.md
+++ b/scripts/research/HYPERCOMPLEX_SSM_LANE.md
@@ -20,7 +20,7 @@ Write-Set:
   scripts/research/ossm_recover.sio
   scripts/research/ossm_separation.sio
   scripts/research/HYPERCOMPLEX_SSM_LANE.md
-  scripts/octonion_probes_gate.sh
+  scripts/ci/octonion_probes_gate.sh
   examples/epistemic/rk4_correlated_uncertainty.sio   (bundled epistemic/GUM example)
   (future: examples/*ossm*.sio, examples/*octonion*.sio, stdlib/ssm/*, stdlib/{algebra,math}/octonion.sio, docs/briefings/OSSM_*.md)
 Read-Set:
@@ -30,7 +30,7 @@ Not-Touched:
   examples/associativity_probe_benchmark.sio — main already carries the gated
   run-pass version (//@ expect-stdout: ALL PASS); this lane defers to it and does
   NOT revert it. The provable separation lives in ossm_separation.sio.
-Required-Gates: scripts/octonion_probes_gate.sh green (compile+run every probe
+Required-Gates: scripts/ci/octonion_probes_gate.sh green (compile+run every probe
   under lean_single, assert invariants in stdout) -> OCTONION_PROBES_GATE_OK.
 Merge-Target: main
 Known-Blockers:
@@ -56,7 +56,7 @@ Note: `ossm_separation.sio` carries `with Mut` on `oct_class`/`left_class`/`righ
 ## Run everything
 
 ```bash
-bash scripts/octonion_probes_gate.sh          # asserts every invariant above
+bash scripts/ci/octonion_probes_gate.sh          # asserts every invariant above
 # or individually:
 for f in oct_truth oct_algebra ossm_recover ossm_separation; do
   SOUNIO_SOUC_ENGINE=lean_single ./bin/souc compile scripts/research/$f.sio -o /tmp/x.elf && /tmp/x.elf


### PR DESCRIPTION
## Summary

Re-author of **#1063** (DIFFERENT ERA, 1352 behind). Restores the O-SSM / octonion probes gate on current `main` with invariants **re-measured 2026-08-18** under `lean_single`.

## Changes

- `scripts/ci/octonion_probes_gate.sh` — five probes, stdout invariants, `GATE_RECEIPT`
- `scripts/ci/classify_ci_impact.sh` — mark gate + `scripts/research/oct_*|ossm_*` as `math`
- `scripts/research/HYPERCOMPLEX_SSM_LANE.md` — path update

## Local receipt

```bash
bash scripts/ci/octonion_probes_gate.sh
# OCTONION_PROBES_GATE_OK
```

## CI wire (blocked)

`.github/workflows/ci.yml` is held by `cursor-2` (`wire-correspondence-gate`). Suggested Contracts step (after Furey octonion):

```yaml
      - name: Octonion / O-SSM probes gate
        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
        run: bash scripts/ci/octonion_probes_gate.sh
```

## Supersedes

Closes the content gap of #1063; that PR should be closed as SUPERSEDED once this lands (branch preserved).

## Test plan

- [x] Gate green locally on tip main
- [ ] Contracts wire after `ci.yml` free
- [ ] CI Decision green