### PR TITLE
ci(lean): name the kvalue-Nat consume step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -740,6 +740,12 @@ jobs:
       # is mention, not use.
       - name: V2 measure-Nat consumer (V1 mutant must fail first)
         run: bash scripts/ci/epistemic_measure_correspondence_gate.sh --lean-consume
+      # Same ritual as measure-Nat: mutant must fail before the consumer
+      # is scored. A green Lean Proofs job whose this step is skipped is
+      # the 390-gate class. Written as the acceptance criterion before
+      # the step is scored.
+      - name: V2 kvalue-Nat consumer (V1 mutant must fail first)
+        run: bash scripts/ci/epistemic_measure_correspondence_gate.sh --lean-consume-kvalue
       - name: Build all default-target proof modules
         run: |
           cd formal/lean4

--- a/docs/audit/epistemic_calculus_spec_divergence/DISPATCH.md
+++ b/docs/audit/epistemic_calculus_spec_divergence/DISPATCH.md
@@ -227,25 +227,29 @@ of the same defect round 1 caught on the *write* side.
 
 **Landed (consumer 2).** `EpistemicEffectsV2_kvalue_nat.lean` cites
 `preservation` and proves `kvalue_nat_reduct_stays_nat`. The
-`--lean-consume` arm (and `--lean-consume-kvalue`) builds that module
-only after `v1_imports_kvalue_nat.lean` fails.
+`--lean-consume-kvalue` arm builds that module only after
+`v1_imports_kvalue_nat.lean` fails. `--lean-consume` stays the
+measure-Nat pair only — one named step, one pair.
 
-**Acceptance for consumer 2 (written before the consumer is scored).**
-A green Lean Proofs *job* is not evidence. The consume step must appear
-`success` and not `skipped` on the PR head. Because
-`.github/workflows/ci.yml` is under an active foreign claim, this
-round extends the existing step `V2 measure-Nat consumer (V1 mutant
-must fail first)` rather than adding a second named step. That step's
-log on the PR head must contain both:
+**Acceptance for the named kvalue step (written before the step is
+scored).** A green Lean Proofs *job* is not evidence. The PR head must
+show this step as `success` and not `skipped`:
+
+```
+success  V2 kvalue-Nat consumer (V1 mutant must fail first)
+```
+
+and that step's log must contain:
 
 ```
 POSITIVE_CONTROL_FIRED: v1_imports_kvalue_nat rejected
 V2_CONSUMED: EpistemicEffectsV2_kvalue_nat built
 ```
 
-A dedicated step name (`V2 kvalue-Nat consumer (V1 mutant must fail
-first)`) is the next `ci.yml` hunk, not a substitute for those lines.
-If the kvalue mutant elaborates, the consumer must not be added.
+A job whose this step is skipped is the 390-gate class. The #1883
+verification (kvalue lines inside the measure-Nat step) does not
+transfer: that head did not have this step. If the kvalue mutant
+elaborates, the consumer must not be scored.
 
 **Deferred — extract the shared spine.** A third module holding `Effect`, `Ty`,
 `EffectSet`, `TyCtx` would stop V2 from being a *client* of the refuted file.

--- a/scripts/ci/epistemic_measure_correspondence_gate.sh
+++ b/scripts/ci/epistemic_measure_correspondence_gate.sh
@@ -261,17 +261,8 @@ if [[ "$LEAN_CONSUME" -eq 1 ]]; then
     TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
     record_failure "v1_mutant_missing:$V1_MUTANT"
   fi
-  if [[ ! -f "$KVALUE_CONSUMER_SOURCE" ]]; then
-    TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
-    record_failure "kvalue_consumer_source_missing:$KVALUE_CONSUMER_SOURCE"
-  fi
-  if [[ ! -f "$KVALUE_V1_MUTANT" ]]; then
-    TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
-    record_failure "kvalue_v1_mutant_missing:$KVALUE_V1_MUTANT"
-  fi
   if [[ "$NOT_RUN" -eq 0 ]]; then
     run_lean_consume
-    run_lean_consume_kvalue
   fi
 fi
 


### PR DESCRIPTION
## Summary

- Adds the Lean Proofs step `V2 kvalue-Nat consumer (V1 mutant must fail first)`.
- `--lean-consume` is the measure-Nat pair only again. One named step, one pair.
- `.github/workflows/*` marks `full`, so Lean Proofs is selected. A docs-only PR would skip this step and that would be the 390-gate class.

## Acceptance (written before this step is scored)

A green Lean Proofs *job* is not evidence. This head must show:

```
success  V2 kvalue-Nat consumer (V1 mutant must fail first)
```

not skipped, and that step's log must contain:

```
POSITIVE_CONTROL_FIRED: v1_imports_kvalue_nat rejected
V2_CONSUMED: EpistemicEffectsV2_kvalue_nat built
```

The #1883 verification (kvalue lines inside the measure-Nat step) does not transfer. That head did not have this step.

## Test plan

- [x] `--lean-consume` local: measure pair only, mutant first, `status=pass total=21`
- [x] `--lean-consume-kvalue` local: kvalue mutant fails (`lit_real` vs `lit_nat`), then consumer builds
- [ ] CI Lean Proofs: the *named* kvalue step is `success`, not `skipped`