### PR TITLE
fix(ci): souc_v2_gate reads producers' exit codes, not tail's

### DIFF
--- a/scripts/ci/souc_v2_gate.sh
+++ b/scripts/ci/souc_v2_gate.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 # souc_v2_gate.sh -- Gate test for lean_single.sio / souc_v2 bootstrap compiler
 # Runs bootstrap fixed-point, souc_v2 split fixed-point, feature tests, regression.
-set -e
+# pipefail: a pipeline's rc must be the producer's, not the reader's.
+# Without it every `prog | tail -1` below read tail's rc (0 for a prog that
+# crashed after printing). The early-exiting-reader shapes this file used to
+# carry are gone too: assertions grep here-strings, not `echo | grep -q`.
+set -eo pipefail
 PASS=0; FAIL=0; TOTAL=0
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
@@ -59,19 +63,28 @@ fi
 S=/tmp/gate_s2.elf
 
 # --- souc_v2 split fixed-point ---
+# Each stage's status must be the compiler's own. This chain used to pipe
+# every stage through `tail -1`, so tail's rc=0 stood in for a stage that
+# failed after emitting output, and all but the last line of each stage's
+# evidence was destroyed in the same stroke. Log to files (the shape the
+# bootstrap stages above already use) and let the chain read the real rc.
 echo ""
 echo "--- souc_v2 split ---"
 TOTAL=$((TOTAL+1))
-if $S self-hosted/compiler/souc_v2/main.sio /tmp/gate_split1.elf 2>&1 | tail -1 && \
+rm -f /tmp/gate_split1.elf /tmp/gate_split2.elf /tmp/gate_split3.elf
+if $S self-hosted/compiler/souc_v2/main.sio /tmp/gate_split1.elf >/tmp/gate_split1.log 2>&1 && \
    chmod +x /tmp/gate_split1.elf && \
-   /tmp/gate_split1.elf self-hosted/compiler/souc_v2/main.sio /tmp/gate_split2.elf 2>&1 | tail -1 && \
+   /tmp/gate_split1.elf self-hosted/compiler/souc_v2/main.sio /tmp/gate_split2.elf >/tmp/gate_split2.log 2>&1 && \
    chmod +x /tmp/gate_split2.elf && \
-   /tmp/gate_split2.elf self-hosted/compiler/souc_v2/main.sio /tmp/gate_split3.elf 2>&1 | tail -1 && \
+   /tmp/gate_split2.elf self-hosted/compiler/souc_v2/main.sio /tmp/gate_split3.elf >/tmp/gate_split3.log 2>&1 && \
    cmp -s /tmp/gate_split2.elf /tmp/gate_split3.elf; then
     echo "PASS: souc_v2 split fixed-point"
     PASS=$((PASS+1))
 else
     echo "FAIL: souc_v2 split fixed-point"
+    for lg in 1 2 3; do
+        tail -n 3 /tmp/gate_split$lg.log 2>/dev/null
+    done
     FAIL=$((FAIL+1))
 fi
 
@@ -82,19 +95,26 @@ echo "--- Feature tests ---"
 run_test() {
     local name=$1 src=$2 expected=$3
     TOTAL=$((TOTAL+1))
-    if timeout 30 $S "$src" /tmp/gate_out.elf 2>/dev/null && \
+    if timeout 30 $S "$src" /tmp/gate_out.elf >/tmp/gate_compile.log 2>&1 && \
        chmod +x /tmp/gate_out.elf 2>/dev/null; then
-        local output
-        output=$(timeout 10 /tmp/gate_out.elf 2>/dev/null) || true
-        if echo "$output" | grep -q "$expected"; then
+        local output rc
+        # The program's exit status is part of the contract. This used to be
+        # `$(...) || true`, which let a binary print the expected text and
+        # then crash and still score PASS. Capture the rc; require 0.
+        set +e
+        output=$(timeout 10 /tmp/gate_out.elf 2>/dev/null)
+        rc=$?
+        set -e
+        if [ $rc -eq 0 ] && grep -q "$expected" <<<"$output"; then
             echo "PASS: $name"
             PASS=$((PASS+1))
         else
-            echo "FAIL: $name (got: $(echo "$output" | head -c 60))"
+            echo "FAIL: $name (rc=$rc, got: ${output:0:60})"
             FAIL=$((FAIL+1))
         fi
     else
         echo "FAIL: $name (compile error)"
+        tail -n 20 /tmp/gate_compile.log 2>/dev/null || true
         FAIL=$((FAIL+1))
     fi
 }
@@ -105,13 +125,17 @@ run_test_exact() {
     TOTAL=$((TOTAL+1))
     if timeout 30 $S "$src" /tmp/gate_out.elf >/tmp/gate_compile.log 2>&1 && \
        chmod +x /tmp/gate_out.elf 2>/dev/null; then
-        local output
-        output=$(timeout 10 /tmp/gate_out.elf "$@" 2>/dev/null) || true
-        if [ "$output" = "$expected" ]; then
+        local output rc
+        # Same contract as run_test: the program's own exit status must be 0.
+        set +e
+        output=$(timeout 10 /tmp/gate_out.elf "$@" 2>/dev/null)
+        rc=$?
+        set -e
+        if [ $rc -eq 0 ] && [ "$output" = "$expected" ]; then
             echo "PASS: $name"
             PASS=$((PASS+1))
         else
-            echo "FAIL: $name"
+            echo "FAIL: $name (rc=$rc)"
             echo "  expected: $(printf '%q' "$expected")"
             echo "  got:      $(printf '%q' "$output")"
             FAIL=$((FAIL+1))
@@ -129,7 +153,7 @@ run_cross_compile_test() {
     if timeout 30 $S "$src" /tmp/gate_cross.out --target "$target" >/tmp/gate_cross.log 2>&1; then
         local kind
         kind=$(file /tmp/gate_cross.out 2>/dev/null || true)
-        if echo "$kind" | grep -q "$expected_kind"; then
+        if grep -q "$expected_kind" <<<"$kind"; then
             echo "PASS: $name"
             PASS=$((PASS+1))
         else
@@ -233,11 +257,11 @@ err_out=$($S /tmp/gate_t8.sio /tmp/gate_err.elf 2>&1 || true)
 # prefix -- so `grep '^error'` on a failing build returned nothing. The
 # contract this test is really for is "a diagnostic names a location and is
 # greppable as an error", so assert that instead of the word "line".
-if echo "$err_out" | grep -q "^error" && echo "$err_out" | grep -qE ":[0-9]+"; then
+if grep -q "^error" <<<"$err_out" && grep -qE ":[0-9]+" <<<"$err_out"; then
     echo "PASS: error_line_numbers"
     PASS=$((PASS+1))
 else
-    echo "FAIL: error_line_numbers (got: $(echo "$err_out" | head -c 80))"
+    echo "FAIL: error_line_numbers (got: ${err_out:0:80})"
     FAIL=$((FAIL+1))
 fi
 


### PR DESCRIPTION
## What

`scripts/ci/souc_v2_gate.sh` — the wired **Feature gate** — decided verdicts on exit codes that did not belong to the thing being measured:

1. **Split fixed-point arm read `tail`'s rc.** `set -e` with no pipefail, and every bootstrap stage piped through `2>&1 | tail -1` — so a compiler that wrote a partial artifact and then failed still returned 0 through the chain. The piping also destroyed all but the last line of each stage's evidence.
2. **Feature tests swallowed the program's rc entirely.** `output=$(timeout 10 /tmp/gate_out.elf 2>/dev/null) || true` then a text match: a binary that printed the expected string and **then crashed** scored PASS.
3. Compile errors in `run_test` went to `/dev/null` (its sibling `run_test_exact` already logged them).

## Fix

- `set -eo pipefail`, and no pipe-to-early-exiting-reader shape remains: the split arm logs each stage to `/tmp/gate_splitN.log` (the exact shape the bootstrap stages at the top of the file already used) and the `&&` chain reads each compiler's real rc. The FAIL branch tails all three logs.
- `run_test` / `run_test_exact`: `set +e; output=$(...); rc=$?; set -e` (the repo's own pattern from `madaros_gum_fo_trust_gate.sh`) and require `rc == 0` alongside the output match. FAIL lines name the rc.
- The file's `echo | grep -q` assertions became here-strings and `${var:0:N}` truncation, so the new pipefail cannot mint EPIPE verdicts out of small writers.

## Verification — measured on this tree (`/tmp/final_boot4.elf`)

| Run | Old code | Fixed code |
|---|---|---|
| Clean gate | 16/16, exit 0 | 16/16, exit 0 — verdicts identical |
| Canary R: program prints `99` then `exit 3` (injected into the program invocation, one-line delta) | **`PASS: generics`** | `FAIL: generics (rc=3, got: 99)` |
| Canary S: split stage writes artifact + log then `exit 7` (one-line delta) | **`PASS: souc_v2 split fixed-point`** | `FAIL: souc_v2 split fixed-point` + diagnostic tail, exit 1 |

Canaries are copies of the gate differing by exactly one injected line each (diff shown in the commit); the clean runs execute the committed file.

## Relation to the census

Sweep finding **F2** (M2 rc-through-pipe + D2 neutralized producer) in `.scratch/EXIT_STATUS_SWEEP_2026-08-17.md`; repair-order item 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
