### PR TITLE
fix(ci): egraph gate no longer reads green on a silent instrument

### DIFF
--- a/scripts/ci/epistemic_egraph_rewrite_gate.sh
+++ b/scripts/ci/epistemic_egraph_rewrite_gate.sh
@@ -42,11 +42,13 @@
 #      skipped and not falsely marked FAIL -- they are real, separate,
 #      already-present defects this gate does not attempt to fix.
 #
-# This gate is therefore honest about three different states: the gate
+# This gate is therefore honest about four different states: the gate
 # logic verified working (T143b/c/d, live, in a freshly built Madaros),
 # the gate logic duplicated but not yet independently exercisable (T83-T85),
-# and a pre-existing crash class blocking further verification (both
-# crashes above) -- rather than reporting one number that blurs the three.
+# a pre-existing crash class blocking further verification (both crashes
+# above), and a run that produced no evidence at all (empty self-test log
+# or every subject absent -- FAIL, never green) -- rather than reporting
+# one number that blurs them.
 set -uo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -95,10 +97,19 @@ else
   L="$(mktemp)"
   # A pre-existing crash further into this same run is expected and is not
   # this gate's concern (see header) -- capture whatever prints before it.
-  timeout 60 "$MADAROS" --self-test > "$L" 2>&1 || true
+  # The rc is recorded, not `|| true`-discarded: a nonzero rc with a
+  # non-empty log is the documented mid-run crash class, but a run that
+  # printed NOTHING is an instrument that did not answer, and an
+  # instrument that did not answer cannot certify anything.
+  madaros_rc=0
+  timeout 60 "$MADAROS" --self-test > "$L" 2>&1 || madaros_rc=$?
+  live_log_bytes="$(wc -c <"$L" 2>/dev/null || echo 0)"
   for t in T143b T143c T143d; do
     TOTAL=$((TOTAL + 1))
-    if grep -q "$t OK" "$L"; then echo "PASS  live:$t"; PASS=$((PASS + 1))
+    if [ "$live_log_bytes" -eq 0 ]; then
+      echo "FAIL  live:$t (self-test log is empty: the instrument produced no evidence, rc=$madaros_rc)"
+      FAIL=$((FAIL + 1))
+    elif grep -q "$t OK" "$L"; then echo "PASS  live:$t"; PASS=$((PASS + 1))
     elif grep -q "FAIL: $t" "$L"; then echo "FAIL  live:$t"; FAIL=$((FAIL + 1))
     else echo "NOT_RUN  live:$t (not reached in self-test log)"; NOT_RUN=$((NOT_RUN + 1)); fi
   done
@@ -114,5 +125,12 @@ TOTAL=$((TOTAL + 2)); NOT_RUN=$((NOT_RUN + 2))
 echo ""
 echo "=== SUMMARY ==="
 echo "PASS=$PASS  FAIL=$FAIL  NOT_RUN=$NOT_RUN  TOTAL=$TOTAL"
-if [ "$FAIL" -eq 0 ]; then echo "GATE: PASS (structural + live checks clean; NOT_RUN entries are known, separately-tracked blockers, not silent passes)"; exit 0
+# Zero-evidence guard: FAIL==0 alone cannot certify green, because every
+# check can be NOT_RUN (subjects moved/renamed, instrument absent or dead).
+# "The instrument did not answer" and "the selected set is empty and clean"
+# are different states; only the second may read PASS (CI trust contract).
+if [ "$PASS" -eq 0 ]; then
+  echo "GATE: FAIL (zero evidence: no check produced a PASS -- all NOT_RUN is a dead or absent instrument, not a green run)"
+  exit 1
+elif [ "$FAIL" -eq 0 ]; then echo "GATE: PASS (structural + live checks clean; NOT_RUN entries are known, separately-tracked blockers, not silent passes)"; exit 0
 else echo "GATE: FAIL"; exit 1; fi


### PR DESCRIPTION
## What

Repair-order item **F4** from the exit-status sweep. The epistemic e-graph
gate's verdict was `FAIL == 0 → exit 0`, with no requirement that anything
actually passed. Three zero-evidence conditions therefore read **green** on
`origin/main` (each measured below, old vs new, same tree):

1. **MADAROS set + executable, empty self-test log.** The live arm ran
   `timeout 60 "$MADAROS" --self-test > "$L" 2>&1 || true` — an instantly
   dying binary (rc 0 *or* segfault) prints nothing, every `grep "T143x OK"`
   falls to NOT_RUN, `FAIL` stays 0, gate exits 0. The `|| true` discarded
   even the rc. This is not hypothetical: the gate is wired in CI
   (`ci.yml:529`) against a madaros built earlier in the same job — a broken
   build step would certify itself green.
2. **Same, with the segfault rc** (`kill -SEGV` shape) — also green.
3. **Every subject absent** (repo restructures, files moved): all 19 checks
   NOT_RUN → `PASS=0 FAIL=0 NOT_RUN=19` → green.

## The fix

- **Empty log is a FAIL, not NOT_RUN.** The producer's rc is recorded
  instead of `|| true`-discarded. Non-empty log with T143 unreached stays
  NOT_RUN — that is the documented pre-existing mid-run crash class, and a
  run that printed *something* is categorically different from a run that
  answered nothing.
- **Zero-evidence guard at the verdict:** `PASS == 0 → GATE: FAIL`.
  "The instrument did not answer" and "the selected set is empty and clean"
  are different states; only the second may read PASS (CI trust contract).
- Header updated: the gate now distinguishes **four** states, not three.

## Verification (local, this tree)

| case (fake madaros unless noted) | old rc | new rc |
|---|---|---|
| empty log, rc 0 (`/bin/true` shape) | **0 (green)** | 1 — `FAIL live:T143b (log empty, rc=0)` |
| empty log, segfault rc 139 | **0 (green)** | 1 — rc surfaced in the FAIL line |
| healthy T143b/c/d log | 0 PASS | 0 PASS — unchanged |
| output but T143 unreached (documented crash class) | 0 NOT_RUN→PASS | 0 NOT_RUN→PASS — semantics preserved |
| explicit `FAIL: T143c` | 1 | 1 — retained |
| all subjects absent (fake root) | **0 (green)** | 1 — zero-evidence guard |
| **real** `artifacts/self-hosted/madaros-self-falsifying` (current source) | — | **PASS live:T143b/c/d**, rc 0 |
| default path, no MADAROS set | 0 | 0 — unchanged |

## Relation to the census

F4 of 7 (`.scratch/EXIT_STATUS_SWEEP_2026-08-17.md`). Follows F1 (#1840),
F3 (#1844), F2 (#1851); F6 is #1858. Mechanism: D1 (`|| true` discarding
the producer's status) plus verdict-completeness — the same "instrument did
not answer ≠ empty selected set" distinction F3 gave the test harness.
