### PR TITLE
feat(lean): first V2 theorem client — preservation on kvalue Nat

### DIFF
--- a/docs/audit/epistemic_calculus_spec_divergence/DISPATCH.md
+++ b/docs/audit/epistemic_calculus_spec_divergence/DISPATCH.md
@@ -173,9 +173,10 @@ PR is unread):
 | `EpistemicEffects` (refuted) | `EpistemicEffectsV2`, `EpistemicPreservationWIP`, `EpistemicPreservationWIP_counterexample` — 3 dependents |
 | `EpistemicEffectsV2` (proven) | **nothing** |
 
-On this branch the second row is `EpistemicEffectsV2_measure_nat` — one
-importer. That is the minimum that stops V2 from being a leaf. It is not
-coverage. See the count under **Landed (consumer)**.
+On this branch the second row is two importers:
+`EpistemicEffectsV2_measure_nat` and `EpistemicEffectsV2_kvalue_nat`.
+That stops V2 from being a leaf. It is not coverage. See the fraction
+under **Coverage**.
 
 The refuted calculus is still the one with more dependents. V2 imports V1
 for shared definitions (`Effect`, `Ty`, `EffectSet`, `emptyE_sub`,
@@ -193,23 +194,58 @@ The correspondence gate's `--lean-consume` arm builds that module only after
 the V1 mutant (`v1_imports_measure_nat.lean`) fails to elaborate. A grep of
 `import EpistemicEffectsV2` without that mutant would measure mention, not use.
 
-**Coverage (measured 2026-08-18 on this file).** One importer ≠ V2 covered.
-Re-derive with the names in `EpistemicEffectsV2.lean` against the consumer
-source, comments stripped:
+**Coverage (measured 2026-08-18, union of V2 importers).** One importer ≠ V2
+covered. Re-derive with the names in `EpistemicEffectsV2.lean` against every
+`EpistemicEffectsV2_*.lean` consumer, comments stripped:
 
 | Layer | Client use | Remainder without an external client |
 |---|---|---|
-| Named theorems (`theorem`, 28) | **0** | **28** — including `preservation` and `effect_progress` |
-| `HasTy` rules (14) | 3 (`t_lit_nat`, `t_measure`, `t_kraw`) | 11 |
-| `Step` rules (19) | 1 (`meas_red`) | 18 |
+| Named theorems (`theorem`, 28) | **1** (`preservation`) | **27** — including `effect_progress` |
+| `HasTy` rules (14) | 4 (`t_lit_nat`, `t_measure`, `t_kraw`, `t_kvalue`) | 10 |
+| `Step` rules (19) | 2 (`meas_red`, `kvalue_red`) | 17 |
 | `IsValue` rules (4) | 1 (`v_nat`) | 3 |
 
-The consumer cites no V2 theorem by name. It reconstructs one path — the
-inverted V1 witness — from constructors. That is one fact of many. The
-gate is right at that grain: it scores use of the import edge, not
-coverage of the metatheory. The next target is a coverage map of the 28
-theorems and the unused rules, not a second banner and not spine
-extraction.
+Round 1 reconstructed the inverted V1 witness from constructors and cited
+**0** theorems. Round 2 cites `preservation` on unwrap. The gate is right
+at import-edge grain; the fraction above is what a reader must see before
+saying "V2 is covered".
+
+**Which theorem first, and why not the obvious ones.** `preservation` and
+`effect_progress` are the headline pair. `effect_progress` is the wrong
+first client: V1 *proves* progress, so a mutant that imports V1 and
+states progress on a well-typed term would likely elaborate. A positive
+control that does not fail measures mention. `preservation` applied to
+the same measure-Nat path as round 1 is the wrong instance: it would
+cite a theorem without touching a new compiler surface.
+
+The instance that has contact with what Madaros actually does is
+`preservation` on `kvalue_red` of `Knowledge<Nat>`. The live checker
+path is `check_knowledge_unwrap` (`self-hosted/check/epistemic.sio`):
+`Knowledge<T>` unwraps to the inner `T`. V1's `kvalue_red` always
+yields `lit_real`. That is the payload-erasure bug on the *read* side
+of the same defect round 1 caught on the *write* side.
+
+**Landed (consumer 2).** `EpistemicEffectsV2_kvalue_nat.lean` cites
+`preservation` and proves `kvalue_nat_reduct_stays_nat`. The
+`--lean-consume` arm (and `--lean-consume-kvalue`) builds that module
+only after `v1_imports_kvalue_nat.lean` fails.
+
+**Acceptance for consumer 2 (written before the consumer is scored).**
+A green Lean Proofs *job* is not evidence. The consume step must appear
+`success` and not `skipped` on the PR head. Because
+`.github/workflows/ci.yml` is under an active foreign claim, this
+round extends the existing step `V2 measure-Nat consumer (V1 mutant
+must fail first)` rather than adding a second named step. That step's
+log on the PR head must contain both:
+
+```
+POSITIVE_CONTROL_FIRED: v1_imports_kvalue_nat rejected
+V2_CONSUMED: EpistemicEffectsV2_kvalue_nat built
+```
+
+A dedicated step name (`V2 kvalue-Nat consumer (V1 mutant must fail
+first)`) is the next `ci.yml` hunk, not a substitute for those lines.
+If the kvalue mutant elaborates, the consumer must not be added.
 
 **Deferred — extract the shared spine.** A third module holding `Effect`, `Ty`,
 `EffectSet`, `TyCtx` would stop V2 from being a *client* of the refuted file.
@@ -257,13 +293,16 @@ do not attempt to close it under this dispatch.
 1. R1 and R2 landed. R3 recorded and explicitly deferred, not silently dropped.
    R1's remaining *fact* (V2 had no importer) is closed by
    `EpistemicEffectsV2_measure_nat.lean`, not by the banner. That close is
-   an import edge, not metatheory coverage: **0 of 28** V2 theorems have an
-   external client. Spine extraction stays deferred — see §5 R1. The
-   coverage map is the next residual, not a restatement of the consumer.
-2. `Lean Proofs` green, with V1, V2, and `EpistemicEffectsV2_measure_nat` all
-   `@[default_target]`. Deleting V1 to make the problem disappear is **out of
-   scope** — the refutation is a result worth keeping, and §1's theorems are
-   its statement.
+   an import edge, not metatheory coverage. After consumer 2 the fraction
+   is **1 of 28** named theorems (`preservation` on `kvalue` of
+   `Knowledge<Nat>`), **4 of 14** `HasTy` rules, **2 of 19** `Step`
+   rules, **1 of 4** `IsValue` rules. Spine extraction stays deferred —
+   see §5 R1. The coverage *fraction* is the residual, updated each
+   round, not a restatement of "V2 has a consumer".
+2. `Lean Proofs` green, with V1, V2, `EpistemicEffectsV2_measure_nat`,
+   and `EpistemicEffectsV2_kvalue_nat` all `@[default_target]`. Deleting
+   V1 to make the problem disappear is **out of scope** — the refutation
+   is a result worth keeping, and §1's theorems are its statement.
 3. The new gate's positive control demonstrated firing, with the output pasted
    into the PR body. A green gate whose control was never shown to fail is not
    evidence.

--- a/formal/lean4/EpistemicEffectsV2_kvalue_nat.lean
+++ b/formal/lean4/EpistemicEffectsV2_kvalue_nat.lean
@@ -1,0 +1,49 @@
+import EpistemicEffectsV2
+
+/-!
+# V2 consumer — `kvalue` of `Knowledge<Nat>` stays `Nat`
+
+This file *cites* `preservation`. The first importer reconstructed the
+measure-Nat path from constructors and cited zero of V2's 28 theorems.
+That is an import edge, not a verifier.
+
+The first named theorem worth a client is not `preservation` applied
+to that same measure-Nat path (no new compiler contact) and not
+`effect_progress` (V1 proves progress; a V1 mutant of progress would
+likely elaborate, so the positive control would not fire).
+
+It is `preservation` applied to `kvalue_red` on `Knowledge<Nat>`.
+The live checker path is `check_knowledge_unwrap` in
+`self-hosted/check/epistemic.sio`: `Knowledge<T>` unwraps to `T`.
+V1's `kvalue_red` always yields `lit_real`. The statement cannot be
+proved under `import EpistemicEffects` — the fixture
+`scripts/ci/fixtures/epistemic_measure_correspondence/v1_imports_kvalue_nat.lean`
+is that attempt, and must fail.
+
+No `sorry`. No `axiom`. No Mathlib.
+-/
+
+namespace Sounio.EpistemicEffectsV2
+
+open Sounio.EpistemicEffects (emptyE)
+
+theorem kvalue_nat_typed (m : KMeta) (hm : kvalid m) :
+    HasTy [] (.kvalue (.kraw (.lit_nat 0) m)) .tnat emptyE :=
+  .t_kvalue _ _ _ _ (.t_kraw _ _ _ _ (.t_lit_nat _ _) (.v_nat 0) hm)
+
+theorem kvalue_nat_steps (m : KMeta) :
+    (.kvalue (.kraw (.lit_nat 0) m)) ⇒ (.lit_nat 0) :=
+  .kvalue_red
+
+/-- Cites `preservation`. The reduct of `kvalue` on a `Knowledge<Nat>`
+    value is still `Nat`. -/
+theorem kvalue_nat_reduct_stays_nat
+    (m : KMeta) (hm : kvalid m) :
+    HasTy [] (.kvalue (.kraw (.lit_nat 0) m)) .tnat emptyE
+    ∧ ((.kvalue (.kraw (.lit_nat 0) m)) ⇒ (.lit_nat 0))
+    ∧ HasTy [] (.lit_nat 0) .tnat emptyE :=
+  ⟨kvalue_nat_typed m hm,
+   kvalue_nat_steps m,
+   preservation (kvalue_nat_typed m hm) (kvalue_nat_steps m)⟩
+
+end Sounio.EpistemicEffectsV2

--- a/formal/lean4/lakefile.lean
+++ b/formal/lean4/lakefile.lean
@@ -647,6 +647,11 @@ lean_lib «EpistemicEffectsV2» where
 @[default_target]
 lean_lib «EpistemicEffectsV2_measure_nat» where
 
+-- Second V2 importer: cites `preservation` on `kvalue` of `Knowledge<Nat>`.
+-- Dual of measure — the compiler's `check_knowledge_unwrap` path.
+@[default_target]
+lean_lib «EpistemicEffectsV2_kvalue_nat» where
+
 -- Refusal as a first-class compilation outcome (E219 / P0-F). A well-typed
 -- program in the extern-call fragment produces a value or refuses; it never
 -- fabricates a zero. Models the historical stub-to-zero backend as a second

--- a/scripts/ci/epistemic_measure_correspondence_gate.sh
+++ b/scripts/ci/epistemic_measure_correspondence_gate.sh
@@ -11,9 +11,12 @@ CHECKER_SOURCE="self-hosted/check/check.sio"
 MODEL_SOURCE="formal/lean4/EpistemicEffectsV2.lean"
 CONSUMER_SOURCE="formal/lean4/EpistemicEffectsV2_measure_nat.lean"
 V1_MUTANT="scripts/ci/fixtures/epistemic_measure_correspondence/v1_imports_measure_nat.lean"
+KVALUE_CONSUMER_SOURCE="formal/lean4/EpistemicEffectsV2_kvalue_nat.lean"
+KVALUE_V1_MUTANT="scripts/ci/fixtures/epistemic_measure_correspondence/v1_imports_kvalue_nat.lean"
 ARTIFACT="${TMPDIR:-/tmp}/epistemic_measure_correspondence_gate.v1.json"
 RUN_POSITIVE_CONTROLS=1
 LEAN_CONSUME=0
+LEAN_CONSUME_KVALUE=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -22,6 +25,7 @@ while [[ $# -gt 0 ]]; do
     --artifact) ARTIFACT="${2:?missing path after --artifact}"; shift 2 ;;
     --control-child) RUN_POSITIVE_CONTROLS=0; shift ;;
     --lean-consume) LEAN_CONSUME=1; shift ;;
+    --lean-consume-kvalue) LEAN_CONSUME_KVALUE=1; shift ;;
     *) echo "epistemic_measure_correspondence_gate: unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -192,6 +196,62 @@ run_lean_consume() {
   echo "[epistemic-correspondence] V2_CONSUMED: EpistemicEffectsV2_measure_nat built"
 }
 
+run_lean_consume_kvalue() {
+  local lean_dir="$ROOT_DIR/formal/lean4"
+  if ! command -v lake >/dev/null 2>&1; then
+    TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
+    record_failure "lake_missing"
+    return
+  fi
+
+  check_grep "kvalue_consumer_imports_v2" \
+    '^import EpistemicEffectsV2$' "$KVALUE_CONSUMER_SOURCE"
+  check_absent "kvalue_consumer_must_not_import_v1_directly" \
+    '^import EpistemicEffects$' "$KVALUE_CONSUMER_SOURCE"
+  check_grep "kvalue_consumer_cites_preservation" \
+    'preservation \(kvalue_nat_typed' "$KVALUE_CONSUMER_SOURCE"
+  check_grep "kvalue_consumer_names_the_unwrap_witness" \
+    '^theorem kvalue_nat_reduct_stays_nat$' "$KVALUE_CONSUMER_SOURCE"
+  check_grep "kvalue_v1_mutant_imports_v1" \
+    '^import EpistemicEffects$' "$KVALUE_V1_MUTANT"
+  check_absent "kvalue_v1_mutant_must_not_import_v2" \
+    '^import EpistemicEffectsV2$' "$KVALUE_V1_MUTANT"
+  check_grep "kvalue_v1_mutant_attempts_the_same_theorem" \
+    '^theorem kvalue_nat_reduct_stays_nat$' "$KVALUE_V1_MUTANT"
+
+  if ! (cd "$lean_dir" && lake build EpistemicEffects) \
+      >"$WORK/lake-v1-kvalue.log" 2>&1; then
+    TOTAL=$((TOTAL + 1)); FAILED=$((FAILED + 1))
+    record_failure "lake_build_v1_failed"
+    sed 's/^/[lake-v1] /' "$WORK/lake-v1-kvalue.log" >&2
+    return
+  fi
+
+  # Arm 3 FIRST. If this mutant elaborates, arm 2 is measuring mention.
+  TOTAL=$((TOTAL + 1))
+  if (cd "$lean_dir" && lake env lean "$ROOT_DIR/$KVALUE_V1_MUTANT") \
+      >"$WORK/v1-kvalue-mutant.log" 2>&1; then
+    FAILED=$((FAILED + 1))
+    record_failure "positive_control_v1_import_kvalue_nat_was_not_rejected"
+    sed 's/^/[v1-kvalue-mutant] /' "$WORK/v1-kvalue-mutant.log" >&2
+    return
+  fi
+  PASSED=$((PASSED + 1))
+  echo "[epistemic-correspondence] POSITIVE_CONTROL_FIRED: v1_imports_kvalue_nat rejected"
+  sed 's/^/[v1-kvalue-mutant] /' "$WORK/v1-kvalue-mutant.log"
+
+  TOTAL=$((TOTAL + 1))
+  if ! (cd "$lean_dir" && lake build EpistemicEffectsV2_kvalue_nat) \
+      >"$WORK/lake-kvalue-consumer.log" 2>&1; then
+    FAILED=$((FAILED + 1))
+    record_failure "v2_kvalue_nat_consumer_failed_to_build"
+    sed 's/^/[lake-kvalue-consumer] /' "$WORK/lake-kvalue-consumer.log" >&2
+    return
+  fi
+  PASSED=$((PASSED + 1))
+  echo "[epistemic-correspondence] V2_CONSUMED: EpistemicEffectsV2_kvalue_nat built"
+}
+
 if [[ "$LEAN_CONSUME" -eq 1 ]]; then
   if [[ ! -f "$CONSUMER_SOURCE" ]]; then
     TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
@@ -201,12 +261,35 @@ if [[ "$LEAN_CONSUME" -eq 1 ]]; then
     TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
     record_failure "v1_mutant_missing:$V1_MUTANT"
   fi
+  if [[ ! -f "$KVALUE_CONSUMER_SOURCE" ]]; then
+    TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
+    record_failure "kvalue_consumer_source_missing:$KVALUE_CONSUMER_SOURCE"
+  fi
+  if [[ ! -f "$KVALUE_V1_MUTANT" ]]; then
+    TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
+    record_failure "kvalue_v1_mutant_missing:$KVALUE_V1_MUTANT"
+  fi
   if [[ "$NOT_RUN" -eq 0 ]]; then
     run_lean_consume
+    run_lean_consume_kvalue
   fi
 fi
 
-if [[ "$RUN_POSITIVE_CONTROLS" -eq 1 && "$NOT_RUN" -eq 0 && "$LEAN_CONSUME" -eq 0 ]]; then
+if [[ "$LEAN_CONSUME_KVALUE" -eq 1 && "$LEAN_CONSUME" -eq 0 ]]; then
+  if [[ ! -f "$KVALUE_CONSUMER_SOURCE" ]]; then
+    TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
+    record_failure "kvalue_consumer_source_missing:$KVALUE_CONSUMER_SOURCE"
+  fi
+  if [[ ! -f "$KVALUE_V1_MUTANT" ]]; then
+    TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
+    record_failure "kvalue_v1_mutant_missing:$KVALUE_V1_MUTANT"
+  fi
+  if [[ "$NOT_RUN" -eq 0 ]]; then
+    run_lean_consume_kvalue
+  fi
+fi
+
+if [[ "$RUN_POSITIVE_CONTROLS" -eq 1 && "$NOT_RUN" -eq 0 && "$LEAN_CONSUME" -eq 0 && "$LEAN_CONSUME_KVALUE" -eq 0 ]]; then
   CHECKER_MUTANT="scripts/ci/fixtures/epistemic_measure_correspondence/checker_fixed_f64.sio"
   MODEL_MUTANT="scripts/ci/fixtures/epistemic_measure_correspondence/model_fixed_treal.lean"
 

--- a/scripts/ci/fixtures/epistemic_measure_correspondence/v1_imports_kvalue_nat.lean
+++ b/scripts/ci/fixtures/epistemic_measure_correspondence/v1_imports_kvalue_nat.lean
@@ -1,0 +1,19 @@
+import EpistemicEffects
+open Sounio.EpistemicEffects
+
+/-
+  Positive control for the V2 `preservation` consumer on unwrap.
+  Same theorem name as `EpistemicEffectsV2_kvalue_nat.lean`, written
+  against the *refuted* calculus. V1's `kraw` has no payload slot, so
+  `t_kraw` types every cell at `Knowledge<Real>` and `kvalue_red`
+  yields `lit_real`, not `lit_nat`. If `lake env lean` on this file
+  exits 0, the consumer arm is measuring mention, not use, and must
+  not be added.
+-/
+
+theorem kvalue_nat_reduct_stays_nat
+    (k : KCell) (hk : kvalid k) :
+    HasTy [] (.kvalue (.kraw k)) .tnat emptyE
+    ∧ ((.kvalue (.kraw k)) ⇒ (.lit_nat 0))
+    ∧ HasTy [] (.lit_nat 0) .tnat emptyE :=
+  ⟨.t_kvalue _ _ _ _ (.t_kraw _ _ hk), .kvalue_red, .t_lit_nat _ _⟩


### PR DESCRIPTION
## Summary

- First *cited* V2 theorem is `preservation`, applied to `kvalue_red` of `Knowledge<Nat>`. That is the compiler's `check_knowledge_unwrap` path, not another reconstruction of measure-Nat.
- `effect_progress` is the wrong first client: V1 proves progress, so a V1 mutant of progress would likely elaborate.
- `preservation` on the same measure-Nat path as #1873 is the wrong instance: it would cite a theorem without new compiler contact.

## Acceptance (written before the consumer was scored)

A green Lean Proofs *job* is not evidence. The consume step must appear **success** and not **skipped** on this head. `.github/workflows/ci.yml` is under cursor-2's active claim, so this PR extends the existing step `V2 measure-Nat consumer (V1 mutant must fail first)` rather than adding a second named step. That step's log must contain:

```
POSITIVE_CONTROL_FIRED: v1_imports_kvalue_nat rejected
V2_CONSUMED: EpistemicEffectsV2_kvalue_nat built
```

A dedicated step name is the next `ci.yml` hunk, not a substitute for those lines.

## Mutant before consumer (measured locally)

```
Application type mismatch: Step.kvalue_red
  has type  (kraw k).kvalue ⇒ lit_real (KCell.value k)
  expected  (kraw k).kvalue ⇒ lit_nat 0
POSITIVE_CONTROL_FIRED: v1_imports_kvalue_nat rejected
V2_CONSUMED: EpistemicEffectsV2_kvalue_nat built
status=pass total=30 (--lean-consume, both pairs)
```

If that mutant had elaborated, the consumer would not have been added.

## Coverage (union of both V2 importers)

| Layer | Used | Remainder |
|---|---:|---:|
| Named theorems (28) | **1** (`preservation`) | 27 |
| `HasTy` (14) | 4 | 10 |
| `Step` (19) | 2 | 17 |
| `IsValue` (4) | 1 | 3 |

## Test plan

- [x] Kvalue mutant `lake env lean` fails after V1 oleans exist (lit_real vs lit_nat, not missing-module)
- [x] `lake build EpistemicEffectsV2_kvalue_nat` passes
- [x] `--lean-consume` runs measure pair then kvalue pair, mutant first each time
- [ ] CI Lean Proofs: existing consume step **success** not skipped; log contains both kvalue lines above