### PR TITLE
fix(ir): refuse unresolved print dispatch instead of dereferencing scalars

### DIFF
--- a/docs/audit/MADAROS_PRINT_DISPATCH_FAIL_CLOSED_2026-08-17.md
+++ b/docs/audit/MADAROS_PRINT_DISPATCH_FAIL_CLOSED_2026-08-17.md
@@ -1,0 +1,192 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-print-dispatch-fail-closed-2026-08-17
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-print-dispatch-fail-closed-2026-08-17
+-->
+
+# Madaros unresolved print dispatch: fail closed
+
+**Date:** 2026-08-18
+**Engine boundary:** Madaros native lowering only. `lean_single` resolves and
+executes the integer `if`-expression witnesses used here.
+**Implementation base:** `origin/main` at `6098da3e82`, including #1799. The
+source-current baseline was built at `d3ea284caf`; `lower.sio` and
+`module_frontend.sio` are byte-for-byte unchanged between that commit and this
+implementation base.
+
+## 1. Decision
+
+An argument may reach the char-pointer `print` builtin only when Madaros has
+positive evidence that the expression produces a string. Known integer and
+floating-point operands continue to use `print_int` and `print_f64`. A kind-0
+operand is refused during lowering; it is not sent to `print`, and it is not
+silently redirected to `print_int`.
+
+This extends, rather than repeats, section 5 of
+`MADAROS_PRINTLN_BOOL_SCALARKIND_SEGV_2026-08-17.md`. That audit closed two
+positive-classification holes and directly measured the remaining integer
+`if`-expression crash. The residual is decisive evidence that the open-ended
+default is the defect: another scalar-kind patch would close one expression
+form while leaving the next unclassified form as a pointer dereference.
+
+## 2. Why refusal, not the numeric fallback
+
+Changing kind 0 to `print_int` removes the `strlen(value-as-pointer)` crash, but
+it does not establish that the value is an integer. A missed string producer
+would print its address or packed handle as a decimal number. That is a wrong
+answer, can disclose process-layout information, and turns a compiler knowledge
+gap into apparently valid program output.
+
+Refusal preserves the stronger invariant: Madaros either selects a printer from
+positive type evidence or emits no program. It trades availability for honesty.
+That trade is visible and recoverable; fabricated numeric output is neither.
+
+The eventual completeness fix is to carry the checker's resolved operand type
+to lowering. Until that path exists, a kind-0 value is evidence that Madaros
+does not know enough to choose an ABI, not evidence that the value is an i64.
+
+## 3. How many sites change
+
+There are exactly two compiler consumers of `println_dispatch_name`:
+
+1. a source call to bare `print(...)`;
+2. a source call to `println(...)` before the newline emission.
+
+Both change only when the first argument has scalar kind 0 and is not positively
+recognized as a string. Explicit `print_int`, `print_f64`, and `print_char`
+calls do not use this decision.
+
+A repository-wide lexical census on this base gives the following upper bound:
+
+| spelling | occurrences in `*.sio` | files |
+|---|---:|---:|
+| `print(` | 62,265 | 2,310 |
+| `println(` | 32,244 | 1,793 |
+| total | 94,509 | not additive |
+
+Command shape: `rg --count-matches --glob '*.sio' '\\bNAME\\('`, summing the
+per-file counts. This is deliberately labeled an upper bound: it includes
+definitions, comments, strings, unreachable code, explicit cases already
+classified as int/float/string, and programs never lowered by Madaros.
+
+The exact behavioral count cannot be obtained from text search. It is the
+dynamic set of Madaros-lowered call sites for which
+`expr_result_scalar_kind_ref == 0` and string recognition is false. Claiming an
+exact corpus number without instrumenting that branch would overstate the
+evidence.
+
+## 4. What is lost
+
+The change can reject a type-correct program that `lean_single` accepts when
+Madaros's lowering classifier has not learned the expression form. The integer
+`if`-expression witness is intentionally such a case. This is a new, explicit
+cross-engine acceptance difference.
+
+The old default also allowed unresolved string producers to print correctly by
+accident. The gate makes that loss concrete with a type-correct string
+`if`-expression: Madaros refuses it while `lean_single` prints `left`. Positive
+controls therefore cover:
+
+- a string parameter;
+- a string-returning call;
+- ordinary integer and f64 operands.
+
+Those controls define the minimum string surface that must remain executable.
+An unrecognized future string producer will now be refused instead of being
+treated as text. That is the cost of fail-closed behavior, and it should be
+removed by extending positive string evidence or carrying checked types, not by
+restoring the unsafe default.
+
+## 5. Acceptance evidence
+
+`scripts/ci/madaros_print_dispatch_refusal_gate.sh` builds Madaros from the
+current source unless an explicit source-current binary is supplied. It checks:
+
+- `print(if-expression-int)` and `println(if-expression-int)` return nonzero,
+  emit the dispatch diagnostic, and leave no ELF;
+- a string-valued `if`-expression is also refused by Madaros, recording the
+  intentional acceptance loss rather than hiding it;
+- all three refusal sources execute under forced `lean_single`, making the
+  engine boundary explicit;
+- string parameter, string-returning call, integer, and f64 controls compile
+  and execute under Madaros.
+
+The pre-fix run is expected to falsify the gate by compiling all three refusal
+witnesses. The two integer programs then fail at runtime; the string program
+prints successfully only because the old unsafe default happens to choose the
+correct ABI. The post-fix run must end with
+`status=pass total=6 passed=6 failed=0 not_run=0`.
+
+### Current-main falsifier
+
+Slurm job `10205` built Madaros from exact source commit
+`d3ea284caf0d490aabcda3207ba7de15e8928bd2` with
+`scripts/ci/build_modular_madaros.sh`. The resulting ELF had SHA-256
+`ac82ead7ab1c07171c7340610fffbda4dc92a5b7fb114d8f9f62f4040d8a0b98`.
+Running the six-case gate against that binary produced the required red
+baseline:
+
+```text
+[madaros-print-dispatch] FAIL: unresolved-print-if was accepted by Madaros (runtime rc=139)
+[madaros-print-dispatch] FAIL: unresolved-println-if was accepted by Madaros (runtime rc=139)
+[madaros-print-dispatch] FAIL: unresolved-string-if was accepted by Madaros (runtime rc=0)
+[madaros-print-dispatch] PASS: string-param compiled and executed under Madaros
+[madaros-print-dispatch] PASS: string-return compiled and executed under Madaros
+[madaros-print-dispatch] PASS: scalar-controls compiled and executed under Madaros
+status=fail total=6 passed=3 failed=3 not_run=0
+```
+
+The two integer witnesses reached `strlen` with a scalar value interpreted as a
+pointer and terminated by signal 11. The string witness executed only because
+the unsafe fallback happened to choose its correct ABI. This is the exact
+behavioral boundary changed by the patch.
+
+### Branch falsifier and repaired receipt
+
+The first branch build, Slurm job `10199` at `e46811bbd7`, was intentionally
+treated as a falsifier rather than a success. It exposed two defects in the
+initial patch: the generic `ir_bodies_failed` path hid the durable diagnostic,
+and a declared string parameter lacked positive string evidence. The gate
+finished `status=fail total=6 passed=2 failed=4 not_run=0`.
+
+The repair reports the stored hard-error reason on every body-lowering exit and
+recognizes declared `string`/`&string` parameter types. Slurm job `10204` built
+the repaired compiler at `ec9f09423d`; its source file hashes are unchanged in
+the rebased commits:
+
+```text
+2fffbe6201247447737bc293d50e825a6c65eb0403ecf17cdca1e60ee47dd3cb  self-hosted/ir/lower.sio
+bb7498e248fc9a645f602fe763ea7c380e449b9f19aae6d9e8b609b9fe56175d  self-hosted/compiler/module_frontend.sio
+```
+
+The rebuilt ELF had SHA-256
+`6185bbcc2d43b84708b574c0f6b2d4b63a3a01047b2e931ae188af38fbb2cf9c`.
+The six-case receipt was:
+
+```text
+[madaros-print-dispatch] PASS: unresolved-print-if is fail-closed in Madaros and executes in lean_single
+[madaros-print-dispatch] PASS: unresolved-println-if is fail-closed in Madaros and executes in lean_single
+[madaros-print-dispatch] PASS: unresolved-string-if is fail-closed in Madaros and executes in lean_single
+[madaros-print-dispatch] PASS: string-param compiled and executed under Madaros
+[madaros-print-dispatch] PASS: string-return compiled and executed under Madaros
+[madaros-print-dispatch] PASS: scalar-controls compiled and executed under Madaros
+MADAROS_PRINT_DISPATCH_REFUSAL_GATE_OK
+status=pass total=6 passed=6 failed=0 not_run=0
+```
+
+The forced-`lean_single` controls printed `LEAN_PRINT=41` and
+`LEAN_PRINTLN=41`, and `LEAN_STRING=left`, all with rc 0. Both Madaros binaries
+were rebuilt from their stated source snapshots on the Sounio Compiler Foundry
+Slurm cluster through the login pod, using OrangeFS run root
+`/orangefs/training/fix3-print-dispatch-e46811bbd7-20260818`. The checked-in
+Madaros wrapper was used only for syntax smoke checks, never as implementation
+evidence.
+
+## 6. Claim boundary
+
+This change proves a printer-dispatch safety property. It does not claim to fix
+the three pre-existing `generic_struct` failures recorded by the parent audit,
+and it does not claim general scalar-kind completeness.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -222,6 +222,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-option-box-deref-2026-06-24 | repo_only | docs/audit/MADAROS_OPTION_BOX_DEREF_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-pbpk28-nn-tensor-compile-runtime-divergence-2026-08-17 | repo_only | docs/audit/MADAROS_PBPK28_NN_TENSOR_COMPILE_RUNTIME_DIVERGENCE_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-post-merge-closeout-2026-06-22 | repo_only | docs/audit/MADAROS_POST_MERGE_CLOSEOUT_2026-06-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-print-dispatch-fail-closed-2026-08-17 | repo_only | docs/audit/MADAROS_PRINT_DISPATCH_FAIL_CLOSED_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-print-int-dispatch-2026-06-20 | repo_only | docs/audit/MADAROS_PRINT_INT_DISPATCH_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-print-negative-f64-2026-07-14 | repo_only | docs/audit/MADAROS_PRINT_NEGATIVE_F64_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-println-bool-scalarkind-segv-2026-08-17 | repo_only | docs/audit/MADAROS_PRINTLN_BOOL_SCALARKIND_SEGV_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -4570,6 +4570,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-print-dispatch-fail-closed-2026-08-17",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_PRINT_DISPATCH_FAIL_CLOSED_2026-08-17.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-print-int-dispatch-2026-06-20",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_PRINT_INT_DISPATCH_2026-06-20.md",

--- a/scripts/ci/fixtures/madaros_print_dispatch_refusal/scalar_controls.sio
+++ b/scripts/ci/fixtures/madaros_print_dispatch_refusal/scalar_controls.sio
@@ -1,0 +1,9 @@
+fn main() -> i32 with IO {
+    print("INT<")
+    print(17)
+    println(">")
+    print("F64<")
+    print(2.5)
+    println(">")
+    0
+}

--- a/scripts/ci/fixtures/madaros_print_dispatch_refusal/string_param.sio
+++ b/scripts/ci/fixtures/madaros_print_dispatch_refusal/string_param.sio
@@ -1,0 +1,9 @@
+fn emit(value: string) with IO {
+    print("PARAM=")
+    println(value)
+}
+
+fn main() -> i32 with IO {
+    emit("param-ok")
+    0
+}

--- a/scripts/ci/fixtures/madaros_print_dispatch_refusal/string_return.sio
+++ b/scripts/ci/fixtures/madaros_print_dispatch_refusal/string_return.sio
@@ -1,0 +1,9 @@
+fn text() -> string {
+    "return-ok"
+}
+
+fn main() -> i32 with IO {
+    print("RETURN=")
+    println(text())
+    0
+}

--- a/scripts/ci/fixtures/madaros_print_dispatch_refusal/unresolved_print_if.sio
+++ b/scripts/ci/fixtures/madaros_print_dispatch_refusal/unresolved_print_if.sio
@@ -1,0 +1,7 @@
+fn main() -> i32 with IO {
+    let value = if true { 41 } else { 42 }
+    print("LEAN_PRINT=")
+    print(value)
+    println("")
+    0
+}

--- a/scripts/ci/fixtures/madaros_print_dispatch_refusal/unresolved_println_if.sio
+++ b/scripts/ci/fixtures/madaros_print_dispatch_refusal/unresolved_println_if.sio
@@ -1,0 +1,6 @@
+fn main() -> i32 with IO {
+    let value = if true { 41 } else { 42 }
+    print("LEAN_PRINTLN=")
+    println(value)
+    0
+}

--- a/scripts/ci/fixtures/madaros_print_dispatch_refusal/unresolved_string_if.sio
+++ b/scripts/ci/fixtures/madaros_print_dispatch_refusal/unresolved_string_if.sio
@@ -1,0 +1,6 @@
+fn main() -> i32 with IO {
+    let value = if true { "left" } else { "right" }
+    print("LEAN_STRING=")
+    println(value)
+    0
+}

--- a/scripts/ci/madaros_print_dispatch_refusal_gate.sh
+++ b/scripts/ci/madaros_print_dispatch_refusal_gate.sh
@@ -7,7 +7,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FIXTURES="$ROOT_DIR/scripts/ci/fixtures/madaros_print_dispatch_refusal"
 KEEP_WORK="${SOUNIO_MADAROS_PRINT_DISPATCH_GATE_KEEP:-0}"
 export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
-TOTAL=5
+TOTAL=6
 PASSED=0
 FAILED=0
 NOT_RUN=0
@@ -146,6 +146,10 @@ expect_madaros_refusal \
   unresolved-println-if \
   "$FIXTURES/unresolved_println_if.sio" \
   'LEAN_PRINTLN=41'
+expect_madaros_refusal \
+  unresolved-string-if \
+  "$FIXTURES/unresolved_string_if.sio" \
+  'LEAN_STRING=left'
 expect_madaros_run string-param "$FIXTURES/string_param.sio" 'PARAM=param-ok'
 expect_madaros_run string-return "$FIXTURES/string_return.sio" 'RETURN=return-ok'
 expect_madaros_run scalar-controls "$FIXTURES/scalar_controls.sio" 'INT<17>' 'F64<2.500000>'

--- a/scripts/ci/madaros_print_dispatch_refusal_gate.sh
+++ b/scripts/ci/madaros_print_dispatch_refusal_gate.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Madaros must never route an unresolved print/println operand to the char*
+# builtin. Positively identified strings and numeric scalars remain executable.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FIXTURES="$ROOT_DIR/scripts/ci/fixtures/madaros_print_dispatch_refusal"
+KEEP_WORK="${SOUNIO_MADAROS_PRINT_DISPATCH_GATE_KEEP:-0}"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+TOTAL=5
+PASSED=0
+FAILED=0
+NOT_RUN=0
+
+if [[ -n "${SOUNIO_MADAROS_PRINT_DISPATCH_GATE_DIR:-}" ]]; then
+  WORK="$SOUNIO_MADAROS_PRINT_DISPATCH_GATE_DIR"
+  if [[ -e "$WORK" ]]; then
+    echo "[madaros-print-dispatch] FAIL: gate directory already exists: $WORK" >&2
+    exit 1
+  fi
+  mkdir -p "$WORK"
+else
+  WORK="$(mktemp -d /tmp/sounio-madaros-print-dispatch.XXXXXX)"
+fi
+
+if [[ "$KEEP_WORK" != "1" ]]; then
+  trap 'rm -rf "$WORK"' EXIT
+fi
+
+MADAROS="${SOUNIO_MADAROS_PRINT_DISPATCH_GATE_BIN:-$WORK/madaros}"
+if [[ -z "${SOUNIO_MADAROS_PRINT_DISPATCH_GATE_BIN:-}" ]]; then
+  if ! bash "$ROOT_DIR/scripts/ci/build_modular_madaros.sh" "$MADAROS" >"$WORK/build.log" 2>&1; then
+    tail -n 80 "$WORK/build.log" >&2 || true
+    echo "[madaros-print-dispatch] FAIL: current-source Madaros build failed" >&2
+    echo "status=fail total=$TOTAL passed=0 failed=1 not_run=$((TOTAL - 1))"
+    exit 1
+  fi
+fi
+
+if [[ ! -x "$MADAROS" ]]; then
+  echo "[madaros-print-dispatch] FAIL: Madaros is not executable: $MADAROS" >&2
+  echo "status=fail total=$TOTAL passed=0 failed=1 not_run=$((TOTAL - 1))"
+  exit 1
+fi
+
+record_pass() {
+  PASSED=$((PASSED + 1))
+  echo "[madaros-print-dispatch] PASS: $1"
+}
+
+record_fail() {
+  FAILED=$((FAILED + 1))
+  echo "[madaros-print-dispatch] FAIL: $1" >&2
+}
+
+expect_madaros_refusal() {
+  local label="$1"
+  local source="$2"
+  local lean_marker="$3"
+  local elf="$WORK/$label.elf"
+  local compile_log="$WORK/$label.compile.log"
+  local run_log="$WORK/$label.run.log"
+  local lean_log="$WORK/$label.lean.log"
+  local compile_rc=0
+
+  set +e
+  "$MADAROS" "$source" -o "$elf" >"$compile_log" 2>&1
+  compile_rc=$?
+  set -e
+
+  if [[ "$compile_rc" -eq 0 ]]; then
+    local run_rc=0
+    chmod +x "$elf"
+    set +e
+    "$elf" >"$run_log" 2>&1
+    run_rc=$?
+    set -e
+    record_fail "$label was accepted by Madaros (runtime rc=$run_rc)"
+    return
+  fi
+  if [[ -e "$elf" ]]; then
+    record_fail "$label refusal left an ELF behind"
+    return
+  fi
+  if ! grep -Fq 'cannot safely lower print/println argument with unresolved scalar kind' "$compile_log"; then
+    cat "$compile_log" >&2
+    record_fail "$label refused without the dispatch diagnostic"
+    return
+  fi
+  if grep -Fq 'Compilation successful' "$compile_log"; then
+    record_fail "$label printed a success marker after refusal"
+    return
+  fi
+
+  if ! SOUNIO_SOUC_ENGINE=lean_single "$ROOT_DIR/bin/souc" run "$source" >"$lean_log" 2>&1; then
+    cat "$lean_log" >&2
+    record_fail "$label lean_single control did not execute"
+    return
+  fi
+  if ! grep -Fq "$lean_marker" "$lean_log"; then
+    cat "$lean_log" >&2
+    record_fail "$label lean_single control produced the wrong value"
+    return
+  fi
+  record_pass "$label is fail-closed in Madaros and executes in lean_single"
+}
+
+expect_madaros_run() {
+  local label="$1"
+  local source="$2"
+  local marker="$3"
+  local marker2="${4:-}"
+  local elf="$WORK/$label.elf"
+  local compile_log="$WORK/$label.compile.log"
+  local run_log="$WORK/$label.run.log"
+
+  if ! "$MADAROS" "$source" -o "$elf" >"$compile_log" 2>&1; then
+    cat "$compile_log" >&2
+    record_fail "$label did not compile"
+    return
+  fi
+  chmod +x "$elf"
+  if ! "$elf" >"$run_log" 2>&1; then
+    cat "$run_log" >&2
+    record_fail "$label did not execute"
+    return
+  fi
+  if ! grep -Fq "$marker" "$run_log"; then
+    cat "$run_log" >&2
+    record_fail "$label output marker is missing"
+    return
+  fi
+  if [[ -n "$marker2" ]] && ! grep -Fq "$marker2" "$run_log"; then
+    cat "$run_log" >&2
+    record_fail "$label second output marker is missing"
+    return
+  fi
+  record_pass "$label compiled and executed under Madaros"
+}
+
+expect_madaros_refusal \
+  unresolved-print-if \
+  "$FIXTURES/unresolved_print_if.sio" \
+  'LEAN_PRINT=41'
+expect_madaros_refusal \
+  unresolved-println-if \
+  "$FIXTURES/unresolved_println_if.sio" \
+  'LEAN_PRINTLN=41'
+expect_madaros_run string-param "$FIXTURES/string_param.sio" 'PARAM=param-ok'
+expect_madaros_run string-return "$FIXTURES/string_return.sio" 'RETURN=return-ok'
+expect_madaros_run scalar-controls "$FIXTURES/scalar_controls.sio" 'INT<17>' 'F64<2.500000>'
+
+if [[ "$FAILED" -ne 0 ]]; then
+  NOT_RUN=$((TOTAL - PASSED - FAILED))
+  echo "status=fail total=$TOTAL passed=$PASSED failed=$FAILED not_run=$NOT_RUN"
+  exit 1
+fi
+
+echo "MADAROS_PRINT_DISPATCH_REFUSAL_GATE_OK"
+echo "status=pass total=$TOTAL passed=$PASSED failed=0 not_run=0"

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -6502,6 +6502,7 @@ pub fn module_frontend_compile_imported_to_file(
             return 1
         }
         if lower_hard_error_pending() {
+            lower_hard_error_report()
             print("Error: refusing to write a binary -- lowering hit a hard error (see the error above)\n")
             module_frontend_global_init_compile_end()
             return 1
@@ -6589,6 +6590,7 @@ pub fn module_frontend_compile_imported_to_file(
         return 1
     }
     if lower_hard_error_pending() {
+        lower_hard_error_report()
         print("Error: refusing to write a binary -- lowering hit a hard error (see the error above)\n")
         module_frontend_global_init_compile_end()
         return 1

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -5060,6 +5060,7 @@ fn module_frontend_lower_program_box_traced_with_epistemic(
     }
     if body_result.had_error {
         trace.last_stage = "lower_bodies_error"
+        lower_hard_error_report()
         return module_frontend_lower_box_error("ir_bodies_failed")
     }
 
@@ -5132,6 +5133,7 @@ fn module_frontend_lower_program_items_box_traced(
     }
     if body_result.had_error {
         trace.last_stage = "lower_bodies_error"
+        lower_hard_error_report()
         return module_frontend_lower_box_error("ir_bodies_failed")
     }
 
@@ -5192,6 +5194,7 @@ fn module_frontend_lower_program_box_traced_with_externs(
     }
     if body_result.had_error {
         trace.last_stage = "lower_bodies_error"
+        lower_hard_error_report()
         return module_frontend_lower_box_error("ir_bodies_failed")
     }
 
@@ -5253,6 +5256,7 @@ fn module_frontend_lower_program_items_box_traced_with_externs(
     }
     if body_result.had_error {
         trace.last_stage = "lower_bodies_error"
+        lower_hard_error_report()
         return module_frontend_lower_box_error("ir_bodies_failed")
     }
 
@@ -5920,6 +5924,7 @@ fn module_frontend_lower_program_full_traced(
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_done\n") }
     if body_result.had_error {
         trace.last_stage = "lower_bodies_error"
+        lower_hard_error_report()
         return IrLowerResult {
             module: ir_empty_module(),
             had_error: true,
@@ -6649,6 +6654,7 @@ fn load_multimodule_lower_program_traced(
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_done\n") }
     if body_result.had_error {
         trace.last_stage = "lower_bodies_error"
+        lower_hard_error_report()
         return ir_empty_module()
     }
 

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -6502,7 +6502,7 @@ pub fn module_frontend_compile_imported_to_file(
             return 1
         }
         if lower_hard_error_pending() {
-            print("Error: refusing to write a truncated binary -- lowering hit a hard capacity wall (see the error above)\n")
+            print("Error: refusing to write a binary -- lowering hit a hard error (see the error above)\n")
             module_frontend_global_init_compile_end()
             return 1
         }
@@ -6589,7 +6589,7 @@ pub fn module_frontend_compile_imported_to_file(
         return 1
     }
     if lower_hard_error_pending() {
-        print("Error: refusing to write a truncated binary -- lowering hit a hard capacity wall (see the error above)\n")
+        print("Error: refusing to write a binary -- lowering hit a hard error (see the error above)\n")
         module_frontend_global_init_compile_end()
         return 1
     }

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -356,8 +356,8 @@ pub fn ir_instr_census_report() with IO, Mut, Panic, Div {
 // "ir_summary_failed: lowering reported an error" and NOTHING anywhere named
 // the cause, because the message that would name it lives at the end of
 // lowerer_lower_fn_item_mut and this path does not go through that function.
-// Exactly one site in the compiler raises the flag, so recording its reason
-// there costs two stores and removes the anonymity for good.
+// Capacity was originally the only site raising the flag. Unresolved print ABI
+// dispatch is now the second; both record an explicit reason before refusing.
 // PARALLEL FLAT ARRAYS, NOT `Name`. Storing a Name into a global OVERRUNS INTO
 // THE NEXT GLOBALS. Reproduced 2026-08-05 with a probe replicating this exact
 // declaration order, compiled by the seed that builds this compiler:
@@ -378,6 +378,8 @@ pub fn ir_instr_census_report() with IO, Mut, Panic, Div {
 var IR_LOWER_HARD_ERROR_FN_BUF: [i8; 128]
 var IR_LOWER_HARD_ERROR_FN_LEN: i64 = 0
 var IR_LOWER_HARD_ERROR_NEEDED: i64 = 0
+// 0=unspecified, 1=instruction capacity, 2=unresolved print ABI.
+var IR_LOWER_HARD_ERROR_REASON: i64 = 0
 // Same flat-array treatment, same reason.
 var IR_LOWER_ERROR_FIRST_FN_BUF: [i8; 128]
 var IR_LOWER_ERROR_FIRST_FN_LEN: i64 = 0
@@ -532,7 +534,11 @@ pub fn lower_hard_error_report() with IO, Mut, Panic, Div {
     if IR_LOWER_HARD_ERROR == 0 {
         return
     }
-    if IR_LOWER_HARD_ERROR_NEEDED > 0 {
+    if IR_LOWER_HARD_ERROR_REASON == 2 {
+        print("  cause: cannot safely lower print/println argument with unresolved scalar kind in function `")
+        ir_print_flat_name(&IR_LOWER_HARD_ERROR_FN_BUF, IR_LOWER_HARD_ERROR_FN_LEN)
+        print("`\n")
+    } else if IR_LOWER_HARD_ERROR_NEEDED > 0 {
         print("  cause: function `")
         ir_print_flat_name(&IR_LOWER_HARD_ERROR_FN_BUF, IR_LOWER_HARD_ERROR_FN_LEN)
         print("` needs at least ")
@@ -550,6 +556,7 @@ pub fn lower_hard_error_reset() with Mut {
     IR_LOWER_HARD_ERROR = 0
     IR_LOWER_HARD_ERROR_NEEDED = 0
     IR_LOWER_HARD_ERROR_LIMIT = 0
+    IR_LOWER_HARD_ERROR_REASON = 0
     IR_LOWER_HARD_ERROR_FN_LEN = 0
     IR_LOWER_ERROR_TOTAL = 0
     IR_LOWER_ERROR_FIRST_FN_LEN = 0
@@ -9676,13 +9683,9 @@ impl Lowerer {
         }
     }
 
-    // Returns the print builtin name for println's first argument.
-    //   int literal / i64 var (scalar_kind=1) → print_int
-    //   f64-valued expression                 → print_f64
-    //   everything else                       → print
-    // Routing f64 through print treats the IEEE bits as a char* and segfaults.
-    // The native backend's print_f64 builtin consumes the lowered f64 payload
-    // through the same integer slot convention used by emitted call arguments.
+    // Returns a print builtin only from positive operand evidence. Kind 0 is
+    // not a string classification: routing its word through print's strlen
+    // path turns values such as integer 1 into address 0x1 and SIGSEGVs.
     fn println_dispatch_name(self, args: &Option<Box<ExprList>>) -> Name with Mut, Panic, Div, Alloc {
         match *args {
             Some(list) => {
@@ -9691,8 +9694,24 @@ impl Lowerer {
                     make_name("print_int")
                 } else if sk == 2 {
                     make_name("print_f64")
-                } else {
+                } else if self.expr_result_is_string_ref(&(*list).head) {
                     make_name("print")
+                } else {
+                    // The name is deliberately numeric as a poison-safe fallback:
+                    // the durable hard error below prevents publication of the ELF,
+                    // while an accidentally bypassed barrier still cannot dereference
+                    // the unresolved word as a char pointer.
+                    if !self.probe_mode {
+                        if IR_LOWER_HARD_ERROR == 0 {
+                            IR_LOWER_HARD_ERROR_REASON = 2
+                            IR_LOWER_HARD_ERROR_NEEDED = 0
+                            IR_LOWER_HARD_ERROR_LIMIT = 0
+                            ir_copy_name_to_flat(&(*self.current_func).name, &! IR_LOWER_HARD_ERROR_FN_BUF, &! IR_LOWER_HARD_ERROR_FN_LEN)
+                        }
+                        IR_LOWER_HARD_ERROR = 1
+                        lower_note_error(9712, (*self.current_func).name)
+                    }
+                    make_name("print_int")
                 }
             }
             _ => make_name("print"),
@@ -9977,8 +9996,9 @@ impl Lowerer {
             // needs to have.
             if !lo.probe_mode {
                 IR_LOWER_HARD_ERROR = 1
-                // Record WHICH function and HOW MANY, here, at the only site
-                // that raises the flag. The end-of-body report in
+                IR_LOWER_HARD_ERROR_REASON = 1
+                // Record WHICH function and HOW MANY at the capacity site. The
+                // end-of-body report in
                 // lowerer_lower_fn_item_mut is richer but only runs on the path
                 // that goes through it; this runs on every path.
                 ir_copy_name_to_flat(&(*current_func_box).name, &! IR_LOWER_HARD_ERROR_FN_BUF, &! IR_LOWER_HARD_ERROR_FN_LEN)

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -10626,7 +10626,13 @@ impl Lowerer {
             return true
         }
         if (*e).kind == ExprKind::ExprIdent {
-            return self.lookup_local_scalar_kind((*e).name) == 3
+            if self.lookup_local_scalar_kind((*e).name) == 3 {
+                return true
+            }
+            // Parameter binding records its declared named type even on paths
+            // where scalar_kind is reserved for numeric dispatch. `string` and
+            // `&string` therefore remain positive evidence, not kind-0 guesses.
+            return lower_name_is_string_type(self.lookup_local_struct_type((*e).name))
         }
         if (*e).kind == ExprKind::ExprBinary {
             if (*e).bin_op == BinaryOp::OpAdd || (*e).bin_op == BinaryOp::OpConcat {


### PR DESCRIPTION
## Decision

Make Madaros print dispatch fail closed. Only positively classified integers, f64 values, and strings select a printer. A scalar-kind-0 non-string operand now records a durable lowering error, emits no ELF, and uses `print_int` only as a poison-safe internal fallback that cannot reach a published binary.

This deliberately chooses refusal over changing the default to `print_int`: a missed string producer printed numerically would be fabricated output and could disclose an address. The honest cost is narrower acceptance until checked operand types are carried into lowering.

## Behavioral surface

- Exactly two compiler consumers change: bare `print(...)` and `println(...)`.
- The repository lexical upper bound is 94,509 `print(`/`println(` occurrences across `*.sio`; the exact dynamic affected set is the kind-0, non-string subset and is not claimed from text search.
- Positive string parameter, string-return, integer, and f64 controls remain executable.
- A string-valued `if` expression is now explicitly refused by Madaros while forced `lean_single` prints `left`; the gate records this acceptance loss instead of hiding it.

## Evidence

- Current-main falsifier, Slurm job `10205`, source `d3ea284caf`: rebuilt ELF `ac82ead...0b98`; both integer witnesses were accepted then exited 139, and the unresolved string witness was accepted. Gate: `3/6` pass, expected red. The compiler files are unchanged from that source commit through the PR base.
- First patch falsifier, Slurm job `10199`: caught a hidden durable diagnostic and a false refusal of a declared string parameter. Gate: `2/6` pass.
- Repaired branch, Slurm job `10204`, code commit before rebase `ec9f09423d`: rebuilt ELF `6185bb...cf9c`; all three ambiguous witnesses refused with the exact diagnostic and no ELF, all positive controls executed. Gate: `6/6` pass. Rebased source hashes are recorded in the audit and unchanged.
- Forced `lean_single` controls: `LEAN_PRINT=41`, `LEAN_PRINTLN=41`, `LEAN_STRING=left`.
- `bash scripts/dev/check_docs_registry.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash -n scripts/ci/madaros_print_dispatch_refusal_gate.sh`
- `git diff --check origin/main...HEAD`

Full commands, outputs, hashes, engine boundary, and claim limits are in `docs/audit/MADAROS_PRINT_DISPATCH_FAIL_CLOSED_2026-08-17.md`.

## Non-claims

This does not fix general scalar-kind completeness or the pre-existing `generic_struct` failures from the parent audit. It does not change explicit `print_int`, `print_f64`, or `print_char` calls.