### PR TITLE
docs(audit) + scripts: ship COMMENT_ONLY_DIVERGENT census category

### DIFF
--- a/docs/audit/CODEGEN_DEAD_BODY_DELETION_2026-08-18.md
+++ b/docs/audit/CODEGEN_DEAD_BODY_DELETION_2026-08-18.md
@@ -167,17 +167,24 @@ Commit: `fix(native): sync name_is_get_arg_count in codegen.sio with codegen_x86
 
 ## Re-census after sync — how many of the 25 residuals fell?
 
-**1 of 25 fell.** The SUBSTANTIVE-DIVERGENT pair (`name_is_get_arg_count`) is now byte-identical (modulo the `pub` visibility, which falls under the 23 PUB-SWAP-ONLY bucket of the original census). The byte-diff re-classification after the sync:
+The byte-diff census (with `stripPub`) **does not** record a fall for #25. The 9-char branch was added to `name_is_get_arg_count` in `codegen.sio`, but the body now carries a sync-provenance block (4 lines) and two `// "arg_count" = 9 chars` / `// "get_arg_count" = 13 chars` markers that `codegen_x86_linux.sio` does not have. After `stripPub`, the bodies still differ in those 5 comment lines, so the byte census still classifies #25 as SUBSTANTIVE-DIVERGENT.
+
+What the sync *did* close is the **logic divergence**, not the byte divergence:
+
+- Pre-sync: `name_is_get_arg_count("arg_count")` returns `false` from `codegen.sio`, `true` from `codegen_x86_linux.sio` — runtime split depending on which module resolves the call. The user-named "bug à espera".
+- Post-sync: `name_is_get_arg_count("arg_count")` returns `true` from both files. No runtime divergence.
+
+The byte-diff re-classification after the sync, faithfully applied:
 
 ```
-IDENTICAL (debt): 24 + 1 (just-synced, modulo pub) = 25
-PUB_SWAP_ONLY (debt+vis): 23
-SUBSTANTIVE_DIVERGENT (bug): 0
+IDENTICAL (debt):              24
+PUB_SWAP_ONLY (debt+vis):      0
+SUBSTANTIVE_DIVERGENT (census): 1   <- #25: comment-only, not logic
 ```
 
-**24 of the 25 residuals remain as pure debt; the 1 bug (SUBSTANTIVE-DIVERGENT) is closed.**
+**The previous "1 of 25 fell" headline in commit `a0da4d95b7` was true at the logic level but did not survive a strict byte-diff census.** Step 6 below re-measures on `origin/main` after PR #1837 merged, with the user's option-1 framing (keep the sync-provenance comment) and the methodology recommendation to introduce a `COMMENT_ONLY_DIVERGENT` category so that #25 stops being listed alongside real runtime bugs.
 
-The remaining 24 IDENTICAL pairs are still the user-named "dívida" — same name in two files, byte-equal bodies, glob-importable. Their consolidation direction analysis is recorded in `CODEGEN_BODY_DIFF_GLOB_HOMONYMS_2026-08-17.md` and was the prior doc's scope; this doc only records the closure of the one divergence.
+The remaining 24 IDENTICAL pairs are still the user-named "dívida" — same name in two files, byte-equal bodies, glob-importable. Their consolidation direction analysis is recorded in `CODEGEN_BODY_DIFF_GLOB_HOMONYMS_2026-08-17.md` and was the prior doc's scope; this doc only records the sync, its deliberate preservation, and the census refinement it motivates.
 
 ## Halt per FLEET_CONSTRAINTS
 
@@ -213,3 +220,92 @@ a869385512 dead-code(codegen_x86_linux): delete compile_ir_function_v2_ref from 
 ```
 
 The "0/25 residual fell" headline in commit 705722f701 was true at the time it was written (the deletion in steps 1–2 doesn't touch any of the 25 names); commit f81031a968 updates the score to **1/25 fell** by closing the SUBSTANTIVE-DIVERGENT pair. See "Re-census after sync" above for the breakdown.
+
+## Step 6 — Post-merge measurement (2026-08-18, after PR #1837 merged in `80cc1366a2`)
+
+User follow-up directive: *"Agora que o v2_ref saiu, mede quantos caem. Por cada um que sobrar: que símbolo, em que dois ficheiros, e se as cópias DIVERGEM ou são idênticas."*
+
+### Re-measurement on origin/main
+
+`git show dde4b0b0d4:self-hosted/native/codegen.sio` and `git show dde4b0b0d4:self-hosted/native/codegen_x86_linux.sio` were extracted and re-classified with the byte-diff census (see `codegen-census/codegen_check_named_residuals.cjs` in the agents scratchpad). Both file snapshots are byte-identical between `dde4b0b0d4` and `64924d371a` (the merge commit `80cc1366a2` of #1837 is present in both).
+
+### How many of the 25 fell with `v2_ref`'s removal?
+
+**Zero.** The two deleted bodies (`compile_ir_function_v2_ref` × 2) are not in the 25-residual set. Removing them is the safe option-3 deletion the user authorised; it does not touch any of the 25 homonym names. The 25-residual landscape is unchanged in count.
+
+### The 25, named on `dde4b0b0d4`
+
+| # | symbol | codegen.sio | codegen_x86_linux.sio | divergence |
+|---:|---|---|---|---|
+| 1 | `ARCH_RISCV64` | L45 | L85 | IDENTICAL |
+| 2 | `ARCH_UNKNOWN` | L42 | L82 | IDENTICAL |
+| 3 | `ARCH_X86_64` | L43 | L83 | IDENTICAL |
+| 4 | `ERR_BACKEND_NOT_IMPLEMENTED` | L66 | L106 | IDENTICAL |
+| 5 | `ERR_INVALID_MATRIX` | L68 | L108 | IDENTICAL |
+| 6 | `ERR_INVALID_TARGET` | L67 | L107 | IDENTICAL |
+| 7 | `ERR_OK` | L65 | L105 | IDENTICAL |
+| 8 | `ERR_TARGET_FLAGS_REQUIRE_NATIVE` | L70 | L110 | IDENTICAL |
+| 9 | `ERR_TRACE_WRITE_FAILED` | L69 | L109 | IDENTICAL |
+| 10 | `FORMAT_ELF64` | L61 | L101 | IDENTICAL |
+| 11 | `FORMAT_MACHO64` | L62 | L102 | IDENTICAL |
+| 12 | `FORMAT_NONE` | L60 | L100 | IDENTICAL |
+| 13 | `FORMAT_PE64` | L63 | L103 | IDENTICAL |
+| 14 | `MACOS_SYS_OPEN` | L5132 | L10523 | IDENTICAL |
+| 15 | `MATRIX_AME` | L58 | L98 | IDENTICAL |
+| 16 | `MATRIX_APPLE_AMX` | L54 | L94 | IDENTICAL |
+| 17 | `MATRIX_AUTO` | L52 | L92 | IDENTICAL |
+| 18 | `MATRIX_IME` | L56 | L96 | IDENTICAL |
+| 19 | `MATRIX_INTEL_AMX` | L55 | L95 | IDENTICAL |
+| 20 | `MATRIX_OFF` | L53 | L93 | IDENTICAL |
+| 21 | `MATRIX_VME` | L57 | L97 | IDENTICAL |
+| 22 | `OS_LINUX` | L48 | L88 | IDENTICAL |
+| 23 | `OS_UNKNOWN` | L47 | L87 | IDENTICAL |
+| 24 | `OS_WINDOWS` | L50 | L90 | IDENTICAL |
+| 25 | `name_is_get_arg_count` | L948 (36 lines) | L1217 (31 lines) | **see below** |
+
+### Reclassification of #25 — the byte-census mislabels this pair
+
+The byte-diff census (with `stripPub` applied) still flags `name_is_get_arg_count` as SUBSTANTIVE-DIVERGENT. The 36-vs-31 line gap is **entirely comments**:
+
+| what differs | codegen.sio | codegen_x86_linux.sio |
+|---|---|---|
+| signature | `pub fn` (visibility) | `fn` (private) |
+| sync-provenance block (4 lines) | present | absent |
+| `// "arg_count" = 9 chars` marker | present | absent |
+| `// "get_arg_count" = 13 chars` marker | present | absent |
+| 9-char `arg_count` byte cascade (9 byte-cmp + return true) | present | present |
+| 13-char `get_arg_count` byte cascade (13 byte-cmp + return true) | present | present |
+
+The byte cascades are byte-equal between the two files (modulo `pub`). The 5-line size delta is exclusively in comments.
+
+**Runtime check:** `name_is_get_arg_count("arg_count")` returns `true` from both files post-`80cc1366a2` (the squash of #1837 carried the 9-char branch forward to codegen.sio). The user's framing "duas cópias DIVERGENTES são um bug à espera" no longer applies at the executable level — there is no logic divergence, only documentation divergence.
+
+### User decision on #25 (option 1, not option 3)
+
+I offered three options for closing the byte-census entry:
+
+1. **Keep as-is** — sync-provenance preserved; #25 stays SUBSTANTIVE-DIVERGENT per byte census.
+2. **Strip the sync-provenance block only** — closes the byte-census entry but loses the historical rasto.
+3. **Align fully to x86_linux** — closes the byte-census entry, loses the sync-provenance AND the `// "arg_count" = 9 chars` / `// "get_arg_count" = 13 chars` markers.
+
+User chose **option 1** with explicit reasoning:
+
+> *"A divergência é INTEIRAMENTE em comentários: a proveniência do sync e os marcadores dos 9 e 13 chars. Isso fecha a minha pergunta — não há fix numa cópia e ausente noutra, portanto não há direcção errada possível no código. E é precisamente por isso que a opção 3 é má. Ela apaga o comentário que regista de onde veio o ramo de 9 chars, para fechar um item de byte-diff num censo. Isso é optimizar a métrica em vez do código: o número 9 é mágico, e o comentário é a única coisa que diz porquê. Daqui a três meses alguém pergunta e a resposta terá desaparecido para satisfazer um contador. O #25 não é um defeito — é um FACTO sobre o par, e o censo devia registá-lo como diferem-só-em-comentários em vez de o listar ao lado de divergências reais. Se o censo não consegue exprimir essa distinção, o defeito é do censo."*
+
+### Census methodology recommendation (the actual fix)
+
+The current byte-diff census collapses three distinct phenomena into one category (SUBSTANTIVE-DIVERGENT). The user-identified gap is a methodology bug, not a code bug. The recommended categories:
+
+```
+IDENTICAL                          bodies byte-equal (modulo `pub`)
+PUB_SWAP_ONLY                      bodies byte-equal after stripping `pub`
+LOGIC_DIVERGENT                     logic differs (e.g. extra byte-cascade branch)
+COMMENT_ONLY_DIVERGENT              bodies differ ONLY in comments — logic byte-equal
+                                   (after stripPub AND stripComments)
+```
+
+`name_is_get_arg_count` on `dde4b0b0d4` classifies as **COMMENT_ONLY_DIVERGENT** under this scheme. `v2_ref`-style runtime divergence is **LOGIC_DIVERGENT** (which is what the original census called SUBSTANTIVE_DIVERGENT). The 24 IDENTICAL pairs above stay IDENTICAL.
+
+This refinement changes nothing about the action set on the 24 IDENTICAL pairs (they remain pure debt, consolidation direction analysis recorded in `CODEGEN_BODY_DIFF_GLOB_HOMONYMS_2026-08-17.md`). It changes the framing of #25 from "bug à espera" to "documented divergence, deliberately preserved". That is the precise status the user's option-1 choice encodes.
+
+A reference implementation of the refined census lives at `codegen-census/codegen_byte_diff_census.cjs` (agents scratchpad) and `codegen-census/codegen_check_named_residuals.cjs` — the latter accepts a hardcoded `RESIDUALS` list and produces the per-symbol classification table used in this step.

--- a/docs/audit/CODEGEN_DEAD_BODY_DELETION_2026-08-18.md
+++ b/docs/audit/CODEGEN_DEAD_BODY_DELETION_2026-08-18.md
@@ -174,15 +174,15 @@ What the sync *did* close is the **logic divergence**, not the byte divergence:
 - Pre-sync: `name_is_get_arg_count("arg_count")` returns `false` from `codegen.sio`, `true` from `codegen_x86_linux.sio` — runtime split depending on which module resolves the call. The user-named "bug à espera".
 - Post-sync: `name_is_get_arg_count("arg_count")` returns `true` from both files. No runtime divergence.
 
-The byte-diff re-classification after the sync, faithfully applied:
+The byte-diff re-classification after the sync, under the three-category scheme that was in force at the time:
 
 ```
 IDENTICAL (debt):              24
 PUB_SWAP_ONLY (debt+vis):      0
-SUBSTANTIVE_DIVERGENT (census): 1   <- #25: comment-only, not logic
+SUBSTANTIVE_DIVERGENT (census): 1   <- #25: comment-only, not logic (the methodology bug)
 ```
 
-**The previous "1 of 25 fell" headline in commit `a0da4d95b7` was true at the logic level but did not survive a strict byte-diff census.** Step 6 below re-measures on `origin/main` after PR #1837 merged, with the user's option-1 framing (keep the sync-provenance comment) and the methodology recommendation to introduce a `COMMENT_ONLY_DIVERGENT` category so that #25 stops being listed alongside real runtime bugs.
+**The previous "1 of 25 fell" headline in commit `a0da4d95b7` was true at the logic level but did not survive a strict byte-diff census.** Step 6 below re-measures on `origin/main` after PR #1837 merged, with the user's option-1 framing (keep the sync-provenance comment) and the methodology refinement that introduces a `COMMENT_ONLY_DIVERGENT` category so that #25 stops being listed alongside real runtime bugs. Under the four-category scheme (now shipped in `scripts/research/codegen_byte_diff_census.cjs`), the 25-residual set re-classifies to 24 IDENTICAL + 0 PUB_SWAP_ONLY + 1 COMMENT_ONLY_DIVERGENT + 0 SUBSTANTIVE_DIVERGENT — i.e. zero runtime-divergent pairs, exactly as the option-1 framing predicted.
 
 The remaining 24 IDENTICAL pairs are still the user-named "dívida" — same name in two files, byte-equal bodies, glob-importable. Their consolidation direction analysis is recorded in `CODEGEN_BODY_DIFF_GLOB_HOMONYMS_2026-08-17.md` and was the prior doc's scope; this doc only records the sync, its deliberate preservation, and the census refinement it motivates.
 
@@ -227,7 +227,7 @@ User follow-up directive: *"Agora que o v2_ref saiu, mede quantos caem. Por cada
 
 ### Re-measurement on origin/main
 
-`git show dde4b0b0d4:self-hosted/native/codegen.sio` and `git show dde4b0b0d4:self-hosted/native/codegen_x86_linux.sio` were extracted and re-classified with the byte-diff census (see `codegen-census/codegen_check_named_residuals.cjs` in the agents scratchpad). Both file snapshots are byte-identical between `dde4b0b0d4` and `64924d371a` (the merge commit `80cc1366a2` of #1837 is present in both).
+`git show dde4b0b0d4:self-hosted/native/codegen.sio` and `git show dde4b0b0d4:self-hosted/native/codegen_x86_linux.sio` were extracted and re-classified with the byte-diff census (see `scripts/research/codegen_check_named_residuals.cjs` in this repo). Both file snapshots are byte-identical between `dde4b0b0d4` and `64924d371a` (the merge commit `80cc1366a2` of #1837 is present in both).
 
 ### How many of the 25 fell with `v2_ref`'s removal?
 
@@ -261,7 +261,7 @@ User follow-up directive: *"Agora que o v2_ref saiu, mede quantos caem. Por cada
 | 22 | `OS_LINUX` | L48 | L88 | IDENTICAL |
 | 23 | `OS_UNKNOWN` | L47 | L87 | IDENTICAL |
 | 24 | `OS_WINDOWS` | L50 | L90 | IDENTICAL |
-| 25 | `name_is_get_arg_count` | L948 (36 lines) | L1217 (31 lines) | **see below** |
+| 25 | `name_is_get_arg_count` | L948 (36 lines) | L1217 (31 lines) | **COMMENT_ONLY_DIVERGENT** (post-refinement census; was SUBSTANTIVE_DIVERGENT under the three-category scheme; see "Census methodology refinement" below) |
 
 ### Reclassification of #25 — the byte-census mislabels this pair
 
@@ -292,20 +292,59 @@ User chose **option 1** with explicit reasoning:
 
 > *"A divergência é INTEIRAMENTE em comentários: a proveniência do sync e os marcadores dos 9 e 13 chars. Isso fecha a minha pergunta — não há fix numa cópia e ausente noutra, portanto não há direcção errada possível no código. E é precisamente por isso que a opção 3 é má. Ela apaga o comentário que regista de onde veio o ramo de 9 chars, para fechar um item de byte-diff num censo. Isso é optimizar a métrica em vez do código: o número 9 é mágico, e o comentário é a única coisa que diz porquê. Daqui a três meses alguém pergunta e a resposta terá desaparecido para satisfazer um contador. O #25 não é um defeito — é um FACTO sobre o par, e o censo devia registá-lo como diferem-só-em-comentários em vez de o listar ao lado de divergências reais. Se o censo não consegue exprimir essa distinção, o defeito é do censo."*
 
-### Census methodology recommendation (the actual fix)
+### Census methodology refinement (shipped in this commit)
 
-The current byte-diff census collapses three distinct phenomena into one category (SUBSTANTIVE-DIVERGENT). The user-identified gap is a methodology bug, not a code bug. The recommended categories:
+The previous byte-diff census collapsed three distinct phenomena into one category (SUBSTANTIVE-DIVERGENT). The user-identified gap was a methodology bug, not a code bug: the census was listing pairs whose bodies differed *only* in inline comments next to pairs whose byte cascades actually disagreed. The four-category scheme now in use:
 
 ```
 IDENTICAL                          bodies byte-equal (modulo `pub`)
 PUB_SWAP_ONLY                      bodies byte-equal after stripping `pub`
-LOGIC_DIVERGENT                     logic differs (e.g. extra byte-cascade branch)
-COMMENT_ONLY_DIVERGENT              bodies differ ONLY in comments — logic byte-equal
+LOGIC_DIVERGENT                    logic differs (e.g. extra byte-cascade branch)
+COMMENT_ONLY_DIVERGENT             bodies differ ONLY in comments — logic byte-equal
                                    (after stripPub AND stripComments)
 ```
 
-`name_is_get_arg_count` on `dde4b0b0d4` classifies as **COMMENT_ONLY_DIVERGENT** under this scheme. `v2_ref`-style runtime divergence is **LOGIC_DIVERGENT** (which is what the original census called SUBSTANTIVE_DIVERGENT). The 24 IDENTICAL pairs above stay IDENTICAL.
+`name_is_get_arg_count` on `dde4b0b0d4` (and on `64924d371a`, which is byte-identical post-`80cc1366a2`) classifies as **COMMENT_ONLY_DIVERGENT** under this scheme. `v2_ref`-style runtime divergence is **LOGIC_DIVERGENT** (which is what the original census called SUBSTANTIVE_DIVERGENT). The 24 IDENTICAL pairs above stay IDENTICAL.
 
 This refinement changes nothing about the action set on the 24 IDENTICAL pairs (they remain pure debt, consolidation direction analysis recorded in `CODEGEN_BODY_DIFF_GLOB_HOMONYMS_2026-08-17.md`). It changes the framing of #25 from "bug à espera" to "documented divergence, deliberately preserved". That is the precise status the user's option-1 choice encodes.
 
-A reference implementation of the refined census lives at `codegen-census/codegen_byte_diff_census.cjs` (agents scratchpad) and `codegen-census/codegen_check_named_residuals.cjs` — the latter accepts a hardcoded `RESIDUALS` list and produces the per-symbol classification table used in this step.
+#### Re-census of the 25 on the four-category scheme
+
+Run on `git show origin/main:self-hosted/native/codegen.sio` (currently `d3ea284caf`) and `git show origin/main:self-hosted/native/codegen_x86_linux.sio`:
+
+```
+Of the 25 residual names:
+  IDENTICAL: 24
+  PUB_SWAP_ONLY: 0
+  COMMENT_ONLY_DIVERGENT: 1   ← name_is_get_arg_count
+  SUBSTANTIVE_DIVERGENT: 0
+  MISSING: 0
+```
+
+`SUBSTANTIVE_DIVERGENT` went from 1 to 0. The single formerly-substantive pair is now correctly classified as `COMMENT_ONLY_DIVERGENT`, exactly as the option-1 framing predicted.
+
+#### Re-census of the full 267-pair homonym corpus
+
+Run on the same files at `origin/main@<current>`:
+
+```
+codegen.sio symbols: 293
+codegen_x86_linux.sio symbols: 585
+Common homonym symbols: 267
+
+IDENTICAL: 183
+PUB_SWAP_ONLY: 33
+COMMENT_ONLY_DIVERGENT: 1   ← name_is_get_arg_count (the only one in the full corpus)
+SUBSTANTIVE_DIVERGENT: 50
+```
+
+Only `name_is_get_arg_count` in the entire 267-pair corpus has a comment-only-but-logic-equal diff. The remaining 50 SUBSTANTIVE_DIVERGENT pairs are genuine logic divergence candidates and remain candidates for directional-sync analysis before any edit.
+
+#### Implementation
+
+The refined census now lives in the repo at:
+
+- `scripts/research/codegen_byte_diff_census.cjs` — the full 267-pair classifier (takes the two `.sio` files as argv).
+- `scripts/research/codegen_check_named_residuals.cjs` — the targeted 25-residual classifier (hardcoded `RESIDUALS` list).
+
+Both are pure-Node CommonJS (`#!/usr/bin/env node`) with zero external deps, so they run inside the prebuilt-toolchain pod without `npm install`. Each carries a header block explaining the four categories and pointing back at this audit doc.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1375
-- Repo-backed topics: 1225
+- Total governed topics: 1379
+- Repo-backed topics: 1229
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 399
-- Authority count `repo_only`: 788
+- Authority count `repo_only`: 792
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 803 topics
+- A2: 807 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 37 topics

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -9,7 +9,7 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.governance.acceptan
 
 # Docs Acceptance Report
 
-This is the editor-in-chief acceptance snapshot generated from `docs/governance/topic-registry.v1.json`.
+This is the editor-in-chief acceptance snapshot for the documentation-governance wave.
 
 ## Verdict
 
@@ -17,49 +17,17 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - Dual-canon sync contract is active across repo docs, website docs, and localized docs metadata.
 - Historical and archived repo docs are labeled and redirected back to the current canonical surface through the authority matrix.
 
-## Scope Summary
+## Scope, ownership, locale and evidence numbers
 
-- Total governed topics: 1379
-- Repo-backed topics: 1229
-- Website-backed topics: 163
-- Dual-canon topics: 13
-- Authority count `archived`: 25
-- Authority count `dual`: 13
-- Authority count `historical`: 399
-- Authority count `repo_only`: 792
-- Authority count `website_only`: 150
+This file intentionally does not carry whole-corpus counts (total governed topics, per-authority
+and per-owner breakdowns, evidence-bearing topics, the validation-surface list). Every one of
+those numbers is a pure function of every governed doc present in the tree at scan time, so a
+snapshot committed by one PR goes stale the instant any *other* PR adds or removes a governed doc
+-- even though neither PR touched the other one's files. Get the live numbers on demand instead
+of trusting a committed snapshot that races against concurrent merges:
 
-## Ownership Summary
+    node scripts/docs/report_acceptance.mjs
 
-- A0: 1 topics
-- A1: 1 topics
-- A2: 807 topics
-- A3: 10 topics
-- A4: 32 topics
-- A5: 37 topics
-- A6: 434 topics
-- A7: 57 topics
-
-## Locale Acceptance
-
-- Docs collection topics with full six-locale coverage: 37/37
-- All governed website docs topics are present in `en`, `pt`, `el`, `zh`, `ja`, and `es`.
-- English-only website collections allowed by policy and marked in the registry: tutorials: 42; showcases: 63; blog: 21
-
-## Evidence-Bearing Topics
-
-- repo.docs.implementation.paper-artifact-packaging-spec: scripts/paper/package_paper_artifacts.sh, scripts/paper/paper_submission_pack.sh
-- repo.frontdoor.docs-index: docs/governance/DOCS_AUTHORITY_MATRIX.md
-- repo.governance.acceptance-report: docs/governance/topic-registry.v1.json, docs/governance/DOCS_AUTHORITY_MATRIX.md
-- repo.governance.authority-matrix: docs/governance/topic-registry.v1.json
-- website.docs.gpu: artifacts/omega/gpu_runtime_attest_gate.v1.json
-- website.docs.vancomycin-uncertainty: website/public/docs/assets/vancomycin-ship/check_pass.png
-
-## Validation Surfaces
-
-- `bash paper/reproduce.sh`
-- `bash scripts/check_docs_consistency.sh`
-- `bash scripts/check_docs_registry.sh`
-- `bash scripts/fast_gate.sh`
-- `node website/scripts/check-docs-parity.mjs`
-- `npm --prefix website run check:quality`
+Per-topic governance (metadata headers, locale coverage, evidence artifacts, broken links) stays
+gated exactly as before, from `docs/governance/topic-registry.v1.json`; only the aggregate corpus counters
+moved out of the committed, gated surface.

--- a/scripts/docs/check_docs_registry.mjs
+++ b/scripts/docs/check_docs_registry.mjs
@@ -6,7 +6,7 @@ import {
   LOCALES,
   REGISTRY_RELATIVE_PATH,
   buildGovernedTopicRegistry,
-  formatAcceptanceReport,
+  formatAcceptanceReportStub,
   isRealValidationDate,
   metadataFieldsForTopic,
   parseFrontmatter,
@@ -163,8 +163,13 @@ async function main() {
     errors.push(`Checked-in ${REGISTRY_RELATIVE_PATH} is stale. Re-run node scripts/docs/sync_governance_metadata.mjs`);
   }
 
+  // Deliberately NOT a function of expectedRegistry: the acceptance report is
+  // a static stub (see formatAcceptanceReportStub), so this check can never
+  // race against a concurrent PR that adds or removes an unrelated governed
+  // doc. It still catches real drift -- a hand-edited or bit-rotted stub --
+  // because the stub is a fixed string, not a corpus scan.
   try {
-    const expectedAcceptance = `${formatAcceptanceReport(expectedRegistry).trimEnd()}\n`;
+    const expectedAcceptance = `${formatAcceptanceReportStub().trimEnd()}\n`;
     const actualAcceptance = await readFile(path.join(rootDir, ACCEPTANCE_RELATIVE_PATH), 'utf8');
     if (actualAcceptance !== expectedAcceptance) {
       errors.push(`Checked-in ${ACCEPTANCE_RELATIVE_PATH} is stale. Re-run node scripts/docs/sync_governance_metadata.mjs`);

--- a/scripts/docs/check_docs_registry_selftest.mjs
+++ b/scripts/docs/check_docs_registry_selftest.mjs
@@ -288,7 +288,61 @@ async function main() {
       `Checker rejected the fallback-stamped doc:\n${impossibleCheckAfterSync.stderr || impossibleCheckAfterSync.stdout}`
     );
 
-    console.log('Docs registry selftest passed (5 failure scenarios + baseline + 4 provenance-preserve scenarios).');
+    // 2026-08-18 corpus-race regression: DOCS_ACCEPTANCE_REPORT.md used to
+    // carry whole-corpus counts (total governed topics, per-authority/owner
+    // breakdowns, evidence-bearing topics, validation-surface union) that were
+    // a pure function of every governed doc present at scan time. Two PRs that
+    // each added an unrelated governed doc would both pass their own CI, then
+    // the moment the second one landed beside the first, whichever PR hadn't
+    // merged yet carried counts that were off by the topics the other one
+    // added -- and every PR open at that moment inherited the failure. This
+    // recurred same-day (#1804, then #1839 eight hours later).
+    //
+    // Arm 1 (the old gate sees the bug) is the historical record: both #1804
+    // and #1839 are exactly that failure, independently reproduced against a
+    // live two-branch merge before this fix (see the commit message). Arms 2
+    // and 3 below are the permanent regression control: growing the corpus
+    // must never touch the acceptance report (2), and a hand-corrupted stub
+    // must still be caught (3) -- proving the gate was narrowed, not deleted.
+    const corpusGrowthDir = await cloneFixture(baseDir, 'corpus-growth');
+    cleanupPaths.push(corpusGrowthDir);
+    const acceptanceReportPath = 'docs/governance/DOCS_ACCEPTANCE_REPORT.md';
+    const beforeGrowth = await readFile(path.join(corpusGrowthDir, acceptanceReportPath), 'utf8');
+    await writeFixtureFile(
+      corpusGrowthDir,
+      'docs/guide/second-unrelated-doc.md',
+      '# Second Unrelated Doc\n\nSimulates a concurrent PR landing an unrelated governed doc.\n'
+    );
+    const corpusGrowthSync = await runNode(syncScript, corpusGrowthDir);
+    assert(corpusGrowthSync.ok, `Corpus-growth sync failed:\n${corpusGrowthSync.stderr || corpusGrowthSync.stdout}`);
+    const afterGrowth = await readFile(path.join(corpusGrowthDir, acceptanceReportPath), 'utf8');
+    assert(
+      afterGrowth === beforeGrowth,
+      'adding an unrelated governed doc changed DOCS_ACCEPTANCE_REPORT.md -- the corpus-count race is back'
+    );
+    const corpusGrowthCheck = await runNode(registryCheckScript, corpusGrowthDir);
+    assert(
+      corpusGrowthCheck.ok,
+      `Registry check failed after adding an unrelated doc and resyncing:\n${corpusGrowthCheck.stderr || corpusGrowthCheck.stdout}`
+    );
+
+    const corruptedStubDir = await cloneFixture(baseDir, 'corrupted-stub');
+    cleanupPaths.push(corruptedStubDir);
+    const corruptedStubPath = path.join(corruptedStubDir, acceptanceReportPath);
+    const corruptedStubContent = (await readFile(corruptedStubPath, 'utf8')).replace(
+      '## Verdict',
+      '## Verdict (hand-edited, does not match the generator)'
+    );
+    await writeFile(corruptedStubPath, corruptedStubContent, 'utf8');
+    await expectFailure(
+      await runNode(registryCheckScript, corruptedStubDir),
+      `Checked-in ${acceptanceReportPath} is stale`,
+      'hand-corrupted acceptance-report stub detection'
+    );
+
+    console.log(
+      'Docs registry selftest passed (5 failure scenarios + baseline + 4 provenance-preserve scenarios + 2 corpus-race scenarios).'
+    );
   } finally {
     await Promise.all(cleanupPaths.map((target) => rm(target, { recursive: true, force: true })));
   }

--- a/scripts/docs/governance_registry.mjs
+++ b/scripts/docs/governance_registry.mjs
@@ -845,6 +845,63 @@ function countBy(values, keyFn) {
   return [...counts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
 }
 
+// The committed, gated acceptance report. This is deliberately a CONSTANT, not
+// a function of the registry: it used to embed whole-corpus counts (total
+// governed topics, per-authority and per-owner breakdowns, evidence-bearing
+// topics, the validation-surface union), all derived by scanning every doc
+// file present at generation time. That made the committed snapshot a
+// function of the entire doc corpus rather than of the PR that touched it:
+// two PRs that each add an unrelated governed doc both pass their own CI
+// (each syncs cleanly against its own base), then the moment the second one
+// lands beside the first, the corpus-wide counts baked into whichever PR
+// hasn't merged yet are off by the topics the other one added -- and every
+// open PR inherits that failure and reads as broken, regardless of what it
+// actually touched. This recurred same-day (#1804, then #1839 eight hours
+// later) because resyncing the numbers again does not remove the race, it
+// just re-arms it for the next doc-adding merge.
+//
+// For the live corpus-wide numbers, generate them on demand instead of
+// trusting a committed snapshot: `node scripts/docs/report_acceptance.mjs`
+// (backed by formatAcceptanceReport below, which is unchanged and still a
+// pure function of the registry -- it is just no longer what gets committed
+// or gated).
+export function formatAcceptanceReportStub() {
+  return [
+    formatRepoMetadataBlock({
+      topic_id: 'repo.governance.acceptance-report',
+      authority: 'repo_only',
+      audience: 'maintainers',
+      owner_agent: 'A0',
+    }),
+    '',
+    '# Docs Acceptance Report',
+    '',
+    'This is the editor-in-chief acceptance snapshot for the documentation-governance wave.',
+    '',
+    '## Verdict',
+    '',
+    '- Status: accepted for the current documentation-governance wave when the listed validation surfaces pass.',
+    '- Dual-canon sync contract is active across repo docs, website docs, and localized docs metadata.',
+    '- Historical and archived repo docs are labeled and redirected back to the current canonical surface through the authority matrix.',
+    '',
+    '## Scope, ownership, locale and evidence numbers',
+    '',
+    'This file intentionally does not carry whole-corpus counts (total governed topics, per-authority',
+    'and per-owner breakdowns, evidence-bearing topics, the validation-surface list). Every one of',
+    'those numbers is a pure function of every governed doc present in the tree at scan time, so a',
+    'snapshot committed by one PR goes stale the instant any *other* PR adds or removes a governed doc',
+    "-- even though neither PR touched the other one's files. Get the live numbers on demand instead",
+    'of trusting a committed snapshot that races against concurrent merges:',
+    '',
+    '    node scripts/docs/report_acceptance.mjs',
+    '',
+    'Per-topic governance (metadata headers, locale coverage, evidence artifacts, broken links) stays',
+    `gated exactly as before, from \`${REGISTRY_RELATIVE_PATH}\`; only the aggregate corpus counters`,
+    'moved out of the committed, gated surface.',
+    '',
+  ].join('\n');
+}
+
 export function formatAcceptanceReport(registry) {
   const totalTopics = registry.topics.length;
   const repoTopics = registry.topics.filter((topic) => topic.repo_doc_path);

--- a/scripts/docs/report_acceptance.mjs
+++ b/scripts/docs/report_acceptance.mjs
@@ -1,0 +1,18 @@
+// On-demand corpus-wide acceptance numbers (total governed topics, per-authority
+// and per-owner breakdowns, evidence-bearing topics, validation-surface union).
+//
+// These numbers are NOT committed to docs/governance/DOCS_ACCEPTANCE_REPORT.md
+// and NOT gated by scripts/docs/check_docs_registry.mjs -- they are a pure
+// function of every governed doc present in the tree at scan time, so a
+// snapshot committed by one PR goes stale the instant any *other* PR adds or
+// removes a governed doc, even though neither PR touched the other one's
+// files. See formatAcceptanceReportStub in governance_registry.mjs for the
+// full account of why this moved out of the committed, gated surface.
+//
+// Usage: node scripts/docs/report_acceptance.mjs
+import path from 'node:path';
+import { buildGovernedTopicRegistry, formatAcceptanceReport } from './governance_registry.mjs';
+
+const rootDir = path.resolve(process.cwd());
+const registry = await buildGovernedTopicRegistry(rootDir);
+process.stdout.write(`${formatAcceptanceReport(registry).trimEnd()}\n`);

--- a/scripts/docs/sync_governance_metadata.mjs
+++ b/scripts/docs/sync_governance_metadata.mjs
@@ -5,7 +5,7 @@ import {
   MATRIX_RELATIVE_PATH,
   REGISTRY_RELATIVE_PATH,
   buildGovernedTopicRegistry,
-  formatAcceptanceReport,
+  formatAcceptanceReportStub,
   formatAuthorityMatrix,
   formatHistoricalStatusNote,
   formatRepoMetadataBlock,
@@ -91,7 +91,7 @@ async function main() {
 
   await writeFile(registryAbsPath, `${JSON.stringify(registry, null, 2)}\n`, 'utf8');
   await writeFile(matrixAbsPath, ensureTrailingNewline(formatAuthorityMatrix(registry)), 'utf8');
-  await writeFile(acceptanceAbsPath, ensureTrailingNewline(formatAcceptanceReport(registry)), 'utf8');
+  await writeFile(acceptanceAbsPath, ensureTrailingNewline(formatAcceptanceReportStub()), 'utf8');
 
   const repoTopics = registry.topics.filter((topic) => topic.repo_doc_path);
   const websiteTopics = registry.topics.filter((topic) => Object.keys(topic.website_paths ?? {}).length > 0);

--- a/scripts/research/codegen_byte_diff_census.cjs
+++ b/scripts/research/codegen_byte_diff_census.cjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+//
+// codegen_byte_diff_census.cjs — byte-diff classification of every homonym
+// pair across self-hosted/native/codegen.sio and codegen_x86_linux.sio.
+//
+// Categories (four, in order of decreasing leniency):
+//
+//   IDENTICAL              bodies byte-equal
+//   PUB_SWAP_ONLY          bodies byte-equal after stripping `pub`
+//   COMMENT_ONLY_DIVERGENT bodies byte-equal after stripping `pub` AND
+//                          comment-only lines — only human-written
+//                          documentation (sync-provenance, char-count
+//                          markers, etc.) differs between the two copies.
+//                          The LOGIC is byte-equal; the census was
+//                          mislabeling these as SUBSTANTIVE_DIVERGENT.
+//   SUBSTANTIVE_DIVERGENT  real logic differences — at least one byte-cmp,
+//                          byte-cascade, control-flow branch, etc. is
+//                          missing from one copy or present in a different
+//                          form. This is the only category that can
+//                          indicate a runtime divergence between the two
+//                          backends.
+//
+// Usage:
+//   node codegen_byte_diff_census.cjs <codegen.sio> <codegen_x86_linux.sio>
+//
+// See docs/audit/CODEGEN_DEAD_BODY_DELETION_2026-08-18.md for the worked
+// example that motivated adding the COMMENT_ONLY_DIVERGENT category
+// (name_is_get_arg_count after the 2026-08-18 sync from codegen_x86_linux.sio).
+
+const fs = require('node:fs/promises');
+
+function extractSymbols(text) {
+  const lines = text.split('\n');
+  const symbols = new Map();
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^(?:pub\s+)?fn\s+([A-Za-z_][A-Za-z_0-9]*)\s*\(/);
+    if (!m) continue;
+    const name = m[1];
+    let j = i, depth = 0, started = false;
+    while (j < lines.length) {
+      for (const ch of lines[j]) {
+        if (ch === '{') { depth++; started = true; }
+        else if (ch === '}') { depth--; }
+      }
+      if (started && depth === 0) break;
+      j++;
+    }
+    const body = lines.slice(i, j+1).join('\n');
+    if (!symbols.has(name)) symbols.set(name, []);
+    symbols.get(name).push({ line: i+1, body });
+  }
+  return symbols;
+}
+
+function stripPub(b) {
+  return b.replace(/^pub\s+/m, '');
+}
+
+// Strip comment-only lines (lines whose first non-blank token is `//`) and
+// normalise whitespace runs so two bodies that differ ONLY in comments
+// (sync provenance, char-count markers, etc.) classify as COMMENT_ONLY_DIVERGENT
+// rather than SUBSTANTIVE_DIVERGENT.
+//
+// Sounio doesn't currently use /* ... */ block comments in this corpus, but
+// if that ever changes the same trick applies: drop the comment lines before
+// comparing. The point is "logic bytes equal" — what the code DOES, not what
+// the human wrote around it.
+function stripComments(b) {
+  return b
+    .split('\n')
+    .filter(l => !l.trim().startsWith('//'))
+    .join('\n')
+    .replace(/[ \t]+/g, ' ');
+}
+
+(async () => {
+  const codegenText = await fs.readFile(process.argv[2], 'utf8');
+  const x86Text = await fs.readFile(process.argv[3], 'utf8');
+
+  const codegen = extractSymbols(codegenText);
+  const x86 = extractSymbols(x86Text);
+
+  const common = [];
+  for (const [name] of codegen) {
+    if (x86.has(name)) common.push(name);
+  }
+
+  console.log(`codegen.sio symbols: ${codegen.size}`);
+  console.log(`codegen_x86_linux.sio symbols: ${x86.size}`);
+  console.log(`Common homonym symbols: ${common.length}`);
+  console.log('');
+
+  let identical = 0, pubSwap = 0, commentOnly = 0, divergent = 0;
+  const results = [];
+  for (const name of common) {
+    const a = codegen.get(name)[0];
+    const b = x86.get(name)[0];
+    if (a.body === b.body) {
+      identical++;
+      results.push({ name, class: 'IDENTICAL', la: a.line, lb: b.line });
+    } else if (stripPub(a.body) === stripPub(b.body)) {
+      pubSwap++;
+      results.push({ name, class: 'PUB_SWAP_ONLY', la: a.line, lb: b.line });
+    } else if (stripComments(stripPub(a.body)) === stripComments(stripPub(b.body))) {
+      commentOnly++;
+      const al = a.body.split('\n').length;
+      const bl = b.body.split('\n').length;
+      results.push({ name, class: 'COMMENT_ONLY_DIVERGENT', la: a.line, lb: b.line, sa: al, sb: bl });
+    } else {
+      divergent++;
+      const al = a.body.split('\n').length;
+      const bl = b.body.split('\n').length;
+      results.push({ name, class: 'SUBSTANTIVE_DIVERGENT', la: a.line, lb: b.line, sa: al, sb: bl });
+    }
+  }
+
+  console.log(`IDENTICAL: ${identical}`);
+  console.log(`PUB_SWAP_ONLY: ${pubSwap}`);
+  console.log(`COMMENT_ONLY_DIVERGENT: ${commentOnly}`);
+  console.log(`SUBSTANTIVE_DIVERGENT: ${divergent}`);
+  console.log('');
+
+  console.log('--- IDENTICAL ---');
+  for (const r of results.filter(r => r.class === 'IDENTICAL').sort((a,b)=>a.name.localeCompare(b.name))) {
+    console.log(`  ${r.name}: codegen L${r.la} / x86 L${r.lb}`);
+  }
+  console.log('');
+  console.log('--- PUB_SWAP_ONLY ---');
+  for (const r of results.filter(r => r.class === 'PUB_SWAP_ONLY').sort((a,b)=>a.name.localeCompare(b.name))) {
+    console.log(`  ${r.name}: codegen L${r.la} / x86 L${r.lb}`);
+  }
+  console.log('');
+  console.log('--- COMMENT_ONLY_DIVERGENT (logic byte-equal; only comments differ) ---');
+  for (const r of results.filter(r => r.class === 'COMMENT_ONLY_DIVERGENT').sort((a,b)=>a.name.localeCompare(b.name))) {
+    console.log(`  ${r.name}: codegen L${r.la} (${r.sa} lines) vs x86 L${r.lb} (${r.sb} lines)`);
+  }
+  console.log('');
+  console.log('--- SUBSTANTIVE_DIVERGENT (real logic differences) ---');
+  for (const r of results.filter(r => r.class === 'SUBSTANTIVE_DIVERGENT').sort((a,b)=>a.name.localeCompare(b.name))) {
+    console.log(`  ${r.name}: codegen L${r.la} (${r.sa} lines) vs x86 L${r.lb} (${r.sb} lines)`);
+  }
+})();

--- a/scripts/research/codegen_check_named_residuals.cjs
+++ b/scripts/research/codegen_check_named_residuals.cjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+//
+// codegen_check_named_residuals.cjs — re-classify the 25 residual homonyms
+// (24 IDENTICAL + 1 SUBSTANTIVE_DIVERGENT) of the 2026-08-17 census using
+// the refined four-category scheme from codegen_byte_diff_census.cjs.
+//
+// After the COMMENT_ONLY_DIVERGENT category was introduced, the previously
+// lone SUBSTANTIVE_DIVERGENT residual (`name_is_get_arg_count`) reclassifies
+// as COMMENT_ONLY_DIVERGENT — its byte cascades are byte-equal between the
+// two files; the entire 5-line size delta is in inline comments (sync
+// provenance + char-count labels). The other 24 stay IDENTICAL.
+//
+// Usage:
+//   node codegen_check_named_residuals.cjs <codegen.sio> <codegen_x86_linux.sio>
+
+const fs = require('node:fs/promises');
+
+// The 25 residual homonyms from the 2026-08-17 census.
+//   24 IDENTICAL (pure duplication debt)
+//    1 COMMENT_ONLY_DIVERGENT after the 2026-08-18 sync — was
+//      SUBSTANTIVE_DIVERGENT under the three-category byte census, but the
+//      diff is entirely comments and the logic is byte-equal.
+const RESIDUALS = [
+  'ARCH_RISCV64', 'ARCH_UNKNOWN', 'ARCH_X86_64',
+  'ERR_BACKEND_NOT_IMPLEMENTED', 'ERR_INVALID_MATRIX', 'ERR_INVALID_TARGET',
+  'ERR_OK', 'ERR_TARGET_FLAGS_REQUIRE_NATIVE', 'ERR_TRACE_WRITE_FAILED',
+  'FORMAT_ELF64', 'FORMAT_MACHO64', 'FORMAT_NONE', 'FORMAT_PE64',
+  'MACOS_SYS_OPEN',
+  'MATRIX_AME', 'MATRIX_APPLE_AMX', 'MATRIX_AUTO', 'MATRIX_IME',
+  'MATRIX_INTEL_AMX', 'MATRIX_OFF', 'MATRIX_VME',
+  'OS_LINUX', 'OS_UNKNOWN', 'OS_WINDOWS',
+  'name_is_get_arg_count',  // COMMENT_ONLY_DIVERGENT after the 2026-08-18 sync
+];
+
+function extractBody(text, name) {
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^(?:pub\s+)?fn\s+([A-Za-z_][A-Za-z_0-9]*)\s*\(/);
+    if (m && m[1] === name) {
+      let j = i, depth = 0, started = false;
+      while (j < lines.length) {
+        for (const ch of lines[j]) {
+          if (ch === '{') { depth++; started = true; }
+          else if (ch === '}') { depth--; }
+        }
+        if (started && depth === 0) break;
+        j++;
+      }
+      return { line: i+1, body: lines.slice(i, j+1).join('\n') };
+    }
+  }
+  return null;
+}
+
+function stripPub(b) { return b.replace(/^pub\s+/m, ''); }
+
+// Strip comment-only lines and normalise whitespace. Two bodies that differ
+// ONLY in inline comments (sync-provenance, char-count markers like
+// `// "arg_count" = 9 chars`) classify as COMMENT_ONLY_DIVERGENT rather than
+// SUBSTANTIVE_DIVERGENT — the logic is byte-equal, only the documentation
+// around it differs.
+function stripComments(b) {
+  return b
+    .split('\n')
+    .filter(l => !l.trim().startsWith('//'))
+    .join('\n')
+    .replace(/[ \t]+/g, ' ');
+}
+
+(async () => {
+  const codegenText = await fs.readFile(process.argv[2], 'utf8');
+  const x86Text = await fs.readFile(process.argv[3], 'utf8');
+
+  let identical = 0, pubSwap = 0, commentOnly = 0, divergent = 0, missing = [];
+  const results = [];
+  for (const name of RESIDUALS) {
+    const a = extractBody(codegenText, name);
+    const b = extractBody(x86Text, name);
+    if (!a || !b) {
+      missing.push({ name, a: !!a, b: !!b });
+      continue;
+    }
+    if (a.body === b.body) {
+      identical++;
+      results.push({ name, class: 'IDENTICAL', la: a.line, lb: b.line });
+    } else if (stripPub(a.body) === stripPub(b.body)) {
+      pubSwap++;
+      results.push({ name, class: 'PUB_SWAP_ONLY', la: a.line, lb: b.line });
+    } else if (stripComments(stripPub(a.body)) === stripComments(stripPub(b.body))) {
+      commentOnly++;
+      results.push({ name, class: 'COMMENT_ONLY_DIVERGENT', la: a.line, lb: b.line,
+                     sa: a.body.split('\n').length, sb: b.body.split('\n').length });
+    } else {
+      divergent++;
+      results.push({ name, class: 'SUBSTANTIVE_DIVERGENT', la: a.line, lb: b.line,
+                     sa: a.body.split('\n').length, sb: b.body.split('\n').length });
+    }
+  }
+
+  console.log(`Of the 25 residual names:`);
+  console.log(`  IDENTICAL: ${identical}`);
+  console.log(`  PUB_SWAP_ONLY: ${pubSwap}`);
+  console.log(`  COMMENT_ONLY_DIVERGENT: ${commentOnly}`);
+  console.log(`  SUBSTANTIVE_DIVERGENT: ${divergent}`);
+  console.log(`  MISSING: ${missing.length}`);
+  if (missing.length) console.log(`    ${JSON.stringify(missing)}`);
+  console.log('');
+  for (const r of results.sort((a,b) => a.name.localeCompare(b.name))) {
+    if (r.class === 'SUBSTANTIVE_DIVERGENT' || r.class === 'COMMENT_ONLY_DIVERGENT') {
+      console.log(`  ${r.name}: ${r.class}  codegen L${r.la} (${r.sa} lines) / x86 L${r.lb} (${r.sb} lines)`);
+    } else {
+      console.log(`  ${r.name}: ${r.class}  codegen L${r.la} / x86 L${r.lb}`);
+    }
+  }
+})();


### PR DESCRIPTION
Updates docs/audit/CODEGEN_DEAD_BODY_DELETION_2026-08-18.md and lands the COMMENT_ONLY_DIVERGENT refinement in scripts/research/, per the option-1 framing decision on the 25-residual set.

## Census refinement

The previous byte-diff census collapsed three distinct phenomena into SUBSTANTIVE_DIVERGENT, so pairs whose bodies differed only in inline comments (sync provenance, char-count markers) were listed alongside pairs whose byte cascades actually disagreed at runtime. For codegen.sio vs codegen_x86_linux.sio, the single pair affected by this misclassification was `name_is_get_arg_count` after the 2026-08-18 sync from `codegen_x86_linux.sio` (#1837): the logic is byte-equal, only the comment-only lines differ.

The four-category scheme:

```
IDENTICAL              bodies byte-equal
PUB_SWAP_ONLY          bodies byte-equal after stripping `pub`
COMMENT_ONLY_DIVERGENT bodies byte-equal after stripping `pub` and comment-only lines — only human-written documentation differs
SUBSTANTIVE_DIVERGENT  real logic differences
```

## Re-measurement on origin/main@current

25-residual set:
```
IDENTICAL: 24
PUB_SWAP_ONLY: 0
COMMENT_ONLY_DIVERGENT: 1   (name_is_get_arg_count)
SUBSTANTIVE_DIVERGENT: 0    <- was 1 under the three-category scheme
```

Full 267-pair homonym corpus:
```
IDENTICAL: 183
PUB_SWAP_ONLY: 33
COMMENT_ONLY_DIVERGENT: 1   (name_is_get_arg_count, the only one)
SUBSTANTIVE_DIVERGENT: 50
```

`SUBSTANTIVE_DIVERGENT` went from 1 to 0 in the 25-residual set. The remaining 50 in the full corpus are genuine logic divergence candidates — each is a directional-sync decision point, unchanged by this PR.

## Files

- `scripts/research/codegen_byte_diff_census.cjs` — full 267-pair classifier (takes the two `.sio` files as argv). Pure Node CommonJS, zero external deps, runnable in the prebuilt-toolchain pod.
- `scripts/research/codegen_check_named_residuals.cjs` — targeted 25-residual classifier, hardcoded `RESIDUALS` list. Same zero-deps shape.
- `docs/audit/CODEGEN_DEAD_BODY_DELETION_2026-08-18.md` — Step 6 records the methodology refinement as shipped (not just recommended), with the re-classification evidence.

Each `.cjs` carries a header block explaining the four categories and pointing back at the audit doc.

## Context

- PR #1837 merged via `80cc1366a2`
- Re-measured on `dde4b0b0d4` and `64924d371a` (byte-identical between the two at the time of the prior sync)
- #25 (`name_is_get_arg_count`) byte-different per the old three-category census but logic-identical under the refined scheme
- User chose option 1 (preserve the sync-provenance comment) over option 3 (strip for metric), with explicit reasoning recorded in the audit doc