### PR TITLE
refactor(ir): sort_functions_by_name takes &! IrModule — in-place, no by-value array

### DIFF
--- a/docs/audit/MADAROS_BOX_AUTODEREF_MAIN_REPRODUCTION_2026-08-17.md
+++ b/docs/audit/MADAROS_BOX_AUTODEREF_MAIN_REPRODUCTION_2026-08-17.md
@@ -300,39 +300,3 @@ recorded, so its definition looks dead and the sweep deletes live code,
 silently, at rc=0). Raising `IR_MAX_INSTRS` without raising `DCE_MAX_INSTRS`
 and every per-instruction context that stops at its own cap converts an
 honest refusal into silent miscompilation. That is a separate, larger task.
-
-The lever was then PROVEN by the minimal coordinated slice (2026-08-18,
-branch `lane/empryo-1/gen2-raise-measure-20260818`, source build SHA-256
-`da172b4f…`). All eight coupled files were free of claims at the time
-(grok-cli2's `lower.sio` claim expired between 17:55Z and 17:58Z; fable-1's
-`codegen_x86_linux.sio` claim had cleared). The slice raised `IR_MAX_FUNCS`
-8192 → 16384 together with every array indexed by the IrModule.functions
-slot — `IrModule.functions`, `normalize.sio`'s two `[IrFunction; …]` sites,
-`lower.sio`'s `elem_kinds`, `fn_offsets` in `codegen_x86_linux`/`elf`/
-`elf_bulk`/`reloc`/`frame`, `elf.sio`'s `name_offsets` — and the region
-table (`IR_REGION_*` arrays + `ir_region_table_capacity()` 8448 → 16640,
-keeping the +256 margin). The specializer needed no change: reachable marks
-are 7029, already under `SPEC_DCE_MAX=8192`.
-
-Result, measured on the from-source raise build:
-
-    rung check   rc=0 errors=0          (gen1 typechecks main.sio)
-    rung gen2    rc=139 — but the slot-census wall is GONE. The failure is
-                 now a DIFFERENT wall: `run_compiler_main_self_tests` needs
-                 33829 IR instructions vs IR_MAX_INSTRS=16384, and the
-                 refusal path then segfaults.
-
-No regressions: `box_all_read_forms.sio` still prints `BOXMATRIX OK` rc=0,
-and the DCE reachability gate passes all three arms (keeps 602 live, drops
-300/303 dead, carries 6000 functions to a correct binary).
-
-SAFE STOP POINT, per the execution order: the coordinated `IR_MAX_FUNCS`
-raise is self-consistent and regression-free, and it is where this lane
-stops. The next wall is per-function `IR_MAX_INSTRS`, which is NOT a simple
-bump — `ir/dce.sio:31` caps liveness at `DCE_MAX_INSTRS=8192`, and the
-`irfunction_instr_capacity_coherence_gate.sh` header is explicit that a
-truncated liveness analysis is a WRONG analysis (a use past the cap is never
-recorded, so its definition looks dead and the sweep deletes live code,
-silently, at rc=0). Raising `IR_MAX_INSTRS` without raising `DCE_MAX_INSTRS`
-and every per-instruction context that stops at its own cap converts an
-honest refusal into silent miscompilation. That is a separate, larger task.

--- a/docs/audit/MADAROS_IR_CAPACITY_OBJECT_DESIGN_DISPATCH_2026-08-18.md
+++ b/docs/audit/MADAROS_IR_CAPACITY_OBJECT_DESIGN_DISPATCH_2026-08-18.md
@@ -1,0 +1,92 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-ir-capacity-object-design-dispatch-2026-08-18
+authority: repo_only
+audience: users
+last_validated: 2026-08-18
+validated_by: empryo-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-ir-capacity-object-design-dispatch-2026-08-18
+-->
+
+# Dispatch — IR capacities should be ONE object, not dozens of coupled literals
+
+**Filed:** 2026-08-18 · **Status:** OPEN (design dispatch, not yet implemented) · **Lane:** empryo-1
+
+## The problem, measured
+
+The `IR_MAX_FUNCS` raise (#1897, 8192 → 16384) needed **eight files** touched
+in lockstep because the capacity is expressed as dozens of independent
+literals that must agree:
+
+| Site | Literal | Role |
+|---|---|---|
+| `ir/ir.sio:35` | `IR_MAX_FUNCS = 16384` | the constant itself |
+| `ir/ir.sio:3161` | `[IrFunction; 16384]` | `IrModule.functions` |
+| `ir/ir.sio:1131-1141` | `[i64; 16640]` ×5 + `ir_region_table_capacity()` | region table (MUST exceed `IR_MAX_FUNCS`) |
+| `ir/normalize.sio` | `[IrFunction; 16384]` ×2 | sort + normalize scratch |
+| `ir/lower.sio:682` | `elem_kinds: [i64; 16384]` | indexed by the functions slot |
+| `native/codegen_x86_linux.sio` | `fn_offsets: [i64; 16384]` ×4 | backend offsets |
+| `native/elf.sio`, `elf_bulk.sio`, `reloc.sio`, `frame.sio` | `fn_offsets` / `name_offsets` | ELF emission |
+
+Miss one and the failure is either a loud type error (best case) or a silent
+drop (the historical case the `ir_capacity` fixture exists to catch: past the
+literal, a function's symbol and offset were simply DROPPED, exit 0, no
+error). The same shape repeats for every other capacity:
+
+- `IR_MAX_INSTRS = 16384` is coupled to `DCE_MAX_INSTRS = 8192`
+  (`ir/dce.sio:31`) — a truncated liveness analysis is a WRONG analysis, not a
+  weaker one, so these must move together or not at all.
+- `SPEC_DCE_MAX = 8192` / `SPEC_DCE_SLOTS = 16384` (`check/specializer.sio`)
+  and the `[i64; 16384]` mark arrays.
+- `HLIR_MAX_LOCALS = 8192` (`hlir/ir.sio`).
+
+## The design
+
+These capacities should be **one object**, not scattered literals:
+
+```
+struct IrCapacities {
+    max_functions: i64,
+    region_slots: i64,          // MUST be > max_functions (+ margin)
+    max_instructions: i64,
+    dce_liveness_slots: i64,    // MUST be >= max_instructions
+    backend_offset_slots: i64,  // MUST be >= max_functions
+    ...
+}
+```
+
+with a single constructor that enforces the invariants
+(`region_slots > max_functions`, `dce_liveness_slots >= max_instructions`)
+and a single place to raise a ceiling. The arrays that are currently
+fixed-size inline (`[IrFunction; N]`, `fn_offsets: [i64; N]`) would be sized
+from that object.
+
+## Why this also fixes the value-semantics cost
+
+Duplicating arrays inline is what makes the by-value semantics expensive:
+`IrModule.functions: [IrFunction; 16384]` is what makes `IrModule` a ~23 MiB
+struct, and every by-value pass of it invites a deep-copy reading even where
+the lowering happens to handle-pass it. Moving the backing storage to
+**dynamic allocation** (one heap/arena buffer per capacity, sized from the
+object) collapses `IrModule` to a struct of handles + counts, makes by-value
+passes cheap and unambiguous, and removes the entire class of "raise the
+constant, forget an array" failures.
+
+## Scope and stop criteria
+
+This is a **design dispatch, not an implementation**. The implementation is a
+large, multi-file refactor that must:
+
+1. Land behind the `irfunction_instr_capacity_coherence_gate.sh` and the
+   `ir_capacity` fixture (raised past the old ceiling).
+2. NOT raise `IR_MAX_INSTRS` without raising `DCE_MAX_INSTRS` and every
+   per-instruction context that stops at its own cap — that is the
+   silent-miscompile trap named in #1897's safe-stop point.
+3. Keep the recorded fixed-point rung at `check` until gen2 is independently
+   unblocked.
+
+## Related
+
+- #1884 — the capacity raise is not self-contained (region-table coupling)
+- #1897 — the coordinated `IR_MAX_FUNCS` raise, proven and regression-free
+- `scripts/ci/irfunction_instr_capacity_coherence_gate.sh` — the coherence gate
+- `tests/multimodule/ir_capacity/` — the boundary witness

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -212,6 +212,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-imported-module-f64-cast-bitcast-2026-07-14 | repo_only | docs/audit/MADAROS_IMPORTED_MODULE_F64_CAST_BITCAST_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-imported-module-native-path-escalation-2026-07-14 | repo_only | docs/audit/MADAROS_IMPORTED_MODULE_NATIVE_PATH_ESCALATION_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-imported-pbpk28-cn-sigsegv-2026-08-16 | repo_only | docs/audit/MADAROS_IMPORTED_PBPK28_CN_SIGSEGV_2026-08-16.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-ir-capacity-object-design-dispatch-2026-08-18 | repo_only | docs/audit/MADAROS_IR_CAPACITY_OBJECT_DESIGN_DISPATCH_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-match-guards-2026-06-24 | repo_only | docs/audit/MADAROS_MATCH_GUARDS_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-method-call-sigsegv-2026-06-20 | repo_only | docs/audit/MADAROS_METHOD_CALL_SIGSEGV_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-multimodule-fallback-segfault-2026-06-30 | repo_only | docs/audit/MADAROS_MULTIMODULE_FALLBACK_SEGFAULT_2026-06-30.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -4340,6 +4340,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-ir-capacity-object-design-dispatch-2026-08-18",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_IR_CAPACITY_OBJECT_DESIGN_DISPATCH_2026-08-18.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-match-guards-2026-06-24",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_MATCH_GUARDS_2026-06-24.md",

--- a/self-hosted/ir/normalize.sio
+++ b/self-hosted/ir/normalize.sio
@@ -28,24 +28,30 @@ fn name_less_than(a: Name, b: Name) -> bool with Mut, Panic, Div {
     a.len < b.len
 }
 
-// Bubble sort for functions (small arrays, simplicity over performance)
-fn sort_functions_by_name(funcs: [IrFunction; 16384], count: i64) -> [IrFunction; 16384] with Mut, Panic, Div {
-    var sorted = funcs
+// Bubble sort for functions, in place on the module's function table.
+// Takes &! IrModule rather than a by-value [IrFunction; 16384]: the table is a
+// handle into arena storage, so the old signature never copied the ~23 MiB of
+// IrFunction slots — but the by-value spelling invited that reading and runs
+// against the hardening that moves large structural values off by-value passes.
+// Sorting in place through the module reference makes the intent explicit.
+// (&![T; N] on a bare array is broken in the JIT, so the reference is to the
+// struct, not the array.)
+fn sort_functions_by_name(module: &! IrModule) with Mut, Panic, Div {
+    let count = (*module).fn_count
     var i: i64 = 0
     while i < count {
         var j: i64 = 0
         while j < count - 1 {
-            if name_less_than(sorted[j + 1].name, sorted[j].name) {
+            if name_less_than((*module).functions[j + 1].name, (*module).functions[j].name) {
                 // Swap
-                let temp = sorted[j]
-                sorted[j] = sorted[j + 1]
-                sorted[j + 1] = temp
+                let temp = (*module).functions[j]
+                (*module).functions[j] = (*module).functions[j + 1]
+                (*module).functions[j + 1] = temp
             }
             j = j + 1
         }
         i = i + 1
     }
-    sorted
 }
 
 // Bubble sort for string table
@@ -240,14 +246,18 @@ fn normalize_function(func: IrFunction) -> IrFunction with Mut, Panic, Div {
 
 // Normalize an entire module
 fn normalize_ir_module(module: IrModule) -> IrModule with Mut, Panic, Div {
-    // Step 1: Sort functions by name
-    let sorted_funcs = sort_functions_by_name(module.functions, module.fn_count)
+    // Step 1: Sort functions by name, in place on a mutable handle. `var m =
+    // module` is a shallow copy of the struct-of-handles (the function table is
+    // a handle, so this does not copy the table); sorting through &! m reorders
+    // the same backing storage the old by-value path already mutated.
+    var m = module
+    sort_functions_by_name(&! m)
 
     // Step 2: Normalize each function
     var normalized_funcs: [IrFunction; 16384] = [ir_empty_function(); 16384]
     var i: i64 = 0
-    while i < module.fn_count {
-        normalized_funcs[i] = normalize_function(sorted_funcs[i])
+    while i < m.fn_count {
+        normalized_funcs[i] = normalize_function(m.functions[i])
         i = i + 1
     }
 


### PR DESCRIPTION
## Summary

Converts `sort_functions_by_name` from a by-value `[IrFunction; 16384] -> [IrFunction; 16384]` to an in-place `&! IrModule` sort, per the review of #1897. Also dedupes the Box audit doc and files the capacities-as-one-object design dispatch.

## The measurement the review asked for (item 2)

**The conversion changes nothing measurable — and the reason is the finding.** The by-value signature invited the reading that each call copies the ~23 MiB function table in and out. Measured, it never did:

- **Aliasing probe** (decisive): a `[Big; 4]` array-of-struct passed by value, mutated inside the callee, is visible to the caller (`ret=999 local0a=999`). The array is **handle-passed, not copied**. A return-path probe confirms the return aliases too (`local0a=777`).
- **Before/after on a real compile** (box witness, from-source builds): peak RSS `554612 -> 551872 KB`, stack `111268 -> 111272 KB` — unchanged.

So the compiler was already passing this by pointer despite the by-value signature. The change is **hardening, not performance**: the by-value spelling runs against the direction that moves large structural values off by-value passes, and the in-place reference makes the intent explicit. (Uses `&! IrModule`, not `&![T; N]` on the bare array — the known JIT trap.)

## Validation (from-source rebuild SHA-256 `368be1b8…`)

- **typecheck main.sio**: 80 errors before, 80 after — **identical set** (all pre-existing ontology E175); the edit adds ZERO.
- **box_all_read_forms**: `BOXMATRIX OK` rc=0
- **dce_reachability gate**: all three arms pass
- **fixed-point ladder**: reached `check` as recorded, GATE_RC=0

## Also in this PR

- **Dedupe** the fixed-point section of the Box audit doc — the #1897 merge commit left the PROVEN block duplicated (lines 304-338 removed; block1==block2 byte-identical).
- **Design dispatch** (`MADAROS_IR_CAPACITY_OBJECT_DESIGN_DISPATCH_2026-08-18.md`): the IR capacities should be ONE object (`max_functions`, `region_slots`, `max_instructions`, `dce_liveness_slots`, `backend_offset_slots`) with a constructor enforcing the invariants, and the inline arrays moved to dynamic allocation. Filed, not implemented.

## NOT done here (per the review's item 3)

`IR_MAX_INSTRS` is **not** raised. `DCE_MAX_INSTRS=8192` caps liveness, and a truncated liveness analysis is a WRONG analysis (silent miscompile). Capacity, DCE, and the lateral arrays rise together or not at all — that sweep is a separate task, named in the dispatch.