### PR TITLE
fix(ci): zero-evidence floors — a silent instrument must never read green

### DIFF
--- a/scripts/ci/engine_parity_gate.sh
+++ b/scripts/ci/engine_parity_gate.sh
@@ -281,6 +281,21 @@ printf '%s\n' "$sources" \
 
 sort -o "$WORK/results.tsv" "$WORK/results.tsv"
 
+# Completeness floor: parity_one prints exactly one verdict row per program,
+# so any shortfall is a worker that died before answering (OOM kill, broken
+# worker script, dead xargs) -- not a cleaner corpus. Under a wholesale
+# failure every count below reads 0, observed.txt reads empty, and comm
+# reports "no new divergences"; zero evidence must not read as a clean run
+# (the same contract the v2 suite's result-completeness asserts enforce).
+n_rows=$(grep -c . "$WORK/results.tsv" || true)
+if [ "$n_rows" -ne "$total" ]; then
+    echo "[engine-parity] FAIL: incomplete results -- $n_rows of $total programs answered" >&2
+    cut -f2 "$WORK/results.tsv" | sort > "$WORK/answered.txt"
+    printf '%s\n' "$sources" | sort > "$WORK/expected.txt"
+    comm -13 "$WORK/answered.txt" "$WORK/expected.txt" | sed 's/^/  no-verdict: /' >&2
+    exit 1
+fi
+
 agree=$(grep -c '^AGREE'           "$WORK/results.tsv" || true)
 diverge=$(grep -c '^DIVERGE'       "$WORK/results.tsv" || true)
 mad_only=$(grep -c '^MADAROS-ONLY' "$WORK/results.tsv" || true)

--- a/scripts/ci/madaros_corpus_regression_gate.sh
+++ b/scripts/ci/madaros_corpus_regression_gate.sh
@@ -90,6 +90,11 @@ cat > "$WORK/run_one.sh" <<'INNER'
 #!/usr/bin/env bash
 src="$1"
 name="$(basename "$src")"
+# Heartbeat: written before the early exits below, so every selected program
+# answers exactly once regardless of verdict. The gate asserts on this file
+# because actual.txt only records failures -- an empty actual.txt must mean
+# "all passed", never "the instrument answered nothing".
+printf '%s\n' "$name" >> "$WORK/ran.txt"
 elf="$WORK/${name%.sio}.elf"
 
 # A test declaring an environment feature we are not providing is not a failure.
@@ -127,9 +132,21 @@ TR
 chmod +x "$WORK/timeout_run.sh"
 export MADAROS WORK
 
+: > "$WORK/ran.txt"
 printf '%s\n' "${PROGRAMS[@]}" \
   | xargs -P "$JOBS" -I{} "$WORK/run_one.sh" {} \
   | sort > "$WORK/actual.txt"
+
+# Completeness floor: every selected program must have heartbeated. A dead
+# xargs or a broken run_one leaves actual.txt empty, which the comparison
+# below would read as "no new failures" -- zero evidence reading green.
+sort -u -o "$WORK/ran.txt" "$WORK/ran.txt"
+RAN_COUNT="$(grep -c . "$WORK/ran.txt" || true)"
+if [[ "$RAN_COUNT" -ne "${#PROGRAMS[@]}" ]]; then
+  printf '%s\n' "${PROGRAMS[@]##*/}" | sort > "$WORK/expected.txt"
+  comm -13 "$WORK/ran.txt" "$WORK/expected.txt" > "$WORK/unanswered.txt"
+  fail "incomplete run: $RAN_COUNT of ${#PROGRAMS[@]} programs answered; $(wc -l < "$WORK/unanswered.txt" | tr -d ' ') silent (first 10): $(head -10 "$WORK/unanswered.txt" | tr '\n' ' ')"
+fi
 
 ACTUAL_COUNT="$(wc -l < "$WORK/actual.txt" | tr -d ' ')"
 echo "[madaros-corpus] failures observed: $ACTUAL_COUNT / ${#PROGRAMS[@]}"

--- a/scripts/ci/native_v2_gum_primitives_gate.sh
+++ b/scripts/ci/native_v2_gum_primitives_gate.sh
@@ -82,6 +82,15 @@ if [[ ! -f "$MANIFEST_PATH" ]]; then
   echo "[native-v2-gum] FAIL: missing manifest $MANIFEST_PATH" >&2
   exit 1
 fi
+# Manifest row floor: the case loop appends exactly one results row per
+# non-comment data row. An empty manifest runs zero cases, case_count reads
+# 0, and 0 == 0 computes status "pass" -- an instrument that answered
+# nothing certifying itself.
+gum_manifest_rows="$(grep -vE '^[[:space:]]*(#|$)' "$MANIFEST_PATH" | grep -c . || true)"
+if [[ "$gum_manifest_rows" -lt 1 ]]; then
+  echo "[native-v2-gum] FAIL: manifest $MANIFEST_PATH has no data rows -- nothing to verify" >&2
+  exit 1
+fi
 
 bash scripts/ci/native_v2_driver_self_compile_gate.sh >"$SELF_GATE_LOG" 2>&1
 
@@ -214,6 +223,12 @@ fi
 gum_sse2_bool=false
 [[ "${GUM_SSE2_VERIFIED,,}" == "true" ]] && gum_sse2_bool=true
 case_count="$(awk 'NR>1 && NF>0' "$RESULTS_TSV" | wc -l | tr -d ' ')"
+# Every manifest data row must have answered exactly once; a shortfall is
+# lost rows, not a smaller corpus (0 == 0 would otherwise read "pass").
+if [[ "$case_count" -ne "$gum_manifest_rows" ]]; then
+  echo "[native-v2-gum] FAIL: $case_count of $gum_manifest_rows manifest cases produced results -- incomplete pass" >&2
+  exit 1
+fi
 pass_count_gum="$(awk -F'\t' 'NR>1 && $8=="ok"' "$RESULTS_TSV" | wc -l | tr -d ' ')"
 fail_count_gum=$(( case_count - pass_count_gum ))
 if [[ "$pass_count_gum" -eq "$case_count" ]]; then

--- a/scripts/ci/native_v2_imported_body_lowering_gate.sh
+++ b/scripts/ci/native_v2_imported_body_lowering_gate.sh
@@ -160,7 +160,17 @@ CASES_JSON="$(
   done < "$ARTIFACT_DIR/cases.tsv"
 )"
 CASES_JSON="[$CASES_JSON]"
-case_count="$(grep -c . "$ARTIFACT_DIR/cases.tsv" 2>/dev/null || echo 0)"
+# `grep -c` prints 0 itself on an empty file, so `|| echo 0` would append a
+# second 0 (a two-line count) -- `|| true` rescues the exit code only.
+case_count="$(grep -c . "$ARTIFACT_DIR/cases.tsv" 2>/dev/null || true)"
+# Plan floor: the three run_case calls above each append exactly one row or
+# exit 1; anything else at summary time means the plan did not complete and
+# the summary would certify a run that never happened.
+EXPECTED_CASES=3
+if [[ "$case_count" -ne "$EXPECTED_CASES" ]]; then
+  echo "[native-v2-imported-body-lowering] FAIL: cases.tsv has $case_count rows, expected $EXPECTED_CASES -- the plan did not complete" >&2
+  exit 1
+fi
 ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 "$ROOT_DIR/bin/kretikos" json-emit \

--- a/scripts/ci/native_v2_metal_algebra_gate.sh
+++ b/scripts/ci/native_v2_metal_algebra_gate.sh
@@ -73,6 +73,15 @@ if [[ ! -f "$MANIFEST" ]]; then
   printf '%s\t%s\t%s\t%s\t%s\n' "metal_manifest" "structural" "$MANIFEST" "fail" "missing_manifest" >> "$RESULTS_TSV"
   structural_rc=1
 else
+  # Manifest row floor: the structural loop appends exactly one results row
+  # per non-comment data row. An empty or header-only manifest runs the loop
+  # zero times, every count stays 0, and status computes "pass" -- an
+  # instrument that answered nothing certifying itself.
+  manifest_rows="$(tail -n +2 "$MANIFEST" | grep -vE '^[[:space:]]*(#|$)' | grep -c . || true)"
+  if [[ "$manifest_rows" -lt 1 ]]; then
+    echo "[native-v2-metal-algebra] FAIL: manifest $MANIFEST has no data rows -- nothing to verify" >&2
+    exit 1
+  fi
   fail=0
   # Skip header, read each row positionally (manifest schema:
   # case_id, kernel_path, kernel_name, policy).
@@ -100,6 +109,14 @@ else
       printf '%s\t%s\t%s\t%s\t%s\n' "$case_id" "structural_msl" "$kernel_path" "pass" "metal_f64_policy_structural_ok" >> "$RESULTS_TSV"
     fi
   done < <(tail -n +2 "$MANIFEST")
+  # Every data row must have answered exactly once (the loop appends one
+  # results row per case, pass or fail); a shortfall means rows were lost
+  # between the manifest and the results, not that the corpus was smaller.
+  structural_rows="$(awk -F'\t' '$2=="structural_msl"' "$RESULTS_TSV" | wc -l | tr -d ' ')"
+  if [[ "$structural_rows" -ne "$manifest_rows" ]]; then
+    echo "[native-v2-metal-algebra] FAIL: $structural_rows of $manifest_rows manifest rows produced results -- incomplete structural pass" >&2
+    exit 1
+  fi
   [[ "$fail" -gt 0 ]] && structural_rc=1
 fi
 set -e

--- a/scripts/ci/run_pass_output_gate.sh
+++ b/scripts/ci/run_pass_output_gate.sh
@@ -127,6 +127,12 @@ printf '[run-pass-output] checked=%d  PASS=%d  MISMATCH=%d  COMPILE-ERR=%d  RUN-
   "$n_total" "$n_pass" "$n_mismatch" "$n_compile_err" "$n_run_err"
 
 if [ "$MODE" = "baseline" ]; then
+  # A baseline of zero tests blesses every future empty comparison; the scan
+  # must have selected something before its verdict is worth recording.
+  if [ "$n_total" -lt 1 ]; then
+    echo "[run-pass-output] FAIL: no expect-stdout tests found -- the corpus scan answered nothing (marker drift or missing corpus?)" >&2
+    exit 1
+  fi
   mkdir -p "$(dirname "$BASELINE_FILE")"
   cp "$CUR" "$BASELINE_FILE"
   echo "[run-pass-output] BASELINE recorded -> $BASELINE_FILE ($n_total tests)"
@@ -135,6 +141,10 @@ fi
 
 if [ "$MODE" = "strict" ] || [ ! -f "$BASELINE_FILE" ]; then
   [ "$MODE" != "strict" ] && echo "[run-pass-output] no baseline at $BASELINE_FILE -> STRICT mode"
+  if [ "$n_total" -lt 1 ]; then
+    echo "[run-pass-output] FAIL (strict): no expect-stdout tests found -- the corpus scan answered nothing (marker drift or missing corpus?)" >&2
+    exit 1
+  fi
   if [ "$n_mismatch" -eq 0 ] && [ "$n_run_err" -eq 0 ] && [ "$n_compile_err" -eq 0 ]; then
     echo "[run-pass-output] PASS (strict): all $n_total expect-stdout tests produce expected output"
     exit 0


### PR DESCRIPTION
## What

Repair-order item **F8** from the exit-status sweep: the zero-evidence
family. Six gates computed a verdict from counts that could all be zero —
`0 failures`, `0 new divergences`, `0 == 0 → status pass` — with nothing
requiring that the instrument actually answered. Every one of these was
measured reading **green** on `origin/main` under a wholesale-dead run;
each row below is old-vs-new on the same tree.

## The holes and the floors

| gate | hole (old behavior, measured) | floor added |
|---|---|---|
| `engine_parity_gate.sh` | dead xargs → empty `results.tsv` → every count 0 → **"PASS: no new engine divergences (1007 known)" rc 0** | results rows must equal the selected corpus; shortfall names the unanswered programs |
| `madaros_corpus_regression_gate.sh` | dead xargs → `actual.txt` empty → **"PASS: no new failures under Madaros (0 known, 271 newly fixed)" rc 0** on 1749 unanswered programs | per-program heartbeat (written before the legitimate early-exit skips, so `//@ requires: gpu` and `known-failure` still answer once); count must equal PROGRAMS |
| `run_pass_output_gate.sh` | marker drift / empty corpus → `n_total=0` → **"PASS (strict): all 0 expect-stdout tests produce expected output" rc 0**; `--baseline` **recorded a 0-byte baseline** | `n_total ≥ 1` in strict (incl. no-baseline fallback) and before recording a baseline |
| `native_v2_metal_algebra_gate.sh` | header-only manifest → structural loop runs zero times → 0/0/0 → **status pass, rc 0** (stub-instrument bite) | manifest data rows ≥ 1; post-loop structural rows must equal data rows |
| `native_v2_gum_primitives_gate.sh` | empty manifest → `case_count=0`, `pass_count=0` → `0 == 0` → **status pass** | manifest data rows ≥ 1; `case_count` must equal data rows |
| `native_v2_imported_body_lowering_gate.sh` | `grep -c . \|\| echo 0` double-counts (grep already prints `0`; `\|\| echo 0` appends a second → **two-line value, `$(( ))` throws "bad math expression"**) | idiom fixed (`\|\| true`); `case_count` must equal the hard-coded plan size (3) |

The corpus gate's fix is the same distinction F3 gave the test harness:
`actual.txt` only records failures, so "empty" must be provably *all
passed*, never *nothing ran*.

## Verification (local, this tree, old vs new)

| bite | old | new |
|---|---|---|
| engine_parity, `SOUNIO_PARITY_JOBS=abc`, `--only _diag_sobol`, real engines | rc 0, "PASS: no new engine divergences" | rc 1, "incomplete results -- 0 of 1 programs answered" |
| engine_parity healthy: same run, working xargs | — | rc 0, agree=1, PASS (floor satisfied, verdict unchanged) |
| corpus, `SOUNIO_TEST_JOBS=abc`, real madaros | rc 0, "PASS … 271 newly fixed" | rc 1, "incomplete run: 0 of 1749 programs answered" + first silent names |
| run_pass_output `--strict`, empty corpus (stub root) | rc 0, "all 0 tests" | rc 1, "the corpus scan answered nothing" |
| run_pass_output `--baseline`, empty corpus (stub root) | rc 0, recorded 0-byte baseline | rc 1 |
| metal, header-only manifest (stub root, pinned stub souc) | rc 0 | rc 1, "no data rows" |
| metal, healthy manifest | rc 0 | rc 0 — unchanged |
| metal, one kernel file deleted | — | rc 1 via its `missing_msl` row (row floor satisfied: 2 rows = 2 data rows, then fail_count) |
| gum, comment-only manifest | (not reachable to green on this box — driver self-compile needs working souc; the `0 == 0 → pass` arithmetic demonstrated in isolation) | rc 1 at the floor, before any souc use |
| gum, real manifest | — | proceeds past the floor into the normal path |
| imported counting idiom, empty file | `0\n0` — two-line value; `$(( ))` errors | single `0`; floor trips on ≠ 3 |
| `bash -n` × 6 files | — | clean |
| full corpus run, real madaros (current-source build), 4 jobs | — | floor silent under real parallelism: all 1749 answered ("failures observed: 287 / 1749"); the verdict itself is **FAIL — 56 new failures, 40 fixed** vs the checked-in baseline. That is the instrument answering, not a floor trip — and independent of these edits (no compiler path touched; the gate is deliberately unwired per `ci.yml:530`, so this is the first live full-corpus verdict in a while) |

## Relation to the census

F8 of 7 (`.scratch/EXIT_STATUS_SWEEP_2026-08-17.md`). Follows F1 (#1840),
F3 (#1844), F2 (#1851), F6 (#1858), F4 (#1860). Same principle as F3/F4:
"the instrument did not answer" must never read as "the selected set is
empty and clean" (CI trust contract). F7 remains.
