### PR TITLE
docs(audit): the gen2 capacity raise is not self-contained — region table coupling measured

### DIFF
--- a/docs/audit/MADAROS_BOX_AUTODEREF_MAIN_REPRODUCTION_2026-08-17.md
+++ b/docs/audit/MADAROS_BOX_AUTODEREF_MAIN_REPRODUCTION_2026-08-17.md
@@ -242,3 +242,25 @@ larger IR slot budget or a tighter live-set, not the Box fix.
 What this means: do not expect gen2 to turn green from the Box fix alone.
 The recorded rung stays `check`; the ladder is unchanged, and that is the
 correct, bounded result.
+
+Attempted the documented lever and found why it is not self-contained
+(2026-08-18, same lane). Raising `IR_MAX_FUNCS` 8192 → 16384 requires, in
+the same change:
+
+1. `ir_region_table_capacity()` (`self-hosted/ir/ir.sio:1141`, currently
+   8448) MUST exceed `IR_MAX_FUNCS` — its own comment records the bisect
+   ("8189 live slots compile, 8190 and 8191 do not"). At 16384 the region
+   table is the binding constraint and the contract check refuses.
+2. The coupled array literals: `IrModule.functions` (`[IrFunction; 8192]`),
+   `normalize.sio`'s two `[IrFunction; 8192]` sites, the four backends'
+   `fn_offsets: [i64; 8192]` (`codegen_x86_linux`, `elf`, `elf_bulk`,
+   `reloc`), and `SPEC_DCE_SLOTS`/`SPEC_DCE_MAX` plus the `[i64; 16384]`
+   mark arrays in `specializer.sio`.
+3. The fixture `tests/multimodule/ir_capacity/` raised past the old ceiling,
+   and the literal sweep the probe gate's header demands.
+
+A partial raise (constant + arrays, without the region table) was applied
+and reverted in this worktree; nothing shipped. The lever is real but it is
+a coordinated multi-file change with its own risk profile, not a one-line
+constant bump. That is the next task, named and scoped, and it is separate
+from the Box repair this audit is about.


### PR DESCRIPTION
## Summary

- The rung-gen2 wall (9097 slots vs cap 8191) has a documented lever — raise `IR_MAX_FUNCS` — but this PR records, from an attempted raise on a scratch worktree, that the lever is **not self-contained**.
- The binding constraint the probe gate only hints at: `ir_region_table_capacity()` (`self-hosted/ir/ir.sio:1141`, currently 8448) MUST exceed `IR_MAX_FUNCS` — its own comment records the bisect ("8189 live slots compile, 8190 and 8191 do not"). At 16384 the region table refuses before the slot census ever does.
- Names the full coupled surface for the next lane: `IrModule.functions` + `normalize.sio` (`[IrFunction; 8192]`), `fn_offsets [i64; 8192]` in four backends, `SPEC_DCE_SLOTS`/`SPEC_DCE_MAX` + the `[i64; 16384]` mark arrays in `specializer.sio`, plus the `ir_capacity` fixture raised past the old ceiling and the literal sweep the probe gate demands.
- A partial raise was applied and reverted on the scratch worktree; nothing compiler-facing ships here. Doc-only.

## Validation

- `bash scripts/dev/check_docs_registry.sh` — pass
- Governance metadata re-synced
- The attempted raise was measured, not assumed: the region-table coupling is read from `ir.sio:1136-1141`'s own bisect record, cross-checked against the 9097/8191 census in the A/B above it in the same doc.