### PR TITLE
ci: wire f64_bitcast_sitofp_boundary_gate.sh (one forgotten leftover)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,13 @@ jobs:
       # (F1 rc=1 + FABRICATED_ZERO; F2 huge+mark; lean_single non-zero var).
       - name: Epistemic fabrication detect (zero GUM variance / bit-pattern confidence)
         run: bash scripts/ci/epistemic_fabrication_detect_gate.sh
+      # F2 trigger boundary: Knowledge.confidence sitofp (~4e18). Detect-and-pass
+      # while the defect is live (KCONF rc!=0 + R25_BITCAST_SITOFP); CONTROLS and
+      # USER must stay green; lean_single KCONF is the probability-scale ref.
+      # Measured 3 s on origin/main 0256abf344. No skip — same #1778 class as
+      # fabrication-detect. One forgotten leftover; the f128 ladder stays unwired.
+      - name: f64 bitcast/sitofp boundary (Knowledge.confidence F2)
+        run: bash scripts/ci/f64_bitcast_sitofp_boundary_gate.sh
       - name: FPGA receipt staleness gate
         run: bash scripts/ci/fpga_receipt_staleness_gate.sh
       - name: Heuristic metaphor-firewall gate

--- a/scripts/dev/ci_gate_workflow_reachability.py
+++ b/scripts/dev/ci_gate_workflow_reachability.py
@@ -7,9 +7,9 @@ invocations (bash/sh/source), not comments and not inventory globs.
 
 Positive control (must be non-zero on this repo): at least one gate is
 reachable (ci.yml names several) AND at least one named leftover is not
-(f64_bitcast_sitofp_boundary_gate.sh). A census that reports 0 leftovers,
-or 0 reachable, has not measured. The original three named orphans
-(correspondence, fabrication-detect, ontology enforcement) are wired.
+(madaros_f128_f256_ladder_gate.sh). A census that reports 0 leftovers,
+or 0 reachable, has not measured. The 2026-08-18 named three plus the
+F2 bitcast/sitofp boundary gate are wired.
 
 Usage:
   python3 scripts/dev/ci_gate_workflow_reachability.py
@@ -67,10 +67,9 @@ INVENTORY_MARKERS = (
 )
 
 # Remaining forgotten leftovers after the 2026-08-18 named-three landing
-# (#1845 correspondence, #1836 fabrication + ontology). Wiring one of
-# these without removing it here is a REFUTE, not a silent pass.
+# plus the F2 bitcast/sitofp boundary wire. Wiring one of these without
+# removing it here is a REFUTE, not a silent pass.
 NAMED_DIRECT_ORPHANS = (
-    "f64_bitcast_sitofp_boundary_gate.sh",
     "madaros_f128_f256_ladder_gate.sh",
     "madaros_f128_f256_v0c_wire_gate.sh",
     "madaros_f128_f256_v0d_softfloat_gate.sh",


### PR DESCRIPTION
## Summary

- Wires **only** `scripts/ci/f64_bitcast_sitofp_boundary_gate.sh` in Contracts, next to the #1792 fabrication-detect step.
- This is the F2 trigger-boundary gate (`docs/audit/MADAROS_F64_BITCAST_SITOFP_BOUNDARY_2026-08-17.md`): Knowledge.confidence sitofp (~4e18). Detect-and-pass while the defect is live.
- Updates the reachability leftover control so a re-run shows reachable +1 / leftover −1 / forgotten −1.

Does **not** wire the f128/f256 ladder, `print_f64_negative`, `mli_s3_bit_identity`, or `stdlib_source_byte_ceiling`.

## Local measurement (`0256abf344`)

```text
bash scripts/ci/f64_bitcast_sitofp_boundary_gate.sh
# elapsed_sec=3 rc=0
# CONTROLS Madaros 13-row matrix green
# USER MiniF f64 + MiniI i64 healthy
# KCONF Madaros sitofp fail-closed (rc=1, defect live)
# lean_single KCONF probability-scale (R25 ~0.66)

python3 scripts/dev/ci_gate_workflow_reachability.py
# before: reachable 89, leftover 381, forgotten 8
# after:  reachable 90, leftover 380, forgotten 7
```

No skip rule: 3 s, and hiding this behind impact is the #1778 class. Changing `ci.yml` marks full impact; that is intended.

## Test plan

- [x] Gate green locally with CONTROLS/USER/KCONF/lean arms
- [x] `check_workflow_script_refs.sh` passed (137 refs)
- [x] Instrument +1 / −1 / −1; remaining six named leftovers unreachable
- [ ] Contracts + CI Decision on this PR