### PR TITLE
fix(souc): refuse bare `souc <src> -o` instead of writing a file named `-o`

### DIFF
--- a/bin/souc
+++ b/bin/souc
@@ -199,7 +199,17 @@ fi
 # Keep routing this through the lean_single bootstrap ELF even though Madaros is
 # the default verb-oriented engine; the modular launcher does not implement the
 # raw `SRC OUT` ABI.
+#
+# Fail-closed: a flag-looking second argument is not an output path.
+# `souc file.sio -o dest.elf` used to exec lean_single with OUT=`-o`, write a
+# file literally named `-o`, and exit 0. That is the silent-success class.
+# See docs/audit/SOUC_WRAPPER_BARE_DASH_O_SWALLOW_DISPATCH_2026-08-18.md.
 if [[ $# -ge 2 && "${1:-}" == *.sio ]]; then
+  if [[ "${2:-}" == -* ]]; then
+    echo "souc: refused: bare form 'souc $1 $2 …' would treat '$2' as the output filename and exit 0" >&2
+    echo "souc: use: souc compile $1 -o <out>" >&2
+    exit 2
+  fi
   if _science_boundary_requested "$@"; then
     _reject_science_without_madaros
   fi

--- a/docs/audit/SOUC_WRAPPER_BARE_DASH_O_SWALLOW_DISPATCH_2026-08-18.md
+++ b/docs/audit/SOUC_WRAPPER_BARE_DASH_O_SWALLOW_DISPATCH_2026-08-18.md
@@ -1,0 +1,64 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.souc-wrapper-bare-dash-o-swallow-dispatch-2026-08-18
+authority: repo_only
+audience: users
+last_validated: 2026-08-18
+validated_by: grok-cli1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.souc-wrapper-bare-dash-o-swallow-dispatch-2026-08-18
+-->
+
+# Dispatch: `bin/souc <file> -o <out>` swallows `-o` as the output name and exits 0
+
+**Date:** 2026-08-18
+**Status:** CLOSED — fail-closed refusal landed in `bin/souc`.
+**Owner:** grok-cli1 (opened the dispatch; no other lane held `bin/souc`).
+**Not this dispatch:** the E230 handle-table diagnostic, or the E230-patch
+3-slot aggregate crash (minimax-cli1 / grok-cli5).
+**Surface:** `bin/souc` raw positional `SRC OUT` route.
+
+## Symptom (measured)
+
+On the E230 v3 STAGE (`/orangefs/training/e230-v3-20260818T155411Z`):
+
+```text
+souc w2.sio -o w2.elf     # rc=0
+# wrote a file literally named `-o` (36924 bytes)
+# w2.elf was never created
+# compile log: lean_single (`source: w2.sio`, `elf: -o 36924 bytes`)
+```
+
+The command reported success and did not produce the named output. Independent
+confirm (grok-cli5 case D): lean_single ELF for that source is 36924 bytes —
+the same artefact, two lanes.
+
+## Mechanism
+
+`bin/souc` treated any invocation whose first argument is `*.sio` and whose
+argc ≥ 2 as the historical lean_single `SRC OUT` ABI and `exec`'d the seed
+with the raw argv. `-o` became OUT.
+
+`souc --version` still printed Madaros. A gate that keyed off `--version`
+claimed Madaros while the compile ran on the seed.
+
+## Correction (landed)
+
+Before the lean_single `exec`, if the second argument looks like a flag
+(`-*`, including `-o`), refuse:
+
+- exit 2
+- do not `exec` lean_single
+- do not write a file named `-o`
+- name the intended form: `souc compile <src> -o <out>`
+
+Legitimate raw form `souc <src.sio> <out>` is unchanged (`scripts/ci/real_language_runner_gate.sh` 6/7).
+
+## Radius
+
+14 scripts under `scripts/ci` use some `.sio -o` form. Zero used the bare
+no-verb form. The only in-tree caller was the E230 ceiling gate, rewritten
+to the verb. This patch removes the trap for every future caller.
+
+## AI disclosure
+
+Symptom capture, localisation, and the fail-closed wrapper edit by AI agent
+(grok-cli1) under human direction, 2026-08-18. GAIDeT-ICMJE 2025.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -305,6 +305,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.seed-fix-general-lvalue-deref-store-2026-06-24 | repo_only | docs/audit/SEED_FIX_GENERAL_LVALUE_DEREF_STORE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.seed-fix-value-nested-field-store-2026-06-24 | repo_only | docs/audit/SEED_FIX_VALUE_NESTED_FIELD_STORE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sigsegv-pbpk28-private-struct-2026-06-02 | repo_only | docs/audit/SIGSEGV_PBPK28_PRIVATE_STRUCT_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.souc-wrapper-bare-dash-o-swallow-dispatch-2026-08-18 | repo_only | docs/audit/SOUC_WRAPPER_BARE_DASH_O_SWALLOW_DISPATCH_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sounio-release-production-readiness-2026-06-22 | repo_only | docs/audit/SOUNIO_RELEASE_PRODUCTION_READINESS_2026-06-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sounio-science-flex-2026-07-27 | repo_only | docs/audit/SOUNIO_SCIENCE_FLEX_2026-07-27.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.spnn-quantnn-mod-export-2026-08-14 | repo_only | docs/audit/SPNN_QUANTNN_MOD_EXPORT_2026-08-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -6479,6 +6479,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.souc-wrapper-bare-dash-o-swallow-dispatch-2026-08-18",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/SOUC_WRAPPER_BARE_DASH_O_SWALLOW_DISPATCH_2026-08-18.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.sounio-release-production-readiness-2026-06-22",
       "collection": "repo",
       "repo_doc_path": "docs/audit/SOUNIO_RELEASE_PRODUCTION_READINESS_2026-06-22.md",


### PR DESCRIPTION
## Why

`bin/souc <file.sio> -o <out>` is the raw lean_single `SRC OUT` form. The wrapper treated `-o` as the output filename, wrote a file literally named `-o`, and exited 0. Gates then proceeded as if compilation had produced the named ELF.

Independent confirm of the artefact size: grok-cli5, reducing a different crash (case D, lean_single ELF for a 3-slot aggregate), measured **36924 bytes** — the same size as the `-o` file this lane caught on the E230 STAGE. Two lanes, two methods, same artefact.

## What

Before the lean_single `exec`, refuse a flag-looking second argument (`-*`, including `-o`):

- exit 2
- do not write `-o`
- name the intended form: `souc compile <src> -o <out>`

Legitimate `souc <src.sio> <out>` is unchanged.

## Corpus sweep (`scripts/ci`, `scripts/dev`)

Zero callers use the bare no-verb form with `-o` (operator-measured earlier).

Live positional `bin/souc <src.sio> <out>` callers — all have a non-flag OUT, so this patch does **not** touch them:

| script | call |
|---|---|
| `scripts/ci/real_language_runner_gate.sh` | `./bin/souc examples/hello.sio "$TMP_RAW"` (gate 6/7) |
| `scripts/ci/knowledge_context_phase2_ontology_gate.sh` | `bin/souc lean_frontend.sio "$FRONTEND"` and ast-probe |
| `scripts/ci/ontology_bundle_directive_native_scan_gate.sh` | `bin/souc lean_frontend.sio "$FRONTEND"` |
| `scripts/ci/ontology_cache_frontend_composition_gate.sh` | `bin/souc "$FRONTEND_SRC" "$FRONTEND"` |

`scripts/dev` positional compiles (`run_kaxi_*`, `run_metal_test.sh`, `run_runpass_parse_only_current.sh`) default to the raw ELF `bin/souc-linux-x86_64`, not the wrapper.

Replayed on this branch:

- `souc examples/hello.sio hello.raw.elf` → rc=0, 36636 B, `\x7fELF`
- `souc self-hosted/compiler/lean_frontend.sio <out>` → rc=0, 44829690 B, `\x7fELF` (the ontology-gate compile)

## Negative control (required)

Bare form **must** exit nonzero **and** name the verb:

```
$ souc t.sio -o t.elf
souc: refused: bare form 'souc t.sio -o …' would treat '-o' as the output filename and exit 0
souc: use: souc compile t.sio -o <out>
# rc=2; no file named `-o`; no t.elf
```

A refusal that does not say what to type instead turns the trap into a wall.

## Matrix A / B / C (surgical, not broad)

| | command | rc | artefact | engine log |
|---|---|---|---|---|
| **A** trap | `souc t.sio -o t.elf` | **2** | no `-o`, no `t.elf` | wrapper refusal (names `souc compile`) |
| **B** positional | `souc t.sio t_raw.elf` | 0 | 36567 B, `\x7fELF` | lean_single |
| **C** verb | `souc compile t.sio -o t_verb.elf` | 0 | 8648 B | Madaros |

B is the reason this fix is safe: the legitimate positional form still works. Killing that form would be worse than the defect.

## E230 selftest vs this wrapper

The ceiling gate (`souc compile` + S0/S1) was re-run with **this** `bin/souc` on the E230-patched Madaros ELF:

- S0: Madaros, ELF 8648 B, `run_rc=42`
- S1: 3-slot aggregate rc=139 → `REFUSE_MEASURE` (no W numbers; expected while the E230 patch still crashes 3-slot structs)
- inject `bare` / `engine` / `rc-pipe`: still exit 2 (`SELFTEST_FAIL`)
- inject `bare` now fails at the wrapper refusal (`compile_rc=2`) instead of writing `-o` — the trap is gone and the selftest still fires

The gate this lane spent the day repairing still runs.

Not this PR: E230 diagnostic, or the E230-patch 3-slot aggregate crash (minimax-cli1).
