### PR TITLE
feat(website): withhold the March 13/13 GPU numeral without an engine

### DIFF
--- a/website/src/components/home/ProofStrip.astro
+++ b/website/src/components/home/ProofStrip.astro
@@ -1,6 +1,7 @@
 ---
 import { getLocalizedPath, type Locale } from '../../lib/i18n';
 import { getProofData } from '../../lib/proofData';
+import { gpuFace, gpuMayPrint, gpuRefusal, gpuShortRefusal } from '../../lib/gpuPublicHonesty';
 
 interface Props {
   locale: Locale;
@@ -21,9 +22,11 @@ const items = [
     detail: `${proof.stdlib.activeModuleEntrypoints} active module entrypoints`,
   },
   {
-    value: `${proof.gpu.publicPassCount}/${proof.gpu.publicCheckCount}`,
+    value: gpuMayPrint() ? gpuFace() : gpuShortRefusal(),
     label: 'public GPU contract checks passing',
-    detail: `${proof.gpu.attestedTargetCount} attested binary targets`,
+    detail: gpuMayPrint()
+      ? `${proof.gpu.attestedTargetCount} attested binary targets`
+      : gpuRefusal(),
   },
   {
     value: `${proof.stdlib.hyperPassCount}/${proof.stdlib.hyperTotalCount}`,

--- a/website/src/lib/dissertationHonestyNow.ts
+++ b/website/src/lib/dissertationHonestyNow.ts
@@ -28,6 +28,8 @@
  * PEND is its own category. It is not a pass. Hiding it would make
  * 19 + 33 look like 53.
  * Do not treat #1874 (wire two leftover greens) as current main.
+ * Reachability and engine live in measurementClaim.ts — this file
+ * is the pbpk_suite instance, not a second kernel.
  */
 
 export const MS_HOUR = 3_600_000;
@@ -38,25 +40,45 @@ export type FailFamily = {
   id: 'toolchain' | 'resource-ceiling' | 'science';
 };
 
-/**
- * Machine label from the cursor-2 reachability census.
- * Face is `not in CI`. Do not print `manual-by-design` — that sounds
- * like a choice. Nobody chose this. The chain is dead.
- */
-export const REACHABILITIES = ['WORKFLOW-UNREACHABLE'] as const;
-export type Reachability = (typeof REACHABILITIES)[number];
+import {
+  COMPILER_ENGINES,
+  REACHABILITIES,
+  isCompilerEngine,
+  isReachability,
+  reachabilityComplete,
+  reachabilityFace,
+  type CompilerEngine,
+  type Reachability,
+  type ReachabilityBinding,
+} from './measurementClaim';
 
+export {
+  COMPILER_ENGINES,
+  REACHABILITIES,
+  isCompilerEngine,
+  isReachability,
+  reachabilityFace,
+};
+export type { CompilerEngine, Reachability };
+
+/**
+ * Face of a reachability binding. `not in CI` is the unreachable
+ * gloss. A reachable claim must carry the workflow line or it is
+ * incomplete — a label that can only say "no" is a constant.
+ */
+export function REACHABILITY_FACE_OF(b: ReachabilityBinding): string {
+  return reachabilityFace(b);
+}
+
+/** @deprecated use reachabilityFace — kept so existing gloss sites compile */
 export const REACHABILITY_FACE = {
   'WORKFLOW-UNREACHABLE': 'not in CI',
+  'WORKFLOW-REACHABLE': 'in CI',
 } as const;
-
-export const COMPILER_ENGINES = ['Madaros', 'lean_single'] as const;
-export type CompilerEngine = (typeof COMPILER_ENGINES)[number];
 
 export type MeasureProvenance = {
   engine: CompilerEngine;
-  reachability: Reachability;
-};
+} & ReachabilityBinding;
 
 export type SuiteMeasure = {
   gate: string;
@@ -68,6 +90,8 @@ export type SuiteMeasure = {
   pr: number;
   engine: CompilerEngine;
   reachability: Reachability;
+  workflow?: string;
+  line?: number;
   registered: number;
   pass: number;
   fail: number;
@@ -82,6 +106,8 @@ export type SuiteMeasure = {
     sourceSha: string;
     engine: CompilerEngine;
     reachability: Reachability;
+    workflow?: string;
+    line?: number;
     pass: number;
     fail: number;
     pend: number;
@@ -134,16 +160,28 @@ export function ledgerCloses(m: SuiteMeasure): boolean {
   return outcomesSum(m) === m.registered && familiesSum(m) === m.fail;
 }
 
-export function isCompilerEngine(value: string): value is CompilerEngine {
-  return (COMPILER_ENGINES as readonly string[]).includes(value);
+export function bindingOf(m: {
+  reachability: Reachability;
+  workflow?: string;
+  line?: number;
+}): ReachabilityBinding {
+  if (m.reachability === 'WORKFLOW-REACHABLE') {
+    return {
+      reachability: 'WORKFLOW-REACHABLE',
+      workflow: m.workflow ?? '',
+      line: m.line ?? 0,
+    };
+  }
+  return { reachability: 'WORKFLOW-UNREACHABLE' };
 }
 
-export function isReachability(value: string): value is Reachability {
-  return (REACHABILITIES as readonly string[]).includes(value);
-}
-
-export function provenanceComplete(m: MeasureProvenance): boolean {
-  return isCompilerEngine(m.engine) && isReachability(m.reachability);
+export function provenanceComplete(m: {
+  engine: string;
+  reachability: Reachability;
+  workflow?: string;
+  line?: number;
+}): boolean {
+  return isCompilerEngine(m.engine) && reachabilityComplete(bindingOf(m));
 }
 
 export function measureMayPrint(m: SuiteMeasure): boolean {
@@ -185,7 +223,7 @@ export function suiteFaceParts(m: SuiteMeasure): SuiteFaceParts {
     );
   }
   const numeral = `${m.fail} FAIL / ${m.registered}`;
-  const gloss = `${m.engine} · ${REACHABILITY_FACE[m.reachability]} · operator remeasure ${m.measuredAt} · #${m.pr}`;
+  const gloss = `${m.engine} · ${reachabilityFace(bindingOf(m))} · operator remeasure ${m.measuredAt} · #${m.pr}`;
   return { numeral, gloss, face: `${numeral} · ${gloss}` };
 }
 
@@ -199,7 +237,7 @@ export function priorFace(m: SuiteMeasure): string {
       'dissertationHonestyNow: refuse to print the prior pbpk_suite numeral without reachability and engine',
     );
   }
-  return `${m.prior.fail} FAIL / ${m.prior.pass} PASS / ${m.prior.pend} PEND · ${m.prior.engine} · ${REACHABILITY_FACE[m.prior.reachability]} · ${m.prior.measuredOn} · job ${m.prior.job}`;
+  return `${m.prior.fail} FAIL / ${m.prior.pass} PASS / ${m.prior.pend} PEND · ${m.prior.engine} · ${reachabilityFace(bindingOf(m.prior))} · ${m.prior.measuredOn} · job ${m.prior.job}`;
 }
 
 if (!measureMayPrint(PBPK_SUITE_NOW)) {

--- a/website/src/lib/gpuPublicHonesty.ts
+++ b/website/src/lib/gpuPublicHonesty.ts
@@ -1,0 +1,56 @@
+/**
+ * U2 — GPU public contract 13/13. March 2026. Never in CI.
+ *
+ * This is the same class as the June 6/6 and the May 251/251: a green
+ * count that survived because nobody ran it. The artifact names
+ * `souc-linux-x86_64-gpu` / `souc 1.0.0-beta.4`. That is a launcher,
+ * not Madaros or lean_single. Do not invent an engine.
+ *
+ * Instance of MeasurementClaim, not a third kernel.
+ */
+
+import {
+  claimFace,
+  claimMayPrint,
+  claimRefusal,
+  type MeasurementClaim,
+} from './measurementClaim';
+
+export const GPU_PUBLIC: MeasurementClaim = {
+  id: 'gpu-public-contract',
+  kind: 'green-count',
+  gate: null,
+  engine: null,
+  reachability: 'WORKFLOW-UNREACHABLE',
+  measuredAt: '2026-03-09T21:56:35Z',
+  artifact: 'artifacts/omega/gpu_public_contract.v1.json',
+  parts: { pass: 13, total: 13, notPublic: 3 },
+};
+
+export function gpuPartsClose(c: MeasurementClaim): boolean {
+  return c.parts.pass === c.parts.total && c.parts.total === 13 && c.parts.notPublic === 3;
+}
+
+export function gpuMayPrint(): boolean {
+  return claimMayPrint(GPU_PUBLIC, gpuPartsClose);
+}
+
+export function gpuFace(): string {
+  return claimFace(
+    GPU_PUBLIC,
+    gpuPartsClose,
+    `${GPU_PUBLIC.parts.pass} pass / ${GPU_PUBLIC.parts.total}`,
+  );
+}
+
+export function gpuRefusal(): string {
+  return claimRefusal(GPU_PUBLIC, 'GPU public contract');
+}
+
+export function gpuShortRefusal(): string {
+  return '—';
+}
+
+export function copyLeaksGpuNumeral(text: string): boolean {
+  return /\b13\s*\/\s*13\b/.test(text);
+}

--- a/website/src/lib/measurementClaim.ts
+++ b/website/src/lib/measurementClaim.ts
@@ -1,0 +1,91 @@
+/**
+ * One claim type for every numeral the site is allowed to print.
+ *
+ * suiteFaceParts is the pbpk_suite instance. The GPU 13/13 is another.
+ * A third one-off kernel would be the same class as an undated 6/6:
+ * a new place that looks protected and is not.
+ *
+ * A claim may not print unless three things close: the parts sum,
+ * the engine is named (Madaros or lean_single), and reachability is
+ * complete. Reachability that can only say "no" is a constant, not
+ * a label. WORKFLOW-REACHABLE therefore requires the workflow file
+ * and the line that invokes the gate. Without that pair, a 13/13
+ * that enters CI tomorrow would keep saying "not in CI".
+ *
+ * `bin/souc` and `souc-linux-x86_64-gpu` are launchers, not engines.
+ * Do not invent Madaros or lean_single from a path.
+ */
+
+export const COMPILER_ENGINES = ['Madaros', 'lean_single'] as const;
+export type CompilerEngine = (typeof COMPILER_ENGINES)[number];
+
+export const REACHABILITIES = ['WORKFLOW-UNREACHABLE', 'WORKFLOW-REACHABLE'] as const;
+export type Reachability = (typeof REACHABILITIES)[number];
+
+export type ReachabilityBinding =
+  | { reachability: 'WORKFLOW-UNREACHABLE' }
+  | { reachability: 'WORKFLOW-REACHABLE'; workflow: string; line: number };
+
+export type ClaimKind = 'outcome' | 'variance' | 'green-count' | 'inventory';
+
+export type MeasurementClaim = ReachabilityBinding & {
+  id: string;
+  kind: ClaimKind;
+  gate: string | null;
+  engine: CompilerEngine | null;
+  measuredAt: string;
+  artifact: string;
+  parts: Record<string, number>;
+};
+
+export function isCompilerEngine(value: string): value is CompilerEngine {
+  return (COMPILER_ENGINES as readonly string[]).includes(value);
+}
+
+export function isReachability(value: string): value is Reachability {
+  return (REACHABILITIES as readonly string[]).includes(value);
+}
+
+export function reachabilityComplete(b: ReachabilityBinding): boolean {
+  if (b.reachability === 'WORKFLOW-UNREACHABLE') return true;
+  return (
+    b.reachability === 'WORKFLOW-REACHABLE' &&
+    typeof b.workflow === 'string' &&
+    b.workflow.endsWith('.yml') &&
+    Number.isInteger(b.line) &&
+    b.line > 0
+  );
+}
+
+export function reachabilityFace(b: ReachabilityBinding): string {
+  if (b.reachability === 'WORKFLOW-UNREACHABLE') return 'not in CI';
+  return `in CI · ${b.workflow}:${b.line}`;
+}
+
+export function claimEngineOk(c: MeasurementClaim): boolean {
+  return c.engine !== null && isCompilerEngine(c.engine);
+}
+
+export function claimMayPrint(
+  c: MeasurementClaim,
+  partsClose: (claim: MeasurementClaim) => boolean,
+): boolean {
+  return partsClose(c) && claimEngineOk(c) && reachabilityComplete(c);
+}
+
+export function claimFace(
+  c: MeasurementClaim,
+  partsClose: (claim: MeasurementClaim) => boolean,
+  numeral: string,
+): string {
+  if (!claimMayPrint(c, partsClose) || c.engine === null) {
+    throw new Error(
+      `measurementClaim: refuse to print ${c.id} without reachability and engine`,
+    );
+  }
+  return `${numeral} · ${c.engine} · ${reachabilityFace(c)} · artifact ${c.measuredAt} · ${c.artifact}`;
+}
+
+export function claimRefusal(c: MeasurementClaim, noun: string): string {
+  return `${noun} · ${reachabilityFace(c)} · artifact ${c.measuredAt.slice(0, 10)} · engine unnamed`;
+}

--- a/website/src/pages/language.astro
+++ b/website/src/pages/language.astro
@@ -8,6 +8,7 @@ import E219DiagnosticExhibit from '../components/language/E219DiagnosticExhibit.
 import { getLocaleFromUrl, getLocalizedPath, loadTranslations } from '../lib/i18n';
 import { publicContract } from '../data/artifactStatus';
 import HonestStatusSection from '../components/status/HonestStatusSection.astro';
+import { gpuFace, gpuMayPrint, gpuRefusal } from '../lib/gpuPublicHonesty';
 
 const locale = getLocaleFromUrl(Astro.url);
 const t = await loadTranslations(locale);
@@ -465,7 +466,7 @@ let weight: kg = 78.5
               Kernel syntax is integrated into the language — a Sounio function annotated
               <code class="font-mono text-[0.85em] bg-[rgba(255,255,255,0.07)] px-[0.3em] rounded">with GPU</code> compiles to PTX via a backend bridge.
               The world's first GUM uncertainty propagation through a GPU WMMA kernel
-              is verified in <code class="font-mono text-[0.85em] bg-[rgba(255,255,255,0.07)] px-[0.3em] rounded">tests/stdlib/gpu/</code> (13/13 gate PASS on CUDA hardware).
+              is verified in <code class="font-mono text-[0.85em] bg-[rgba(255,255,255,0.07)] px-[0.3em] rounded">tests/stdlib/gpu/</code> ({gpuMayPrint() ? gpuFace() : gpuRefusal()}).
               The end-to-end driver path requires a CUDA-capable host —
               <code class="font-mono text-[0.85em] bg-[rgba(255,255,255,0.07)] px-[0.3em] rounded">gpu/lib.sio</code> is currently an empty stub.
             </p>

--- a/website/src/pages/proof.astro
+++ b/website/src/pages/proof.astro
@@ -6,6 +6,7 @@ import EpistemicGateExhibit from '../components/proof/EpistemicGateExhibit.astro
 import { getProofData } from '../lib/proofData';
 import { publicContract } from '../data/artifactStatus';
 import { getLocaleFromUrl, loadTranslations, getLocalizedPath } from '../lib/i18n';
+import { gpuFace, gpuMayPrint, gpuRefusal, gpuShortRefusal } from '../lib/gpuPublicHonesty';
 
 const locale = getLocaleFromUrl(Astro.url);
 const t = await loadTranslations(locale);
@@ -54,8 +55,10 @@ const proofOverviewCards = [
   },
   {
     title: locale === 'pt' ? 'Contrato GPU público' : 'GPU public contract',
-    value: `${proofHub.gpu.publicPassCount}/${proofHub.gpu.publicCheckCount}`,
-    detail: `${proofHub.gpu.attestedTargetCount} attested binary targets`,
+    value: gpuMayPrint() ? gpuFace() : gpuShortRefusal(),
+    detail: gpuMayPrint()
+      ? `${proofHub.gpu.attestedTargetCount} attested binary targets`
+      : gpuRefusal(),
   },
 ];
 


### PR DESCRIPTION
## Summary

- The March **13/13** GPU public contract is the same class as the June 6/6: green, never in CI, more readers than `/honesty`.
- Artifact `artifacts/omega/gpu_public_contract.v1.json` dated **2026-03-09**. Profile names `souc-linux-x86_64-gpu` / `souc 1.0.0-beta.4`. That is a launcher, not Madaros or lean_single. Do not invent an engine.
- New kernel `website/src/lib/measurementClaim.ts`. `suiteFaceParts` is the pbpk_suite instance. The GPU claim is another instance, not a third one-off.
- Reachability now has two values. `WORKFLOW-REACHABLE` is incomplete without `workflow` + `line`. A label that can only say `not in CI` is a constant; a 13/13 that enters CI tomorrow must not keep that gloss.

Surfaces (`/language`, `/proof`, ProofStrip) show:

`GPU public contract · not in CI · artifact 2026-03-09 · engine unnamed`

`gpuFace()` / `claimFace()` throw. The refusal does not contain 13. Archive `GPUProofSection.astro` is untouched.

Does not close U1 (251/251) — that is `#1888`. Does not touch the leftover dissertation GUM/Hessian claims.

## Test plan

- [x] `npm run check:astro` — 0 errors
- [x] `npm run check:i18n`
- [x] `npm run check:routes`
- [ ] Do **not** run `npm run build` / `check:quality` locally
- [ ] Website + Contracts (real signal after `#1843`)