### PR TITLE
fix(ci): compile-fail harness contract — diagnostic not crash (#1053)

### DIFF
--- a/scripts/ci/compile_fail_harness_contract_gate.sh
+++ b/scripts/ci/compile_fail_harness_contract_gate.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Positive-control contract for compile-fail harness behaviour in
+# scripts/dev/run_sio_test_suite_v2.sh:
+#   matching diagnostic  → accept
+#   wrong diagnostic     → reject
+#   SEGV / signal        → reject (never a valid compile-fail)
+#   timeout              → reject
+#
+# GATE_CONTRACT: v0
+# GATE_ID: compile_fail_harness_contract
+# GATE_CLAIMS: compile-fail means diagnostic, not crash or hang
+# GATE_ENGINE: harness (fake compilers)
+# GATE_RESULT_ON_SKIP: fail
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/scripts/dev/run_sio_test_suite_v2.sh"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/sounio-compile-fail-contract.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+[[ -f "$RUNNER" ]] || { echo "missing runner: $RUNNER" >&2; exit 1; }
+bash -n "$RUNNER"
+
+FIXTURE="$WORK_DIR/compile_fail_contract.sio"
+TEST_LIST="$WORK_DIR/tests.txt"
+cat >"$FIXTURE" <<'FIXT'
+//@ compile-fail
+//@ error-pattern: expected compiler diagnostic
+//@ timeout: 1
+
+fn main() {}
+FIXT
+printf '%s\n' "$FIXTURE" >"$TEST_LIST"
+
+cat >"$WORK_DIR/diagnostic-souc" <<'EOFC'
+#!/usr/bin/env bash
+printf 'expected compiler diagnostic\n' >&2
+exit 1
+EOFC
+
+cat >"$WORK_DIR/wrong-diagnostic-souc" <<'EOFC'
+#!/usr/bin/env bash
+printf 'different compiler failure\n' >&2
+exit 1
+EOFC
+
+cat >"$WORK_DIR/signal-souc" <<'EOFC'
+#!/usr/bin/env bash
+printf 'expected compiler diagnostic\n' >&2
+kill -s SEGV "$$"
+EOFC
+
+cat >"$WORK_DIR/timeout-souc" <<'EOFC'
+#!/usr/bin/env bash
+sleep 5
+EOFC
+
+chmod +x "$WORK_DIR"/*-souc
+
+HARNESS_RC=0
+run_harness() {
+  local compiler="$1"
+  local log="$2"
+  if SOUNIO_TEST_SOUC_BIN="$compiler" SOUNIO_TEST_JOBS=1 \
+      bash "$RUNNER" --test-list "$TEST_LIST" --jobs 1 >"$log" 2>&1; then
+    HARNESS_RC=0
+  else
+    HARNESS_RC=$?
+  fi
+}
+
+expect_failure() {
+  local label="$1"
+  local expected="$2"
+  local log="$3"
+  if [[ "$HARNESS_RC" -eq 0 ]]; then
+    echo "compile-fail harness: ${label} was accepted" >&2
+    cat "$log" >&2
+    exit 1
+  fi
+  if ! grep -Fq "$expected" "$log"; then
+    echo "compile-fail harness: ${label} did not report: ${expected}" >&2
+    cat "$log" >&2
+    exit 1
+  fi
+}
+
+run_harness "$WORK_DIR/diagnostic-souc" "$WORK_DIR/diagnostic.log"
+if [[ "$HARNESS_RC" -ne 0 ]]; then
+  echo 'compile-fail harness: matching diagnostic was rejected' >&2
+  cat "$WORK_DIR/diagnostic.log" >&2
+  exit 1
+fi
+grep -Fq 'All tests passed!' "$WORK_DIR/diagnostic.log" \
+  || grep -Fq 'Pass:' "$WORK_DIR/diagnostic.log" \
+  || { echo 'compile-fail harness: no pass summary' >&2; cat "$WORK_DIR/diagnostic.log" >&2; exit 1; }
+
+run_harness "$WORK_DIR/wrong-diagnostic-souc" "$WORK_DIR/wrong-diagnostic.log"
+expect_failure 'wrong diagnostic' 'missing error: expected compiler diagnostic' "$WORK_DIR/wrong-diagnostic.log"
+
+run_harness "$WORK_DIR/signal-souc" "$WORK_DIR/signal.log"
+expect_failure 'signal termination' 'compile terminated by signal 11' "$WORK_DIR/signal.log"
+
+run_harness "$WORK_DIR/timeout-souc" "$WORK_DIR/timeout.log"
+expect_failure 'timeout' 'compile timed out after 1s' "$WORK_DIR/timeout.log"
+
+echo 'COMPILE_FAIL_HARNESS_CONTRACT_PASS'
+echo "[compile-fail-contract] GATE_RECEIPT id=compile_fail_harness_contract result=pass measured=1 inputs=4 assertions=4"
+exit 0

--- a/scripts/dev/run_sio_test_suite_v2.sh
+++ b/scripts/dev/run_sio_test_suite_v2.sh
@@ -8,7 +8,7 @@
 #
 # Annotations:
 #   //@ run-pass              — expect exit 0
-#   //@ compile-fail          — expect exit != 0
+#   //@ compile-fail          — expect a compiler diagnostic, not a timeout or signal
 #   //@ ignore                — skip this test
 #   //@ check-only            — compile only, do not execute
 #   //@ expect-stdout: X      — stdout must contain X (run-pass only)
@@ -424,22 +424,36 @@ run_test() {
         
     elif $is_compile_fail; then
         local tmp_out
+        local compile_exit_code=0
+        local check_error_patterns=false
         tmp_out="$(mktemp /tmp/sounio-cf-XXXXXX.elf)"
-        output=$(timeout "$timeout_val" "$SOUC_BIN" compile "$file" -o "$tmp_out" 2>&1) || exit_code=$?
+        output=$(timeout "$timeout_val" "$SOUC_BIN" compile "$file" -o "$tmp_out" 2>&1) || compile_exit_code=$?
         rm -f "$tmp_out"
-        
-        if [[ $exit_code -eq 124 ]]; then
+
+        if [[ $compile_exit_code -eq 124 ]]; then
             test_output="compile timed out after ${timeout_val}s"
-        elif [[ $exit_code -eq 0 ]] && grep -qF "typecheck: failed" <<<"$output"; then
             exit_code=1
-        elif [[ $exit_code -eq 0 ]]; then
+        # Shells encode signal termination as 128 + signal. A crash is never
+        # a valid compile-fail rejection, even when its output matches.
+        elif [[ $compile_exit_code -ge 128 && $compile_exit_code -le 192 ]]; then
+            local signal_num=$((compile_exit_code - 128))
+            test_output="compile terminated by signal ${signal_num} (exit ${compile_exit_code})"
+            exit_code=1
+        elif [[ $compile_exit_code -ge 125 && $compile_exit_code -le 127 ]]; then
+            test_output="compile harness exited ${compile_exit_code}"
+            exit_code=1
+        elif [[ $compile_exit_code -eq 0 ]] && grep -qF "typecheck: failed" <<<"$output"; then
+            check_error_patterns=true
+            exit_code=0
+        elif [[ $compile_exit_code -eq 0 ]]; then
             test_output="expected compile failure but passed"
             exit_code=1
         else
-            exit_code=0  # Reset - compile failure is expected
+            check_error_patterns=true
+            exit_code=0
         fi
 
-        if [[ $exit_code -ne 124 && $test_output != "expected compile failure but passed" ]]; then
+        if $check_error_patterns; then
             for pattern in "${error_patterns[@]}"; do
                 if ! grep -qiF -- "$pattern" <<<"$output"; then
                     exit_code=1
@@ -447,9 +461,6 @@ run_test() {
                     break
                 fi
             done
-            if [[ -z "$test_output" ]]; then
-                exit_code=0  # Reset - compile failure is expected
-            fi
         fi
     elif $is_typecheck_fail; then
         # Proof-carrying tests: the illegal inference must be rejected by the


### PR DESCRIPTION
## Summary

Re-author of **#1053** (DIFFERENT ERA, 1361 behind). compile-fail means a **compiler diagnostic**, not a hang or SEGV.

## Changes

- `scripts/dev/run_sio_test_suite_v2.sh` — reject timeout (124), signals (128–192), harness 125–127; only diagnostic exits check `//@ error-pattern`
- `scripts/ci/compile_fail_harness_contract_gate.sh` — positive controls: match / wrong pattern / SEGV / timeout

## Local receipt

```bash
bash scripts/ci/compile_fail_harness_contract_gate.sh
# COMPILE_FAIL_HARNESS_CONTRACT_PASS
```

## CI wire (blocked)

`.github/workflows/ci.yml` held by another lane. Suggested Contracts step (near harness self-tests):

```yaml
      - name: Compile-fail harness contract
        run: bash scripts/ci/compile_fail_harness_contract_gate.sh
```

## Supersedes

Content of #1053; close #1053 as SUPERSEDED after merge.

## Test plan

- [x] Contract gate green locally
- [ ] Contracts wire when `ci.yml` free
- [ ] Full Test Suite (no unexpected compile-fail cascade under stage2)