### PR TITLE
feat(website): withhold the 251/251 reliability numeral without an engine

### DIFF
--- a/website/src/components/home/LivingLanguagePulse.astro
+++ b/website/src/components/home/LivingLanguagePulse.astro
@@ -2,6 +2,7 @@
 import { artifactStatus, publicContract } from '../../data/artifactStatus';
 import { getLocalizedPath } from '../../lib/i18n';
 import type { Locale } from '../../lib/i18n';
+import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal } from '../../lib/stdlibReliabilityHonesty';
 
 interface Props {
   locale?: Locale;
@@ -158,6 +159,7 @@ const copy: Record<string, {
 const d = copy[locale] ?? copy.en;
 const { metrics, versions, defaultWorkflow, honestStatus } = publicContract;
 const stdlib = metrics.stdlibReliabilityGate;
+const reliabilityOk = reliabilityMayPrint();
 const sourceFileCount = metrics.selfHostedSourceFiles;
 const sourceLineCount = metrics.selfHostedSourceLines;
 const parsedGeneratedDate = new Date(artifactStatus.generatedAt);
@@ -165,7 +167,7 @@ const generatedDate = Number.isNaN(parsedGeneratedDate.getTime())
   ? artifactStatus.generatedAt.slice(0, 10)
   : parsedGeneratedDate.toISOString().slice(0, 10);
 const reliabilityPercent =
-  stdlib.total > 0 ? Math.round((stdlib.pass / stdlib.total) * 100) : null;
+  reliabilityOk && stdlib.total > 0 ? Math.round((stdlib.pass / stdlib.total) * 100) : null;
 const localeCodes = ['pt', 'el', 'zh', 'zh-hk', 'ja', 'es'];
 const localizedDocs = import.meta.glob('../../content/docs/{pt,el,zh,zh-hk,ja,es}/**/*.{md,mdx}', { eager: true });
 const englishDocs = import.meta.glob('../../content/docs/en/**/*.{md,mdx}', { eager: true });
@@ -192,9 +194,14 @@ const localizedFamilyNote =
     expectedShowcasesCount > 0 ? `showcases ${localizedShowcasesCount}/${expectedShowcasesCount}` : 'showcases no data',
     expectedTutorialsCount > 0 ? `tutorials ${localizedTutorialsCount}/${expectedTutorialsCount}` : 'tutorials no data',
   ].join(' · ');
-const reliabilityValue = reliabilityPercent == null ? 'no data' : `${reliabilityPercent}%`;
-const reliabilityNote =
-  stdlib.total > 0 ? `${stdlib.pass}/${stdlib.total} pass · FAIL=${stdlib.fail}` : 'gate inventory unavailable';
+const reliabilityValue = reliabilityOk
+  ? reliabilityPercent == null
+    ? 'no data'
+    : `${reliabilityPercent}%`
+  : '—';
+const reliabilityNote = reliabilityOk
+  ? reliabilityFace()
+  : reliabilityRefusal();
 
 const signals = [
   {

--- a/website/src/components/home/NumbersSection.astro
+++ b/website/src/components/home/NumbersSection.astro
@@ -1,11 +1,14 @@
 ---
 import { publicContract } from "../../data/artifactStatus";
 import { getLocaleFromUrl } from "../../lib/i18n";
+import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal, reliabilityShortRefusal } from "../../lib/stdlibReliabilityHonesty";
 
 const locale = getLocaleFromUrl(Astro.url);
 const { metrics, bootstrap, versions } = publicContract;
-const gate = metrics.stdlibReliabilityGate;
 const full = metrics.fullTestSuite;
+const reliabilityOk = reliabilityMayPrint();
+const reliabilityShown = reliabilityOk ? reliabilityFace() : reliabilityShortRefusal();
+const reliabilityLabel = reliabilityOk ? undefined : reliabilityRefusal();
 const selfHostedLines = metrics.selfHostedSourceLines;
 const stdlibFiles = metrics.stdlibInventoryFiles;
 
@@ -192,9 +195,9 @@ const d = t[locale] || t.en;
 
       <div class="text-center">
         <div class="text-3xl sm:text-4xl md:text-5xl lg:text-7xl font-extrabold text-[var(--color-text-primary)] tracking-tight mb-2 overflow-hidden text-ellipsis whitespace-nowrap">
-          {gate.pass}/{gate.total}
+          {reliabilityShown}
         </div>
-        <div class="text-xs sm:text-sm text-[var(--color-text-secondary)]">{d.stdlibGate}</div>
+        <div class="text-xs sm:text-sm text-[var(--color-text-secondary)]">{reliabilityLabel ?? d.stdlibGate}</div>
       </div>
 
       <div class="text-center">

--- a/website/src/components/home/ProofStrip.astro
+++ b/website/src/components/home/ProofStrip.astro
@@ -1,6 +1,7 @@
 ---
 import { getLocalizedPath, type Locale } from '../../lib/i18n';
 import { getProofData } from '../../lib/proofData';
+import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal, reliabilityShortRefusal } from '../../lib/stdlibReliabilityHonesty';
 
 interface Props {
   locale: Locale;
@@ -16,9 +17,11 @@ const items = [
     detail: proof.release.generatedAtUtc ? `Provenance checked ${proof.release.generatedAtUtc.slice(0, 10)}` : 'Provenance tracked in-tree',
   },
   {
-    value: `${proof.stdlib.passCount}/${proof.stdlib.totalCount}`,
+    value: reliabilityMayPrint() ? reliabilityFace() : reliabilityShortRefusal(),
     label: 'stdlib reliability fixtures passing',
-    detail: `${proof.stdlib.activeModuleEntrypoints} active module entrypoints`,
+    detail: reliabilityMayPrint()
+      ? `${proof.stdlib.activeModuleEntrypoints} active module entrypoints`
+      : reliabilityRefusal(),
   },
   {
     value: `${proof.gpu.publicPassCount}/${proof.gpu.publicCheckCount}`,

--- a/website/src/components/status/FeatureStatusPanel.astro
+++ b/website/src/components/status/FeatureStatusPanel.astro
@@ -1,9 +1,10 @@
 ---
 import { publicContract, artifactStatus } from "../../data/artifactStatus";
 import ArtifactStatusTable from "./ArtifactStatusTable.astro";
+import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal } from "../../lib/stdlibReliabilityHonesty";
 
 const { versions, defaultWorkflow, metrics } = publicContract;
-const gate = metrics.stdlibReliabilityGate;
+const reliabilityShown = reliabilityMayPrint() ? reliabilityFace() : reliabilityRefusal();
 ---
 
 <div class="grid gap-6 not-prose">
@@ -39,7 +40,7 @@ const gate = metrics.stdlibReliabilityGate;
           )}
           <tr class="border-b border-[var(--glass-border)]">
             <td class="py-3 pr-4 font-medium text-[var(--color-text-primary)]">Stdlib reliability gate</td>
-            <td class="py-3">{gate.pass} pass / {gate.fail} fail / {gate.skip} skip / {gate.total} total</td>
+            <td class="py-3">{reliabilityShown}</td>
           </tr>
           {metrics.fullTestSuite && (
             <tr class="border-b border-[var(--glass-border)]">

--- a/website/src/components/status/HonestStatusSection.astro
+++ b/website/src/components/status/HonestStatusSection.astro
@@ -2,6 +2,12 @@
 import { publicContract } from "../../data/artifactStatus";
 import { KineticText } from "../common/KineticText";
 import { getLocaleFromUrl, getLocalizedPath } from "../../lib/i18n";
+import {
+  filterReliabilityLeaks,
+  reliabilityFace,
+  reliabilityMayPrint,
+  reliabilityRefusal,
+} from "../../lib/stdlibReliabilityHonesty";
 
 interface Props {
   heading?: string;
@@ -157,10 +163,10 @@ const clinicalMissing = [
 ];
 
 const { works, scaffolding, missing } = publicContract.honestStatus;
-const displayWorks = clinical ? clinicalWorks : works;
+const displayWorks = clinical ? clinicalWorks : filterReliabilityLeaks(works);
 const displayScaffolding = clinical ? clinicalScaffolding : scaffolding;
 const displayMissing = clinical ? clinicalMissing : missing;
-const gate = publicContract.metrics.stdlibReliabilityGate;
+const gatePrintable = reliabilityMayPrint();
 const syncedAt = publicContract.metrics.stdlibReliabilityGate.artifact;
 ---
 
@@ -174,7 +180,8 @@ const syncedAt = publicContract.metrics.stdlibReliabilityGate.artifact;
       <p class="section-subhead">{resolvedSubhead}</p>
       {!clinical && (
         <p class="text-[0.78rem] text-[var(--color-text-tertiary)]">
-          {d.gateLabel} {gate.pass} {d.pass} / {gate.fail} {d.fail} / {gate.skip} {d.skip} / {gate.total} {d.total}
+          {d.gateLabel}{' '}
+          {gatePrintable ? reliabilityFace() : reliabilityRefusal()}
           · {d.source} <code class="font-mono text-[0.85em]">{syncedAt}</code>
         </p>
       )}

--- a/website/src/lib/stdlibReliabilityHonesty.ts
+++ b/website/src/lib/stdlibReliabilityHonesty.ts
@@ -1,0 +1,114 @@
+/**
+ * Homepage 251/251 is the twin of the June 6/6.
+ *
+ * The committed artifact is 2026-05-12. `npm run sync:artifacts` on
+ * 2026-08-17 copied it into artifactStatus.ts. That is not a remasure.
+ * The script lives at scripts/stdlib_reliability_gate.sh → scripts/dev/,
+ * not under scripts/ci/, and is not named in .github/. It is outside
+ * the cursor-2 468-gate census. Nobody chose this. There was nowhere
+ * to notice.
+ *
+ * The JSON names `bin/souc` 1.0.0-beta.5 on the science-pipeline arm.
+ * That is not Madaros and not lean_single. Do not invent an engine.
+ * Same rule as pbpk_suite: no engine and no reachability, no numeral.
+ *
+ * This file is the kernel. Do not edit artifactStatus.ts — the next
+ * sync will overwrite it. Every surface that used to print 251/0
+ * must come through here.
+ */
+
+import {
+  REACHABILITY_FACE,
+  isCompilerEngine,
+  isReachability,
+  type CompilerEngine,
+  type Reachability,
+} from './dissertationHonestyNow';
+
+export type ReliabilityMeasure = {
+  gate: string;
+  measuredAt: string;
+  artifact: string;
+  syncAt: string;
+  pass: number;
+  fail: number;
+  skip: number;
+  total: number;
+  /**
+   * Null until a remasure names Madaros or lean_single.
+   * `bin/souc` is a launcher, not an engine.
+   */
+  engine: CompilerEngine | null;
+  reachability: Reachability;
+  namedLauncher: string;
+};
+
+export const STDLIB_RELIABILITY: ReliabilityMeasure = {
+  gate: 'scripts/stdlib_reliability_gate.sh',
+  measuredAt: '2026-05-12T15:38:17Z',
+  artifact: 'artifacts/stdlib/stdlib_reliability_status.v1.json',
+  syncAt: '2026-08-17T02:17:14.465Z',
+  pass: 251,
+  fail: 0,
+  skip: 0,
+  total: 251,
+  engine: null,
+  reachability: 'WORKFLOW-UNREACHABLE',
+  namedLauncher: 'bin/souc 1.0.0-beta.5',
+};
+
+export function reliabilityLedgerCloses(m: ReliabilityMeasure): boolean {
+  return m.pass + m.fail + m.skip === m.total && m.total > 0;
+}
+
+export function reliabilityProvenanceComplete(m: ReliabilityMeasure): boolean {
+  return m.engine !== null && isCompilerEngine(m.engine) && isReachability(m.reachability);
+}
+
+export function reliabilityMayPrint(m: ReliabilityMeasure = STDLIB_RELIABILITY): boolean {
+  return reliabilityLedgerCloses(m) && reliabilityProvenanceComplete(m);
+}
+
+/**
+ * Canonical face. Throws if engine or reachability is missing.
+ * Callers that want a fallback must use reliabilityRefusal().
+ */
+export function reliabilityFace(m: ReliabilityMeasure = STDLIB_RELIABILITY): string {
+  if (!reliabilityMayPrint(m) || m.engine === null) {
+    throw new Error(
+      'stdlibReliabilityHonesty: refuse to print the reliability numeral without reachability and engine',
+    );
+  }
+  return `${m.pass} pass / ${m.total} · ${m.engine} · ${REACHABILITY_FACE[m.reachability]} · artifact ${m.measuredAt} · ${m.artifact}`;
+}
+
+/**
+ * What a surface may show when the numeral is forbidden.
+ * Must not contain pass, fail, or total counts.
+ */
+export function reliabilityRefusal(m: ReliabilityMeasure = STDLIB_RELIABILITY): string {
+  return `stdlib reliability · ${REACHABILITY_FACE[m.reachability]} · artifact ${m.measuredAt.slice(0, 10)} · engine unnamed`;
+}
+
+export function reliabilityShortRefusal(): string {
+  return '—';
+}
+
+/**
+ * True when copy would leak the bound counts (the generated
+ * honestStatus line "251 / 251 stdlib reliability tests pass").
+ */
+export function copyLeaksReliabilityNumeral(text: string): boolean {
+  const { pass, total } = STDLIB_RELIABILITY;
+  const passRe = new RegExp(`\\b${pass}\\b`);
+  const totalRe = new RegExp(`\\b${total}\\b`);
+  return passRe.test(text) && totalRe.test(text);
+}
+
+export function filterReliabilityLeaks<T extends { title: string; detail: string }>(
+  items: readonly T[],
+): T[] {
+  return items.filter(
+    (item) => !copyLeaksReliabilityNumeral(item.title) && !copyLeaksReliabilityNumeral(item.detail),
+  );
+}

--- a/website/src/pages/about/index.astro
+++ b/website/src/pages/about/index.astro
@@ -2,12 +2,13 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getLocaleFromUrl, getLocalizedPath, loadTranslations } from '../../lib/i18n';
 import { publicContract } from '../../data/artifactStatus';
+import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal, reliabilityShortRefusal } from '../../lib/stdlibReliabilityHonesty';
 
 const locale = getLocaleFromUrl(Astro.url);
 const t = await loadTranslations(locale);
 const { metrics, versions } = publicContract;
-const gate = metrics.stdlibReliabilityGate;
 const full = metrics.fullTestSuite;
+const reliabilityOk = reliabilityMayPrint();
 
 const aboutBreadcrumbSchema = {
   "@context": "https://schema.org",
@@ -121,7 +122,7 @@ const aboutBreadcrumbSchema = {
         <ul class="stats-list">
           <li><span class="stat-number">3,224</span><span class="stat-label">commits</span></li>
           <li><span class="stat-number">{metrics.stdlibInventoryFiles ?? "—"}</span><span class="stat-label">stdlib .sio files</span></li>
-          <li><span class="stat-number">{gate.pass}/{gate.total}</span><span class="stat-label">stdlib reliability gate</span></li>
+          <li><span class="stat-number">{reliabilityOk ? reliabilityFace() : reliabilityShortRefusal()}</span><span class="stat-label">{reliabilityOk ? 'stdlib reliability gate' : reliabilityRefusal()}</span></li>
           <li><span class="stat-number">{full ? `${full.pass}/${full.total}` : "—"}</span><span class="stat-label">full suite</span></li>
           <li><span class="stat-number">1,000+</span><span class="stat-label">e-graph rewrite rules</span></li>
           <li><span class="stat-number">86K</span><span class="stat-label">max parameters (O-SSM)</span></li>

--- a/website/src/pages/language.astro
+++ b/website/src/pages/language.astro
@@ -8,12 +8,13 @@ import E219DiagnosticExhibit from '../components/language/E219DiagnosticExhibit.
 import { getLocaleFromUrl, getLocalizedPath, loadTranslations } from '../lib/i18n';
 import { publicContract } from '../data/artifactStatus';
 import HonestStatusSection from '../components/status/HonestStatusSection.astro';
+import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal } from '../lib/stdlibReliabilityHonesty';
 
 const locale = getLocaleFromUrl(Astro.url);
 const t = await loadTranslations(locale);
 const { bootstrap, metrics } = publicContract;
-const gate = metrics.stdlibReliabilityGate;
 const fullSuite = metrics.fullTestSuite;
+const reliabilityShown = reliabilityMayPrint() ? reliabilityFace() : reliabilityRefusal();
 
 const languageBreadcrumbSchema = {
   "@context": "https://schema.org",
@@ -475,7 +476,7 @@ let weight: kg = 78.5
           <div class="glass rounded-[var(--radius-xl)] p-[1.1rem] grid gap-[0.5rem]">
             <h3 class="text-[1rem] font-[680] text-[var(--color-text-primary)]">Test gate snapshot</h3>
             <p class="text-[0.88rem] text-[var(--color-text-secondary)] leading-[1.65]">
-              Stdlib reliability gate: <strong class="text-[var(--color-text-primary)]">{gate.pass} pass / {gate.fail} fail / {gate.skip} skip</strong> across {gate.total} tests.{fullSuite ? ` README full-suite snapshot: ${fullSuite.pass}/${fullSuite.total}.` : ""} See <a href={getLocalizedPath('/proof#test-gate', locale)} class="text-[var(--color-accent-gold-soft)] hover:underline">/proof §4</a>.
+              Stdlib reliability gate: <strong class="text-[var(--color-text-primary)]">{reliabilityShown}</strong>{fullSuite ? ` README full-suite snapshot: ${fullSuite.pass}/${fullSuite.total}.` : ""} See <a href={getLocalizedPath('/proof#test-gate', locale)} class="text-[var(--color-accent-gold-soft)] hover:underline">/proof §4</a>.
             </p>
           </div>
 

--- a/website/src/pages/plan.astro
+++ b/website/src/pages/plan.astro
@@ -1,13 +1,14 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { publicContract } from '../data/artifactStatus';
+import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal } from '../lib/stdlibReliabilityHonesty';
 import { getLocaleFromUrl, getLocalizedPath, loadTranslations } from '../lib/i18n';
 
 const locale = getLocaleFromUrl(Astro.url);
 const t = await loadTranslations(locale);
 const { metrics, versions } = publicContract;
-const stdlibGate = metrics.stdlibReliabilityGate;
 const fullSuite = metrics.fullTestSuite;
+const reliabilityOk = reliabilityMayPrint();
 
 const planBreadcrumbSchema = {
   "@context": "https://schema.org",
@@ -58,8 +59,10 @@ const operatingPlan = [
 const evidenceGates = [
   {
     name: 'Stdlib reliability',
-    value: `${stdlibGate.pass}/${stdlibGate.total}`,
-    detail: 'Current standard-library reliability gate reflected from artifact status.',
+    value: reliabilityOk ? reliabilityFace() : reliabilityRefusal(),
+    detail: reliabilityOk
+      ? 'Current standard-library reliability gate reflected from artifact status.'
+      : 'Artifact names a launcher, not an engine. Sync is not a remasure.',
   },
   {
     name: 'Full suite',

--- a/website/src/pages/proof.astro
+++ b/website/src/pages/proof.astro
@@ -6,6 +6,7 @@ import EpistemicGateExhibit from '../components/proof/EpistemicGateExhibit.astro
 import { getProofData } from '../lib/proofData';
 import { publicContract } from '../data/artifactStatus';
 import { getLocaleFromUrl, loadTranslations, getLocalizedPath } from '../lib/i18n';
+import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal, reliabilityShortRefusal } from '../lib/stdlibReliabilityHonesty';
 
 const locale = getLocaleFromUrl(Astro.url);
 const t = await loadTranslations(locale);
@@ -31,8 +32,9 @@ const proofBreadcrumbSchema = {
 
 const proofHub = getProofData();
 const { bootstrap, metrics } = publicContract;
-const gate = metrics.stdlibReliabilityGate;
 const fullSuite = metrics.fullTestSuite;
+const reliabilityOk = reliabilityMayPrint();
+const reliabilityShown = reliabilityOk ? reliabilityFace() : reliabilityRefusal();
 
 const proofOverviewCards = [
   {
@@ -44,7 +46,7 @@ const proofOverviewCards = [
   },
   {
     title: locale === 'pt' ? 'Fiabilidade stdlib' : 'Stdlib reliability',
-    value: `${proofHub.stdlib.passCount}/${proofHub.stdlib.totalCount}`,
+    value: reliabilityOk ? reliabilityFace() : reliabilityShortRefusal(),
     detail: `${proofHub.stdlib.activeModuleEntrypoints} active entrypoints`,
   },
   {
@@ -406,24 +408,12 @@ typecheck: failed`}</code></pre>
       </div>
 
       <p class="text-[0.95rem] text-[var(--color-text-secondary)] leading-[1.75]">
-        The committed stdlib reliability gate reports <strong class="text-[var(--color-text-primary)]">{gate.pass} pass / {gate.fail} fail / {gate.skip} skip</strong> across {gate.total} gate tests (source: <code class="font-mono text-[0.85em]">{gate.artifact}</code>).{fullSuite ? ` The README full-suite snapshot is ${fullSuite.pass}/${fullSuite.total} tests pass.` : ""} If this page disagrees with README.md or the artifacts, those sources win.
+        The committed stdlib reliability gate reports <strong class="text-[var(--color-text-primary)]">{reliabilityShown}</strong> (source: <code class="font-mono text-[0.85em]">{publicContract.metrics.stdlibReliabilityGate.artifact}</code>).{fullSuite ? ` The README full-suite snapshot is ${fullSuite.pass}/${fullSuite.total} tests pass.` : ""} If this page disagrees with README.md or the artifacts, those sources win.
       </p>
 
-      <pre class="rounded-[var(--radius-lg)] bg-[#1e1e1e] text-[#d4d4d4] text-[0.88rem] font-mono p-[1rem] overflow-x-auto leading-relaxed border border-white/10"><code>{`$ bash scripts/run_sio_test_suite.sh
-
-=== Sounio Test Suite ===
-Using souc: ./bin/souc
-Parallel jobs: 64
-
-Found {gate.total} stdlib reliability gate tests
-
-=== Results ===
-  Pass: {gate.pass}
-  Fail: {gate.fail}
-  Skip: {gate.skip}
-  Total: {gate.total}
-
-All tests passed!`}</code></pre>
+      <pre class="rounded-[var(--radius-lg)] bg-[#1e1e1e] text-[#d4d4d4] text-[0.88rem] font-mono p-[1rem] overflow-x-auto leading-relaxed border border-white/10"><code>{reliabilityOk
+        ? `$ bash scripts/stdlib_reliability_gate.sh\n\n${reliabilityFace()}`
+        : `$ bash scripts/stdlib_reliability_gate.sh\n\n${reliabilityRefusal()}\n# numeral withheld — engine unnamed, not in CI`}</code></pre>
 
       <div class="flex flex-wrap gap-[0.6rem] text-[0.85rem]">
         <a


### PR DESCRIPTION
## Summary

- The homepage / `/language` / `/proof` / `/about` / `/plan` printed **251 pass / 0 fail** as the stdlib reliability gate.
- That number is `artifacts/stdlib/stdlib_reliability_status.v1.json` from **2026-05-12**. `sync:artifacts` on 2026-08-17 copied it. That is not a remasure.
- The script is `scripts/stdlib_reliability_gate.sh` → `scripts/dev/`. It is not under `scripts/ci/`, not named in `.github/`, and outside the cursor-2 468-gate census.
- The JSON names `bin/souc` 1.0.0-beta.5 on the science-pipeline arm. That is a launcher, not Madaros or lean_single. **Do not invent an engine.**

Same rule as `#1864` / `pbpk_suite`: no engine and no reachability, no numeral.

`reliabilityFace()` throws. Surfaces show:

`stdlib reliability · not in CI · artifact 2026-05-12 · engine unnamed`

The refusal string does not contain 251. The generated `honestStatus` line that leaked `251 / 251` is filtered out. `artifactStatus.ts` is not edited — the next sync would overwrite it.

## Test plan

- [x] `npm run check:astro` — 0 errors
- [x] `npm run check:i18n`
- [x] `npm run check:routes`
- [ ] Do **not** run `npm run build` / `check:quality` locally
- [ ] Website + Contracts (Contracts is a real signal after `#1843`)