### PR TITLE
ci: retarget reachability leftover control after #1836

### DIFF
--- a/scripts/dev/ci_gate_workflow_reachability.py
+++ b/scripts/dev/ci_gate_workflow_reachability.py
@@ -7,9 +7,9 @@ invocations (bash/sh/source), not comments and not inventory globs.
 
 Positive control (must be non-zero on this repo): at least one gate is
 reachable (ci.yml names several) AND at least one named leftover is not
-(epistemic_fabrication_detect_gate.sh). A census that reports 0 leftovers,
-or 0 reachable, has not measured. Correspondence was the third named
-orphan; it is wired in ci.yml Contracts as of the 2026-08-18 one-gate PR.
+(f64_bitcast_sitofp_boundary_gate.sh). A census that reports 0 leftovers,
+or 0 reachable, has not measured. The original three named orphans
+(correspondence, fabrication-detect, ontology enforcement) are wired.
 
 Usage:
   python3 scripts/dev/ci_gate_workflow_reachability.py
@@ -66,12 +66,17 @@ INVENTORY_MARKERS = (
     "rglob",
 )
 
-# Remaining named forgotten leftovers. Correspondence left this list when
-# it was wired in Contracts (one gate per PR). Do not add a newly wired
-# name back here — that would REFUTE the instrument.
+# Remaining forgotten leftovers after the 2026-08-18 named-three landing
+# (#1845 correspondence, #1836 fabrication + ontology). Wiring one of
+# these without removing it here is a REFUTE, not a silent pass.
 NAMED_DIRECT_ORPHANS = (
-    "epistemic_fabrication_detect_gate.sh",
-    "madaros_ontology_enforcement_gate.sh",
+    "f64_bitcast_sitofp_boundary_gate.sh",
+    "madaros_f128_f256_ladder_gate.sh",
+    "madaros_f128_f256_v0c_wire_gate.sh",
+    "madaros_f128_f256_v0d_softfloat_gate.sh",
+    "madaros_print_f64_negative_gate.sh",
+    "mli_s3_bit_identity_gate.sh",
+    "stdlib_source_byte_ceiling_gate.sh",
 )
 
 DISSERTATION_GATES = (
@@ -326,8 +331,8 @@ def main() -> int:
         else:
             pass
     missing_named = [o for o in NAMED_DIRECT_ORPHANS if o in reach_names]
-    # Remaining named leftovers must stay unreachable. Wiring one without
-    # removing it from NAMED_DIRECT_ORPHANS is a REFUTE, not a silent pass.
+    # Remaining forgotten leftovers must stay unreachable. Wiring one
+    # without removing it from NAMED_DIRECT_ORPHANS is a REFUTE.
     if missing_named:
         print(
             f"REFUTE: named direct orphans resolved as reachable: {missing_named}",


### PR DESCRIPTION
## Summary

- #1836 landed on `main` (`200b53419b`) and wired the remaining two named leftovers (`epistemic_fabrication_detect_gate.sh` in Contracts, `madaros_ontology_enforcement_gate.sh` in Witness). Correspondence was already on main via #1845.
- The census instrument then **REFUTEd** on current `main`: those two names are reachable. This PR moves the named-leftover control to the seven forgotten gates that are still unwired.

Does not wire anything. The 2026-08-18 snapshot TSV is not rewritten.

## Measurement on `200b53419b` then this change

```text
# before (stale control list): exit 2
REFUTE: named direct orphans resolved as reachable:
  epistemic_fabrication_detect_gate.sh, madaros_ontology_enforcement_gate.sh

# after:
gates_total=470  reachable=89  leftover=381  forgotten=8
named leftovers still unreachable: the seven below
```

Remaining forgotten controls: `f64_bitcast_sitofp_boundary`, `madaros_f128_f256_{ladder,v0c_wire,v0d_softfloat}`, `madaros_print_f64_negative`, `mli_s3_bit_identity`, `stdlib_source_byte_ceiling`.

(Census day was 468/85/383/10. Population grew by two gates on `main`; one of those is reachable, one is a new forgotten. Do not quote 85 as current.)

## Test plan

- [x] Instrument REFUTE reproduced on `main` with the old list
- [x] Instrument exit 0 after retarget; seven named leftovers still unreachable
- [ ] Contracts / CI Decision on this PR