### PR TITLE
fix(stdlib): expose dissertation cross-module helpers

### DIFF
--- a/stdlib/darwin_pbpk/drugs/rapamycin.sio
+++ b/stdlib/darwin_pbpk/drugs/rapamycin.sio
@@ -62,7 +62,7 @@ fn rapa_sqrt_drug(x: f64) -> f64 {
 //   Deep adipose distribution is OUT OF SCOPE for a 48h BBB focus study.
 //   For multi-day deep-tissue studies, use the full 14-compartment tsit5 model.
 
-fn rapamycin_mean_params() -> PBPKParams14 {
+pub fn rapamycin_mean_params() -> PBPKParams14 {
     var prm = default_pbpk_params()
 
     // Clearance: CYP3A4-dominated, fu_plasma=0.08 unbound cleared

--- a/stdlib/darwin_pbpk/scenarios/oral_rapamycin_bbb.sio
+++ b/stdlib/darwin_pbpk/scenarios/oral_rapamycin_bbb.sio
@@ -49,7 +49,7 @@ pub struct OralBBBTrace {
     success: bool,
 }
 
-fn oral_trace_zero() -> OralBBBTrace {
+pub fn oral_trace_zero() -> OralBBBTrace {
     OralBBBTrace {
         n_points: 0,
         times_h:   [0.0; 32],

--- a/stdlib/math/pure.sio
+++ b/stdlib/math/pure.sio
@@ -90,7 +90,7 @@ fn min_i32(a: i32, b: i32) -> i32 {
 // reach the true sqrt — returning ~10⁻⁶ instead of ~10⁻⁸. Range
 // reduction is bit-deterministic and adds at worst ~30 multiplications
 // for f64-representable inputs.
-fn sqrt(x: f64) -> f64 with Mut, Div, Panic {
+pub fn sqrt(x: f64) -> f64 with Mut, Div, Panic {
     if x <= 0.0 { return 0.0 }
     var v = x
     var s = 1.0


### PR DESCRIPTION
## Classification

The six dissertation-suite E175 failures collapse to three genuinely private definitions. They are stdlib visibility omissions, not Madaros resolver defects.

| Suite case | Private definition | Owner verdict |
|---|---|---|
| `dissertation_oral_pd` | `rapamycin_mean_params` | stdlib PBPK missing `pub` |
| `dissertation_steady_state` | `rapamycin_mean_params` | stdlib PBPK missing `pub` |
| `dissertation_steady_state_fullvd` | `oral_trace_zero` through `steady_state_runner` | stdlib PBPK missing `pub` |
| `dissertation_scenario_gate` | `rapamycin_mean_params` | stdlib PBPK missing `pub` |
| `halo_pgx_gate` | `math::pure::sqrt` through `aggregate_confidence` | stdlib math missing `pub` |
| `dissertation_pgx_demo` | `math::pure::sqrt` through `aggregate_confidence` | stdlib math missing `pub` |

No private helper was copied into a caller. This PR changes only the intended module boundaries.

## Source-built measurement

Slurm job `10172` built Madaros from this branch:

- build rc 0
- ELF sha256 `01eef6fb3df12255360d51c5f16055bb69ca3eeacd24ebb37379c7e2c3f31d07`
- all six dissertation cases: `E175=0`
- genuine private cross-module fixture: `E175=1`
- mutation removing `pub` from `rapamycin_mean_params`: `E175=1`
- mutation removing `pub` from `sqrt`: `E175=2`
- mutation removing `pub` from `oral_trace_zero`: `E175=1`
- instrument verdict: `STATUS=PASS FAILURES=0`

Three cases become check-green immediately: oral PD, haloperidol PGx gate, and the PGx demo. The remaining three move honestly to already-existing non-E175 diagnostics:

- both steady-state demos: E008 in `ssr_run_one_interval` plus three E137 `print_i64` diagnostics
- scenario gate: E137 `print_i64` in `bbb_voi_print`

Those residuals are separate families and are intentionally untouched.