### PR TITLE
fix(ir): Knowledge.confidence is f64 at layout — close KCONF-BITCAST-SITOFP

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -886,11 +886,18 @@ fn lower_monolithic_public_probe_boundary(label: string) with IO {
 // marks float and a.value * a.value uses real f64 mul (with is_float=0, integer
 // imul on IEEE bits: aa=0, Var(4a²)=0 under default Madaros).
 //
-// confidence is i64 (is_float=3 integer marker). Was wrongly is_float=1 which
-// polluted field_is_float_by_name_simple("confidence") for EVERY struct field
-// named confidence (MiniEp, Epistemic, …). Result: OpGe/OpSub on confidence
-// took the float path → sub printed f64(-800.0) bits; if conf>=800 → 0.
-// See docs/audit/MADAROS_FIELD_IF_I64_2026-07-26.md / #1496.
+// Knowledge.confidence is f64 probability ε ∈ (0,1] (is_float=1).
+// Historical trap (#1496 / MADAROS_FIELD_IF_I64): marking this float while
+// field_is_float_by_name_simple("confidence") was name-global forced EVERY
+// struct field named confidence onto the float path — MiniEp/Epistemic i64
+// 0–1000 scales broke (OpGe/OpSub took float → if conf>=800 → 0).
+// Mitigation now in place: name_simple is UNANIMOUS (mixed float+int name
+// → false) and FieldGet prefers field_is_float_for_base_ref (typed base).
+// So Knowledge can be honest f64 again without reopening #1496 on MiniI.
+// Dual defect closed by this flip: KCONF-BITCAST-SITOFP (F2) — f64 bits in
+// an i64-kind slot → sitofp on arithmetic → ~4.6e18 (ep28 TEST 6).
+// See docs/audit/MADAROS_F64_BITCAST_SITOFP_BOUNDARY_2026-08-17.md.
+// Apply package: docs/audit/KCONF_BITCAST_APPLY_PACKAGE_2026-08-18.md
 pub(crate) fn ir_register_knowledge_layout(table: StructLayoutTable) -> StructLayoutTable with Mut, Panic, Div {
     var t = table
     if t.count >= 1024 {
@@ -900,7 +907,7 @@ pub(crate) fn ir_register_knowledge_layout(table: StructLayoutTable) -> StructLa
     var fields: [StructFieldEntry; 64] = [empty_struct_field_entry(); 64]
     fields[0] = StructFieldEntry { name_id: ir_intern_name(make_name("value")), index: 0, is_float: 1, elem_type_name_id: ir_intern_name(ir_empty_name()), word_scalar_array_len: 0, named_type_name_id: 0 }
     fields[1] = StructFieldEntry { name_id: ir_intern_name(make_name("variance")), index: 1, is_float: 1, elem_type_name_id: ir_intern_name(ir_empty_name()), word_scalar_array_len: 0, named_type_name_id: 0 }
-    fields[2] = StructFieldEntry { name_id: ir_intern_name(make_name("confidence")), index: 2, is_float: 3, elem_type_name_id: ir_intern_name(ir_empty_name()), word_scalar_array_len: 0, named_type_name_id: 0 }
+    fields[2] = StructFieldEntry { name_id: ir_intern_name(make_name("confidence")), index: 2, is_float: 1, elem_type_name_id: ir_intern_name(ir_empty_name()), word_scalar_array_len: 0, named_type_name_id: 0 }
     t.entries[idx as usize] = StructLayoutEntry {
         type_name: make_name("Knowledge"),
         fields: fields,

--- a/tests/run-pass/f64_bitcast_boundary_knowledge_conf.sio
+++ b/tests/run-pass/f64_bitcast_boundary_knowledge_conf.sio
@@ -1,9 +1,7 @@
 //@ run-pass
-//@ known-failure: Madaros Knowledge.confidence is laid out as i64 (is_float=3) while
-//@   constructors store an f64 epsilon payload; arithmetic/compare emit sitofp of the
-//@   IEEE bits → magnitude ~4e18. lean_single keeps the probability. See audit
-//@   MADAROS_F64_BITCAST_SITOFP_BOUNDARY_2026-08-17.md (mechanism KCONF).
-//@ description: F2 smoking-gun — Knowledge.confidence * f64 / weighted sum (ep28 shape)
+//@ description: F2 closed — Knowledge.confidence is f64 at IR layout (is_float=1);
+//@   typed-base field kind keeps MiniI/Epistemic i64 confidence honest (#1496).
+//@   Was sitofp ~4e18 under is_float=3; see MADAROS_F64_BITCAST_SITOFP_BOUNDARY.
 
 fn main() -> i64 with IO, Mut, Div, Panic, Epistemic {
     // R20 — ctor form Knowledge(v, e=ε, prov=…)


### PR DESCRIPTION
## Summary

Closes **KCONF-BITCAST-SITOFP** (F2): `Knowledge.confidence` was `is_float: 3` while constructors store an f64 ε ∈ (0,1]. Arithmetic/`sitofp` yielded ~4.6e18 on dissertation `epistemic_pbpk28` TEST 6.

- One hunk in `ir_register_knowledge_layout`: `is_float: 3 → 1` (+ comment)
- Clears `//@ known-failure` on the F2 witness
- Does **not** reopen #1496: name_simple is unanimous; FieldGet prefers `field_is_float_for_base_ref`

## Measurement (Madaros rebuilt from this tip — **not** E230-patched)

Instrument: `artifacts/self-hosted/madaros` ELF `\x7fELF` 100084302 bytes via `scripts/ci/build_modular_madaros.sh`. Used `souc compile … -o …` (not bare `-o`).

| Check | Madaros (source) | lean_single |
|---|---|---|
| `f64_bitcast_sitofp_boundary_gate` | **KCONF_ALL_OK** (was BITCAST_SITOFP) | KCONF_ALL_OK |
| USER R23/R24 (#1496 twin) | OK | — |
| ep28 TEST 6 `AUC confidence` | **0.671038** | **0.671038** |
| FABRICATION markers | absent | absent |
| Suite | ALL 9 PASSED | ALL 9 PASSED |
| `\|conf − 0.671038\|` | `< 1e-5` | `< 1e-5` |

Package that waited on the lease: `docs/audit/KCONF_BITCAST_APPLY_PACKAGE_2026-08-18.md`.

## Test plan

- [x] Source-built Madaros gate + ep28 dual-engine
- [ ] CI Contracts (`f64_bitcast` + `epistemic_fabrication_detect` should take healthy F2 arm)
- [ ] Confirm no E230 aggregate patch in this branch