### PR TITLE
feat(website): prove WORKFLOW-REACHABLE with the two #1880 wires

### DIFF
--- a/website/src/components/honesty/DissertationNowPanel.astro
+++ b/website/src/components/honesty/DissertationNowPanel.astro
@@ -11,6 +11,11 @@ import {
   suiteFaceParts,
   umbrellaFace,
 } from '../../lib/dissertationHonestyNow';
+import {
+  CI_WIRE_PR,
+  confidenceGateRefusal,
+  frontendParityRefusal,
+} from '../../lib/dissertationWiredHonesty';
 import ReceiptLink from './ReceiptLink.astro';
 import type { Locale } from '../../lib/i18n';
 import './DissertationNowPanel.css';
@@ -27,6 +32,8 @@ const prior = closed ? priorFace(m) : '';
 const umbrella = umbrellaFace();
 const umbrellaHref = `https://github.com/Sounio-lang/sounio/blob/${UMBRELLA_CLOSURE_SHA}/${UMBRELLA_CLOSURE_DOC}`;
 const umbrellaPrHref = `https://github.com/Sounio-lang/sounio/pull/${UMBRELLA_CLOSURE_PR}`;
+const wired = `${confidenceGateRefusal()} · ${frontendParityRefusal()}`;
+const wiredPrHref = `https://github.com/Sounio-lang/sounio/pull/${CI_WIRE_PR}`;
 
 type Copy = {
   kicker: string;
@@ -201,6 +208,9 @@ const prHref = `https://github.com/Sounio-lang/sounio/pull/${m.pr}`;
         <p class="dnow-umbrella">
           {umbrella} · <a href={umbrellaPrHref}>#{UMBRELLA_CLOSURE_PR}</a> ·{' '}
           <a href={umbrellaHref}>{UMBRELLA_CLOSURE_DOC}</a>
+        </p>
+        <p class="dnow-umbrella">
+          {wired} · <a href={wiredPrHref}>#{CI_WIRE_PR}</a>
         </p>
       </footer>
     </aside>

--- a/website/src/lib/dissertationHonestyNow.ts
+++ b/website/src/lib/dissertationHonestyNow.ts
@@ -27,9 +27,11 @@
  *
  * PEND is its own category. It is not a pass. Hiding it would make
  * 19 + 33 look like 53.
- * Do not treat #1874 (wire two leftover greens) as current main.
- * Reachability and engine live in measurementClaim.ts — this file
- * is the pbpk_suite instance, not a second kernel.
+ * #1880 wired confidence + frontend_parity into ci.yml. Those two
+ * are REACHABLE instances in dissertationWiredHonesty.ts. This file
+ * is still the pbpk_suite instance. Do not copy their binding here.
+ * suiteFaceParts refuses through claimMayPrint — the same predicate
+ * as U2. A second throw path would be a second render path.
  */
 
 export const MS_HOUR = 3_600_000;
@@ -43,11 +45,13 @@ export type FailFamily = {
 import {
   COMPILER_ENGINES,
   REACHABILITIES,
+  claimMayPrint,
   isCompilerEngine,
   isReachability,
   reachabilityComplete,
   reachabilityFace,
   type CompilerEngine,
+  type MeasurementClaim,
   type Reachability,
   type ReachabilityBinding,
 } from './measurementClaim';
@@ -70,11 +74,50 @@ export function REACHABILITY_FACE_OF(b: ReachabilityBinding): string {
   return reachabilityFace(b);
 }
 
-/** @deprecated use reachabilityFace — kept so existing gloss sites compile */
-export const REACHABILITY_FACE = {
-  'WORKFLOW-UNREACHABLE': 'not in CI',
-  'WORKFLOW-REACHABLE': 'in CI',
-} as const;
+export function suiteAsClaim(m: SuiteMeasure): MeasurementClaim {
+  return {
+    id: 'pbpk-suite',
+    kind: 'outcome',
+    gate: m.gate,
+    engine: m.engine,
+    ...bindingOf(m),
+    measuredAt: m.measuredAt,
+    artifact: m.doc,
+    parts: {
+      pass: m.pass,
+      fail: m.fail,
+      pend: m.pend,
+      skip: m.skip,
+      unknown: m.unknown,
+      registered: m.registered,
+    },
+  };
+}
+
+export function priorAsClaim(m: SuiteMeasure): MeasurementClaim {
+  return {
+    id: 'pbpk-suite-prior',
+    kind: 'outcome',
+    gate: m.gate,
+    engine: m.prior.engine,
+    ...bindingOf(m.prior),
+    measuredAt: m.prior.measuredOn,
+    artifact: `job ${m.prior.job}`,
+    parts: {
+      pass: m.prior.pass,
+      fail: m.prior.fail,
+      pend: m.prior.pend,
+      registered: m.registered,
+    },
+  };
+}
+
+export function suitePartsClose(c: MeasurementClaim): boolean {
+  return (
+    c.parts.pass + c.parts.fail + c.parts.pend + (c.parts.skip || 0) + (c.parts.unknown || 0) ===
+    c.parts.registered
+  );
+}
 
 export type MeasureProvenance = {
   engine: CompilerEngine;
@@ -185,7 +228,11 @@ export function provenanceComplete(m: {
 }
 
 export function measureMayPrint(m: SuiteMeasure): boolean {
-  return ledgerCloses(m) && provenanceComplete(m) && provenanceComplete(m.prior);
+  return (
+    ledgerCloses(m) &&
+    claimMayPrint(suiteAsClaim(m), suitePartsClose) &&
+    claimMayPrint(priorAsClaim(m), suitePartsClose)
+  );
 }
 
 /**
@@ -219,7 +266,7 @@ export type SuiteFaceParts = {
 export function suiteFaceParts(m: SuiteMeasure): SuiteFaceParts {
   if (!measureMayPrint(m)) {
     throw new Error(
-      'dissertationHonestyNow: refuse to print a pbpk_suite numeral without reachability and engine',
+      'measurementClaim: refuse to print pbpk-suite without reachability and engine',
     );
   }
   const numeral = `${m.fail} FAIL / ${m.registered}`;

--- a/website/src/lib/dissertationWiredHonesty.ts
+++ b/website/src/lib/dissertationWiredHonesty.ts
@@ -1,0 +1,83 @@
+/**
+ * #1880 wired two leftover dissertation greens into Contracts.
+ *
+ * Until these exist as MeasurementClaim instances, reachability can
+ * only say "not in CI". That is a constant, not a label. The suite
+ * (pbpk_suite) is still UNREACHABLE — it hangs off the dead umbrella.
+ * These two do not. Do not copy their REACHABLE binding onto the suite.
+ *
+ * Neither has a remasure that names Madaros or lean_single. The
+ * numeral therefore stays refused. The face is allowed to say yes:
+ * in CI · .github/workflows/ci.yml:LINE.
+ *
+ * Lines measured on origin/main after #1880 (12ebda238d). If ci.yml
+ * moves the steps, this file must move with them or construction
+ * still says a line that is no longer the wire.
+ */
+
+import {
+  assertReachabilityComplete,
+  claimMayPrint,
+  claimRefusal,
+  type MeasurementClaim,
+} from './measurementClaim';
+
+export const CI_WORKFLOW = '.github/workflows/ci.yml';
+export const CI_WIRE_PR = 1880;
+export const CI_WIRE_SHA = '12ebda238d';
+export const CI_WIRED_AT = '2026-08-18T17:41:05Z';
+
+export const DISSERTATION_CONFIDENCE_GATE: MeasurementClaim = {
+  id: 'dissertation-confidence-gate',
+  kind: 'outcome',
+  gate: 'scripts/ci/dissertation_confidence_gate_gate.sh',
+  engine: null,
+  reachability: 'WORKFLOW-REACHABLE',
+  workflow: CI_WORKFLOW,
+  line: 110,
+  measuredAt: CI_WIRED_AT,
+  artifact: CI_WORKFLOW,
+  parts: {},
+};
+
+export const DISSERTATION_FRONTEND_PARITY: MeasurementClaim = {
+  id: 'dissertation-frontend-parity',
+  kind: 'outcome',
+  gate: 'scripts/ci/dissertation_frontend_parity_gate.sh',
+  engine: null,
+  reachability: 'WORKFLOW-REACHABLE',
+  workflow: CI_WORKFLOW,
+  line: 117,
+  measuredAt: CI_WIRED_AT,
+  artifact: CI_WORKFLOW,
+  parts: {},
+};
+
+export function wiredPartsClose(_c: MeasurementClaim): boolean {
+  return true;
+}
+
+export function confidenceGateMayPrint(): boolean {
+  return claimMayPrint(DISSERTATION_CONFIDENCE_GATE, wiredPartsClose);
+}
+
+export function frontendParityMayPrint(): boolean {
+  return claimMayPrint(DISSERTATION_FRONTEND_PARITY, wiredPartsClose);
+}
+
+export function confidenceGateRefusal(): string {
+  return claimRefusal(DISSERTATION_CONFIDENCE_GATE, 'dissertation confidence gates');
+}
+
+export function frontendParityRefusal(): string {
+  return claimRefusal(DISSERTATION_FRONTEND_PARITY, 'dissertation frontend parity');
+}
+
+assertReachabilityComplete(DISSERTATION_CONFIDENCE_GATE, DISSERTATION_CONFIDENCE_GATE.id);
+assertReachabilityComplete(DISSERTATION_FRONTEND_PARITY, DISSERTATION_FRONTEND_PARITY.id);
+
+if (confidenceGateMayPrint() || frontendParityMayPrint()) {
+  throw new Error(
+    'dissertationWiredHonesty: #1880 names no engine — refuse to print a numeral for a wire',
+  );
+}

--- a/website/src/lib/gpuPublicHonesty.ts
+++ b/website/src/lib/gpuPublicHonesty.ts
@@ -10,6 +10,7 @@
  */
 
 import {
+  assertReachabilityComplete,
   claimFace,
   claimMayPrint,
   claimRefusal,
@@ -54,3 +55,5 @@ export function gpuShortRefusal(): string {
 export function copyLeaksGpuNumeral(text: string): boolean {
   return /\b13\s*\/\s*13\b/.test(text);
 }
+
+assertReachabilityComplete(GPU_PUBLIC, GPU_PUBLIC.id);

--- a/website/src/lib/measurementClaim.ts
+++ b/website/src/lib/measurementClaim.ts
@@ -57,6 +57,18 @@ export function reachabilityComplete(b: ReachabilityBinding): boolean {
   );
 }
 
+/**
+ * Construction refusal. A REACHABLE claim missing the workflow line
+ * must not load — that is how a label that can only say "no" comes back.
+ */
+export function assertReachabilityComplete(b: ReachabilityBinding, id: string): void {
+  if (!reachabilityComplete(b)) {
+    throw new Error(
+      `measurementClaim: ${id} reachability incomplete — WORKFLOW-REACHABLE requires a .yml path and line > 0`,
+    );
+  }
+}
+
 export function reachabilityFace(b: ReachabilityBinding): string {
   if (b.reachability === 'WORKFLOW-UNREACHABLE') return 'not in CI';
   return `in CI · ${b.workflow}:${b.line}`;

--- a/website/src/pages/dissertation/index.astro
+++ b/website/src/pages/dissertation/index.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import DissertationViewer from '../../components/dissertation/DissertationViewer';
+import { frontendParityRefusal } from '../../lib/dissertationWiredHonesty';
 ---
 
 <BaseLayout
@@ -28,8 +29,8 @@ import DissertationViewer from '../../components/dissertation/DissertationViewer
       <DissertationViewer client:only="react" />
       <p class="text-[0.85rem] text-[var(--color-text-tertiary)] mt-4">
         Numerical parity with the Sounio <code>tsit5_pbpk14</code> reference solver is enforced by
-        <code>scripts/ci/dissertation_frontend_parity_gate.sh</code>. The figures shown here are
-        bit-traceable to the committed gates that run on every push to <code>main</code>.
+        <code>scripts/ci/dissertation_frontend_parity_gate.sh</code>.
+        {frontendParityRefusal()}.
       </p>
     </div>
   </section>


### PR DESCRIPTION
## Summary

- Condition 2 first: reachability can now say yes. `#1880` put `dissertation_confidence_gate_gate.sh` at `.github/workflows/ci.yml:110` and `dissertation_frontend_parity_gate.sh` at `:117`. Those two are `MeasurementClaim` instances with `WORKFLOW-REACHABLE` + the workflow line. Face: `in CI · .github/workflows/ci.yml:LINE`. No engine — the numeral still throws.
- `suiteFaceParts` now refuses through `claimMayPrint`, the same predicate as U2 GPU. A second throw path would be a second render path.
- Removed the deprecated `REACHABILITY_FACE` map that said bare `in CI` without the line.
- `/dissertation` no longer claims the figures "run on every push to main" in raw prose. It interpolates `frontendParityRefusal()`.
- `/honesty` footer shows both REACHABLE refusals next to the suite, which stays `not in CI` (umbrella). Do not copy the `#1880` binding onto `pbpk_suite`.
- U2 remains `engine: null`, `WORKFLOW-UNREACHABLE`. User-facing GPU surfaces (`/language`, `/proof`, ProofStrip) still go through `gpuMayPrint` / `gpuFace` / `gpuRefusal`. Archive `GPUProofSection.astro` is unused. The 7/7 hyper still paints — not this PR.

## Test plan

- [x] `npm run check:astro` — 0 errors
- [x] `npm run check:i18n`
- [x] `npm run check:routes`
- [ ] Contracts + Website on the PR
- [ ] Confirm `/honesty` footer contains `in CI · .github/workflows/ci.yml:110` and `:117`, and does not contain `13`
- [ ] Confirm `/dissertation` no longer says "every push to main"