### PR TITLE
docs(audit): close E230 by refutation — the wall is already named

### DIFF
--- a/docs/audit/HANDLE_TABLE_E230_REFUTATION_2026-08-18.md
+++ b/docs/audit/HANDLE_TABLE_E230_REFUTATION_2026-08-18.md
@@ -1,0 +1,109 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.handle-table-e230-refutation-2026-08-18
+authority: repo_only
+audience: users
+last_validated: 2026-08-18
+validated_by: grok-cli1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.handle-table-e230-refutation-2026-08-18
+-->
+
+# E230 handle-ceiling diagnostic — closed by refutation (2026-08-18)
+
+**Status:** CLOSED. The proposed target did not exist. Do not reopen E230
+to add `count=` / `4194304` / `(2^22)` to the refusal so a gate has
+something to grep.
+**Verdict:** the handle table is already fail-closed. Capacity is
+4 194 304 (2²²). Overflow prints `madaros: handles full` and
+`emit_exit(182)`. There is no E230, no count, no capacity in the
+message.
+**Not this closeout:** raising the ceiling, reclamation, or a later
+optional dispatch that adds `N of M` to the existing line. That would
+be a new ticket, not E230.
+
+`E230` in this document means the *proposed handle-table diagnostic*.
+It is not the existing raw-pointer error E230 in
+`docs/internal/compiler/RAW_FIELD_TERMINAL_CONTRACT.md`. Do not merge
+the two.
+
+## Recommendation: B, not A
+
+**A** would add the missing number to the runtime diagnostic, then
+write a gate that greps it. **B** records that the wall is already
+named and fail-closed, and keeps a one-witness gate that checks the
+string that exists.
+
+B is the close. Adding a number so the instrument has a target is
+building the target to justify the instrument. The number has modest
+operational value (did I really burn 4 M slots, or is the table
+corrupt at 100?). That value does not keep E230 open. It can be a
+separate, tiny dispatch later: print `N of M` on the line that already
+exists, with the 3-slot must-run selftest in front, and without a 90 %
+warning or a `runtime_context_size` bump. The v3 patch that tried to
+do all of that at once SIGSEGV'd every 3-slot aggregate (grok-cli5,
+14-cell matrix). Re-entering that site under the E230 name is how this
+lane spent three rounds measuring nothing.
+
+## What was measured (unpatched Madaros, 2026-08-18)
+
+Compiler: default Madaros, `runtime_context_size() = 248`, no
+`e230_90` field. 3-slot substrate (`struct { x,y,z: i64 }`, N=1) runs
+`rc=0`. Same shape with `Alloc`, N=1000: `rc=0`, stdout `done\n`.
+
+| N | rc | stdout | stderr |
+|---:|---:|---|---|
+| 1 | 0 | empty | empty |
+| 1 000 | 0 | `done\n` | empty |
+| **4 194 320** (capacity+16) | **182** | empty | `madaros: handles full\n` (22 bytes) |
+
+STAGE: `/orangefs/training/handle-ceiling-unpatched-20260818T180747Z`.
+ELF 12 744 B, `\x7fELF`, compiled with `souc compile`.
+
+The wall has a name. It does not have a number. The E230 gate was
+written to grep a diagnostic current Madaros does not emit.
+
+## Why the instrument looked infinitely broken
+
+Three verification rounds, each closing a real instrument defect:
+
+1. Compile without checking an ELF existed (`souc src.sio -o dest`
+   wrote a file named `-o`, rc=0).
+2. Wrong engine (that bare form is lean_single `SRC OUT`).
+3. `run_rc` read through a pipe on empty ELF stdout (`set -o pipefail`
+   aborted the rest).
+4. Witnesses were 3-slot structs on a compiler that could not
+   construct them (the E230 *patch*, not Madaros). Same crash, dressed
+   as a measurement.
+
+Those defects were real. They were also what you find when the signal
+behind the instrument does not exist. No amount of gate repair makes
+`warning[E230]` appear on a binary that never prints it.
+
+## What a gate may claim
+
+`scripts/ci/handle_table_ceiling_gate.sh` now asserts only what was
+measured:
+
+- 3-slot aggregate must **run** (`rc=0`) or the gate **refuses to
+  measure** (do not emit handle-ceiling numbers from a compiler that
+  cannot build structs).
+- A loop of capacity+16 handle-consuming allocs must exit **182** and
+  print `madaros: handles full`.
+
+It must not grep `E230`, `count=`, or `4194304`. Those strings are not
+on the current path.
+
+## Do not reopen as E230
+
+If a later lane wants `count=N of M` on the existing line:
+
+- New dispatch, new name. Not E230.
+- Do not bump `runtime_context_size` for a once-per-process 90 % flag.
+- Do not emit a 90 % warning unless someone files that as its own
+  target, with a substrate selftest in front.
+- The 3-slot must-run cell is mandatory. A patch that cannot construct
+  `{x,y,z: i64}` must not ship.
+
+## AI disclosure
+
+Measurement, refutation, and closeout by AI agent (grok-cli1) under
+human direction, 2026-08-18. GAIDeT-ICMJE 2025.

--- a/docs/audit/MADAROS_HANDLE_TABLE_182_LIFETIME_DISPATCH_2026-08-17.md
+++ b/docs/audit/MADAROS_HANDLE_TABLE_182_LIFETIME_DISPATCH_2026-08-17.md
@@ -16,6 +16,11 @@ and from the println/SIGSEGV-139 family
 ([`MADAROS_PRINTLN_BOOL_SCALARKIND_SEGV_2026-08-17.md`](MADAROS_PRINTLN_BOOL_SCALARKIND_SEGV_2026-08-17.md)).
 **Status:** mechanism CONFIRMED with a quantified minimal witness; root cause
 KNOWN and OPEN. This is a dispatch (classification + fix directions), not a fix.
+**E230:** the proposed *named count/capacity diagnostic* was closed by
+refutation on 2026-08-18 — the wall already prints `madaros: handles full`
+and exits 182; it does not emit E230 or `count=`. See
+[`HANDLE_TABLE_E230_REFUTATION_2026-08-18.md`](HANDLE_TABLE_E230_REFUTATION_2026-08-18.md).
+Do not reopen E230 to invent a number for a gate to grep.
 **Owner:** Madaros native GC lane (compiler). Merge/authority: codex-2.
 **Prior art:** `docs/handoff/repros/handle_table_2pow20_wrap_madaros.sio` (2²⁰
 era); commits `a1959e00c2` (Sprint 90 GC activation), `0b6a03c58a` (4096→2²⁰),

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -156,6 +156,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.github-mergeability-cache-staleness-census-2026-08-18 | repo_only | docs/audit/GITHUB_MERGEABILITY_CACHE_STALENESS_CENSUS_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.gpu-pipeline-sota-assessment-2026-05-30 | repo_only | docs/audit/GPU_PIPELINE_SOTA_ASSESSMENT_2026-05-30.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.gum-fo-propagation-hidden-by-main-vacuous-harness-dispatch-2026-08-10 | repo_only | docs/audit/GUM_FO_PROPAGATION_HIDDEN_BY_MAIN_VACUOUS_HARNESS_DISPATCH_2026-08-10.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.handle-table-e230-refutation-2026-08-18 | repo_only | docs/audit/HANDLE_TABLE_E230_REFUTATION_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.handle-table-reclamation-design-2026-08-17 | repo_only | docs/audit/HANDLE_TABLE_RECLAMATION_DESIGN_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.hypercomplex-651-rootcause-2026-07-14 | repo_only | docs/audit/HYPERCOMPLEX_651_ROOTCAUSE_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.hypercomplex-algebra-audit-2026-07-14 | repo_only | docs/audit/HYPERCOMPLEX_ALGEBRA_AUDIT_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -3052,6 +3052,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.handle-table-e230-refutation-2026-08-18",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/HANDLE_TABLE_E230_REFUTATION_2026-08-18.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.handle-table-reclamation-design-2026-08-17",
       "collection": "repo",
       "repo_doc_path": "docs/audit/HANDLE_TABLE_RECLAMATION_DESIGN_2026-08-17.md",

--- a/scripts/ci/handle_table_ceiling_gate.sh
+++ b/scripts/ci/handle_table_ceiling_gate.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# handle_table_ceiling_gate.sh — the handle wall is fail-closed and named.
+#
+# Closed by refutation 2026-08-18 (docs/audit/HANDLE_TABLE_E230_REFUTATION_2026-08-18.md).
+# Current Madaros prints "madaros: handles full" and exits 182. It does not
+# print E230, count=, or 4194304. This gate asserts only the string and rc
+# that exist. Do not add greps for a diagnostic that is not on the path.
+#
+# Compile is `souc compile <src> -o <out>` (never the bare form).
+# A 3-slot aggregate must RUN before any ceiling number is emitted.
+#
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+unset SOUC_BIN SOUNIO_SOUC_BIN SOUNIO_SOUC_ENGINE || true
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
+SOUC="${SOUC:-$ROOT/bin/souc}"
+[[ -x "$SOUC" ]] || { echo "FAIL souc not executable: $SOUC" >&2; exit 2; }
+if [[ "${SOUNIO_SOUC_ENGINE:-}" == "lean_single" ]]; then
+    echo "FAIL this gate asserts the Madaros handle wall; refuse lean_single" >&2
+    exit 2
+fi
+
+CAPACITY=4194304
+CEILING_ITERS=$((CAPACITY + 16))
+
+echo "=== handle_table_ceiling_gate ==="
+echo "souc=$SOUC"
+echo "souc_version=$("$SOUC" --version 2>/dev/null | head -1 || echo unknown)"
+[[ -n "${MADAROS_RAW_BIN:-}" ]] && echo "MADAROS_RAW_BIN=$MADAROS_RAW_BIN"
+echo "capacity=$CAPACITY ceiling_iters=$CEILING_ITERS"
+
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/handle-ceiling-gate.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+selftest_fail() {
+    echo "FAIL gate self-test [$1]: $2" >&2
+    echo "HANDLE_TABLE_CEILING_GATE_SELFTEST_FAIL [$1]" >&2
+    exit 2
+}
+
+classify_engine() {
+    if grep -qE '(^Madaros |Compilation successful)' "$1"; then
+        echo madaros
+    elif grep -qE '(^source: |^tokens:|^elf: )' "$1"; then
+        echo lean_single
+    else
+        echo unknown
+    fi
+}
+
+assert_elf() {
+    local label="$1" path="$2"
+    [[ -s "$path" ]] || selftest_fail "$label" "compile produced no/empty file at $path"
+    local magic
+    magic="$(od -An -tx1 -N4 "$path" | tr -d ' \n')"
+    [[ "$magic" == "7f454c46" ]] || selftest_fail "$label" "$path is not ELF (magic=$magic)"
+    echo "elf_ok=$path bytes=$(stat -c%s "$path") magic=7f454c46"
+}
+
+compile_and_run() {
+    local label="$1" sio="$2" elf="$3"
+    local clog="$TMP/${label}.compile.out"
+    rm -f -- "$PWD/-o" "$elf"
+    local crc=0 rrc=0
+    set +e
+    timeout 300 "$SOUC" compile "$sio" -o "$elf" > "$clog" 2>&1
+    crc=$?
+    set -e
+    local engine
+    engine="$(classify_engine "$clog")"
+    echo "compile_rc=$crc compile_engine=$engine — $label"
+    [[ $crc -eq 0 ]] || {
+        sed -n '1,40p' "$clog" | sed 's/^/    /' >&2
+        selftest_fail "$label" "compiler refused the witness"
+    }
+    [[ -e "$PWD/-o" ]] && selftest_fail "$label" "compile wrote a literal -o file"
+    assert_elf "$label" "$elf"
+    [[ "$engine" == "madaros" ]] || selftest_fail "$label" "compile log named engine=$engine; need Madaros"
+    set +e
+    timeout 600 "$elf" > "$TMP/${label}.run.out" 2> "$TMP/${label}.run.err"
+    rrc=$?
+    set -e
+    printf '%s\n' "$rrc" > "$TMP/${label}.run.rc"
+    echo "run_rc=$rrc"
+    echo "stderr (last 10):"
+    tail -10 "$TMP/${label}.run.err" | sed 's/^/    /'
+}
+
+###############################################################################
+# S1 — 3-slot aggregate must RUN. If this compiler cannot construct a
+# 3-i64 struct, every later number would be a crash report. Refuse.
+###############################################################################
+cat > "$TMP/s1.sio" <<'EOF'
+struct S1 { x: i64, y: i64, z: i64 }
+fn main() -> i64 {
+    let _s = S1 { x: 1, y: 2, z: 3 }
+    0
+}
+EOF
+echo
+echo "--- S1: 3-slot aggregate must run ---"
+compile_and_run S1 "$TMP/s1.sio" "$TMP/S1.elf"
+S1_RC="$(cat "$TMP/S1.run.rc")"
+if [[ "$S1_RC" != "0" ]]; then
+    echo "HANDLE_TABLE_CEILING_GATE_REFUSE_MEASURE [S1] rc=$S1_RC" >&2
+    selftest_fail S1 "3-slot aggregate did not run (rc=$S1_RC); refuse to measure the ceiling"
+fi
+echo "S1_OK rc=0"
+
+###############################################################################
+# Ceiling witness — capacity+16 handle-consuming allocs.
+# PASS: rc=182 and stderr contains "madaros: handles full".
+###############################################################################
+cat > "$TMP/ceiling.sio" <<EOF
+struct H { x: i64, y: i64, z: i64 }
+fn alloc_one() -> H with Alloc { H { x: 1, y: 1, z: 1 } }
+fn main() -> i64 with IO, Mut, Panic, Div, Alloc {
+    var i: i64 = 0
+    while i < $CEILING_ITERS {
+        let _x = alloc_one()
+        i = i + 1
+    }
+    print("done\\n")
+    0
+}
+EOF
+echo
+echo "--- ceiling: $CEILING_ITERS allocs (capacity $CAPACITY) ---"
+compile_and_run ceiling "$TMP/ceiling.sio" "$TMP/ceiling.elf"
+C_RC="$(cat "$TMP/ceiling.run.rc")"
+
+echo
+echo "=== handle_table_ceiling_gate verdict ==="
+if [[ "$C_RC" == "182" ]] && grep -qF 'madaros: handles full' "$TMP/ceiling.run.err"; then
+    echo "PASS ceiling rc=182 named 'madaros: handles full'"
+    echo "HANDLE_TABLE_CEILING_GATE_OK"
+    exit 0
+fi
+echo "FAIL ceiling: want rc=182 and stderr 'madaros: handles full'; got rc=$C_RC" >&2
+echo "HANDLE_TABLE_CEILING_GATE_FAIL" >&2
+exit 1


### PR DESCRIPTION
## Verdict

**B.** Close E230 by refutation. The handle wall is already fail-closed: capacity 2²², `madaros: handles full`, `rc=182`. There is no E230, no `count=`, no `4194304` in the message. A gate that grepped those strings spent three rounds repairing an instrument aimed at a diagnostic current Madaros does not emit.

Adding the number (A) so the instrument has a target is building the target to justify the instrument. Counts can be a later, tiny, separately-named dispatch. They must not reopen E230. The v3 patch that tried to add them SIGSEGV'd every 3-slot aggregate.

## Measured (unpatched Madaros)

| N | rc | stderr |
|---:|---:|---|
| 1 (3-slot substrate) | 0 | empty |
| 1 000 | 0 | empty (`done` on stdout) |
| 4 194 320 | **182** | `madaros: handles full` |

## What lands

- `docs/audit/HANDLE_TABLE_E230_REFUTATION_2026-08-18.md` — the close, so this cannot vanish into a chat
- Cross-link on the 182 lifetime dispatch
- `scripts/ci/handle_table_ceiling_gate.sh` — S1 must run, then one witness: rc=182 and the existing string. Re-run on this branch: `HANDLE_TABLE_CEILING_GATE_OK`

Do not grep `E230` in that gate.