### PR TITLE
fix(ci): wired presence asserts read the producer, not the pipe

### DIFF
--- a/scripts/ci/cd_tower_seam_gate.sh
+++ b/scripts/ci/cd_tower_seam_gate.sh
@@ -13,8 +13,8 @@ python3 scripts/research/cd_tower_seam_oracle.py > "$WORK/py_all.txt"
 # souc omits ZDEQ64 (dim-64 ZD scan left to the oracle); compare the lines souc DID emit.
 grep -aE '^(LSQ|FWD|SEAM|ZDEQ|NA|OS)[0-9]' "$WORK/py_all.txt" | grep -v '^ZDEQ64 ' | sort > "$WORK/py.txt"
 fail=0
-diff "$WORK/souc.txt" "$WORK/py.txt" >/dev/null || { echo "MISMATCH:"; diff "$WORK/souc.txt" "$WORK/py.txt" | head; fail=1; }
-echo "$OUT" | grep -qa '^TOWER OK' || { echo "verdict != TOWER OK"; fail=1; }
+diff "$WORK/souc.txt" "$WORK/py.txt" >/dev/null || { echo "MISMATCH:"; diff "$WORK/souc.txt" "$WORK/py.txt" | sed -n '1,10p'; fail=1; }
+grep -qa '^TOWER OK' <<<"$OUT" || { echo "verdict != TOWER OK"; fail=1; }
 # the converse (off-seam <=> ZD) at dim 64, carried by the oracle's full scan:
 [ "$(grep '^ZDEQ64 ' "$WORK/py_all.txt" | awk '{print $2}')" = "1" ] || { echo "dim-64 ZD coincidence failed"; fail=1; }
 [ "$fail" -eq 0 ] || { echo "cd-tower gate: FAIL"; exit 1; }

--- a/scripts/ci/claim_ast_gate.sh
+++ b/scripts/ci/claim_ast_gate.sh
@@ -27,8 +27,12 @@ echo "A2_PREPROCESSOR_IDENTITY PASS"
 python3 "${PREPROCESSOR}" --test || fail "preprocessor roundtrip failed"
 echo "A3_A4_PREPROCESSOR_ROUNDTRIP PASS"
 
-# A5: no parser files modified in this diff
-if git diff --name-only HEAD | grep -q '^self-hosted/parser/'; then
+# A5: no parser files modified in this diff. Capture first: through the pipe
+# a failing `git diff` reads as "no parser files" (grep's empty result
+# decides), which is a silent pass on a broken instrument; the capture keeps
+# git's own status visible.
+changed_paths="$(git diff --name-only HEAD)"
+if grep -q '^self-hosted/parser/' <<<"$changed_paths"; then
     fail "parser files modified"
 fi
 echo "A5_NO_PARSER_TOUCH PASS"

--- a/scripts/ci/kretikos_kaxi_phase_y_gate.sh
+++ b/scripts/ci/kretikos_kaxi_phase_y_gate.sh
@@ -49,8 +49,12 @@ if ! command -v cc >/dev/null 2>&1; then
   echo "kretikos_kaxi_phase_y_gate: SKIPPED (cc missing)"
   exit 0
 fi
-if ! ldconfig -p 2>/dev/null | grep -q libcuda &&
-   ! find /usr/lib /usr/local/lib -name "libcuda.so*" -maxdepth 3 2>/dev/null | grep -q libcuda; then
+# `find | grep -q` EPIPEs when CUDA exists (many matches, find is still
+# writing when grep -q exits) and pipefail turns that into "not found" --
+# the arm selector concluded no-CUDA exactly when CUDA was present. Find
+# stops itself now (-print -quit), and ldconfig's output is captured whole.
+if ! grep -q libcuda <<<"$(ldconfig -p 2>/dev/null || true)" &&
+   [[ -z "$(find /usr/lib /usr/local/lib -name "libcuda.so*" -maxdepth 3 -print -quit 2>/dev/null || true)" ]]; then
   echo "kretikos_kaxi_phase_y_gate: SKIPPED (libcuda not found)"
   exit 0
 fi

--- a/scripts/ci/mli_s3_bit_identity_gate.sh
+++ b/scripts/ci/mli_s3_bit_identity_gate.sh
@@ -89,9 +89,9 @@ PINNED="$(od -An -v -tu1 -j "$TOFF" -N "$TSIZE" "$TMP/golden.elf" | tr -s ' \n' 
 }')" || fail "could not find the second prologue (function boundary)"
 
 # Positive controls on the extraction itself.
-echo "$PINNED" | grep -q "72 184 0 0 0 0 0 0 240 63" \
+grep -q "72 184 0 0 0 0 0 0 240 63" <<<"$PINNED" \
     || fail "extracted bytes lack the movabs(1.0) pattern — wrong boundary?"
-[ "$(echo "$PINNED" | awk '{print $NF}')" = "195" ] \
+[ "$(awk '{print $NF}' <<<"$PINNED")" = "195" ] \
     || fail "extracted bytes do not end in ret — wrong boundary?"
 
 # ---------------------------------------------------------------- pipeline B

--- a/scripts/ci/native_v2_frontend_convergence_gate.sh
+++ b/scripts/ci/native_v2_frontend_convergence_gate.sh
@@ -624,7 +624,7 @@ run_case "lean_frontend_imported_ir_summary" "$LOG_DIR/lean_frontend.imported_ir
 run_case "lean_modular_imported_ir_summary" "$LOG_DIR/lean_modular.imported_ir_summary.log" \
   "$SOUC_BIN" run self-hosted/compiler/lean.sio -- --ir-summary tests/selfhost/native_runtime/import_nested_main_42.sio
 run_case "lean_modular_probe_load_ir" "$LOG_DIR/lean_modular.probe_load_ir.log" \
-  bash -c 'set -o pipefail; "$1" run self-hosted/compiler/lean.sio -- --probe-load-ir examples/hello.sio | grep -q "probe_load_ir: ok"' \
+  bash -c 'out="$("$1" run self-hosted/compiler/lean.sio -- --probe-load-ir examples/hello.sio 2>&1)"; printf "%s\n" "$out"; grep -q "probe_load_ir: ok" <<<"$out"' \
   bash "$SOUC_BIN"
 run_case "lean_modular_probe_load_ir_trace" "$LOG_DIR/lean_modular.probe_load_ir_trace.log" \
   bash -c 'out="$("$1" run self-hosted/compiler/lean.sio -- --probe-load-ir-trace tests/selfhost/native_runtime/import_nested_main_42.sio 2>&1)"; printf "%s\n" "$out"; grep -q "body_lowered=3" <<<"$out" && grep -q "probe_load_ir_trace: ok" <<<"$out"' \

--- a/scripts/ci/ontology_cli_smoke_gate.sh
+++ b/scripts/ci/ontology_cli_smoke_gate.sh
@@ -82,7 +82,13 @@ compile_test_binary() {
         exit 1
     fi
     patch_source
-    if "$SOUC_BIN" --help 2>/dev/null | grep -q "compile <file.sio>"; then
+    # Capture, don't pipe: through the pipe it is grep's match that decides,
+    # so a failing `--help` whose stdout happens to contain the flag would
+    # still select the new interface, and an early-exiting `grep -q` can
+    # EPIPE the writer under pipefail. The rc decides; the match only refines.
+    help_rc=0
+    help_out="$("$SOUC_BIN" --help 2>/dev/null)" || help_rc=$?
+    if [[ "$help_rc" -eq 0 ]] && grep -q "compile <file.sio>" <<<"$help_out"; then
         compile_cmd=( "$SOUC_BIN" compile "$PATCHED_SRC" -o "$TEST_BIN" )
     else
         compile_cmd=( "$SOUC_BIN" "$PATCHED_SRC" "$TEST_BIN" )
@@ -99,7 +105,7 @@ compile_test_binary() {
 test_resolve_curie() {
     local out
     out="$(run_ont resolve ALG:0000001)"
-    if echo "$out" | grep -q 'curie: ALG:0000001'; then
+    if grep -q 'curie: ALG:0000001' <<<"$out"; then
         ok "resolve CURIE"
     else
         fail "resolve CURIE"
@@ -109,7 +115,7 @@ test_resolve_curie() {
 test_resolve_label() {
     local out
     out="$(run_ont resolve "Ring")"
-    if echo "$out" | grep -q 'curie: ALG:0000005'; then
+    if grep -q 'curie: ALG:0000005' <<<"$out"; then
         ok "resolve by label"
     else
         fail "resolve by label"
@@ -119,7 +125,7 @@ test_resolve_label() {
 test_resolve_synonym() {
     local out
     out="$(run_ont resolve "Algebraic group")"
-    if echo "$out" | grep -q 'curie: ALG:0000002'; then
+    if grep -q 'curie: ALG:0000002' <<<"$out"; then
         ok "resolve by synonym"
     else
         fail "resolve by synonym"
@@ -173,7 +179,7 @@ test_fuzzy_limit() {
 test_count_prefix() {
     local out
     out="$(run_ont count GO:)"
-    if echo "$out" | grep -q '112'; then
+    if grep -q '112' <<<"$out"; then
         ok "count prefix"
     else
         fail "count prefix"
@@ -183,7 +189,7 @@ test_count_prefix() {
 test_count_total() {
     local out
     out="$(run_ont count)"
-    if echo "$out" | grep -q '1008'; then
+    if grep -q '1008' <<<"$out"; then
         ok "count total"
     else
         fail "count total"
@@ -193,7 +199,7 @@ test_count_total() {
 test_is_subclass() {
     local out
     out="$(run_ont is-subclass ALG:0000003 ALG:0000001)"
-    if echo "$out" | grep -q 'yes'; then
+    if grep -q 'yes' <<<"$out"; then
         ok "is-subclass true"
     else
         fail "is-subclass true"
@@ -203,7 +209,7 @@ test_is_subclass() {
 test_ancestors() {
     local out
     out="$(run_ont ancestors ALG:0000003)"
-    if echo "$out" | grep -q 'ALG:0000002' && echo "$out" | grep -q 'ALG:0000001'; then
+    if grep -q 'ALG:0000002' <<<"$out" && grep -q 'ALG:0000001' <<<"$out"; then
         ok "ancestors"
     else
         fail "ancestors"
@@ -213,7 +219,7 @@ test_ancestors() {
 test_validate() {
     local out rc=0
     out="$(run_ont validate)" || rc=$?
-    if [[ "$rc" -eq 0 ]] && echo "$out" | grep -q 'VALID'; then
+    if [[ "$rc" -eq 0 ]] && grep -q 'VALID' <<<"$out"; then
         ok "validate"
     else
         fail "validate"
@@ -223,7 +229,7 @@ test_validate() {
 test_stats() {
     local out
     out="$(run_ont stats)"
-    if echo "$out" | grep -q 'ALG:' && echo "$out" | grep -q 'Max depth:' && echo "$out" | grep -q 'Root terms:'; then
+    if grep -q 'ALG:' <<<"$out" && grep -q 'Max depth:' <<<"$out" && grep -q 'Root terms:' <<<"$out"; then
         ok "stats"
     else
         fail "stats"
@@ -233,7 +239,7 @@ test_stats() {
 test_format_json() {
     local out
     out="$(run_ont --format json resolve ALG:0000001)"
-    if echo "$out" | grep -q '"curie": "ALG:0000001"'; then
+    if grep -q '"curie": "ALG:0000001"' <<<"$out"; then
         ok "--format json"
     else
         fail "--format json"
@@ -243,7 +249,7 @@ test_format_json() {
 test_format_tsv() {
     local out
     out="$(run_ont --format tsv resolve ALG:0000001)"
-    if echo "$out" | grep -q $'ALG:0000001\tAlgebra'; then
+    if grep -q $'ALG:0000001\tAlgebra' <<<"$out"; then
         ok "--format tsv"
     else
         fail "--format tsv"
@@ -275,7 +281,7 @@ validate
 EOF
     local out
     out="$(run_ont batch "$batch_file")"
-    if echo "$out" | grep -q 'ALG:0000001' && echo "$out" | grep -q '112' && echo "$out" | grep -q 'ALG:0000002' && echo "$out" | grep -q 'ALG:' && echo "$out" | grep -q 'VALID'; then
+    if grep -q 'ALG:0000001' <<<"$out" && grep -q '112' <<<"$out" && grep -q 'ALG:0000002' <<<"$out" && grep -q 'ALG:' <<<"$out" && grep -q 'VALID' <<<"$out"; then
         ok "batch mode"
     else
         fail "batch mode"
@@ -285,7 +291,7 @@ EOF
 test_unresolved() {
     local out
     out="$(run_ont resolve NONEXISTENT:999)"
-    if echo "$out" | grep -q 'unresolved'; then
+    if grep -q 'unresolved' <<<"$out"; then
         ok "unresolved CURIE"
     else
         fail "unresolved CURIE"

--- a/scripts/ci/sedenion_cd_qbig_gate.sh
+++ b/scripts/ci/sedenion_cd_qbig_gate.sh
@@ -11,8 +11,8 @@ run_souc() { if [ "$SOUC" = "./bin/souc" ]; then ./bin/souc run "$1" 2>/dev/null
 OUT="$(run_souc tests/run-pass/sedenion_cd_qbig.sio)"
 echo "$OUT" | grep -aE '^(RES|ANNIHILATION_C1) ' > "$WORK/souc.txt"
 python3 scripts/research/sedenion_cd_qbig_oracle.py | grep -E '^(RES|ANNIHILATION_C1) ' > "$WORK/py.txt"
-diff "$WORK/souc.txt" "$WORK/py.txt" >/dev/null || { echo "MISMATCH:"; diff "$WORK/souc.txt" "$WORK/py.txt" | head; echo "cd-qbig gate: FAIL"; exit 1; }
-echo "$OUT" | grep -qa '^CDQBIG OK' || { echo "verdict != CDQBIG OK"; echo "cd-qbig gate: FAIL"; exit 1; }
+diff "$WORK/souc.txt" "$WORK/py.txt" >/dev/null || { echo "MISMATCH:"; diff "$WORK/souc.txt" "$WORK/py.txt" | sed -n '1,10p'; echo "cd-qbig gate: FAIL"; exit 1; }
+grep -qa '^CDQBIG OK' <<<"$OUT" || { echo "verdict != CDQBIG OK"; echo "cd-qbig gate: FAIL"; exit 1; }
 echo "CROSS-VERIFIED: exact unbounded-Q CD product (16 comps). Case 1 annihilates EXACTLY at 10^80"
 echo "  (all 16 comps 0); case 2 residues (mod 1e9+7) match the Python oracle in order. Exact decimals"
 echo "  witnessed by Lean (native Int). #651 circumvented via a minimal working-primitive BigInt."

--- a/scripts/ci/sedenion_phi_injectivity_gate.sh
+++ b/scripts/ci/sedenion_phi_injectivity_gate.sh
@@ -27,9 +27,9 @@ OUT="$("$SOUC" run tests/stdlib/nn/test_fractal_sedenion_e2e.sio 2>/tmp/phi_inj_
   echo "[phi-inj] FAIL: Sounio test exited nonzero"; echo "$OUT"; tail -20 /tmp/phi_inj_sio.log; exit 1; }
 # run-pass exit 0 above already guarantees fail==0 (main returns 0 iff all pass);
 # these greps confirm the new tests actually ran.
-echo "$OUT" | grep -q "T9 OK"  || { echo "[phi-inj] FAIL: T9 missing"; echo "$OUT"; exit 1; }
-echo "$OUT" | grep -q "T10 OK" || { echo "[phi-inj] FAIL: T10 missing"; echo "$OUT"; exit 1; }
-echo "$OUT" | grep -q "/ 10 passed" || { echo "[phi-inj] FAIL: passed-line missing"; echo "$OUT"; exit 1; }
+grep -q "T9 OK" <<<"$OUT"  || { echo "[phi-inj] FAIL: T9 missing"; echo "$OUT"; exit 1; }
+grep -q "T10 OK" <<<"$OUT" || { echo "[phi-inj] FAIL: T10 missing"; echo "$OUT"; exit 1; }
+grep -q "/ 10 passed" <<<"$OUT" || { echo "[phi-inj] FAIL: passed-line missing"; echo "$OUT"; exit 1; }
 echo "[phi-inj]   Sounio: 10 / 10 passed (T9, T10 present; exit 0)"
 
 echo "[phi-inj] PASS: Φ̄ non-injective (126, 42 collisions) machine-checked in both codebases"

--- a/scripts/ci/self_falsifying_compiler_gate.sh
+++ b/scripts/ci/self_falsifying_compiler_gate.sh
@@ -97,44 +97,44 @@ run_case() {
 
 # F2: without the flag claims are inert — compile and run normally.
 run_case F2 zero run "$TEST_SIO" -o "$TMP_DIR/f2.elf"
-printf '%s\n' "$OUT" | grep -q "SELF_FALSIFYING_COMPILER_TEST_OK" \
+grep -q "SELF_FALSIFYING_COMPILER_TEST_OK" <<<"$OUT" \
     || fail "F2: expected run marker without --verify-claims, got: $OUT"
-printf '%s\n' "$OUT" | grep -q "CLAIM_FAIL" \
+grep -q "CLAIM_FAIL" <<<"$OUT" \
     && fail "F2: claim gates ran without --verify-claims: $OUT"
 echo "F2_INERT_DEFAULT PASS"
 
 # F3: no claims → no-op.
 run_case F3 zero run "$FIX/self_falsifying_no_claims.sio" -o "$TMP_DIR/f3.elf" --verify-claims
-printf '%s\n' "$OUT" | grep -q "VERIFY_CLAIMS_NOOP" \
+grep -q "VERIFY_CLAIMS_NOOP" <<<"$OUT" \
     || fail "F3: expected VERIFY_CLAIMS_NOOP, got: $OUT"
-printf '%s\n' "$OUT" | grep -q "SELF_FALSIFYING_NO_CLAIMS_OK" \
+grep -q "SELF_FALSIFYING_NO_CLAIMS_OK" <<<"$OUT" \
     || fail "F3: expected compile+run to proceed, got: $OUT"
 echo "F3_NO_CLAIMS_NOOP PASS"
 
 # F4: all gates pass → verification succeeds and codegen+run proceed.
 run_case F4 zero run "$FIX/self_falsifying_claims_pass_only.sio" -o "$TMP_DIR/f4.elf" --verify-claims
-printf '%s\n' "$OUT" | grep -q "CLAIM_PASS sfc_only_pass" \
+grep -q "CLAIM_PASS sfc_only_pass" <<<"$OUT" \
     || fail "F4: expected CLAIM_PASS sfc_only_pass, got: $OUT"
-printf '%s\n' "$OUT" | grep -q "CLAIM_SKIP sfc_metadata_only (no-gate)" \
+grep -q "CLAIM_SKIP sfc_metadata_only (no-gate)" <<<"$OUT" \
     || fail "F4: expected CLAIM_SKIP sfc_metadata_only (no-gate), got: $OUT"
-printf '%s\n' "$OUT" | grep -q "VERIFY_CLAIMS_OK" \
+grep -q "VERIFY_CLAIMS_OK" <<<"$OUT" \
     || fail "F4: expected VERIFY_CLAIMS_OK, got: $OUT"
-printf '%s\n' "$OUT" | grep -q "SELF_FALSIFYING_PASS_ONLY_OK" \
+grep -q "SELF_FALSIFYING_PASS_ONLY_OK" <<<"$OUT" \
     || fail "F4: expected codegen+run to proceed, got: $OUT"
 echo "F4_PASS_ONLY PASS"
 
 # F5: a failing gate falsifies its claim and blocks codegen; the archived
 # claim's (failing) gate must be skipped.
 run_case F5 nonzero run "$TEST_SIO" -o "$TMP_DIR/f5.elf" --verify-claims
-printf '%s\n' "$OUT" | grep -q "CLAIM_PASS sfc_gate_pass" \
+grep -q "CLAIM_PASS sfc_gate_pass" <<<"$OUT" \
     || fail "F5: expected CLAIM_PASS sfc_gate_pass, got: $OUT"
-printf '%s\n' "$OUT" | grep -q "CLAIM_FAIL sfc_gate_fail" \
+grep -q "CLAIM_FAIL sfc_gate_fail" <<<"$OUT" \
     || fail "F5: expected CLAIM_FAIL sfc_gate_fail, got: $OUT"
-printf '%s\n' "$OUT" | grep -q "CLAIM_SKIP sfc_archived (archived)" \
+grep -q "CLAIM_SKIP sfc_archived (archived)" <<<"$OUT" \
     || fail "F5: expected CLAIM_SKIP sfc_archived (archived), got: $OUT"
-printf '%s\n' "$OUT" | grep -q "VERIFY_CLAIMS_FALSIFIED" \
+grep -q "VERIFY_CLAIMS_FALSIFIED" <<<"$OUT" \
     || fail "F5: expected VERIFY_CLAIMS_FALSIFIED, got: $OUT"
-printf '%s\n' "$OUT" | grep -q "SELF_FALSIFYING_COMPILER_TEST_OK" \
+grep -q "SELF_FALSIFYING_COMPILER_TEST_OK" <<<"$OUT" \
     && fail "F5: codegen+run proceeded despite falsified claim: $OUT"
 [[ ! -f "$TMP_DIR/f5.elf" ]] \
     || fail "F5: ELF emitted despite falsified claim"
@@ -144,9 +144,9 @@ echo "F5_FAIL_BLOCKS PASS"
 # falsified claim and exit non-zero.
 rm -f "$TMP_DIR/f7.elf"
 run_case F7 nonzero "$TEST_SIO" -o "$TMP_DIR/f7.elf" --verify-claims
-printf '%s\n' "$OUT" | grep -q "VERIFY_CLAIMS_FALSIFIED" \
+grep -q "VERIFY_CLAIMS_FALSIFIED" <<<"$OUT" \
     || fail "F7: expected VERIFY_CLAIMS_FALSIFIED, got: $OUT"
-printf '%s\n' "$OUT" | grep -q "Compilation successful" \
+grep -q "Compilation successful" <<<"$OUT" \
     && fail "F7: default lane compiled despite falsified claim: $OUT"
 [[ ! -f "$TMP_DIR/f7.elf" ]] \
     || fail "F7: default lane emitted ELF despite falsified claim"
@@ -155,9 +155,9 @@ echo "F7_DEFAULT_LANE_BLOCKS PASS"
 # F6 (optional): timeout enforcement — costs ~30s wall-clock.
 if [[ "${SFC_TEST_TIMEOUT:-0}" == "1" ]]; then
     run_case F6 nonzero run "$FIX/self_falsifying_claims_timeout.sio" -o "$TMP_DIR/f6.elf" --verify-claims
-    printf '%s\n' "$OUT" | grep -q "CLAIM_TIMEOUT sfc_gate_timeout" \
+    grep -q "CLAIM_TIMEOUT sfc_gate_timeout" <<<"$OUT" \
         || fail "F6: expected CLAIM_TIMEOUT sfc_gate_timeout, got: $OUT"
-    printf '%s\n' "$OUT" | grep -q "VERIFY_CLAIMS_FALSIFIED" \
+    grep -q "VERIFY_CLAIMS_FALSIFIED" <<<"$OUT" \
         || fail "F6: expected VERIFY_CLAIMS_FALSIFIED, got: $OUT"
     echo "F6_TIMEOUT PASS"
 else

--- a/scripts/ci/semantic_orc_depression_orc_gate.sh
+++ b/scripts/ci/semantic_orc_depression_orc_gate.sh
@@ -29,23 +29,23 @@ SWOW_OUT="$("${SOUC}" run "${SWOW_SRC}" 2>&1)" || fail "depression_swow_orc.sio 
 echo "${SWOW_OUT}"
 echo ""
 
-echo "${SWOW_OUT}" | grep -q "SOUNIO_DEPRESSION_SWOW_ORC_PASS" \
+grep -q "SOUNIO_DEPRESSION_SWOW_ORC_PASS" <<<"${SWOW_OUT}" \
     || fail "token SOUNIO_DEPRESSION_SWOW_ORC_PASS not found"
 echo "✓ SOUNIO_DEPRESSION_SWOW_ORC_PASS present"
 
 # Verify all 5 groups produced output
-echo "${SWOW_OUT}" | grep -q "control" \
+grep -q "control" <<<"${SWOW_OUT}" \
     || fail "control group missing from output"
-echo "${SWOW_OUT}" | grep -q "minimum" \
+grep -q "minimum" <<<"${SWOW_OUT}" \
     || fail "minimum group missing from output"
-echo "${SWOW_OUT}" | grep -q "severe" \
+grep -q "severe" <<<"${SWOW_OUT}" \
     || fail "severe group missing from output"
 echo "✓ all 5 groups present in output"
 
 # Verify minimum has highest neg% (non-monotonic finding)
 # Extract neg% for minimum and severe; minimum should be higher
-MIN_LINE="$(echo "${SWOW_OUT}" | grep "minimum")"
-echo "${MIN_LINE}" | grep -q "neg%=0\." || echo "${MIN_LINE}" | grep -q "neg%=1\." \
+MIN_LINE="$(grep "minimum" <<<"${SWOW_OUT}")"
+grep -q "neg%=0\." <<<"${MIN_LINE}" || grep -q "neg%=1\." <<<"${MIN_LINE}" \
     || fail "minimum group neg% field missing"
 echo "✓ minimum group neg% field present"
 
@@ -58,20 +58,21 @@ SEM_OUT="$("${SOUC}" run "${SEMANTIC_SRC}" 2>&1)" || fail "depression_semantic_o
 echo "${SEM_OUT}"
 echo ""
 
-echo "${SEM_OUT}" | grep -q "SOUNIO_DEPRESSION_SEMANTIC_ORC_PASS" \
+grep -q "SOUNIO_DEPRESSION_SEMANTIC_ORC_PASS" <<<"${SEM_OUT}" \
     || fail "token SOUNIO_DEPRESSION_SEMANTIC_ORC_PASS not found"
 echo "✓ SOUNIO_DEPRESSION_SEMANTIC_ORC_PASS present"
 
-echo "${SEM_OUT}" | grep -q "VERIFIED: minimum group has most negative mean curvature" \
+grep -q "VERIFIED: minimum group has most negative mean curvature" <<<"${SEM_OUT}" \
     || fail "minimum group ordering verification failed"
 echo "✓ minimum most-hyperbolic ordering verified"
 
-echo "${SEM_OUT}" | grep -q "VERIFIED: moderate group least hyperbolic" \
+grep -q "VERIFIED: moderate group least hyperbolic" <<<"${SEM_OUT}" \
     || fail "non-monotonic finding verification failed"
 echo "✓ non-monotonic finding (moderate least hyperbolic) verified"
 
 # Verify CI format: minimum CI should be entirely negative
-echo "${SEM_OUT}" | grep "minimum" | grep -q "CI=\[-" \
+min_ci="$(grep "minimum" <<<"${SEM_OUT}" || true)"
+grep -q "CI=\[-" <<<"$min_ci" \
     || fail "minimum CI does not start negative"
 echo "✓ minimum CI negative-definite"
 
@@ -87,12 +88,12 @@ EPI_OUT="$("${SOUC}" run "${EPI_SRC}" 2>&1)" || fail "depression_epistemic_orc.s
 echo "${EPI_OUT}"
 echo ""
 
-echo "${EPI_OUT}" | grep -q "SOUNIO_DEPRESSION_EPISTEMIC_ORC_PASS" \
+grep -q "SOUNIO_DEPRESSION_EPISTEMIC_ORC_PASS" <<<"${EPI_OUT}" \
     || fail "token SOUNIO_DEPRESSION_EPISTEMIC_ORC_PASS not found"
 echo "✓ SOUNIO_DEPRESSION_EPISTEMIC_ORC_PASS present"
 
 # Density-matched separation gate must verify (effect survives density control)
-echo "${EPI_OUT}" | grep -q "VERIFIED: subclinical most hyperbolic" \
+grep -q "VERIFIED: subclinical most hyperbolic" <<<"${EPI_OUT}" \
     || fail "density-matched separation gate not verified"
 echo "✓ subclinical-most-hyperbolic separation verified at matched density"
 echo ""

--- a/scripts/ci/sigpipe_hygiene_gate.sh
+++ b/scripts/ci/sigpipe_hygiene_gate.sh
@@ -65,18 +65,62 @@ echo "fixed forms: here-string grep and sed top-10 decide correctly on 200 KiB+ 
 # Executable lines only: comments may name the forbidden shape while
 # documenting why it is forbidden, and that is not a regression.
 executable() { grep -v '^[[:space:]]*#' "$1"; }
-# No `echo "$captured" | grep -q` in the harness (the false-"missing" shape).
-if executable "$HARNESS" | grep -n 'echo "$output" | grep -q\|echo "$test_output" | grep -q' >/dev/null; then
-    executable "$HARNESS" | grep -n 'echo "$output" | grep -q\|echo "$test_output" | grep -q' | sed 's/^/  /'
-    fail "verdict-carrying echo|grep -q pipeline is back in $HARNESS"
-fi
-# No `| head` in the probe's executable lines: it runs under set -euo
-# pipefail, and any early-exiting reader there can kill the step before its
-# own exit path.
-if executable "$PROBE" | grep -n '| head' >/dev/null; then
-    executable "$PROBE" | grep -n '| head' | sed 's/^/  /'
-    fail "early-exiting '| head' reader is back in $PROBE"
-fi
-echo "shape ban: no echo|grep -q in $HARNESS, no | head in $PROBE"
+
+# Every file below carried a verdict-deciding `echo ... | grep -q` (or a
+# printf writer) that #1763 exiled from the harness and the wired-presence
+# change exiled from the gates: `grep -q` exits at first match, the flushing
+# writer fails under pipefail, and a present needle reads as absent.
+SHAPE_BAN_GREPQ_FILES=(
+    "$HARNESS"
+    "$PROBE"
+    scripts/ci/ontology_cli_smoke_gate.sh
+    scripts/ci/self_falsifying_compiler_gate.sh
+    scripts/ci/semantic_orc_depression_orc_gate.sh
+    scripts/ci/sedenion_phi_injectivity_gate.sh
+    scripts/ci/sedenion_cd_qbig_gate.sh
+    scripts/ci/cd_tower_seam_gate.sh
+    scripts/ci/sounio_validation.sh
+    scripts/ci/mli_s3_bit_identity_gate.sh
+    scripts/ci/kretikos_kaxi_phase_y_gate.sh
+    scripts/ci/claim_ast_gate.sh
+    scripts/ci/native_v2_frontend_convergence_gate.sh
+)
+# Same mechanism, reader side: `| head` exits after its window and any writer
+# still flushing fails under pipefail before its own exit path runs. The
+# harness is not listed here: its two `| head` uses are display-only and were
+# reviewed as noise-free in #1763.
+SHAPE_BAN_HEAD_FILES=(
+    "$PROBE"
+    scripts/ci/ontology_cli_smoke_gate.sh
+    scripts/ci/self_falsifying_compiler_gate.sh
+    scripts/ci/semantic_orc_depression_orc_gate.sh
+    scripts/ci/sedenion_phi_injectivity_gate.sh
+    scripts/ci/sedenion_cd_qbig_gate.sh
+    scripts/ci/cd_tower_seam_gate.sh
+    scripts/ci/sounio_validation.sh
+    scripts/ci/mli_s3_bit_identity_gate.sh
+    scripts/ci/kretikos_kaxi_phase_y_gate.sh
+    scripts/ci/claim_ast_gate.sh
+    scripts/ci/native_v2_frontend_convergence_gate.sh
+)
+# The ban greps capture whole and assert on the capture: `executable | grep -q`
+# here would recreate the banned mechanism inside the gate that bans it.
+for f in "${SHAPE_BAN_GREPQ_FILES[@]}"; do
+    [[ -f "$f" ]] || fail "guarded file absent: $f (nothing to scan)"
+    viol="$(executable "$f" | grep -nE '(echo|printf) [^|]*\| *grep -q' || true)"
+    if [[ -n "$viol" ]]; then
+        printf '%s\n' "$viol" | sed "s|^|$f:|"
+        fail "verdict-carrying echo|grep -q pipeline is back in $f"
+    fi
+done
+for f in "${SHAPE_BAN_HEAD_FILES[@]}"; do
+    [[ -f "$f" ]] || fail "guarded file absent: $f (nothing to scan)"
+    viol="$(executable "$f" | grep -nE '\| *head\b' || true)"
+    if [[ -n "$viol" ]]; then
+        printf '%s\n' "$viol" | sed "s|^|$f:|"
+        fail "early-exiting '| head' reader is back in $f"
+    fi
+done
+echo "shape ban: no echo|grep -q in ${#SHAPE_BAN_GREPQ_FILES[@]} files, no | head in ${#SHAPE_BAN_HEAD_FILES[@]} files"
 
 echo "SIGPIPE_HYGIENE_GATE_OK"

--- a/scripts/ci/sounio_validation.sh
+++ b/scripts/ci/sounio_validation.sh
@@ -94,7 +94,7 @@ validate_file() {
     
     if [ $exit_code -eq 0 ]; then
         # Check for warnings
-        if echo "$output" | grep -q "⚠"; then
+        if grep -q "⚠" <<<"$output"; then
             print_warning "File has warnings (but no errors)"
             echo "$output" | grep -A2 -B2 "⚠"
             return 0  # Warnings don't fail CI by default


### PR DESCRIPTION
## What

Repair-order item **F6** from the exit-status sweep. A verdict-carrying
pipeline under `set -euo pipefail` whose reader is `grep -q` can lose the
writer: `grep -q` exits at first match, closes the pipe, the flushing `echo`
fails with EPIPE, pipefail turns that into the pipeline's status, and a
**present** needle reads as absent (the #1763 harness incident). The same
sweep found the shape wired into presence asserts across ten more gates,
plus three sites where the pipe lets the *reader's* outcome stand in for the
producer's own status (a failing producer reading as a passing condition).

## The fix

**54 mechanical conversions, 11 files** — `echo "$captured" | grep -q 'PAT'`
→ `grep -q 'PAT' <<<"$captured"` (no writer process to lose):

| file | sites |
|---|---|
| `scripts/ci/ontology_cli_smoke_gate.sh` | 20 |
| `scripts/ci/self_falsifying_compiler_gate.sh` | 17 (printf writer) |
| `scripts/ci/semantic_orc_depression_orc_gate.sh` | 11 |
| `scripts/ci/sedenion_phi_injectivity_gate.sh` | 3 |
| `scripts/ci/sedenion_cd_qbig_gate.sh` | 1 + `\| head` → `sed -n '1,10p'` |
| `scripts/ci/cd_tower_seam_gate.sh` | 1 + `\| head` → `sed -n '1,10p'` |
| `scripts/ci/sounio_validation.sh` | 1 |
| `scripts/ci/mli_s3_bit_identity_gate.sh` | 1 + awk capture |

**6 hand sites** where the mechanism is the producer's status, not the match:

- `ontology_cli_smoke_gate.sh:85` — interface selection now requires
  `--help` rc 0; previously a *failing* `--help` whose stdout happened to
  contain `compile <file.sio>` still selected the new interface.
- `kretikos_kaxi_phase_y_gate.sh:52` — CUDA arm selection: `find \| grep -q`
  EPIPEs precisely when CUDA **exists** (many matches, find still writing),
  so the gate concluded "no CUDA, skip GPU arm" exactly when CUDA was
  present. Now `find -print -quit` + whole-output capture.
- `claim_ast_gate.sh:31` — parser-touch check captures `git diff` first; a
  failing git diff through the pipe read as "no parser files" (silent pass
  on a broken instrument).
- `native_v2_frontend_convergence_gate.sh:627` — probe case rewritten to
  the capture-then-grep shape its sibling case already uses.
- `semantic_orc_depression_orc_gate.sh:47,74` — grep captures moved off
  pipes.

**Hygiene gate extended** (`scripts/ci/sigpipe_hygiene_gate.sh`): the shape
ban grows from 2 guarded files to two lists — 13 files banning
`(echo|printf) … | grep -q`, 12 banning `\| head` (the harness keeps its two
#1763-reviewed display-only `| head` uses). A listed file going absent fails
the gate ("nothing to scan"), and the ban's own greps capture whole rather
than `| grep -q` — the gate must not recreate what it bans.

## Verification (all local, this tree)

| instrument | result |
|---|---|
| `bash -n` × 12 touched files | clean |
| hygiene gate, clean tree | OK (13 + 12 files scanned) |
| bite: `echo \| grep -q` injected into listed file | FAIL, names `file:line` |
| bite: `\| head` injected | FAIL |
| bite: violation in the harness itself | FAIL |
| bite: shape named in a comment only | PASS (executable-line filter) |
| bite: listed file renamed away | FAIL "guarded file absent" |
| mli_s3_bit_identity_gate | PASS — 106 bytes bit-identical |
| claim_ast_gate | PASS |
| cd_tower_seam_gate | PASS |
| sedenion_cd_qbig_gate | PASS |
| semantic_orc_depression_orc_gate | PASS |
| kretikos gate, CUDA-less box | SKIPPED via the new selector (correct arm) |
| ontology interface canary (real `bin/souc --help`) | new and old agree: legacy interface |
| ontology canary, adversarial: failing `--help` (rc 3) that prints the flag | old selects **new** interface (silent wrong); new fails closed on rc |
| sounio_validation | rc 1 with and without the change — 6 pre-existing failing files on `origin/main`; the edit touches only the warnings display path |
| phi_injectivity, native_v2 probe case | this box's `bin/souc` madaros build fails (`no ELF` / status 139) before the converted lines; phi logs byte-identical to `origin/main`'s gate run from the same path; probe case old form rc=1 = new form rc=1 (environmental parity) |
| self_falsifying_compiler_gate | PASS — full gate incl. madaros build; all 17 sites exercised (F2–F5, F7 clauses) |

## Deliberately not converted

- `grep -c` captures (`ontology … :132` etc.) — `grep -c` reads all input;
  no early exit, no EPIPE, mechanism absent.
- `sounio_validation.sh:99` `grep -A2 -B2` display-only context print —
  reads all input.
- The harness's two `| head` — display-only, noise-reviewed in #1763.

## Relation to the census

F6 of 7 in the repair order (`.scratch/EXIT_STATUS_SWEEP_2026-08-17.md`).
Follows F1 (#1840), F3 (#1844), F2 (#1851). Mechanisms M1 (pipefail EPIPE)
and the D-family (producer failure reading as condition success) at the
wired-assert tier; F4/F8/F7 remain.
