### PR TITLE
ci: leftover-gate budget — wire only the two cheap-green dissertation leftovers

### DIFF
--- a/docs/audit/CI_GATE_BUDGET_2026-08-18.tsv
+++ b/docs/audit/CI_GATE_BUDGET_2026-08-18.tsv
@@ -1,0 +1,38 @@
+gate	family	elapsed_sec	rc	capped	polarity	propose_wire	note
+dissertation_confidence_gate_gate.sh	dissertation	1	0	no	green	yes	Contribution 2. Remeasured 0.693 s wall on 6098da3e82, rc=0. date+s first pass was 0–1 s.
+dissertation_frontend_parity_gate.sh	dissertation	2	0	no	green	yes	PBPK14 dual-Sounio 14/14 + Node product arm. Remeasured 1.942 s wall on 6098da3e82, rc=0.
+dissertation_dossier_gate.sh	dissertation	1	1	no	red	no	4 fails: dossier_smoke check/compile; binary not executable; no PASS dossier_smoke.
+dissertation_pbpk28_parity_gate.sh	dissertation	9	1	no	red	no	case7 semaglutide ref: E175 private fn + E008 bergman_glucose_insulin return type. Madaros preflight rc=1.
+dissertation_pbpk_hessian_gate.sh	dissertation	5	1	no	red	no	var_o1 golden 2.050168e-7 vs runtime 0.000000 (zero GUM variance). Mutates hessian CSV if left dirty.
+dissertation_pbpk_suite_gate.sh	dissertation	110	1	no	red	no	Default souc-seq-leansingle.sh (do not pin Madaros). 52/53 PASS; FAIL pbpk28_rapamycin_clinical rc=1 (90 s timeout). PEND semaglutide clinical. SOUNIO_DPS_GATE_SKIP=1 is vacuous skip — not used here.
+168_biology_validation_gate.sh	forgotten	5	0	no	green	no	Cheap green; not a dissertation candidate.
+claim_native_gate.sh	forgotten	180	124	yes	capped	no	>=180 s. Partial N2 PASS. Not finished under cap.
+compile_fail_harness_contract_gate.sh	forgotten	1	0	no	green	no	Cheap green; harness contract, not dissertation.
+ffi_posix_builtin_gate.sh	forgotten	180	124	yes	capped	no	>=180 s hang with empty stdout. Gate builds Madaros from source unless SOUNIO_GATE_SOUC is set — full self-compile, not a Contracts candidate.
+kretikos_kaxi_fmad_invariance_gate.sh	forgotten	0	0	no	skip-vacuous	no	SKIPPED (no CUDA). Green is not a measurement.
+kretikos_kaxi_phase_j_aggregate_gate.sh	forgotten	3	0	no	green	no	6/0 PASS. Cheap; not dissertation.
+kretikos_kaxi_round_mode_gate.sh	forgotten	75	1	no	red	no	PTX golden rm kernel missing add.rm/sub.rm/mul.rm.f64.
+madaros_f128_f256_ladder_gate.sh	forgotten	4	1	no	red	no	V0-A E218 still active. Known: wiring this reds every PR.
+madaros_f128_f256_v0c_wire_gate.sh	forgotten	1	1	no	red	no	V0-C scaffold, external wire corpus unconsumed.
+madaros_f128_f256_v0d_softfloat_gate.sh	forgotten	0	1	no	red	no	V0-D scaffold, softfloat hard corpus unconsumed.
+madaros_imported_ep_var_preserve_gate.sh	forgotten	7	1	no	red	no	bin/madaros SIGSEGV during run. Do not wire.
+madaros_ols_fixed_e2e_gate.sh	forgotten	2	0	no	green	no	Cheap green; not dissertation.
+madaros_print_f64_negative_gate.sh	forgotten	2	0	no	green	no	Named leftover. Cheap; not dissertation.
+madaros_zero_provenance_failclosed_gate.sh	forgotten	2	0	no	green	no	Cheap green; not dissertation.
+mir_instr_capacity_coherence_gate.sh	forgotten	0	0	no	green	no	Source-text coherence check. Cheap; not dissertation.
+mli_s3_bit_identity_gate.sh	forgotten	5	0	no	green	no	Named leftover. Cheap; not dissertation.
+native_capacity_tiers_gate.sh	forgotten	0	1	no	red	no	label_tier_4096_below_ir_max_instrs_16384.
+octonion_probes_gate.sh	forgotten	1	0	no	green	no	Cheap green; not dissertation.
+oopsla2027_paper_gate.sh	forgotten	0	1	no	red	no	OOPSLA2027_PAPER_VERDICT INCOMPLETE.
+paper168_cocycle_subspace_gate.sh	forgotten	180	124	yes	capped	no	>=180 s. Partial PASS k8/k9. Not finished under cap.
+paper_168_theorem_claims_gate.sh	forgotten	0	1	no	red	no	ModuleNotFoundError: numpy. Vacuous-red on this pod; not a Contracts candidate.
+run_pass_output_gate.sh	forgotten	53	0	no	green	no	219 checked vs committed baseline (25 mismatches already in baseline). 53 s — too dear for Contracts; not dissertation.
+self_falsifying_compilation_line_gate.sh	forgotten	1	0	no	green	no	SUBSTRATE_LIVE corpus-bound. Cheap; not dissertation. Rungs below are red or incomplete.
+self_falsifying_compilation_line_r11_gate.sh	forgotten	0	1	no	red	no	ModuleNotFoundError: numpy.
+self_falsifying_compilation_line_r17_gate.sh	forgotten	0	1	no	red	no	SURFACE_ONLY__NOT_CERTIFIED.
+self_falsifying_compilation_line_r2_gate.sh	forgotten	0	1	no	red	no	INCOMPLETE.
+self_falsifying_compilation_line_r4_gate.sh	forgotten	46	1	no	red	no	known correction daa0635d0 no longer lands in a graded bucket.
+self_falsifying_compilation_line_r5_gate.sh	forgotten	0	1	no	red	no	INCOMPLETE.
+self_falsifying_compiler_gate.sh	forgotten	180	124	yes	capped	no	>=180 s. Partial F1_SURFACE PASS. Not finished under cap.
+stdlib_source_byte_ceiling_gate.sh	forgotten	4	0	no	green	no	Named leftover. Cheap; not dissertation.
+witness_based_compilation_paper_gate.sh	forgotten	0	0	no	green	no	DRAFT_TOKEN_BOUND. Cheap; not dissertation.

--- a/docs/audit/CI_GATE_BUDGET_2026-08-18.tsv
+++ b/docs/audit/CI_GATE_BUDGET_2026-08-18.tsv
@@ -1,38 +1,38 @@
-gate	family	elapsed_sec	rc	capped	polarity	propose_wire	note
-dissertation_confidence_gate_gate.sh	dissertation	1	0	no	green	yes	Contribution 2. Remeasured 0.693 s wall on 6098da3e82, rc=0. date+s first pass was 0–1 s.
-dissertation_frontend_parity_gate.sh	dissertation	2	0	no	green	yes	PBPK14 dual-Sounio 14/14 + Node product arm. Remeasured 1.942 s wall on 6098da3e82, rc=0.
-dissertation_dossier_gate.sh	dissertation	1	1	no	red	no	4 fails: dossier_smoke check/compile; binary not executable; no PASS dossier_smoke.
-dissertation_pbpk28_parity_gate.sh	dissertation	9	1	no	red	no	case7 semaglutide ref: E175 private fn + E008 bergman_glucose_insulin return type. Madaros preflight rc=1.
-dissertation_pbpk_hessian_gate.sh	dissertation	5	1	no	red	no	var_o1 golden 2.050168e-7 vs runtime 0.000000 (zero GUM variance). Mutates hessian CSV if left dirty.
-dissertation_pbpk_suite_gate.sh	dissertation	110	1	no	red	no	Default souc-seq-leansingle.sh (do not pin Madaros). 52/53 PASS; FAIL pbpk28_rapamycin_clinical rc=1 (90 s timeout). PEND semaglutide clinical. SOUNIO_DPS_GATE_SKIP=1 is vacuous skip — not used here.
-168_biology_validation_gate.sh	forgotten	5	0	no	green	no	Cheap green; not a dissertation candidate.
-claim_native_gate.sh	forgotten	180	124	yes	capped	no	>=180 s. Partial N2 PASS. Not finished under cap.
-compile_fail_harness_contract_gate.sh	forgotten	1	0	no	green	no	Cheap green; harness contract, not dissertation.
-ffi_posix_builtin_gate.sh	forgotten	180	124	yes	capped	no	>=180 s hang with empty stdout. Gate builds Madaros from source unless SOUNIO_GATE_SOUC is set — full self-compile, not a Contracts candidate.
-kretikos_kaxi_fmad_invariance_gate.sh	forgotten	0	0	no	skip-vacuous	no	SKIPPED (no CUDA). Green is not a measurement.
-kretikos_kaxi_phase_j_aggregate_gate.sh	forgotten	3	0	no	green	no	6/0 PASS. Cheap; not dissertation.
-kretikos_kaxi_round_mode_gate.sh	forgotten	75	1	no	red	no	PTX golden rm kernel missing add.rm/sub.rm/mul.rm.f64.
-madaros_f128_f256_ladder_gate.sh	forgotten	4	1	no	red	no	V0-A E218 still active. Known: wiring this reds every PR.
-madaros_f128_f256_v0c_wire_gate.sh	forgotten	1	1	no	red	no	V0-C scaffold, external wire corpus unconsumed.
-madaros_f128_f256_v0d_softfloat_gate.sh	forgotten	0	1	no	red	no	V0-D scaffold, softfloat hard corpus unconsumed.
-madaros_imported_ep_var_preserve_gate.sh	forgotten	7	1	no	red	no	bin/madaros SIGSEGV during run. Do not wire.
-madaros_ols_fixed_e2e_gate.sh	forgotten	2	0	no	green	no	Cheap green; not dissertation.
-madaros_print_f64_negative_gate.sh	forgotten	2	0	no	green	no	Named leftover. Cheap; not dissertation.
-madaros_zero_provenance_failclosed_gate.sh	forgotten	2	0	no	green	no	Cheap green; not dissertation.
-mir_instr_capacity_coherence_gate.sh	forgotten	0	0	no	green	no	Source-text coherence check. Cheap; not dissertation.
-mli_s3_bit_identity_gate.sh	forgotten	5	0	no	green	no	Named leftover. Cheap; not dissertation.
-native_capacity_tiers_gate.sh	forgotten	0	1	no	red	no	label_tier_4096_below_ir_max_instrs_16384.
-octonion_probes_gate.sh	forgotten	1	0	no	green	no	Cheap green; not dissertation.
-oopsla2027_paper_gate.sh	forgotten	0	1	no	red	no	OOPSLA2027_PAPER_VERDICT INCOMPLETE.
-paper168_cocycle_subspace_gate.sh	forgotten	180	124	yes	capped	no	>=180 s. Partial PASS k8/k9. Not finished under cap.
-paper_168_theorem_claims_gate.sh	forgotten	0	1	no	red	no	ModuleNotFoundError: numpy. Vacuous-red on this pod; not a Contracts candidate.
-run_pass_output_gate.sh	forgotten	53	0	no	green	no	219 checked vs committed baseline (25 mismatches already in baseline). 53 s — too dear for Contracts; not dissertation.
-self_falsifying_compilation_line_gate.sh	forgotten	1	0	no	green	no	SUBSTRATE_LIVE corpus-bound. Cheap; not dissertation. Rungs below are red or incomplete.
-self_falsifying_compilation_line_r11_gate.sh	forgotten	0	1	no	red	no	ModuleNotFoundError: numpy.
-self_falsifying_compilation_line_r17_gate.sh	forgotten	0	1	no	red	no	SURFACE_ONLY__NOT_CERTIFIED.
-self_falsifying_compilation_line_r2_gate.sh	forgotten	0	1	no	red	no	INCOMPLETE.
-self_falsifying_compilation_line_r4_gate.sh	forgotten	46	1	no	red	no	known correction daa0635d0 no longer lands in a graded bucket.
-self_falsifying_compilation_line_r5_gate.sh	forgotten	0	1	no	red	no	INCOMPLETE.
-self_falsifying_compiler_gate.sh	forgotten	180	124	yes	capped	no	>=180 s. Partial F1_SURFACE PASS. Not finished under cap.
-stdlib_source_byte_ceiling_gate.sh	forgotten	4	0	no	green	no	Named leftover. Cheap; not dissertation.
-witness_based_compilation_paper_gate.sh	forgotten	0	0	no	green	no	DRAFT_TOKEN_BOUND. Cheap; not dissertation.
+gate	family	kind	elapsed_sec	rc	capped	polarity	propose_wire	note
+dissertation_confidence_gate_gate.sh	dissertation	gate_cost	1	0	no	green	yes	Contribution 2. Remeasured 0.693 s wall on 6098da3e82, rc=0. date+s first pass was 0–1 s.
+dissertation_frontend_parity_gate.sh	dissertation	gate_cost	2	0	no	green	yes	PBPK14 dual-Sounio 14/14 + Node product arm. Remeasured 1.942 s wall on 6098da3e82, rc=0.
+dissertation_dossier_gate.sh	dissertation	gate_cost	1	1	no	red	no	4 fails: dossier_smoke check/compile; binary not executable; no PASS dossier_smoke.
+dissertation_pbpk28_parity_gate.sh	dissertation	gate_cost	9	1	no	red	no	case7 semaglutide ref: E175 private fn + E008 bergman_glucose_insulin return type. Madaros preflight rc=1.
+dissertation_pbpk_hessian_gate.sh	dissertation	gate_cost	5	1	no	red	no	var_o1 golden 2.050168e-7 vs runtime 0.000000 (zero GUM variance). Mutates hessian CSV if left dirty.
+dissertation_pbpk_suite_gate.sh	dissertation	gate_cost	110	1	no	red	no	Default souc-seq-leansingle.sh (do not pin Madaros). 52/53 PASS; FAIL pbpk28_rapamycin_clinical rc=1 (90 s timeout). PEND semaglutide clinical. SOUNIO_DPS_GATE_SKIP=1 is vacuous skip — not used here.
+168_biology_validation_gate.sh	forgotten	gate_cost	5	0	no	green	no	Cheap green; not a dissertation candidate.
+claim_native_gate.sh	forgotten	timeout-cap	180	124	yes	capped	no	>=180 s. Partial N2 PASS. Not finished under cap.
+compile_fail_harness_contract_gate.sh	forgotten	gate_cost	1	0	no	green	no	Cheap green; harness contract, not dissertation.
+ffi_posix_builtin_gate.sh	forgotten	rebuild	180	124	yes	capped	no	NOT a slow gate. kind=rebuild: unless SOUNIO_GATE_SOUC is set, the script runs build_modular_madaros.sh before any witness. The 180 s cap with empty stdout is the accidental self-compile, not the POSIX reframe/execution arms. Wiring this to Contracts would bill every PR a Madaros rebuild.
+kretikos_kaxi_fmad_invariance_gate.sh	forgotten	skip-vacuous	0	0	no	skip-vacuous	no	SKIPPED (no CUDA). Green is not a measurement. kind=skip-vacuous.
+kretikos_kaxi_phase_j_aggregate_gate.sh	forgotten	gate_cost	3	0	no	green	no	6/0 PASS. Cheap; not dissertation.
+kretikos_kaxi_round_mode_gate.sh	forgotten	gate_cost	75	1	no	red	no	PTX golden rm kernel missing add.rm/sub.rm/mul.rm.f64.
+madaros_f128_f256_ladder_gate.sh	forgotten	gate_cost	4	1	no	red	no	V0-A E218 still active. Known: wiring this reds every PR.
+madaros_f128_f256_v0c_wire_gate.sh	forgotten	gate_cost	1	1	no	red	no	V0-C scaffold, external wire corpus unconsumed.
+madaros_f128_f256_v0d_softfloat_gate.sh	forgotten	gate_cost	0	1	no	red	no	V0-D scaffold, softfloat hard corpus unconsumed.
+madaros_imported_ep_var_preserve_gate.sh	forgotten	gate_cost	7	1	no	red	no	bin/madaros SIGSEGV during run. Do not wire.
+madaros_ols_fixed_e2e_gate.sh	forgotten	gate_cost	2	0	no	green	no	Cheap green; not dissertation.
+madaros_print_f64_negative_gate.sh	forgotten	gate_cost	2	0	no	green	no	Named leftover. Cheap; not dissertation.
+madaros_zero_provenance_failclosed_gate.sh	forgotten	gate_cost	2	0	no	green	no	Cheap green; not dissertation.
+mir_instr_capacity_coherence_gate.sh	forgotten	gate_cost	0	0	no	green	no	Source-text coherence check. Cheap; not dissertation.
+mli_s3_bit_identity_gate.sh	forgotten	gate_cost	5	0	no	green	no	Named leftover. Cheap; not dissertation.
+native_capacity_tiers_gate.sh	forgotten	gate_cost	0	1	no	red	no	label_tier_4096_below_ir_max_instrs_16384.
+octonion_probes_gate.sh	forgotten	gate_cost	1	0	no	green	no	Cheap green; not dissertation.
+oopsla2027_paper_gate.sh	forgotten	gate_cost	0	1	no	red	no	OOPSLA2027_PAPER_VERDICT INCOMPLETE.
+paper168_cocycle_subspace_gate.sh	forgotten	timeout-cap	180	124	yes	capped	no	>=180 s. Partial PASS k8/k9. Not finished under cap.
+paper_168_theorem_claims_gate.sh	forgotten	gate_cost	0	1	no	red	no	ModuleNotFoundError: numpy. Vacuous-red on this pod; not a Contracts candidate.
+run_pass_output_gate.sh	forgotten	gate_cost	53	0	no	green	no	219 checked vs committed baseline (25 mismatches already in baseline). 53 s — too dear for Contracts; not dissertation.
+self_falsifying_compilation_line_gate.sh	forgotten	gate_cost	1	0	no	green	no	SUBSTRATE_LIVE corpus-bound. Cheap; not dissertation. Rungs below are red or incomplete.
+self_falsifying_compilation_line_r11_gate.sh	forgotten	gate_cost	0	1	no	red	no	ModuleNotFoundError: numpy.
+self_falsifying_compilation_line_r17_gate.sh	forgotten	gate_cost	0	1	no	red	no	SURFACE_ONLY__NOT_CERTIFIED.
+self_falsifying_compilation_line_r2_gate.sh	forgotten	gate_cost	0	1	no	red	no	INCOMPLETE.
+self_falsifying_compilation_line_r4_gate.sh	forgotten	gate_cost	46	1	no	red	no	known correction daa0635d0 no longer lands in a graded bucket.
+self_falsifying_compilation_line_r5_gate.sh	forgotten	gate_cost	0	1	no	red	no	INCOMPLETE.
+self_falsifying_compiler_gate.sh	forgotten	timeout-cap	180	124	yes	capped	no	>=180 s. Partial F1_SURFACE PASS. Not finished under cap.
+stdlib_source_byte_ceiling_gate.sh	forgotten	gate_cost	4	0	no	green	no	Named leftover. Cheap; not dissertation.
+witness_based_compilation_paper_gate.sh	forgotten	gate_cost	0	0	no	green	no	DRAFT_TOKEN_BOUND. Cheap; not dissertation.

--- a/docs/audit/CI_GATE_UMBRELLA_CLOSURE_2026-08-18.tsv
+++ b/docs/audit/CI_GATE_UMBRELLA_CLOSURE_2026-08-18.tsv
@@ -1,0 +1,27 @@
+gate	hop	via_parent	reachable	class	direct_github_mention	in_mention_orphan_390
+native_v2_cpu_compiler_umbrella_gate.sh	0		no	unclassified	no	yes
+dissertation_pbpk_suite_gate.sh	1	native_v2_cpu_compiler_umbrella_gate.sh	no	manual-by-design	no	yes
+kretikos_kaxi_gate.sh	1	native_v2_cpu_compiler_umbrella_gate.sh	no	manual-by-design	no	yes
+kretikos_kaxi_iso_budget_gate.sh	1	native_v2_cpu_compiler_umbrella_gate.sh	no	manual-by-design	no	yes
+kretikos_kaxi_phase_j_gate.sh	1	native_v2_cpu_compiler_umbrella_gate.sh	no	manual-by-design	no	yes
+kretikos_kaxi_phase_y_gate.sh	1	native_v2_cpu_compiler_umbrella_gate.sh	no	manual-by-design	no	yes
+lean_single_fixed_point_gate.sh	1	native_v2_cpu_compiler_umbrella_gate.sh	no	manual-by-design	no	yes
+native_v2_driver_self_compile_gate.sh	1	native_v2_cpu_compiler_umbrella_gate.sh	no	manual-by-design	no	yes
+native_v2_e2e_codegen_suite_gate.sh	1	native_v2_cpu_compiler_umbrella_gate.sh	no	manual-by-design	no	yes
+native_v2_epistemic_science_spine_gate.sh	1	native_v2_cpu_compiler_umbrella_gate.sh	no	manual-by-design	no	yes
+native_v2_f64_ladder_gate.sh	1	native_v2_cpu_compiler_umbrella_gate.sh	no	manual-by-design	no	yes
+native_v2_gum_primitives_gate.sh	1	native_v2_cpu_compiler_umbrella_gate.sh	no	manual-by-design	no	yes
+native_v2_imported_captured_closure_boundary_gate.sh	1	native_v2_cpu_compiler_umbrella_gate.sh	no	manual-by-design	no	yes
+native_v2_imported_closure_boundary_gate.sh	1	native_v2_cpu_compiler_umbrella_gate.sh	no	manual-by-design	no	yes
+native_v2_semantic_hardening_gate.sh	1	native_v2_cpu_compiler_umbrella_gate.sh	no	manual-by-design	no	yes
+native_v2_struct_gate.sh	1	native_v2_cpu_compiler_umbrella_gate.sh	no	manual-by-design	no	yes
+canonical_compiler_gate.sh	2	lean_single_fixed_point_gate.sh	yes	workflow-reachable	yes	no
+kaxi_ptx_golden_gate.sh	2	kretikos_kaxi_gate.sh	no	unclassified	no	yes
+native_v2_hof_closure_gate.sh	2	native_v2_imported_closure_boundary_gate.sh	no	unclassified	no	yes
+native_v2_imported_body_lowering_gate.sh	2	native_v2_imported_closure_boundary_gate.sh	no	unclassified	no	yes
+native_v2_imported_core_abi_gate.sh	2	native_v2_struct_gate.sh	no	unclassified	no	yes
+native_v2_imported_hof_abi_gate.sh	2	native_v2_struct_gate.sh	no	unclassified	no	yes
+native_v2_metal_algebra_gate.sh	2	native_v2_struct_gate.sh	no	unclassified	no	yes
+native_v2_nvidia_bare_metal_gate.sh	2	native_v2_struct_gate.sh	no	unclassified	no	yes
+native_v2_serious_track_gate.sh	2	native_v2_driver_self_compile_gate.sh	no	unclassified	no	yes
+native_v2_frontend_convergence_gate.sh	3	native_v2_imported_core_abi_gate.sh	no	unclassified	no	yes


### PR DESCRIPTION
## Summary

- Measured wall-clock + polarity for the **6 dissertation leftover gates** and the **36 forgotten leftovers** on `origin/main` (`d3ea284caf`, then rechecked the two green candidates on `6098da3e82`). Receipt: `docs/audit/CI_GATE_BUDGET_2026-08-18.tsv`.
- **Proposal: wire only two.** `dissertation_confidence_gate_gate.sh` (**0.7 s**, rc=0) and `dissertation_frontend_parity_gate.sh` (**1.9 s**, rc=0). Both green on default Madaros with env scrubbed of `/workspace/sounio`.
- The other four dissertation gates are **red on main**. Wiring any of them would paint Contracts red on every open PR. The 36 forgotten leftovers stay unwired — some are cheap and green, none are the dissertation pair this dispatch asked for.

This PR lands the receipt. The `ci.yml` hunk below is the intended follow-up commit. It is **not applied here** because `.github/workflows/ci.yml` is claimed by cursor-3 (`v2-measure-nat-consumer`, Lean V2 consumer near line 710). Request sent on the coord bus. Next-Command: when that lease drops, apply the hunk and drop the two names from leftover/forgotten on the next census run (#1865 stays a census PR).

## Measured dissertation six

SHA `d3ea284caf` unless noted. Env: `SOUC_BIN`/`SOUNIO_STDLIB_PATH` pinned to this worktree, `MADAROS_STACK_KB=524288`. Suite deliberately **unsets** `SOUC_BIN` so it uses `scripts/ci/souc-seq-leansingle.sh` (its default). Cap 180 s except suite 900 s.

| Gate | s | rc | Polaridade | Wirar? |
|---|---:|---:|---|---|
| `dissertation_confidence_gate_gate.sh` | **0.7** | 0 | green (honest ceiling + overclaim + non-literal ε) | **yes** |
| `dissertation_frontend_parity_gate.sh` | **1.9** | 0 | green (14/14 dual-Sounio + Node product arm) | **yes** |
| `dissertation_dossier_gate.sh` | 1 | 1 | red — `dossier_smoke` check/compile fail | no |
| `dissertation_pbpk_hessian_gate.sh` | 5 | 1 | red — `var_o1` golden `2.05e-7` vs runtime `0.000000` | no |
| `dissertation_pbpk28_parity_gate.sh` | 9 | 1 | red — E175 private + E008 Bergman return type (semaglutide case7) | no |
| `dissertation_pbpk_suite_gate.sh` | **110** | 1 | red — 52/53 PASS; FAIL `pbpk28_rapamycin_clinical` (90 s timeout). PEND semaglutide clinical | no |

Cost if both candidates are wired: **~3 s** on Contracts, no skip. Same #1778 class as fabrication-detect / bitcast: hiding them behind impact would recreate the day we spent closing. Changing `ci.yml` marks full impact; that is intended.

`SOUNIO_DPS_GATE_SKIP=1` makes the suite exit 0 without running. That skip was **not** set. The 110 s / rc=1 number is a real run.

## Forgotten 36 — why not those

Cheap and green, **not** proposed: `compile_fail_harness_contract` 1 s, `octonion_probes` 1 s, `ols_fixed_e2e` / `print_f64_negative` / `zero_provenance` 2 s, `kretikos_kaxi_phase_j` 3 s, `stdlib_source_byte_ceiling` 4 s, `168_biology` / `mli_s3` 5 s, plus a handful of sub-second source/paper checks. Leave them leftover.

Do **not** wire (red or vacuous or too dear):

- f128 ladder family (4 s / 1 s / 0 s, all rc=1, V0-A E218). Known: one wire reds every PR.
- `madaros_imported_ep_var_preserve` 7 s, SIGSEGV.
- `kretikos_kaxi_fmad_invariance` 0 s **SKIP** (no CUDA) — green is not a measurement.
- `ffi_posix_builtin` ≥180 s, empty stdout: it **builds Madaros from source** unless `SOUNIO_GATE_SOUC` is set. Not a Contracts tax.
- `claim_native`, `paper168_cocycle`, `self_falsifying_compiler` ≥180 s capped, unfinished.
- `run_pass_output` 53 s green-vs-baseline (25 mismatches already in the baseline). Too dear, not dissertation.
- SFCL rungs r2/r5/r11/r17 red or incomplete; r4 46 s red.

Instrument controls (the runner is not a silent always-green):

| Control | Expected | Result |
|---|---|---|
| Cheap pass records rc=0 under cap | confidence / frontend | 0.7 s / 1.9 s, rc=0 |
| Fail records rc≠0 | dossier, hessian, pbpk28, suite, f128 | all rc=1, not capped |
| Timeout fires | claim_native, ffi_posix, paper168_cocycle, sfcl-compiler | `capped=yes`, rc=124 |
| Vacuous skip is labelled | fmad invariance | `SKIPPED (no CUDA)` |

First pbpk28 run that inherited `/workspace/sounio/bin/madaros` SIGSEGV'd. Discarded. The 9 s / E175+E008 number is the scrubbed remesure.

## Intended `ci.yml` hunk (Contracts, after the bitcast step)

```yaml
      # Dissertation leftovers that are cheap and green on origin/main
      # (d3ea284caf / 6098da3e82). Confidence 0.7 s, frontend parity 1.9 s.
      # No skip — same #1778 class as fabrication-detect. The other four
      # dissertation leftovers stay unwired: dossier/hessian/pbpk28/suite
      # are red (1 s / 5 s / 9 s / 110 s). Receipt:
      # docs/audit/CI_GATE_BUDGET_2026-08-18.tsv
      - name: Dissertation compile-time confidence gates (Contribution 2)
        run: bash scripts/ci/dissertation_confidence_gate_gate.sh
      - name: Dissertation frontend PBPK14 dual-Sounio parity
        run: bash scripts/ci/dissertation_frontend_parity_gate.sh
```

Does **not** wire the 36 forgotten leftovers, the f128 ladder, or the four red dissertation gates.

## Test plan

- [x] Six dissertation + 36 forgotten timed sequentially with env scrubbed
- [x] Suite remesured on its default lean_single shim (not Madaros pin)
- [x] Confidence + frontend rechecked on `6098da3e82` (0.7 s / 1.9 s, rc=0)
- [x] Positive controls: timeout, fail, skip-vacuous all fired
- [ ] Apply the hunk once cursor-3 releases `ci.yml`
- [ ] `check_workflow_script_refs.sh` after the wire
- [ ] Reachability leftover −2 / forgotten −2 (confidence + frontend were forgotten in pass-2)