### PR TITLE
feat(website): withhold the May 7/7 hyper numeral without an engine

### DIFF
--- a/website/scripts/check-route-contract.mjs
+++ b/website/scripts/check-route-contract.mjs
@@ -83,3 +83,4 @@ async function run() {
 }
 
 await run();
+await import('./check-unguarded-numerals.mjs');

--- a/website/scripts/check-unguarded-numerals.mjs
+++ b/website/scripts/check-unguarded-numerals.mjs
@@ -1,0 +1,75 @@
+/**
+ * Closed green-counts must not interpolate outside the throw functions.
+ * A leak here means the kernel is a list of sites, not an invariant.
+ *
+ * Closed: U1 251/251, U2 13/13, U3 7/7.
+ * Archive and docs locales are not live faces.
+ */
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const root = path.resolve(process.cwd(), 'src');
+
+const SKIP_DIR = new Set(['_archive', 'content', 'node_modules']);
+
+const CLOSED_PATTERNS = [
+  { id: 'U2-13/13', re: /\b13\s*\/\s*13\b/ },
+  { id: 'U1-251/251', re: /\b251\s*\/\s*251\b/ },
+  { id: 'U3-7/7', re: /\b7\s*\/\s*7\b/ },
+  { id: 'raw-hyperPassCount', re: /hyperPassCount/ },
+  { id: 'raw-hyperTotalCount', re: /hyperTotalCount/ },
+  { id: 'raw-publicPassCount', re: /publicPassCount/ },
+  { id: 'raw-hyperLanes', re: /hyperLanes/ },
+];
+
+const KERNEL_DIR = path.join(root, 'lib');
+
+async function walk(dir, out = []) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIR.has(entry.name)) continue;
+      await walk(full, out);
+      continue;
+    }
+    if (!/\.(astro|ts|tsx)$/.test(entry.name)) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+function isKernelFile(file) {
+  const rel = path.relative(KERNEL_DIR, file);
+  if (rel.startsWith('..')) return false;
+  return /Honesty|measurementClaim|proofData|artifactStatus/.test(rel);
+}
+
+async function run() {
+  const files = [
+    ...(await walk(path.join(root, 'pages'))),
+    ...(await walk(path.join(root, 'components'))),
+  ];
+
+  const leaks = [];
+  for (const file of files) {
+    if (isKernelFile(file)) continue;
+    const text = await readFile(file, 'utf8');
+    for (const { id, re } of CLOSED_PATTERNS) {
+      if (re.test(text)) {
+        leaks.push(`${id} ${path.relative(process.cwd(), file)}`);
+      }
+    }
+  }
+
+  if (leaks.length > 0) {
+    console.error('Unguarded closed numerals:');
+    for (const row of leaks) console.error(`- ${row}`);
+    process.exit(1);
+  }
+
+  console.log('OK: closed numerals (U1/U2/U3) do not interpolate outside the kernel.');
+}
+
+await run();

--- a/website/src/components/home/ProofStrip.astro
+++ b/website/src/components/home/ProofStrip.astro
@@ -2,6 +2,7 @@
 import { getLocalizedPath, type Locale } from '../../lib/i18n';
 import { getProofData } from '../../lib/proofData';
 import { gpuFace, gpuMayPrint, gpuRefusal, gpuShortRefusal } from '../../lib/gpuPublicHonesty';
+import { hyperFace, hyperMayPrint, hyperRefusal, hyperShortRefusal } from '../../lib/stdlibHyperHonesty';
 import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal, reliabilityShortRefusal } from '../../lib/stdlibReliabilityHonesty';
 
 interface Props {
@@ -32,9 +33,11 @@ const items = [
       : gpuRefusal(),
   },
   {
-    value: `${proof.stdlib.hyperPassCount}/${proof.stdlib.hyperTotalCount}`,
+    value: hyperMayPrint() ? hyperFace() : hyperShortRefusal(),
     label: 'required hyper lanes passing',
-    detail: `science runtime status: ${proof.stdlib.scienceStatus}`,
+    detail: hyperMayPrint()
+      ? `science runtime status: ${proof.stdlib.scienceStatus}`
+      : hyperRefusal(),
   },
 ];
 ---

--- a/website/src/components/status/FeatureStatusPanel.astro
+++ b/website/src/components/status/FeatureStatusPanel.astro
@@ -1,6 +1,7 @@
 ---
 import { publicContract, artifactStatus } from "../../data/artifactStatus";
 import ArtifactStatusTable from "./ArtifactStatusTable.astro";
+import { hyperFace, hyperMayPrint, hyperRefusal } from "../../lib/stdlibHyperHonesty";
 import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal } from "../../lib/stdlibReliabilityHonesty";
 
 const { versions, defaultWorkflow, metrics } = publicContract;
@@ -58,7 +59,7 @@ const reliabilityShown = reliabilityMayPrint() ? reliabilityFace() : reliability
           </tr>
           <tr>
             <td class="py-3 pr-4 font-medium text-[var(--color-text-primary)]">Hyper lanes</td>
-            <td class="py-3">{metrics.hyperLanes} required lanes — see <code>artifacts/stdlib/stdlib_hyper_execution_status.v1.json</code></td>
+            <td class="py-3">{hyperMayPrint() ? hyperFace() : hyperRefusal()}</td>
           </tr>
         </tbody>
       </table>

--- a/website/src/lib/stdlibHyperHonesty.ts
+++ b/website/src/lib/stdlibHyperHonesty.ts
@@ -1,0 +1,65 @@
+/**
+ * U3 — stdlib hyper lanes 7/7. May 2026. Never in CI.
+ *
+ * Same morning as the 251/251 reliability JSON (15:35 vs 15:38).
+ * `scripts/stdlib/stdlib_hyper_execution_gate.sh` is not under
+ * scripts/ci/ and is not named in .github/. Zero workflow matches.
+ * The JSON names no Madaros and no lean_single. Do not invent an
+ * engine. A sync is not a remasure.
+ *
+ * Instance of MeasurementClaim, not a fourth kernel. If this
+ * numeral could not be a claim, the kernel would be the wrong
+ * shape — it is not. Same green-count as U1 and U2.
+ */
+
+import {
+  assertReachabilityComplete,
+  claimFace,
+  claimMayPrint,
+  claimRefusal,
+  type MeasurementClaim,
+} from './measurementClaim';
+
+export const STDLIB_HYPER: MeasurementClaim = {
+  id: 'stdlib-hyper-lanes',
+  kind: 'green-count',
+  gate: 'scripts/stdlib/stdlib_hyper_execution_gate.sh',
+  engine: null,
+  reachability: 'WORKFLOW-UNREACHABLE',
+  measuredAt: '2026-05-12T15:35:29Z',
+  artifact: 'artifacts/stdlib/stdlib_hyper_execution_status.v1.json',
+  parts: { pass: 7, fail: 0, skip: 0, total: 7 },
+};
+
+export function hyperPartsClose(c: MeasurementClaim): boolean {
+  return (
+    c.parts.pass + c.parts.fail + c.parts.skip === c.parts.total &&
+    c.parts.total === 7
+  );
+}
+
+export function hyperMayPrint(): boolean {
+  return claimMayPrint(STDLIB_HYPER, hyperPartsClose);
+}
+
+export function hyperFace(): string {
+  return claimFace(
+    STDLIB_HYPER,
+    hyperPartsClose,
+    `${STDLIB_HYPER.parts.pass} pass / ${STDLIB_HYPER.parts.total}`,
+  );
+}
+
+export function hyperRefusal(): string {
+  return claimRefusal(STDLIB_HYPER, 'stdlib hyper lanes');
+}
+
+export function hyperShortRefusal(): string {
+  return '—';
+}
+
+export function copyLeaksHyperNumeral(text: string): boolean {
+  return /\b7\s*\/\s*7\b/.test(text);
+}
+
+assertReachabilityComplete(STDLIB_HYPER, STDLIB_HYPER.id);


### PR DESCRIPTION
## Summary

- U3 7/7 **fits the kernel**. Same green-count as U1/U2: `engine: null`, `WORKFLOW-UNREACHABLE`, artifact `2026-05-12T15:35:29Z`, gate `scripts/stdlib/stdlib_hyper_execution_gate.sh`, zero `.github/` matches. No engine in the JSON. Do not invent one.
- ProofStrip and FeatureStatusPanel go through `hyperFace` / `hyperRefusal`. `hyperFace()` throws. Refusal has no 7.
- `_archive/index.v0.astro` still has a naked 7. Not a live page (same class as `GPUProofSection.astro`).
- `check:routes` now runs `check-unguarded-numerals.mjs`: live pages/components may not interpolate 7/7, 13/13, 251/251, `hyperPassCount`, or `hyperLanes`. That is construction for the **closed** greens, not yet for every numeral.

## Inverse scan (question 2)

The kernel is **not** yet an invariant of the site. After U3, these live paths still produce a measurement-like numeral without `claimFace` / `claimRefusal` / `suiteFaceParts`:

- **U5** `1000+` / `FAIL=0` — CompilerDepth, CompilerPipeline, `/language`, `/about`, `/compiler` (hardcoded; e-graph gate is in `ci.yml`, pages do not read it)
- **U4 inventory** — `stdlibInventoryFiles` 927, `scienceLanes` 2, self-hosted LOC/files on NumbersSection / about / FeatureStatusPanel
- **fullTestSuite** — FeatureStatusPanel / plan interpolate `pass/total` when non-null (currently `null` → honest `not published` on plan)
- **U11/U12** — `/dissertation` live ConfidenceGate and GumBudgetBar cite leftover umbrella gates
- **docs locales** — still repeat 251 in MDX (not this PR)

A later page can still write `{n}/{n}` and ship. The new check only closes the three greens already refused.

## REACHABLE (question 3)

Done on `#1902` (this PR stacks on it). Live instances: `ci.yml:110` and `:117`. `/dissertation` interpolates `frontendParityRefusal()` (`in CI · .github/workflows/ci.yml:117`). Deprecated `in CI` map without a line is gone. `pbpk_suite` stays `not in CI`.

## Test plan

- [x] `check:astro` 0
- [x] `check:i18n`
- [x] `check:routes` (includes numeral check)
- [ ] Website + Contracts on the stacked PR
- [ ] Confirm homepage ProofStrip shows `—` / hyper refusal, not `7/7`