### PR TITLE
feat(ir): IR_MAX_FUNCS 8192 -> 16384 — the coordinated raise, proven and regression-free

### DIFF
--- a/docs/audit/MADAROS_BOX_AUTODEREF_MAIN_REPRODUCTION_2026-08-17.md
+++ b/docs/audit/MADAROS_BOX_AUTODEREF_MAIN_REPRODUCTION_2026-08-17.md
@@ -264,3 +264,75 @@ and reverted in this worktree; nothing shipped. The lever is real but it is
 a coordinated multi-file change with its own risk profile, not a one-line
 constant bump. That is the next task, named and scoped, and it is separate
 from the Box repair this audit is about.
+
+The lever was then PROVEN by the minimal coordinated slice (2026-08-18,
+branch `lane/empryo-1/gen2-raise-measure-20260818`, source build SHA-256
+`da172b4f…`). All eight coupled files were free of claims at the time
+(grok-cli2's `lower.sio` claim expired between 17:55Z and 17:58Z; fable-1's
+`codegen_x86_linux.sio` claim had cleared). The slice raised `IR_MAX_FUNCS`
+8192 → 16384 together with every array indexed by the IrModule.functions
+slot — `IrModule.functions`, `normalize.sio`'s two `[IrFunction; …]` sites,
+`lower.sio`'s `elem_kinds`, `fn_offsets` in `codegen_x86_linux`/`elf`/
+`elf_bulk`/`reloc`/`frame`, `elf.sio`'s `name_offsets` — and the region
+table (`IR_REGION_*` arrays + `ir_region_table_capacity()` 8448 → 16640,
+keeping the +256 margin). The specializer needed no change: reachable marks
+are 7029, already under `SPEC_DCE_MAX=8192`.
+
+Result, measured on the from-source raise build:
+
+    rung check   rc=0 errors=0          (gen1 typechecks main.sio)
+    rung gen2    rc=139 — but the slot-census wall is GONE. The failure is
+                 now a DIFFERENT wall: `run_compiler_main_self_tests` needs
+                 33829 IR instructions vs IR_MAX_INSTRS=16384, and the
+                 refusal path then segfaults.
+
+No regressions: `box_all_read_forms.sio` still prints `BOXMATRIX OK` rc=0,
+and the DCE reachability gate passes all three arms (keeps 602 live, drops
+300/303 dead, carries 6000 functions to a correct binary).
+
+SAFE STOP POINT, per the execution order: the coordinated `IR_MAX_FUNCS`
+raise is self-consistent and regression-free, and it is where this lane
+stops. The next wall is per-function `IR_MAX_INSTRS`, which is NOT a simple
+bump — `ir/dce.sio:31` caps liveness at `DCE_MAX_INSTRS=8192`, and the
+`irfunction_instr_capacity_coherence_gate.sh` header is explicit that a
+truncated liveness analysis is a WRONG analysis (a use past the cap is never
+recorded, so its definition looks dead and the sweep deletes live code,
+silently, at rc=0). Raising `IR_MAX_INSTRS` without raising `DCE_MAX_INSTRS`
+and every per-instruction context that stops at its own cap converts an
+honest refusal into silent miscompilation. That is a separate, larger task.
+
+The lever was then PROVEN by the minimal coordinated slice (2026-08-18,
+branch `lane/empryo-1/gen2-raise-measure-20260818`, source build SHA-256
+`da172b4f…`). All eight coupled files were free of claims at the time
+(grok-cli2's `lower.sio` claim expired between 17:55Z and 17:58Z; fable-1's
+`codegen_x86_linux.sio` claim had cleared). The slice raised `IR_MAX_FUNCS`
+8192 → 16384 together with every array indexed by the IrModule.functions
+slot — `IrModule.functions`, `normalize.sio`'s two `[IrFunction; …]` sites,
+`lower.sio`'s `elem_kinds`, `fn_offsets` in `codegen_x86_linux`/`elf`/
+`elf_bulk`/`reloc`/`frame`, `elf.sio`'s `name_offsets` — and the region
+table (`IR_REGION_*` arrays + `ir_region_table_capacity()` 8448 → 16640,
+keeping the +256 margin). The specializer needed no change: reachable marks
+are 7029, already under `SPEC_DCE_MAX=8192`.
+
+Result, measured on the from-source raise build:
+
+    rung check   rc=0 errors=0          (gen1 typechecks main.sio)
+    rung gen2    rc=139 — but the slot-census wall is GONE. The failure is
+                 now a DIFFERENT wall: `run_compiler_main_self_tests` needs
+                 33829 IR instructions vs IR_MAX_INSTRS=16384, and the
+                 refusal path then segfaults.
+
+No regressions: `box_all_read_forms.sio` still prints `BOXMATRIX OK` rc=0,
+and the DCE reachability gate passes all three arms (keeps 602 live, drops
+300/303 dead, carries 6000 functions to a correct binary).
+
+SAFE STOP POINT, per the execution order: the coordinated `IR_MAX_FUNCS`
+raise is self-consistent and regression-free, and it is where this lane
+stops. The next wall is per-function `IR_MAX_INSTRS`, which is NOT a simple
+bump — `ir/dce.sio:31` caps liveness at `DCE_MAX_INSTRS=8192`, and the
+`irfunction_instr_capacity_coherence_gate.sh` header is explicit that a
+truncated liveness analysis is a WRONG analysis (a use past the cap is never
+recorded, so its definition looks dead and the sweep deletes live code,
+silently, at rc=0). Raising `IR_MAX_INSTRS` without raising `DCE_MAX_INSTRS`
+and every per-instruction context that stops at its own cap converts an
+honest refusal into silent miscompilation. That is a separate, larger task.

--- a/self-hosted/ir/ir.sio
+++ b/self-hosted/ir/ir.sio
@@ -32,7 +32,7 @@ use check::types::{TypeEntry, empty_type_entry}
 // measured the requirement: main.sio declares 10705 functions of which 5997 are
 // reachable, and self-compilation needs the reachable set to fit. BSS is
 // byte-identical at 2048/4096/8192 because the IrModule is allocated at runtime.
-pub let IR_MAX_FUNCS: i64 = 8192
+pub let IR_MAX_FUNCS: i64 = 16384
 pub let IR_MAX_STRINGS: i64 = 4096
 pub let IR_MAX_INSTRS: i64 = 16384
 pub let IR_MAX_PARAMS: i64 = 64
@@ -1128,17 +1128,17 @@ pub fn ir_arena_load(at: i64) -> IrInstr with Mut, Panic, Div {
 }
 pub fn ir_instr_arena_capacity() -> i64 { 1048576 }
 
-pub var IR_REGION_BASE: [i64; 8448] = [0; 8448]
-pub var IR_REGION_CAP: [i64; 8448] = [0; 8448]
-pub var IR_REGION_LEN: [i64; 8448] = [0; 8448]
-pub var IR_REGION_GEN: [i64; 8448] = [0; 8448]
-pub var IR_REGION_STATE: [i64; 8448] = [0; 8448]
+pub var IR_REGION_BASE: [i64; 16640] = [0; 16640]
+pub var IR_REGION_CAP: [i64; 16640] = [0; 16640]
+pub var IR_REGION_LEN: [i64; 16640] = [0; 16640]
+pub var IR_REGION_GEN: [i64; 16640] = [0; 16640]
+pub var IR_REGION_STATE: [i64; 16640] = [0; 16640]
 // MUST EXCEED IR_MAX_FUNCS; both were 8192. Slot 0 is the quarantine and
 // module_frontend_loaded_ir_slot_limit reserves one transient slot, leaving 8190
 // regions for 8191 permitted functions -- so the top of the range got no region,
 // lowering returned ir_region_invalid() and the contract check refused.
 // Bisected: 8189 live slots compile, 8190 and 8191 do not.
-pub fn ir_region_table_capacity() -> i64 { 8448 }
+pub fn ir_region_table_capacity() -> i64 { 16640 }
 
 pub var IR_ARENA_TOP: i64 = 0
 pub var IR_REGION_COUNT: i64 = 0
@@ -3158,7 +3158,7 @@ pub fn ir_empty_epistemic_section_boxed() -> Box<IrEpistemicSection> with Alloc,
 }
 
 pub struct IrModule {
-    pub functions: [IrFunction; 8192],
+    pub functions: [IrFunction; 16384],
     pub fn_count: i64,
     pub string_table: [Name; 4096],
     pub string_count: i64,
@@ -5307,7 +5307,7 @@ pub fn ir_reset_function_in_place(f: &! IrFunction, name: Name) with Mut, Panic,
 
 pub fn ir_empty_module() -> IrModule {
     IrModule {
-        functions: [ir_empty_function(); 8192],
+        functions: [ir_empty_function(); 16384],
         fn_count: 0,
         string_table: [ir_empty_name(); 4096],
         string_count: 0,

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -679,12 +679,12 @@ fn fo_xfer_global_set(name: Name, kind: i64, lit: f64, fwd: Name) with Mut, Pani
 pub struct LowerGlobalTypeTable {
     // Indexed by IrModule.functions slot. Keep this aligned with IR_MAX_FUNCS;
     // source array lengths are literal-only in the bootstrap grammar.
-    elem_kinds: [i64; 8192],
+    elem_kinds: [i64; 16384],
 }
 
 fn empty_lower_global_type_table() -> LowerGlobalTypeTable {
     LowerGlobalTypeTable {
-        elem_kinds: [0; 8192],
+        elem_kinds: [0; 16384],
     }
 }
 
@@ -922,7 +922,7 @@ pub(crate) fn ir_register_knowledge_layout(table: StructLayoutTable) -> StructLa
 // ---------------------------------------------------------------------------
 // `Box::new(ir_empty_module())` (and friends) evaluated as field initialisers
 // of a single Lowerer { ... } literal keep several multi-MiB temps live at once:
-//   IrModule            ~11.5 MiB  ([IrFunction; 8192] after instr arena)
+//   IrModule            ~23 MiB  ([IrFunction; 16384] after instr arena)
 //   StructLayoutTable   ~3.3 MiB
 //   LowerLocalStack     ~1.6 MiB
 // Concurrent peak ≈ 16 MiB inside lowerer_new alone — enough, with parent frames

--- a/self-hosted/ir/normalize.sio
+++ b/self-hosted/ir/normalize.sio
@@ -29,7 +29,7 @@ fn name_less_than(a: Name, b: Name) -> bool with Mut, Panic, Div {
 }
 
 // Bubble sort for functions (small arrays, simplicity over performance)
-fn sort_functions_by_name(funcs: [IrFunction; 8192], count: i64) -> [IrFunction; 8192] with Mut, Panic, Div {
+fn sort_functions_by_name(funcs: [IrFunction; 16384], count: i64) -> [IrFunction; 16384] with Mut, Panic, Div {
     var sorted = funcs
     var i: i64 = 0
     while i < count {
@@ -244,7 +244,7 @@ fn normalize_ir_module(module: IrModule) -> IrModule with Mut, Panic, Div {
     let sorted_funcs = sort_functions_by_name(module.functions, module.fn_count)
 
     // Step 2: Normalize each function
-    var normalized_funcs: [IrFunction; 8192] = [ir_empty_function(); 8192]
+    var normalized_funcs: [IrFunction; 16384] = [ir_empty_function(); 16384]
     var i: i64 = 0
     while i < module.fn_count {
         normalized_funcs[i] = normalize_function(sorted_funcs[i])

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -10618,7 +10618,7 @@ let A64_PREVIEW_PATCH_JCC: i64 = 2
 
 struct A64PreviewCompiler {
     code: CodeBuffer,
-    fn_offsets: [i64; 8192],
+    fn_offsets: [i64; 16384],
     fn_count: i64,
     label_offsets: [i64; 64],
     label_patch_offsets: [i64; 128],
@@ -10637,7 +10637,7 @@ struct A64PreviewCompiler {
 fn a64_preview_compiler_new() -> A64PreviewCompiler {
     A64PreviewCompiler {
         code: code_buffer_new(),
-        fn_offsets: [-1; 8192],
+        fn_offsets: [-1; 16384],
         fn_count: 0,
         label_offsets: [-1; 64],
         label_patch_offsets: [0; 128],
@@ -11848,7 +11848,7 @@ fn finalize_elf64_relocatable(
     data: StringTable,
     rela: RelaSection,
     symbols: SymbolData,
-    fn_offsets: [i64; 8192],
+    fn_offsets: [i64; 16384],
     fn_count: i64
 ) -> Elf64Binary with Mut, Panic, Div {
     var bin = elf_binary_new()
@@ -12077,7 +12077,7 @@ fn so_emit_phdr(bin: &! Elf64Binary, p_type: i64, p_flags: i64, p_offset: i64, p
     elf_emit_u64_ref(bin, p_align)
 }
 
-fn finalize_elf64_shared(code: CodeBuffer, symbols: SymbolData, fn_offsets: [i64; 8192], export_names: [Name; 64], export_count: i64) -> Elf64Binary with Mut, Panic, Div {
+fn finalize_elf64_shared(code: CodeBuffer, symbols: SymbolData, fn_offsets: [i64; 16384], export_names: [Name; 64], export_count: i64) -> Elf64Binary with Mut, Panic, Div {
     var bin = elf_binary_new()
     so_emit_dyn_elf_hdr(&! bin, 2)
     let phdr0_pos = bin.len

--- a/self-hosted/native/elf.sio
+++ b/self-hosted/native/elf.sio
@@ -110,7 +110,7 @@ pub fn elf_binary_new() -> Elf64Binary {
 pub struct SymbolData {
     pub strtab: [i8; 65536],         // null-terminated function name strings
     pub strtab_len: i64,              // current length (index 0 is always \0)
-    pub name_offsets: [i64; 8192],   // strtab byte offset for each function's name
+    pub name_offsets: [i64; 16384],   // strtab byte offset for each function's name
 }
 
 pub fn symbol_data_new() -> SymbolData {
@@ -266,7 +266,7 @@ pub fn elf_builder_emit_payload_ref(
 pub fn elf_builder_emit_strtab_symtab_ref(
     bin: &! Elf64Binary,
     symbols: SymbolData,
-    fn_offsets: [i64; 8192],
+    fn_offsets: [i64; 16384],
     fn_count: i64,
     text_va_base: i64,
     strtab_offset: &! i64,
@@ -461,7 +461,7 @@ pub fn finalize_elf64_for_machine(
     base_addr: i64,
     machine_id: i64,
     symbols: SymbolData,
-    fn_offsets: [i64; 8192],
+    fn_offsets: [i64; 16384],
     fn_count: i64,
     bss_size: i64,
     bss_vaddr: i64
@@ -507,7 +507,7 @@ pub fn finalize_elf64(
     entry_offset: i64,
     base_addr: i64,
     symbols: SymbolData,
-    fn_offsets: [i64; 8192],
+    fn_offsets: [i64; 16384],
     fn_count: i64,
     bss_size: i64,
     bss_vaddr: i64

--- a/self-hosted/native/elf_bulk.sio
+++ b/self-hosted/native/elf_bulk.sio
@@ -493,7 +493,7 @@ fn finalize_elf64_bulk_with_data_len(
     entry_offset: i64,
     base_addr: i64,
     symbols: SymbolData,
-    fn_offsets: [i64; 8192],
+    fn_offsets: [i64; 16384],
     fn_count: i64
 ) -> Elf64Binary with IO, Mut, Panic, Div {
     var bin = elf_binary_new()
@@ -610,7 +610,7 @@ pub fn finalize_elf64_bulk_with_rodata_ref_data_len(
     entry_offset: i64,
     base_addr: i64,
     symbols: SymbolData,
-    fn_offsets: [i64; 8192],
+    fn_offsets: [i64; 16384],
     fn_count: i64
 ) -> Elf64Binary with IO, Mut, Panic, Div {
     var bin = elf_binary_new()
@@ -725,7 +725,7 @@ fn finalize_elf64_bulk(
     entry_offset: i64,
     base_addr: i64,
     symbols: SymbolData,
-    fn_offsets: [i64; 8192],
+    fn_offsets: [i64; 16384],
     fn_count: i64
 ) -> Elf64Binary with IO, Mut, Panic, Div {
     finalize_elf64_bulk_with_data_len(code, rodata, data, data.len, entry_offset, base_addr, symbols, fn_offsets, fn_count)

--- a/self-hosted/native/frame.sio
+++ b/self-hosted/native/frame.sio
@@ -332,7 +332,7 @@ pub struct NativeCompiler {
     pub symbols: SymbolData,            // Function name symbol table for .symtab/.strtab
 
     // Module-level: function layout
-    pub fn_offsets: [i64; 8192],         // function index -> code buffer offset
+    pub fn_offsets: [i64; 16384],        // function index -> code buffer offset
     pub fn_count: i64,
 
     // Per-function: return jump patching

--- a/self-hosted/native/reloc.sio
+++ b/self-hosted/native/reloc.sio
@@ -131,7 +131,7 @@ pub fn add_data_section_reloc(table: RelocationTable, disp_offset: i64, data_off
 pub fn apply_relocations(
     table: RelocationTable,
     buf: CodeBuffer,
-    fn_offsets: [i64; 8192],
+    fn_offsets: [i64; 16384],
     fn_count: i64,
     rodata_file_offset: i64,
     data_file_offset: i64


### PR DESCRIPTION
## Summary

The rung-gen2 slot-census wall (1891 globals + 7206 functions = 9097 vs cap 8191) is cleared by the coordinated raise the audit doc (#1884) scoped. This is the minimal slice that PROVES the lever: every array indexed by the IrModule.functions slot, raised together, plus the region table.

## The claim map (all eight files FREE at the time of the change)

| File | Status |
|---|---|
| `ir/ir.sio` | FREE |
| `ir/normalize.sio` | FREE |
| `ir/lower.sio` | FREE (grok-cli2/family-a-variance claim expired 17:55→17:58Z) |
| `native/codegen_x86_linux.sio` | FREE (fable-1 claim cleared) |
| `native/elf.sio`, `elf_bulk.sio`, `reloc.sio`, `frame.sio` | FREE |

## The coordinated raise

- `IR_MAX_FUNCS` 8192 → 16384; `IrModule.functions` `[IrFunction; 16384]`; empty-module init
- The five `IR_REGION_*` arrays + `ir_region_table_capacity()` 8448 → 16640 (the +256 margin kept — the region table MUST exceed `IR_MAX_FUNCS` or the contract check refuses, per the bisect at `ir.sio:1136`)
- `normalize.sio`'s two `[IrFunction; …]` sites; `lower.sio`'s `elem_kinds` (guards already read `IR_MAX_FUNCS`)
- `fn_offsets` in `codegen_x86_linux`/`elf`/`elf_bulk`/`reloc`/`frame`; `elf.sio`'s `name_offsets`
- Specializer untouched: reachable marks 7029 < `SPEC_DCE_MAX=8192`
- Remaining 8192 literals are strtab/rodata byte buffers + data-length guards, not functions-slot-indexed

## Measured (from-source build SHA-256 `da172b4f…`)

- **Fixed-point ladder**: rung `check` rc=0 errors=0 — gen1 typechecks `main.sio`, which it never did at 8192 (the census refused first). The slot-census wall is GONE.
- **Rung gen2** now reaches lowering and meets the NEXT wall — a different lever: `run_compiler_main_self_tests` needs 33829 IR instructions vs `IR_MAX_INSTRS=16384`. NOT touched here.
- **No regressions**: `box_all_read_forms.sio` → `BOXMATRIX OK` rc=0; DCE reachability gate all three arms pass (keeps 602 live, drops 300/303 dead, carries 6000 functions to a correct binary).

## Safe stop point

This PR stops at the coordinated `IR_MAX_FUNCS` raise. The next wall is per-function `IR_MAX_INSTRS`, which is NOT a simple bump: `ir/dce.sio:31` caps liveness at `DCE_MAX_INSTRS=8192`, and `irfunction_instr_capacity_coherence_gate.sh` is explicit that a truncated liveness analysis is a WRONG analysis (a use past the cap is never recorded, so its definition looks dead and the sweep deletes live code, silently, at rc=0). Raising `IR_MAX_INSTRS` without that sweep is the silent-miscompile trap — a separate, larger task.

## Build-safety warnings honored

- No bare `souc <file> -o` (raw Madaros ELF invoked as `madaros -o out src`)
- No E230 patch in this build (it is a `.scratch` dispatch patch, not on main)