### PR TITLE
fix(ci): leftover instrument — scan-list is not an invoke

### DIFF
--- a/scripts/dev/ci_gate_workflow_reachability.py
+++ b/scripts/dev/ci_gate_workflow_reachability.py
@@ -50,8 +50,13 @@ YAML_RUN_RE = re.compile(
     """
 )
 
-# for-loop bodies list paths on their own continuation lines, then
-# `bash "$g"`. A listed *_gate.sh on a non-comment line is an invoke.
+# YAML `run:` blocks sometimes list gate paths on their own continuation
+# lines, then `bash "$g"`. A listed *_gate.sh on a non-comment YAML line
+# is an invoke. Do NOT apply this to .sh files: scan-lists (sigpipe
+# hygiene SHAPE_BAN_* arrays, gate_vacuity `git ls-files`) name gates
+# without executing them. Treating those as invokes made
+# mli_s3_bit_identity_gate.sh look workflow-reachable and REFUTE'd the
+# leftover instrument after #1880. Pass-2 already drew this line.
 BARE_GATE_RE = re.compile(
     r"(?P<path>scripts/(?:ci|dev)/[A-Za-z0-9_./-]+_gate\.sh)"
 )
@@ -103,13 +108,18 @@ def is_comment_line(path: Path, line: str) -> bool:
 
 def extract_invokes(path: Path, text: str) -> set[str]:
     found: set[str] = set()
+    scanners = [INVOKE_RE, YAML_RUN_RE]
+    # Bare gate paths are invoke only in workflow YAML. In .sh they are
+    # almost always a scan-list or a comment-adjacent inventory.
+    if path.suffix in {".yml", ".yaml"}:
+        scanners.append(BARE_GATE_RE)
     for i, line in enumerate(text.splitlines(), 1):
         if is_comment_line(path, line):
             continue
         if any(m in line for m in INVENTORY_MARKERS) and "_gate.sh" in line:
             # Listing gates is not running them (gate_vacuity_gate.sh).
             continue
-        for rx in (INVOKE_RE, YAML_RUN_RE, BARE_GATE_RE):
+        for rx in scanners:
             for m in rx.finditer(line):
                 found.add(m.group("path"))
     return found
@@ -339,6 +349,20 @@ def main() -> int:
         )
         return 2
 
+    # #1880: these two are in Contracts. If they drop out of the invoke
+    # graph, the leftover census is lying the other way.
+    wired_must_reach = (
+        "dissertation_confidence_gate_gate.sh",
+        "dissertation_frontend_parity_gate.sh",
+    )
+    missing_wired = [n for n in wired_must_reach if n not in reach_names]
+    if missing_wired:
+        print(
+            f"REFUTE: #1880 wires missing from invoke graph: {missing_wired}",
+            file=sys.stderr,
+        )
+        return 2
+
     leftover = len(gates) - n_reach
     summary = {
         "gates_total": len(gates),
@@ -357,6 +381,11 @@ def main() -> int:
             "reachable_nonzero": n_reach > 0,
             "named_orphans_still_unreachable": all(
                 o not in reach_names for o in NAMED_DIRECT_ORPHANS
+            ),
+            "scan_list_not_invoke_mli_s3": "mli_s3_bit_identity_gate.sh"
+            not in reach_names,
+            "dissertation_1880_wires_reachable": all(
+                n in reach_names for n in wired_must_reach
             ),
         },
         "tsv": "",


### PR DESCRIPTION
## Why

After #1880 the leftover instrument exited 2 on `origin/main`: it reported `mli_s3_bit_identity_gate.sh` as workflow-reachable while that name is still a leftover control. The edge was a **scan-list**, not a call. `sigpipe_hygiene_gate.sh` (which *is* in Contracts) names ten `*_gate.sh` files in `SHAPE_BAN_*` arrays and greps them; it never `bash`es them.

That is the same class as treating `gate_vacuity_gate.sh`'s `git ls-files` as invoke: a green leftover count that did not mean the surface ran.

## What changes

`scripts/dev/ci_gate_workflow_reachability.py`: apply `BARE_GATE_RE` only to workflow YAML. `.sh` files keep `bash`/`source`/`run:` matching only.

Does **not** rewrite the 2026-08-18 census TSV (that is a SHA snapshot). Does **not** wire mli_s3 or the four remaining red dissertation leftovers.

## Controls on this tree (`c240e848bf` + this patch)

| Control | Result |
|---|---|
| Instrument rc | **0** (was 2) |
| `dissertation_confidence_gate_gate.sh` reachable | yes (#1880) |
| `dissertation_frontend_parity_gate.sh` reachable | yes (#1880) |
| dissertation leftover | dossier, hessian, pbpk28, suite (the four reds) |
| `mli_s3_bit_identity_gate.sh` leftover | yes (scan-list, not invoke) |
| named orphans still unreachable | all six |
| `sigpipe_hygiene` extract_invokes | empty |

Reachable 91 / leftover 380 on this SHA. The 25-under-umbrella number from `CI_GATE_UMBRELLA_CLOSURE_2026-08-18.tsv` is unchanged: that walk started at the umbrella, not at sigpipe.

## #1865

Pass-2 is a measurement on `64924d371a` ("6/6 never a CI signal"). That sentence is true **of that SHA**. As of `12ebda238d` (#1880) two of the six are in Contracts. Do not merge #1865 as a statement about current main without that date bound.

## Test plan

- [x] `python3 scripts/dev/ci_gate_workflow_reachability.py` exits 0
- [x] #1880 wires present; four red dissertation leftovers absent
- [x] mli_s3 not in invoke graph
- [ ] Contracts / CI Decision (docs+script only)