### PR TITLE
fix(research): land the 2026-07-31 supersession in the forall_n spectral note

### DIFF
--- a/docs/research/cd_tower_zd_fiber_spectral_forall_n_progress_2026-07-26.md
+++ b/docs/research/cd_tower_zd_fiber_spectral_forall_n_progress_2026-07-26.md
@@ -61,6 +61,15 @@ Verdict: `CD_TOWER_ZDFAN_VERDICT ZD_FIBER_SPECTRAL_FORALL_N_STRONG_EVIDENCE_NOT_
   combinatorial factorisation. **Stalled.** The remaining route is the explicit algebraic factorisation
   `A_σ = Cᵀ S C` (Walsh / character-sum type, in the spirit of the ∀n kernel-dimension proof) — not
   found in-session.
+  > **Superseded 2026-07-31 — the factorisation was found.** It is not a Walsh character sum but a
+  > rank-2 folding: `A_σ(l ⊕ L_lo, y) = −A_σ(l, y)`, giving `A_σ = Jᵀ M J` with `J Jᵀ = 2I`, hence
+  > `rank(A_σ) ≤ 2^{n-2}−1` **derived ∀n** and an exact spectral halving. See
+  > `cd_tower_zd_fiber_antisymmetry_lemma_spec_2026-07-31.md` (on the live ZD-fiber lane branch
+  > `research/zd-fiber-antisymmetry-lemma-20260731`, byte-identical to PR #1580's copy; lands with
+  > that lane — linked here without a hyperlink until it reaches main).
+  > This closes the low-rank half only — `V1` (`#spectra = 3·2^{n-5}`) remains **OPEN**. The harness
+  > and verdict token of *this* rung are deliberately left untouched: they are measured objects in the
+  > R13/R14 kill-set corpora.
 - **Flank B — empirical boundary.** Pushed completeness to `n=9` (48) and `n=10` (96), both matching
   `3·2^{n-5}` (vectorised via a precomputed sign table). Five levels now stand.
 
@@ -96,3 +105,8 @@ discipline: real progress + honest boundary, not a claimed solution). The substa
 claim (`n≤8`) was Grok-reviewed in the parent classifier rung; this rung is verified-empirical progress
 plus an explicit open boundary. Numerical certificate; ∀n OPEN. No semantic claim, no clinical content.
 GAIDeT-ICMJE 2025.
+
+**Post-session correction (2026-08-18, landed from the PR #1580 audit):** "not found in-session" was
+true of the 2026-07-26 session and stayed in this disclosure untouched as a measured record — but the
+low-rank factorisation WAS found on 2026-07-31 (rank-2 folding; see the supersession note in §2).
+`V1` remains OPEN; ∀n completeness is still not closed.


### PR DESCRIPTION
## What

Main's `cd_tower_zd_fiber_spectral_forall_n_progress_2026-07-26.md` records the algebraic low-rank factorisation as **"Stalled … not found in-session"** (§2) and repeats "not found" in the §5 AI disclosure. Both were true of the 07-26 session — but **stale since 2026-07-31**, when the factorisation was found: a rank-2 folding `A_σ(l ⊕ L_lo, y) = −A_σ(l, y)` giving `A_σ = Jᵀ M J` with `J Jᵀ = 2I`, hence `rank(A_σ) ≤ 2^{n-2}−1` **derived ∀n** and an exact spectral halving. The supersession note exists in PR #1580 but never reached main; the PR1580 audit (2026-08-18) confirmed main records it nowhere (zero grep hits for the folding / Jᵀ M J / supersession).

## Change (docs-only, 1 file, +14)

- Lands the supersession note at the exact PR location (after the "Stalled" flank-A paragraph): **low-rank half CLOSED ∀n; `V1` (`#spectra = 3·2^{n-5}` ∀n) remains OPEN**. Harness/verdict token deliberately untouched — measured objects in the R13/R14 kill-set corpora.
- One adaptation vs the PR: its hyperlink to `cd_tower_zd_fiber_antisymmetry_lemma_spec_2026-07-31.md` would **dangle** — that file is not on main; it lives on the live ZD-fiber lane branch `research/zd-fiber-antisymmetry-lemma-20260731` (byte-identical to the PR copy, verified by blob diff) and lands with that lane. Referenced in backticks with provenance instead of a broken link.
- Adds a post-session correction paragraph to §5 so "not found in-session" cannot be read as current status.

## Why cherry-pick, not merging #1580

Same rationale as #1854 (the companion 1-WL fix): the audit partitioned #1580's 190 authored files — 98 byte-identical on main, 13 superseded, 78 unique-but-owned-elsewhere (ontology programme, ZD-fiber lane). This note and the 1-WL correction are the two pieces that fix **stale/false status on main** and are time-sensitive for referee-facing use.

Companion: #1854 (qualify WL claim to 1-WL, same audit trail).