### PR TITLE
feat(website): /honesty shows the dated pbpk_suite ledger

### DIFF
--- a/website/src/components/honesty/DissertationNowPanel.astro
+++ b/website/src/components/honesty/DissertationNowPanel.astro
@@ -1,0 +1,165 @@
+---
+import { MeasuredAge } from './MeasuredAge';
+import {
+  PBPK_SUITE_NOW,
+  familyShare,
+  ledgerCloses,
+} from '../../lib/dissertationHonestyNow';
+import type { Locale } from '../../lib/i18n';
+import './DissertationNowPanel.css';
+
+interface Props {
+  locale?: Locale;
+}
+
+const { locale = 'en' } = Astro.props;
+const m = PBPK_SUITE_NOW;
+const closed = ledgerCloses(m);
+
+type Copy = {
+  kicker: string;
+  title: string;
+  fail: string;
+  of: string;
+  registered: string;
+  pass: string;
+  pend: string;
+  skip: string;
+  unknown: string;
+  toolchain: string;
+  toolchainNote: string;
+  ceiling: string;
+  ceilingNote: string;
+  science: string;
+  scienceNote: string;
+  pendNote: string;
+  measured: string;
+  source: string;
+  prior: string;
+};
+
+const copy: Record<string, Copy> = {
+  en: {
+    kicker: 'Now',
+    title: 'pbpk_suite',
+    fail: 'FAIL',
+    of: 'of',
+    registered: 'registered',
+    pass: 'PASS',
+    pend: 'PEND',
+    skip: 'SKIP',
+    unknown: 'UNKNOWN',
+    toolchain: 'toolchain',
+    toolchainNote: 'preflight E175 E137 E170 E009 E011 + epistemic runtime corruption · no owner',
+    ceiling: 'resource ceiling',
+    ceilingNote: 'rc=182 · handles full · five lanes · diagnosis closed',
+    science: 'science / model',
+    scienceNote: 'genuine PK or model defect among the fails',
+    pendNote: 'awaiting observed data · not a pass',
+    measured: 'measured',
+    source: 'source',
+    prior: 'prior',
+  },
+  pt: {
+    kicker: 'Estado actual',
+    title: 'pbpk_suite',
+    fail: 'FAIL',
+    of: 'de',
+    registered: 'registados',
+    pass: 'PASS',
+    pend: 'PEND',
+    skip: 'SKIP',
+    unknown: 'UNKNOWN',
+    toolchain: 'toolchain',
+    toolchainNote: 'preflight E175 E137 E170 E009 E011 + corrupção epistémica de runtime · sem dono',
+    ceiling: 'tecto de recursos',
+    ceilingNote: 'rc=182 · handles full · cinco lanes · diagnóstico fechado',
+    science: 'ciência / modelo',
+    scienceNote: 'defeito genuíno de PK ou de modelo entre as falhas',
+    pendNote: 'à espera de dados observados · não é um pass',
+    measured: 'medido',
+    source: 'fonte',
+    prior: 'anterior',
+  },
+};
+
+const d = copy[locale] ?? copy.en;
+
+const familyCopy = {
+  toolchain: { id: d.toolchain, note: d.toolchainNote },
+  'resource-ceiling': { id: d.ceiling, note: d.ceilingNote },
+  science: { id: d.science, note: d.scienceNote },
+} as const;
+
+const docHref = `https://github.com/Sounio-lang/sounio/blob/${m.docSha}/${m.doc}`;
+const sourceHref = `https://github.com/Sounio-lang/sounio/commit/${m.sourceSha}`;
+const priorHref = `https://github.com/Sounio-lang/sounio/commit/${m.prior.sourceSha}`;
+const prHref = `https://github.com/Sounio-lang/sounio/pull/${m.pr}`;
+---
+
+{
+  closed && (
+    <aside class="dnow" id="now" aria-labelledby="honesty-now-title">
+      <header class="dnow-head">
+        <div>
+          <p class="dnow-kicker">{d.kicker}</p>
+          <h2 class="dnow-title" id="honesty-now-title">{d.title}</h2>
+        </div>
+        <p class="dnow-when">
+          <time datetime={m.measuredAt}>{m.measuredAt}</time>
+          <MeasuredAge measuredAt={m.measuredAt} client:load />
+        </p>
+      </header>
+
+      <p class="dnow-headline">
+        <span class="dnow-fail-n">{m.fail}</span>
+        <span class="dnow-fail-k">{d.fail}</span>
+        <span class="dnow-of">{d.of}</span>
+        <span class="dnow-reg">{m.registered}</span>
+        <span class="dnow-of">{d.registered}</span>
+      </p>
+
+      <ul class="dnow-outcomes">
+        <li><strong>{m.pass}</strong> {d.pass}</li>
+        <li><strong>{m.pend}</strong> {d.pend}</li>
+        <li><strong>{m.skip}</strong> {d.skip}</li>
+        <li><strong>{m.unknown}</strong> {d.unknown}</li>
+      </ul>
+
+      <ul class="dnow-families">
+        {m.families.map((fam) => {
+          const share = familyShare(fam.n, m.fail);
+          const labels = familyCopy[fam.id];
+          return (
+            <li class="dnow-family-row" data-id={fam.id} data-n={fam.n}>
+              <span class="dnow-family-n">{fam.n}</span>
+              <div>
+                <p class="dnow-family-id">{labels.id}</p>
+                <p class="dnow-family-note">{labels.note}</p>
+                <div class="dnow-bar" aria-hidden="true">
+                  <span style={`width: ${(share * 100).toFixed(3)}%`} />
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      <footer class="dnow-foot">
+        <p class="dnow-pend">
+          {d.pend} · {m.pendName} · {d.pendNote}
+        </p>
+        <p class="dnow-meta">
+          {d.measured} {m.measuredAt} · {d.source}{' '}
+          <a href={sourceHref}>{m.sourceSha}</a> · {m.author} ·{' '}
+          <a href={prHref}>#{m.pr}</a> · <a href={docHref}>{m.doc}</a>
+        </p>
+        <p class="dnow-prior">
+          {d.prior} {m.prior.fail} {d.fail} / {m.prior.pass} {d.pass} / {m.prior.pend}{' '}
+          {d.pend} · {m.prior.measuredOn} · job {m.prior.job} ·{' '}
+          <a href={priorHref}>{m.prior.sourceSha}</a>
+        </p>
+      </footer>
+    </aside>
+  )
+}

--- a/website/src/components/honesty/DissertationNowPanel.css
+++ b/website/src/components/honesty/DissertationNowPanel.css
@@ -1,0 +1,236 @@
+/* DissertationNowPanel — tokens only from website/src/styles/global.css.
+   Age is the only coloured signal. Family rows stay ink, not adjectives. */
+
+.dnow {
+  display: grid;
+  gap: 1.15rem;
+  padding: 1.15rem 1.25rem 1.25rem;
+  border-radius: var(--radius-xl);
+  background: var(--color-surface-primary);
+  border: 1px solid var(--color-border-subtle);
+  color: var(--color-text-primary);
+  min-width: 0;
+}
+
+.dnow-head,
+.dnow-meta,
+.dnow-outcomes,
+.dnow-family-row,
+.dnow-family-note,
+.dnow-pend,
+.dnow-prior,
+.dnow-age,
+.dnow-fail-k,
+.dnow-fail-n,
+.dnow-of,
+.dnow-reg,
+.dnow-kicker,
+.dnow-title,
+.dnow-when {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-variant-ligatures: none;
+  font-feature-settings: 'calt' 0, 'liga' 0;
+}
+
+.dnow-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.65rem 1.25rem;
+}
+
+.dnow-kicker {
+  margin: 0;
+  font-size: 0.68rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-accent-teal);
+}
+
+.dnow-title {
+  margin: 0.2rem 0 0;
+  font-size: 0.92rem;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  color: var(--color-text-primary);
+}
+
+.dnow-when {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.45rem 0.75rem;
+  font-size: 0.72rem;
+  color: var(--color-text-tertiary);
+}
+
+.dnow-when time {
+  color: var(--color-text-secondary);
+}
+
+.dnow-age[data-age='lt-48h'] {
+  color: var(--color-epistemic-verified-text);
+}
+
+.dnow-age[data-age='lt-30d'] {
+  color: var(--color-epistemic-uncertain-text);
+}
+
+.dnow-age[data-age='ge-30d'],
+.dnow-age[data-age='invalid'] {
+  color: var(--color-epistemic-refused-text);
+}
+
+.dnow-headline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.55rem 0.85rem;
+  padding-top: 0.15rem;
+  border-top: 1px solid var(--color-border-hairline);
+}
+
+.dnow-fail-n {
+  font-size: clamp(2.4rem, 6vw, 3.4rem);
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  color: var(--color-text-primary);
+}
+
+.dnow-fail-k {
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-epistemic-refused-text);
+}
+
+.dnow-of {
+  font-size: 0.78rem;
+  color: var(--color-text-tertiary);
+}
+
+.dnow-reg {
+  font-size: 1.35rem;
+  color: var(--color-text-primary);
+}
+
+.dnow-outcomes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.55rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.dnow-outcomes li {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  padding: 0.22rem 0.5rem;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--color-border-hairline);
+  background: var(--color-surface-secondary);
+}
+
+.dnow-outcomes strong {
+  font-weight: 650;
+  color: var(--color-text-primary);
+}
+
+.dnow-families {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.dnow-family-row {
+  display: grid;
+  grid-template-columns: 2.4rem minmax(0, 1fr);
+  gap: 0.65rem;
+  align-items: start;
+}
+
+.dnow-family-n {
+  font-size: 1.15rem;
+  font-weight: 650;
+  line-height: 1.1;
+  color: var(--color-text-primary);
+}
+
+.dnow-family-id {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--color-text-primary);
+}
+
+.dnow-family-note {
+  margin: 0.15rem 0 0;
+  font-size: 0.68rem;
+  letter-spacing: 0.01em;
+  color: var(--color-text-tertiary);
+}
+
+.dnow-bar {
+  margin-top: 0.35rem;
+  height: 0.22rem;
+  border-radius: var(--radius-full);
+  background: var(--color-border-hairline);
+  overflow: hidden;
+}
+
+.dnow-bar > span {
+  display: block;
+  height: 100%;
+  background: var(--color-text-primary);
+}
+
+.dnow-family-row[data-n='0'] .dnow-bar > span {
+  width: 0;
+}
+
+.dnow-foot {
+  display: grid;
+  gap: 0.35rem;
+  padding-top: 0.25rem;
+  border-top: 1px solid var(--color-border-hairline);
+}
+
+.dnow-meta,
+.dnow-pend,
+.dnow-prior {
+  margin: 0;
+  font-size: 0.68rem;
+  line-height: 1.55;
+  color: var(--color-text-tertiary);
+}
+
+.dnow-meta a,
+.dnow-prior a {
+  color: var(--color-text-secondary);
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+.dnow-meta a:hover,
+.dnow-prior a:hover {
+  color: var(--color-accent-gold);
+}
+
+@media (min-width: 880px) {
+  .dnow {
+    padding: 1.25rem 1.4rem 1.35rem;
+  }
+
+  .dnow-family-row {
+    grid-template-columns: 2.8rem minmax(0, 1fr);
+  }
+}

--- a/website/src/components/honesty/HonestyArgument.astro
+++ b/website/src/components/honesty/HonestyArgument.astro
@@ -4,6 +4,7 @@ import { E219DiagnosticCodeBlock } from '../epistemic/DiagnosticCodeBlock';
 import { EffectLatticeBadge } from '../epistemic/EffectLatticeBadge';
 import { EpistemicGateCard } from '../epistemic/EpistemicGateCard';
 import FabricatedDatumExhibit from './FabricatedDatumExhibit.astro';
+import DissertationNowPanel from './DissertationNowPanel.astro';
 import { getLocalizedPath } from '../../lib/i18n';
 import type { Locale } from '../../lib/i18n';
 
@@ -184,6 +185,8 @@ const FABRICATED_EPSILON_STAND_IN = 2;
 ---
 
 <article class="honesty">
+  <DissertationNowPanel locale={locale} />
+
   <header class="honesty-hero">
     <p class="honesty-kicker">{localeCopy.kicker}</p>
     <h1 class="honesty-heading">{localeCopy.heading}</h1>

--- a/website/src/components/honesty/MeasuredAge.tsx
+++ b/website/src/components/honesty/MeasuredAge.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { ageBand, ageMs, formatAge } from '../../lib/dissertationHonestyNow';
+
+type Props = {
+  measuredAt: string;
+};
+
+/**
+ * Live age of a dated measurement. The ISO timestamp lives in the
+ * parent so a reader without JS still sees when the number was taken.
+ * This island only adds "11 h" / "62 d". A June 6/6 would read as
+ * days, in the refused token — that is the point of the control.
+ */
+export function MeasuredAge({ measuredAt }: Props) {
+  const [nowMs, setNowMs] = useState<number | null>(null);
+
+  useEffect(() => {
+    setNowMs(Date.now());
+  }, []);
+
+  if (nowMs === null) {
+    return <span className="dnow-age" data-age="pending" hidden />;
+  }
+
+  const ms = ageMs(measuredAt, nowMs);
+  const formatted = formatAge(ms);
+  const band = ageBand(ms);
+
+  if (!formatted || band === 'invalid') {
+    return (
+      <span className="dnow-age" data-age="invalid">
+        {measuredAt}
+      </span>
+    );
+  }
+
+  return (
+    <span className="dnow-age" data-age={band}>
+      {formatted.value}&nbsp;{formatted.unit}
+    </span>
+  );
+}

--- a/website/src/lib/dissertationHonestyNow.ts
+++ b/website/src/lib/dissertationHonestyNow.ts
@@ -1,0 +1,129 @@
+/**
+ * Dated dissertation-suite ledger for /honesty.
+ *
+ * A 6/6 from June survived two months because the page printed the
+ * number and not the date. This module is the opposite: every figure
+ * is bound to the measurement that produced it. Editing one count
+ * without the others must not ship — the ledger throws.
+ *
+ * Source of truth (do not invent a later run):
+ *   docs/audit/DISSERTATION_PBPK_SUITE_REMEASURE_2026-08-17.md
+ *   author grok-cli2 · landed #1818 as 2016efb8e4
+ *   measured on source-built Madaros at d0c798e4ed
+ *   finished 2026-08-17T22:21:35Z
+ *
+ * PEND is its own category. It is not a pass. Hiding it would make
+ * 19 + 33 look like 53.
+ */
+
+export const MS_HOUR = 3_600_000;
+export const MS_DAY = 86_400_000;
+
+export type FailFamily = {
+  n: number;
+  id: 'toolchain' | 'resource-ceiling' | 'science';
+};
+
+export type SuiteMeasure = {
+  gate: string;
+  measuredAt: string;
+  sourceSha: string;
+  docSha: string;
+  author: string;
+  doc: string;
+  pr: number;
+  registered: number;
+  pass: number;
+  fail: number;
+  pend: number;
+  skip: number;
+  unknown: number;
+  pendName: string;
+  families: readonly [FailFamily, FailFamily, FailFamily];
+  prior: {
+    measuredOn: string;
+    job: string;
+    sourceSha: string;
+    pass: number;
+    fail: number;
+    pend: number;
+  };
+};
+
+export const PBPK_SUITE_NOW: SuiteMeasure = {
+  gate: 'scripts/ci/dissertation_pbpk_suite_gate.sh',
+  measuredAt: '2026-08-17T22:21:35Z',
+  sourceSha: 'd0c798e4ed',
+  docSha: '2016efb8e4',
+  author: 'grok-cli2',
+  doc: 'docs/audit/DISSERTATION_PBPK_SUITE_REMEASURE_2026-08-17.md',
+  pr: 1818,
+  registered: 53,
+  pass: 33,
+  fail: 19,
+  pend: 1,
+  skip: 0,
+  unknown: 0,
+  pendName: 'pbpk28_semaglutide_clinical',
+  families: [
+    { n: 12, id: 'toolchain' },
+    { n: 7, id: 'resource-ceiling' },
+    { n: 0, id: 'science' },
+  ],
+  prior: {
+    measuredOn: '2026-08-16',
+    job: '9908',
+    sourceSha: '6f2c4e2461',
+    pass: 28,
+    fail: 24,
+    pend: 1,
+  },
+};
+
+export function outcomesSum(m: SuiteMeasure): number {
+  return m.pass + m.fail + m.pend + m.skip + m.unknown;
+}
+
+export function familiesSum(m: SuiteMeasure): number {
+  return m.families[0].n + m.families[1].n + m.families[2].n;
+}
+
+export function ledgerCloses(m: SuiteMeasure): boolean {
+  return outcomesSum(m) === m.registered && familiesSum(m) === m.fail;
+}
+
+if (!ledgerCloses(PBPK_SUITE_NOW)) {
+  throw new Error(
+    'dissertationHonestyNow: pbpk_suite ledger does not close — refuse to print a total that the parts do not sum to',
+  );
+}
+
+export function ageMs(measuredAt: string, nowMs: number): number {
+  const t = Date.parse(measuredAt);
+  if (Number.isNaN(t)) return Number.NaN;
+  return nowMs - t;
+}
+
+export type AgeBand = 'lt-48h' | 'lt-30d' | 'ge-30d';
+
+export function ageBand(ms: number): AgeBand | 'invalid' {
+  if (!Number.isFinite(ms) || ms < 0) return 'invalid';
+  if (ms < 48 * MS_HOUR) return 'lt-48h';
+  if (ms < 30 * MS_DAY) return 'lt-30d';
+  return 'ge-30d';
+}
+
+export type FormattedAge = { value: number; unit: 'h' | 'd' };
+
+export function formatAge(ms: number): FormattedAge | null {
+  if (!Number.isFinite(ms) || ms < 0) return null;
+  if (ms < 48 * MS_HOUR) {
+    return { value: Math.floor(ms / MS_HOUR), unit: 'h' };
+  }
+  return { value: Math.floor(ms / MS_DAY), unit: 'd' };
+}
+
+export function familyShare(n: number, fail: number): number {
+  if (fail <= 0 || n <= 0) return 0;
+  return n / fail;
+}


### PR DESCRIPTION
## Summary

- `/honesty` now opens with a **NOW** panel: `pbpk_suite` **19 FAIL of 53**, measured **2026-08-17T22:21:35Z**, not an undated adjective.
- Among the 19: **12 toolchain** (E175 E137 E170 E009 E011 + epistemic runtime corruption, no owner), **7 resource ceiling** (`rc=182`, diagnosis closed), **0 science / model**.
- Outcomes are printed in full: **33 PASS / 1 PEND / 0 SKIP / 0 UNKNOWN**. PEND is `pbpk28_semaglutide_clinical` (awaiting observed data). Hiding it would make 19+33 look like 53.
- The ISO timestamp is in the HTML. A client island adds `10 h` / `73 d`. A June 6/6 would read as days in the refused token. That is the point.
- Kernel `website/src/lib/dissertationHonestyNow.ts` throws if the parts do not sum. Source: `docs/audit/DISSERTATION_PBPK_SUITE_REMEASURE_2026-08-17.md` (grok-cli2, #1818, source `d0c798e4ed`). Prior row: 24 FAIL / 28 PASS / 1 PEND on 2026-08-16 job 9908. No “improved” copy — both dates are visible.
- Tokens only from `website/src/styles/global.css`. Age is the only coloured signal.

## Test plan

- [x] `npm run check:i18n` — 7 locales match
- [x] `npm run check:astro` — 0 errors
- [x] `npm run check:routes` — OK
- [ ] Do **not** run `npm run build` / `check:quality` locally (regenerates `artifactStatus.ts`)
- [ ] After merge, `#1833` (story rewrite) must keep `<DissertationNowPanel />` at the top of `HonestyArgument.astro`