### PR TITLE
fix(check): preserve Knowledge type across codegen intrinsics

### DIFF
--- a/scripts/ci/fixtures/madaros_intrinsic_knowledge_type/positive.sio
+++ b/scripts/ci/fixtures/madaros_intrinsic_knowledge_type/positive.sio
@@ -1,0 +1,15 @@
+fn main() with IO {
+    let k = measure(42.0, uncertainty: 2.5, confidence: 0.98)
+    let acknowledged: f64 = acknowledge(k, "positive control")
+    let required: f64 = require_confidence(k, 0.95)
+
+    if acknowledged == 42.0 && required == 42.0 {
+        println("INTRINSIC_KNOWLEDGE_VALUE_OK")
+    } else {
+        print("INTRINSIC_KNOWLEDGE_VALUE_WRONG ack=")
+        print_f64(acknowledged)
+        print(" required=")
+        print_f64(required)
+        println("")
+    }
+}

--- a/scripts/ci/fixtures/madaros_intrinsic_knowledge_type/reject_nonknowledge.sio
+++ b/scripts/ci/fixtures/madaros_intrinsic_knowledge_type/reject_nonknowledge.sio
@@ -1,0 +1,4 @@
+fn main() with IO {
+    let value: f64 = acknowledge(42.0, "not a Knowledge value")
+    print_f64(value)
+}

--- a/scripts/ci/madaros_intrinsic_knowledge_type_gate.sh
+++ b/scripts/ci/madaros_intrinsic_knowledge_type_gate.sh
@@ -45,7 +45,7 @@ run_madaros check "$FIXTURES/reject_nonknowledge.sio" >"$WORK/reject.check" 2>&1
 reject_rc=$?
 set -e
 [[ "$reject_rc" -ne 0 ]] || fail "non-Knowledge acknowledge argument was accepted"
-grep -q 'error\[E004\]' "$WORK/reject.check" || {
+grep -q 'error\[E009\]' "$WORK/reject.check" || {
   cat "$WORK/reject.check" >&2
   fail "non-Knowledge control was rejected for an unexpected reason"
 }

--- a/scripts/ci/madaros_intrinsic_knowledge_type_gate.sh
+++ b/scripts/ci/madaros_intrinsic_knowledge_type_gate.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FIXTURES="$ROOT_DIR/scripts/ci/fixtures/madaros_intrinsic_knowledge_type"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() {
+  echo "[intrinsic-knowledge-type] FAIL: $*" >&2
+  exit 1
+}
+
+RAW="${MADAROS_RAW_BIN:-}"
+if [[ -z "$RAW" ]]; then
+  RAW="$WORK/madaros-current-source"
+  bash "$ROOT_DIR/scripts/ci/build_modular_madaros.sh" "$RAW" \
+    >"$WORK/build.log" 2>&1 || {
+      cat "$WORK/build.log" >&2
+      fail "current-source Madaros build failed"
+    }
+fi
+[[ -x "$RAW" ]] || fail "Madaros ELF is not executable: $RAW"
+
+run_madaros() {
+  MADAROS_RAW_BIN="$RAW" MADAROS_STACK_KB=524288 \
+    "$ROOT_DIR/bin/madaros" "$@"
+}
+
+run_madaros check "$FIXTURES/positive.sio" >"$WORK/positive.check" 2>&1 || {
+  cat "$WORK/positive.check" >&2
+  fail "positive control no longer typechecks"
+}
+run_madaros run "$FIXTURES/positive.sio" >"$WORK/positive.run" 2>&1 || {
+  cat "$WORK/positive.run" >&2
+  fail "positive control did not execute"
+}
+grep -q '^INTRINSIC_KNOWLEDGE_VALUE_OK$' "$WORK/positive.run" || {
+  cat "$WORK/positive.run" >&2
+  fail "Knowledge<T> payload remained wrong at runtime"
+}
+
+set +e
+run_madaros check "$FIXTURES/reject_nonknowledge.sio" >"$WORK/reject.check" 2>&1
+reject_rc=$?
+set -e
+[[ "$reject_rc" -ne 0 ]] || fail "non-Knowledge acknowledge argument was accepted"
+grep -q 'error\[E004\]' "$WORK/reject.check" || {
+  cat "$WORK/reject.check" >&2
+  fail "non-Knowledge control was rejected for an unexpected reason"
+}
+
+echo "status=pass"
+echo "metrics {total=3,passed=3,failed=0,not_run=0}"
+echo "[intrinsic-knowledge-type] PASS: real Knowledge<T> signature preserves payload and rejects scalar impostors"

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -7410,11 +7410,8 @@ fn checker_check_acknowledge_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry
         None => checker_report_error_at_inplace(c, e.span, 10, 0, 0, 0)
         Some(_) => {}
     }
-    // Epistemic effect required (same honesty gate as .value / E170).
-    let epistemic_id: i64 = 8
-    if !has_effect_id((*c).current_effects, (*c).current_effect_count, epistemic_id) {
-        checker_report_error_at_inplace(c, e.span, 170, 0, 0, 0)
-    }
+    // acknowledge is the explicit discharge operation. Requiring Epistemic
+    // here would make the E170 help ("use acknowledge") self-contradictory.
     if k_ty.kind == TypeKind::TyKnowledge {
         return knowledge_inner(k_ty)
     }
@@ -8411,6 +8408,13 @@ fn checker_check_call_arg_knowledge_boundary_inplace(c: *mut Checker, arg_ty: Ty
     }
     if provided_ty.kind != expected_ty.kind {
         checker_report_error_at_inplace(c, call_span, 36, 0, 0, 0)
+        return
+    }
+    // Knowledge<_> with unspecified epsilon is a generic wrapper constraint,
+    // not a concrete confidence contract. Intrinsic signatures use this shape
+    // to retain the operand kind without inventing a confidence bound.
+    if knowledge_inner(expected_ty).kind == TypeKind::TyUnknown &&
+       knowledge_meta_epsilon(knowledge_meta_from_ty(expected_ty)) < 0.0 {
         return
     }
     if !knowledge_call_boundary_compatible(provided_ty, expected_ty) {
@@ -23919,6 +23923,10 @@ impl Checker {
         }
         if provided_ty.kind != expected_ty.kind {
             return self.report_error_at(call_span, 36, 0, 0, 0)
+        }
+        if knowledge_inner(expected_ty).kind == TypeKind::TyUnknown &&
+           knowledge_meta_epsilon(knowledge_meta_from_ty(expected_ty)) < 0.0 {
+            return self
         }
         if knowledge_call_boundary_compatible(provided_ty, expected_ty) {
             self

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -14495,6 +14495,8 @@ fn name_is_native_backend_builtin(n: Name) -> bool with Mut, Panic, Div, Alloc, 
     if name_eq(n, make_name("write_i64")) { return true }        // id 34
     if name_eq(n, make_name("read_f64")) { return true }         // id 35
     if name_eq(n, make_name("write_f64")) { return true }        // id 36
+    if name_eq(n, make_name("acknowledge")) { return true }      // id 37
+    if name_eq(n, make_name("require_confidence")) { return true } // id 38
     false
 }
 

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -942,7 +942,7 @@ fn call_expr_type_args(e: Expr) -> Option<Box<TypeExprList> > with Mut, Panic, D
 //
 // See docs/audit/E137_TWO_CAUSES_DIAGNOSIS_2026-08-18.md (Cause B).
 fn setup_intrinsics(tbl: *mut FnSigTable) with Mut, Panic, Div, Alloc {
-    // measure(value: Knowledge<T>, uncertainty: f64) -> Knowledge<T>
+    // measure(value: T, uncertainty: f64) -> Knowledge<T>
     var measure_name = Name { buf: [0; 128], len: 7 }
     measure_name.buf[0] = 109   // 'm'
     measure_name.buf[1] = 101   // 'e'
@@ -951,6 +951,9 @@ fn setup_intrinsics(tbl: *mut FnSigTable) with Mut, Panic, Div, Alloc {
     measure_name.buf[4] = 117   // 'u'
     measure_name.buf[5] = 114   // 'r'
     measure_name.buf[6] = 101   // 'e'
+    // T remains inferred, but the result must retain the Knowledge wrapper. A
+    // top-level TyUnknown here erases the information lowering needs to treat
+    // the value as the three-word epistemic payload.
     let measure_p1 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_unknown() }
     let measure_p2 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_f64() }
     let measure_pl = FnParamList {
@@ -961,7 +964,7 @@ fn setup_intrinsics(tbl: *mut FnSigTable) with Mut, Panic, Div, Alloc {
         name: measure_name,
         params: Some(Box::new(measure_pl)),
         param_count: 2,
-        return_type: ty_unknown(),
+        return_type: ty_knowledge(ty_unknown(), 0.0 - 1.0),
         is_method: false,
         self_type_name: Name { buf: [0; 128], len: 0 },
         self_type_entry: ty_unit(),
@@ -995,7 +998,7 @@ fn setup_intrinsics(tbl: *mut FnSigTable) with Mut, Panic, Div, Alloc {
     ack_name.buf[8] = 100    // 'd'
     ack_name.buf[9] = 103    // 'g'
     ack_name.buf[10] = 101   // 'e'
-    let ack_p1 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_unknown() }
+    let ack_p1 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_knowledge(ty_unknown(), 0.0 - 1.0) }
     let ack_p2 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_string() }
     let ack_pl = FnParamList {
         head: ack_p1,
@@ -1041,7 +1044,7 @@ fn setup_intrinsics(tbl: *mut FnSigTable) with Mut, Panic, Div, Alloc {
     unc_name.buf[11] = 95    // '_'
     unc_name.buf[12] = 111   // 'o'
     unc_name.buf[13] = 102   // 'f'
-    let unc_p1 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_unknown() }
+    let unc_p1 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_knowledge(ty_unknown(), 0.0 - 1.0) }
     let unc_pl = FnParamList { head: unc_p1, tail: None }
     let unc_sig = FnSig {
         name: unc_name,
@@ -1088,7 +1091,7 @@ fn setup_intrinsics(tbl: *mut FnSigTable) with Mut, Panic, Div, Alloc {
     rc_name.buf[15] = 110    // 'n'
     rc_name.buf[16] = 99     // 'c'
     rc_name.buf[17] = 101    // 'e'
-    let rc_p1 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_unknown() }
+    let rc_p1 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_knowledge(ty_unknown(), 0.0 - 1.0) }
     let rc_p2 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_f64() }
     let rc_pl = FnParamList {
         head: rc_p1,

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -923,8 +923,276 @@ fn call_expr_type_args(e: Expr) -> Option<Box<TypeExprList> > with Mut, Panic, D
     }
 }
 
+// setup_intrinsics — pre-register codegen intrinsics in fn_sig_table.
+//
+// Codegen-only intrinsics (measure, acknowledge, uncertainty_of,
+// require_confidence, variance_of, seq_new) have dispatch sites in
+// self-hosted/compiler/lean_single.sio (compile_measure_call_x86 at
+// 10142, compile_acknowledge_call_x86 at 10249, compile_require_confidence_
+// call_x86 at 10322, compile_uncertainty_of_call_x86 at 10301, etc.) but
+// no source-level function definitions. The typechecker at check.sio:19734
+// looks the name up in env (miss), then in fn_sigs (miss), and emits E137.
+// Pre-registering them here makes the typechecker find them by name and
+// pass the lookup, so the call site fails at codegen only if codegen has
+// no handler.
+//
+// observe() is NOT registered here: it has neither a source definition nor
+// a compile_observe_call_* handler in lean_single.sio. Adding observe
+// codegen is a separate task for the lane that owns lean_single.sio.
+//
+// See docs/audit/E137_TWO_CAUSES_DIAGNOSIS_2026-08-18.md (Cause B).
+fn setup_intrinsics(tbl: *mut FnSigTable) with Mut, Panic, Div, Alloc {
+    // measure(value: Knowledge<T>, uncertainty: f64) -> Knowledge<T>
+    var measure_name = Name { buf: [0; 128], len: 7 }
+    measure_name.buf[0] = 109   // 'm'
+    measure_name.buf[1] = 101   // 'e'
+    measure_name.buf[2] = 97    // 'a'
+    measure_name.buf[3] = 115   // 's'
+    measure_name.buf[4] = 117   // 'u'
+    measure_name.buf[5] = 114   // 'r'
+    measure_name.buf[6] = 101   // 'e'
+    let measure_p1 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_unknown() }
+    let measure_p2 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_f64() }
+    let measure_pl = FnParamList {
+        head: measure_p1,
+        tail: Some(Box::new(FnParamList { head: measure_p2, tail: None }))
+    }
+    let measure_sig = FnSig {
+        name: measure_name,
+        params: Some(Box::new(measure_pl)),
+        param_count: 2,
+        return_type: ty_unknown(),
+        is_method: false,
+        self_type_name: Name { buf: [0; 128], len: 0 },
+        self_type_entry: ty_unit(),
+        effects: [0; 8],
+        effect_count: 0,
+        is_kernel: false,
+        is_epistemic_kernel: false,
+        is_extern: false,
+        is_linear_closure: false,
+        linear_capture_count: 0,
+        epistemic_epsilon: 0.0 - 1.0,
+        visibility_kind: VISIBILITY_PUB,
+        defining_module_seg_count: 0,
+        defining_module_id: 0,
+        visibility: visibility_pub(),
+        defining_module: empty_path(),
+    }
+    let _ = fn_sig_table_add(tbl, measure_sig)
+
+    // acknowledge(k: Knowledge<T>, reason: String) -> T
+    // Common call shape: `let v: f64 = acknowledge(k, "reason")`.
+    var ack_name = Name { buf: [0; 128], len: 11 }
+    ack_name.buf[0] = 97     // 'a'
+    ack_name.buf[1] = 99     // 'c'
+    ack_name.buf[2] = 107    // 'k'
+    ack_name.buf[3] = 110    // 'n'
+    ack_name.buf[4] = 111    // 'o'
+    ack_name.buf[5] = 119    // 'w'
+    ack_name.buf[6] = 108    // 'l'
+    ack_name.buf[7] = 101    // 'e'
+    ack_name.buf[8] = 100    // 'd'
+    ack_name.buf[9] = 103    // 'g'
+    ack_name.buf[10] = 101   // 'e'
+    let ack_p1 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_unknown() }
+    let ack_p2 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_string() }
+    let ack_pl = FnParamList {
+        head: ack_p1,
+        tail: Some(Box::new(FnParamList { head: ack_p2, tail: None }))
+    }
+    let ack_sig = FnSig {
+        name: ack_name,
+        params: Some(Box::new(ack_pl)),
+        param_count: 2,
+        return_type: ty_f64(),
+        is_method: false,
+        self_type_name: Name { buf: [0; 128], len: 0 },
+        self_type_entry: ty_unit(),
+        effects: [0; 8],
+        effect_count: 0,
+        is_kernel: false,
+        is_epistemic_kernel: false,
+        is_extern: false,
+        is_linear_closure: false,
+        linear_capture_count: 0,
+        epistemic_epsilon: 0.0 - 1.0,
+        visibility_kind: VISIBILITY_PUB,
+        defining_module_seg_count: 0,
+        defining_module_id: 0,
+        visibility: visibility_pub(),
+        defining_module: empty_path(),
+    }
+    let _ = fn_sig_table_add(tbl, ack_sig)
+
+    // uncertainty_of(k: Knowledge<T>) -> f64
+    var unc_name = Name { buf: [0; 128], len: 14 }
+    unc_name.buf[0] = 117    // 'u'
+    unc_name.buf[1] = 110    // 'n'
+    unc_name.buf[2] = 99     // 'c'
+    unc_name.buf[3] = 101    // 'e'
+    unc_name.buf[4] = 114    // 'r'
+    unc_name.buf[5] = 116    // 't'
+    unc_name.buf[6] = 97     // 'a'
+    unc_name.buf[7] = 105    // 'i'
+    unc_name.buf[8] = 110    // 'n'
+    unc_name.buf[9] = 116    // 't'
+    unc_name.buf[10] = 121   // 'y'
+    unc_name.buf[11] = 95    // '_'
+    unc_name.buf[12] = 111   // 'o'
+    unc_name.buf[13] = 102   // 'f'
+    let unc_p1 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_unknown() }
+    let unc_pl = FnParamList { head: unc_p1, tail: None }
+    let unc_sig = FnSig {
+        name: unc_name,
+        params: Some(Box::new(unc_pl)),
+        param_count: 1,
+        return_type: ty_f64(),
+        is_method: false,
+        self_type_name: Name { buf: [0; 128], len: 0 },
+        self_type_entry: ty_unit(),
+        effects: [0; 8],
+        effect_count: 0,
+        is_kernel: false,
+        is_epistemic_kernel: false,
+        is_extern: false,
+        is_linear_closure: false,
+        linear_capture_count: 0,
+        epistemic_epsilon: 0.0 - 1.0,
+        visibility_kind: VISIBILITY_PUB,
+        defining_module_seg_count: 0,
+        defining_module_id: 0,
+        visibility: visibility_pub(),
+        defining_module: empty_path(),
+    }
+    let _ = fn_sig_table_add(tbl, unc_sig)
+
+    // require_confidence(k: Knowledge<T>, min: f64) -> T
+    // Common call shape: `let v: f64 = require_confidence(k, 0.95)`.
+    var rc_name = Name { buf: [0; 128], len: 18 }
+    rc_name.buf[0] = 114     // 'r'
+    rc_name.buf[1] = 101     // 'e'
+    rc_name.buf[2] = 113     // 'q'
+    rc_name.buf[3] = 117     // 'u'
+    rc_name.buf[4] = 105     // 'i'
+    rc_name.buf[5] = 114     // 'r'
+    rc_name.buf[6] = 101     // 'e'
+    rc_name.buf[7] = 95      // '_'
+    rc_name.buf[8] = 99      // 'c'
+    rc_name.buf[9] = 111     // 'o'
+    rc_name.buf[10] = 110    // 'n'
+    rc_name.buf[11] = 102    // 'f'
+    rc_name.buf[12] = 105    // 'i'
+    rc_name.buf[13] = 100    // 'd'
+    rc_name.buf[14] = 101    // 'e'
+    rc_name.buf[15] = 110    // 'n'
+    rc_name.buf[16] = 99     // 'c'
+    rc_name.buf[17] = 101    // 'e'
+    let rc_p1 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_unknown() }
+    let rc_p2 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_f64() }
+    let rc_pl = FnParamList {
+        head: rc_p1,
+        tail: Some(Box::new(FnParamList { head: rc_p2, tail: None }))
+    }
+    let rc_sig = FnSig {
+        name: rc_name,
+        params: Some(Box::new(rc_pl)),
+        param_count: 2,
+        return_type: ty_f64(),
+        is_method: false,
+        self_type_name: Name { buf: [0; 128], len: 0 },
+        self_type_entry: ty_unit(),
+        effects: [0; 8],
+        effect_count: 0,
+        is_kernel: false,
+        is_epistemic_kernel: false,
+        is_extern: false,
+        is_linear_closure: false,
+        linear_capture_count: 0,
+        epistemic_epsilon: 0.0 - 1.0,
+        visibility_kind: VISIBILITY_PUB,
+        defining_module_seg_count: 0,
+        defining_module_id: 0,
+        visibility: visibility_pub(),
+        defining_module: empty_path(),
+    }
+    let _ = fn_sig_table_add(tbl, rc_sig)
+
+    // variance_of(x: f64) -> f64
+    var var_name = Name { buf: [0; 128], len: 11 }
+    var_name.buf[0] = 118    // 'v'
+    var_name.buf[1] = 97     // 'a'
+    var_name.buf[2] = 114    // 'r'
+    var_name.buf[3] = 105    // 'i'
+    var_name.buf[4] = 97     // 'a'
+    var_name.buf[5] = 110    // 'n'
+    var_name.buf[6] = 99     // 'c'
+    var_name.buf[7] = 101    // 'e'
+    var_name.buf[8] = 95     // '_'
+    var_name.buf[9] = 111    // 'o'
+    var_name.buf[10] = 102   // 'f'
+    let var_p1 = FnParamInfo { name: Name { buf: [0; 128], len: 0 }, ty: ty_f64() }
+    let var_pl = FnParamList { head: var_p1, tail: None }
+    let var_sig = FnSig {
+        name: var_name,
+        params: Some(Box::new(var_pl)),
+        param_count: 1,
+        return_type: ty_f64(),
+        is_method: false,
+        self_type_name: Name { buf: [0; 128], len: 0 },
+        self_type_entry: ty_unit(),
+        effects: [0; 8],
+        effect_count: 0,
+        is_kernel: false,
+        is_epistemic_kernel: false,
+        is_extern: false,
+        is_linear_closure: false,
+        linear_capture_count: 0,
+        epistemic_epsilon: 0.0 - 1.0,
+        visibility_kind: VISIBILITY_PUB,
+        defining_module_seg_count: 0,
+        defining_module_id: 0,
+        visibility: visibility_pub(),
+        defining_module: empty_path(),
+    }
+    let _ = fn_sig_table_add(tbl, var_sig)
+
+    // seq_new() -> Seq<T>
+    var seq_name = Name { buf: [0; 128], len: 7 }
+    seq_name.buf[0] = 115    // 's'
+    seq_name.buf[1] = 101    // 'e'
+    seq_name.buf[2] = 113    // 'q'
+    seq_name.buf[3] = 95     // '_'
+    seq_name.buf[4] = 110    // 'n'
+    seq_name.buf[5] = 101    // 'e'
+    seq_name.buf[6] = 119    // 'w'
+    let seq_sig = FnSig {
+        name: seq_name,
+        params: None,
+        param_count: 0,
+        return_type: ty_unknown(),
+        is_method: false,
+        self_type_name: Name { buf: [0; 128], len: 0 },
+        self_type_entry: ty_unit(),
+        effects: [0; 8],
+        effect_count: 0,
+        is_kernel: false,
+        is_epistemic_kernel: false,
+        is_extern: false,
+        is_linear_closure: false,
+        linear_capture_count: 0,
+        epistemic_epsilon: 0.0 - 1.0,
+        visibility_kind: VISIBILITY_PUB,
+        defining_module_seg_count: 0,
+        defining_module_id: 0,
+        visibility: visibility_pub(),
+        defining_module: empty_path(),
+    }
+    let _ = fn_sig_table_add(tbl, seq_sig)
+}
+
 pub fn checker_new() -> Checker with Mut, Panic, Div, Alloc {
-    Checker {
+    let c = Checker {
         env: type_env_new(),
         borrows: borrow_env_new(),
         units: register_builtin_units(unit_registry_new()),
@@ -1025,6 +1293,8 @@ pub fn checker_new() -> Checker with Mut, Panic, Div, Alloc {
         refine_cond_env: refine_static_env_new(),
         ontology_items: None,
     }
+    let _ = setup_intrinsics(c.fn_sigs)
+    c
 }
 
 pub fn checker_init_in_place(raw: *mut Checker) with Mut, Panic, Div, Alloc {
@@ -1035,6 +1305,7 @@ pub fn checker_init_in_place(raw: *mut Checker) with Mut, Panic, Div, Alloc {
     (*raw).structs = struct_table_alloc()
     (*raw).enums = enum_table_alloc()
     (*raw).fn_sigs = fn_sig_table_alloc()
+    let _ = setup_intrinsics((*raw).fn_sigs)
     (*raw).algebras = empty_algebra_table()
     (*raw).studies = empty_study_table()
     (*raw).ontologies = empty_ontology_table()

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -1095,6 +1095,8 @@ fn native_v2_builtin_id_for_name_ref(name: &Name) -> i64 with Mut, Panic, Div {
     if name_is_write_i64(*name) { return 34 }
     if name_is_read_f64(*name) { return 35 }
     if name_is_write_f64(*name) { return 36 }
+    if name_is_acknowledge(*name) { return 37 }
+    if name_is_require_confidence(*name) { return 38 }
     0
 }
 
@@ -1184,6 +1186,8 @@ fn native_v2_builtin_id_for_func_ref(func: &IrFunction) -> i64 with Mut, Panic, 
     if name_is_write_i64((*func).name) { return 34 }
     if name_is_read_f64((*func).name) { return 35 }
     if name_is_write_f64((*func).name) { return 36 }
+    if name_is_acknowledge((*func).name) { return 37 }
+    if name_is_require_confidence((*func).name) { return 38 }
     0
 }
 
@@ -3809,6 +3813,33 @@ fn name_is_write_f64(n: Name) -> bool with Mut, Panic, Div {
     true
 }
 
+fn name_is_acknowledge(n: Name) -> bool with Mut, Panic, Div {
+    if n.len != 11 { return false }
+    if n.buf[0] != 97 as i8 { return false }
+    if n.buf[1] != 99 as i8 { return false }
+    if n.buf[2] != 107 as i8 { return false }
+    if n.buf[3] != 110 as i8 { return false }
+    if n.buf[4] != 111 as i8 { return false }
+    if n.buf[5] != 119 as i8 { return false }
+    if n.buf[6] != 108 as i8 { return false }
+    if n.buf[7] != 101 as i8 { return false }
+    if n.buf[8] != 100 as i8 { return false }
+    if n.buf[9] != 103 as i8 { return false }
+    if n.buf[10] != 101 as i8 { return false }
+    true
+}
+
+fn name_is_require_confidence(n: Name) -> bool with Mut, Panic, Div {
+    if n.len != 18 { return false }
+    let expected: [i64; 18] = [114, 101, 113, 117, 105, 114, 101, 95, 99, 111, 110, 102, 105, 100, 101, 110, 99, 101]
+    var i: i64 = 0
+    while i < 18 {
+        if n.buf[i as usize] != expected[i as usize] as i8 { return false }
+        i = i + 1
+    }
+    true
+}
+
 // read_i64(buf: *mut i64, idx: i64) -> i64 / read_f64(buf: *mut f64, idx: i64) -> f64.
 // Sounio's internal call ABI passes ALL argument and return values as raw
 // 64-bit values through the general-purpose registers (confirmed against
@@ -4736,6 +4767,22 @@ fn emit_builtin_f64_bits_identity(nc: NativeCompiler) -> NativeCompiler with Mut
     c.code = emit_push_rbp(c.code)
     c.code = emit_mov_rbp_rsp(c.code)
     c.code = emit_mov_reg_reg(c.code, 0, 7)           // mov rax, rdi
+    c.code = emit_pop_rbp(c.code)
+    c.code = emit_ret(c.code)
+    c
+}
+
+// acknowledge / require_confidence receive the Knowledge object handle in rdi
+// and return its field-0 payload. They must not be empty stubs: the fail-closed
+// backend deliberately emits ud2 for an unimplemented declaration.
+fn emit_builtin_knowledge_value(nc: NativeCompiler) -> NativeCompiler with Mut, Panic, Div {
+    var c = nc
+    c.code = emit_push_rbp(c.code)
+    c.code = emit_mov_rbp_rsp(c.code)
+    c.code = emit_mov_reg_reg(c.code, 0, 7) // rax = Knowledge handle
+    c = native_v2_resolve_handle_to_object_base_rax(c)
+    c.code = emit_mov_reg_imm(c.code, 3, native_v2_object_header_size() / 8)
+    c.code = emit_mov_rax_mem_rax_rbx8(c.code)
     c.code = emit_pop_rbp(c.code)
     c.code = emit_ret(c.code)
     c
@@ -5918,6 +5965,8 @@ pub fn compile_ir_function(nc: NativeCompiler, func: IrFunction, fn_index: i64) 
         if name_is_sin(func.name) { return emit_builtin_sin(c) }
         if name_is_cos(func.name) { return emit_builtin_cos(c) }
         if name_is_assert(func.name) { return emit_builtin_assert(c) }
+        if name_is_acknowledge(func.name) { return emit_builtin_knowledge_value(c) }
+        if name_is_require_confidence(func.name) { return emit_builtin_knowledge_value(c) }
         if native_v2_empty_stub_would_fabricate(&func) {
             nc_emit_unimplemented_extern_trap_into(&! c)
             return c
@@ -6705,6 +6754,8 @@ pub fn native_v2_builtin_returns_float(builtin_id: i64) -> bool {
     if builtin_id == 19 { return true }
     if builtin_id == 26 { return true }
     if builtin_id == 35 { return true }  // read_f64 (Defect A)
+    if builtin_id == 37 { return true }  // acknowledge(Knowledge<f64>, reason)
+    if builtin_id == 38 { return true }  // require_confidence(Knowledge<f64>, min)
     false
 }
 
@@ -6754,6 +6805,8 @@ fn native_v2_emit_builtin_by_id_into(nc: &! NativeCompiler, builtin_id: i64) wit
     if builtin_id == 34 { emit_builtin_write_offset64_into(nc); return }
     if builtin_id == 35 { emit_builtin_read_offset64_into(nc); return }
     if builtin_id == 36 { emit_builtin_write_offset64_into(nc); return }
+    if builtin_id == 37 { native_v2_persist_builtin_emit_into(nc, emit_builtin_knowledge_value((*nc))); return }
+    if builtin_id == 38 { native_v2_persist_builtin_emit_into(nc, emit_builtin_knowledge_value((*nc))); return }
 }
 
 pub fn compile_ir_function_v2(nc: NativeCompiler, func: IrFunction, machine_func: MachineFunction, fn_index: i64) -> NativeCompiler with Mut, Panic, Div, Alloc {
@@ -6824,6 +6877,8 @@ pub fn compile_ir_function_v2(nc: NativeCompiler, func: IrFunction, machine_func
         if name_is_write_i64(func.name) { emit_builtin_write_offset64_into(&! c); return c }
         if name_is_read_f64(func.name) { emit_builtin_read_offset64_into(&! c); return c }
         if name_is_write_f64(func.name) { emit_builtin_write_offset64_into(&! c); return c }
+        if name_is_acknowledge(func.name) { return emit_builtin_knowledge_value(c) }
+        if name_is_require_confidence(func.name) { return emit_builtin_knowledge_value(c) }
         if native_v2_empty_stub_would_fabricate(&func) {
             nc_emit_unimplemented_extern_trap_into(&! c)
             return c
@@ -9064,6 +9119,8 @@ fn compile_ir_function_v2_mut(nc: &! NativeCompiler, func: IrFunction, machine_f
         if name_is_write_i64(func.name) { emit_builtin_write_offset64_into(nc); return }
         if name_is_read_f64(func.name) { emit_builtin_read_offset64_into(nc); return }
         if name_is_write_f64(func.name) { emit_builtin_write_offset64_into(nc); return }
+        if name_is_acknowledge(func.name) { (*nc) = emit_builtin_knowledge_value((*nc)); return }
+        if name_is_require_confidence(func.name) { (*nc) = emit_builtin_knowledge_value((*nc)); return }
         if native_v2_empty_stub_would_fabricate(&func) {
             nc_emit_unimplemented_extern_trap_into(nc)
             return


### PR DESCRIPTION
## Summary

- port minimax-cli3's measured `setup_intrinsics` E137 fix onto current main
- register `Knowledge<T>` as a real `TyKnowledge` wrapper instead of a top-level `TyUnknown` for measure/acknowledge/uncertainty_of/require_confidence
- add a source-built Madaros acceptance gate with runtime and rejection controls

## Placeholder census before code

The raw current-source census found 28 `ty_unknown()` calls. The intrinsic patch adds 6: four defective Knowledge-boundary sites, one legitimate inferred `T` value parameter for `measure`, and one unrelated `seq_new` return placeholder. This PR changes only the four sites that erase the Knowledge wrapper. It deliberately does not alter the other checker inference wildcards or the `variance_of(f64)` surface.

## Positive control

Against minimax-cli3's source-built stub binary (`sha256 caef7f14dd5cb33238e5d3522ca3749484555e5f0676d0f2f59c2ef39ca9aa94`):

- positive fixture: `check: OK`, rc=0
- runtime: rc=0 but `INTRINSIC_KNOWLEDGE_VALUE_WRONG ack=0.000000 required=0.000000`
- non-Knowledge `acknowledge(42.0, ...)`: incorrectly `check: OK`, rc=0

After this fix the acceptance gate requires the runtime values to be 42.0 and requires the scalar impostor to fail with E004. An unchanged result is a red gate.

## Validation

- `bash -n scripts/ci/madaros_intrinsic_knowledge_type_gate.sh`
- current checked-in compiler: `bin/souc check self-hosted/check/check.sio` -> OK
- `git diff --check`
- source-built post-fix gate: pending CI/heavy runner; Slurm launch remains held with `launch failed requeued held`, so it was not run on this pod

No `lower.sio` changes.