### PR TITLE
ci: actually wire the two cheap-green dissertation leftovers (#1874 follow-through)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,27 @@ jobs:
       # fabrication-detect. One forgotten leftover; the f128 ladder stays unwired.
       - name: f64 bitcast/sitofp boundary (Knowledge.confidence F2)
         run: bash scripts/ci/f64_bitcast_sitofp_boundary_gate.sh
+      # Dissertation leftovers that are cheap and green on origin/main
+      # (d3ea284caf / 6098da3e82; receipt #1874). Confidence 0.7 s,
+      # frontend parity 1.9 s. No skip — same #1778 class as
+      # fabrication-detect. The other four dissertation leftovers stay
+      # unwired: dossier/hessian/pbpk28/suite are red (1 s / 5 s / 9 s /
+      # 110 s). Neither script builds Madaros from source or reads
+      # SOUNIO_GATE_SOUC; both resolve the checked-in souc wrapper.
+      # Pin SOUC_BIN so a missing pin cannot wander into a from-source
+      # rebuild (the ffi_posix_builtin class from the #1874 receipt).
+      - name: Dissertation compile-time confidence gates (Contribution 2)
+        env:
+          SOUC_BIN: ${{ github.workspace }}/bin/souc
+          SOUNIO_STDLIB_PATH: ${{ github.workspace }}/stdlib
+          MADAROS_STACK_KB: "524288"
+        run: bash scripts/ci/dissertation_confidence_gate_gate.sh
+      - name: Dissertation frontend PBPK14 dual-Sounio parity
+        env:
+          SOUC_BIN: ${{ github.workspace }}/bin/souc
+          SOUNIO_STDLIB_PATH: ${{ github.workspace }}/stdlib
+          MADAROS_STACK_KB: "524288"
+        run: bash scripts/ci/dissertation_frontend_parity_gate.sh
       - name: FPGA receipt staleness gate
         run: bash scripts/ci/fpga_receipt_staleness_gate.sh
       - name: Heuristic metaphor-firewall gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,23 +92,25 @@ jobs:
       # fabrication-detect. One forgotten leftover; the f128 ladder stays unwired.
       - name: f64 bitcast/sitofp boundary (Knowledge.confidence F2)
         run: bash scripts/ci/f64_bitcast_sitofp_boundary_gate.sh
-      # Dissertation leftovers that are cheap and green on origin/main
-      # (d3ea284caf / 6098da3e82; receipt #1874). Confidence 0.7 s,
-      # frontend parity 1.9 s. No skip — same #1778 class as
-      # fabrication-detect. The other four dissertation leftovers stay
-      # unwired: dossier/hessian/pbpk28/suite are red (1 s / 5 s / 9 s /
-      # 110 s). Neither script builds Madaros from source or reads
-      # SOUNIO_GATE_SOUC; both resolve the checked-in souc wrapper.
-      # Pin SOUC_BIN so a missing pin cannot wander into a from-source
-      # rebuild (the ffi_posix_builtin class from the #1874 receipt).
+      # This is the wire that #1874's squash title claimed. That squash
+      # landed only the budget/umbrella receipts (two TSV files). Do not
+      # rewrite 0ff0b39764 — this step is the missing ci.yml change.
+      # Confidence 0.7 s and frontend parity 1.9 s, both green. No skip
+      # (#1778 class). dossier/hessian/pbpk28/suite stay unwired: red on
+      # main (1 s / 5 s / 9 s / 110 s). Neither script builds Madaros
+      # from source; both resolve the checked-in souc wrapper. Still pin
+      # SOUNIO_GATE_SOUC and SOUC_BIN to that wrapper so a missing pin
+      # cannot become a from-source rebuild (ffi_posix_builtin class).
       - name: Dissertation compile-time confidence gates (Contribution 2)
         env:
+          SOUNIO_GATE_SOUC: ${{ github.workspace }}/bin/souc
           SOUC_BIN: ${{ github.workspace }}/bin/souc
           SOUNIO_STDLIB_PATH: ${{ github.workspace }}/stdlib
           MADAROS_STACK_KB: "524288"
         run: bash scripts/ci/dissertation_confidence_gate_gate.sh
       - name: Dissertation frontend PBPK14 dual-Sounio parity
         env:
+          SOUNIO_GATE_SOUC: ${{ github.workspace }}/bin/souc
           SOUC_BIN: ${{ github.workspace }}/bin/souc
           SOUNIO_STDLIB_PATH: ${{ github.workspace }}/stdlib
           MADAROS_STACK_KB: "524288"


### PR DESCRIPTION
## Why this PR exists

`0ff0b39764` (#1874, squash) is titled \"ci: leftover-gate budget — wire only the two cheap-green dissertation leftovers\". What it actually changed:

```text
docs/audit/CI_GATE_BUDGET_2026-08-18.tsv
docs/audit/CI_GATE_UMBRELLA_CLOSURE_2026-08-18.tsv
2 files changed, 65 insertions
```

Zero lines of `.github/workflows/ci.yml`. The receipts are good and stay. The title promised a wire that did not happen. Do not rewrite that commit. This PR is the additive close: land the wiring in its own commit so the log is true going forward.

## What lands

- Contracts runs `dissertation_confidence_gate_gate.sh` and `dissertation_frontend_parity_gate.sh`. No skip (#1778 class).
- Does **not** wire dossier / hessian / pbpk28 / suite — red on `origin/main` (1 s / 5 s / 9 s / 110 s).
- Each step sets **`SOUNIO_GATE_SOUC`** and `SOUC_BIN` to `${{ github.workspace }}/bin/souc`, plus `SOUNIO_STDLIB_PATH` and `MADAROS_STACK_KB=524288`.

These two scripts do not call `build_modular_madaros` and do not read `SOUNIO_GATE_SOUC` themselves. The pin is the contract anyway: a missing `SOUNIO_GATE_SOUC` is how `ffi_posix_builtin` turns a gate into a per-PR Madaros rebuild. The #1874 receipt split that out as `kind=rebuild`, not a cost number.

## Already measured on this PR (before the env pin)

Contracts run `32162212825` on `fa7f1f6f2c` executed both steps and passed:

- confidence: honest ceiling PASS, overclaim EpistemicComplete, non-literal ε rejected
- frontend: `PARITY_PASS 14/14` (then CI Decision SUCCESS)

Local remesure after adding `SOUNIO_GATE_SOUC`: 0.70 s / 1.97 s, both rc=0.

## Test plan

- [x] `origin/main` `ci.yml` still has neither basename (the gap is real)
- [x] Only those two dissertation `run:` lines added
- [x] `SOUNIO_GATE_SOUC` + `SOUC_BIN` pinned on both steps
- [x] `check_workflow_script_refs.sh` passed (140)
- [x] Prior Contracts run on this PR already executed both gates
- [ ] Contracts + CI Decision on the pin commit