### PR TITLE
feat(seed): SeedReceipt — structured proof for lean_single refresh

### DIFF
--- a/docs/ops/LEAN_SINGLE_SEED_REFRESH.md
+++ b/docs/ops/LEAN_SINGLE_SEED_REFRESH.md
@@ -267,21 +267,80 @@ scripts/dev/souc-build-lock.sh make build                 # Makefile chain; md5 
 ```
 
 **Never sufficient alone:** "md5 changed", "binary is newer", "make build ran",
-"file size grew", "CI green on an unrelated job".
+"file size grew", "CI green on an unrelated job", "procedure exited 0".
+
+### 2.5b SeedReceipt — procedure vs proof
+
+`--execute` always writes a **SeedReceipt** (not optional):
+
+```
+artifacts/seed-refresh/SeedReceipt-<UTC>.json
+artifacts/seed-refresh/SeedReceipt-<UTC>.txt
+artifacts/seed-refresh/SeedReceipt.latest.json   # stable pointer
+```
+
+Schema: `docs/ops/SEED_RECEIPT.schema.json`  
+Emitter: `scripts/dev/write_seed_receipt.py`  
+Validate later:
+
+```bash
+bash scripts/dev/refresh_lean_seed.sh \
+  --verify-receipt artifacts/seed-refresh/SeedReceipt.latest.json
+```
+
+| field | purpose |
+|---|---|
+| `source.sha256` | exact `lean_single.sio` bytes that were compiled |
+| `input_seed.sha256` | g0 / starting ELF (before the chain) |
+| `generations[]` | g0…gN with md5 + sha256 each |
+| **`fixed_point`** | **FIELD**, not a step log — see below |
+| `output_seed.sha256` | installed / to-commit ELF |
+| `environment` | placement, hostname, `slurm_partition`, `slurm_job_id`, nodelist |
+| `checks` | canonical_compiler_gate / verify_lean_seed pass\|fail |
+| `limits.provenance_note` | what the receipt deliberately does **not** claim |
+
+**Fixed point as a field (must be confirmable by eye):**
+
+```text
+--- md5 side-by-side (must be identical) ---
+gk_md5:       <H>
+gk_plus1_md5: <H>
+md5_equal: true
+--- sha256 side-by-side (must be identical) ---
+gk_sha256:       <S>
+gk_plus1_sha256: <S>
+sha256_equal: true
+verified: true
+```
+
+If a reader cannot confirm `gk_md5 == gk_plus1_md5` without re-running the
+chain, the receipt proves nothing. `--verify-receipt` fails closed when the
+two lines differ or `verified` is not true.
+
+**What a green `canonical_compiler_gate` is not:** it checks
+`md5(committed ELF) == md5(that ELF compiling current source)` — self-repro
+stability. It does **not** prove the ELF was *derived from* that source rather
+than substituted from another generation that happens to self-reproduce it.
+The generation table + `input_seed` hashes are the provenance trail; a future
+gate should require a SeedReceipt, not only the self-repro equality. Tracked
+as the next trust-anchor step, not implemented in this recipe amendment.
 
 ### 2.6 Commit
 
 ```bash
 git add bin/souc-lean-single-x86_64
+# optional but recommended: commit the receipt next to the blob or under artifacts/
+git add artifacts/seed-refresh/SeedReceipt-<UTC>.json
 # if SRC changed in the same PR, add it in the same commit or the immediately
 # preceding one — never land SRC without the matching ELF on the merge tip.
 git commit -m "$(cat <<'EOF'
 build(seed): refresh bin/souc-lean-single-x86_64 to lean_single fixed point
 
-canonical md5=<H>
-settled generation=gK (g{K-1}==gK)
-placement=srun/cpu-ops
-verified=canonical_compiler_gate + verify_lean_seed
+settle: gK==g{K+1} md5=<H>
+receipt: artifacts/seed-refresh/SeedReceipt-<UTC>.json
+canonical: committed==self-compile==<H>
+placement: srun/cpu-ops
+verified: canonical_compiler_gate + verify_lean_seed
 EOF
 )"
 ```
@@ -360,14 +419,17 @@ binary path).
 
 | path | role |
 |---|---|
-| `scripts/dev/refresh_lean_seed.sh` | print / check / stage / execute driver |
+| `scripts/dev/refresh_lean_seed.sh` | print / check / stage / execute / verify-receipt driver |
+| `scripts/dev/write_seed_receipt.py` | emit + validate SeedReceipt (JSON + human .txt) |
+| `docs/ops/SEED_RECEIPT.schema.json` | SeedReceipt schema v1 |
 | `scripts/dev/slurm_srun_minimal.sh` | supported Slurm launch (`srun` only) |
 | `scripts/dev/souc-build-lock.sh` | pod serialisation if local-locked |
-| `scripts/ci/canonical_compiler_gate.sh` | CI FAIL/PASS on md5 match |
+| `scripts/ci/canonical_compiler_gate.sh` | CI FAIL/PASS on self-repro md5 match (not provenance) |
 | `scripts/ci/verify_lean_seed.sh` | FP + determinism (+ optional DDC) |
 | `bin/souc-lean-single-x86_64` | **the** committed seed ELF |
 | `self-hosted/compiler/lean_single.sio` | seed source |
-| `docs/audit/CANONICAL_COMPILER_GATE_STRUCTURAL_COST_2026-08-18.md` | why this page exists |
+| `artifacts/seed-refresh/` | default SeedReceipt output directory |
+| `docs/audit/CANONICAL_COMPILER_GATE_STRUCTURAL_COST_2026-08-18.md` | why the recipe exists |
 
 ---
 

--- a/docs/ops/SEED_RECEIPT.schema.json
+++ b/docs/ops/SEED_RECEIPT.schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sounio.dev/schemas/SeedReceipt.v1.json",
+  "title": "Sounio SeedReceipt",
+  "description": "Structured proof that a lean_single seed refresh settled a fixed point. Procedure says work ran; this receipt lets someone verify it was done well months later without re-running.",
+  "type": "object",
+  "required": [
+    "schema",
+    "schema_version",
+    "receipt_utc",
+    "source",
+    "input_seed",
+    "generations",
+    "fixed_point",
+    "output_seed",
+    "environment",
+    "checks",
+    "limits"
+  ],
+  "properties": {
+    "schema": { "const": "sounio.SeedReceipt" },
+    "schema_version": { "type": "integer", "minimum": 1 },
+    "receipt_utc": { "type": "string" },
+    "git_commit": { "type": "string" },
+    "git_branch": { "type": "string" },
+    "source": {
+      "type": "object",
+      "required": ["path", "sha256", "md5", "bytes"],
+      "properties": {
+        "path": { "type": "string" },
+        "sha256": { "type": "string", "minLength": 64, "maxLength": 64 },
+        "md5": { "type": "string", "minLength": 32, "maxLength": 32 },
+        "bytes": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "input_seed": {
+      "type": "object",
+      "required": ["path", "sha256", "md5", "bytes"],
+      "properties": {
+        "path": { "type": "string" },
+        "sha256": { "type": "string", "minLength": 64, "maxLength": 64 },
+        "md5": { "type": "string", "minLength": 32, "maxLength": 32 },
+        "bytes": { "type": "integer", "minimum": 1 },
+        "role": { "type": "string" }
+      }
+    },
+    "generations": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "required": ["gen", "gen_index", "md5", "sha256"],
+        "properties": {
+          "gen": { "type": "string" },
+          "gen_index": { "type": "integer", "minimum": 0 },
+          "md5": { "type": "string", "minLength": 32, "maxLength": 32 },
+          "sha256": { "type": "string", "minLength": 64, "maxLength": 64 },
+          "path": { "type": "string" }
+        }
+      }
+    },
+    "fixed_point": {
+      "type": "object",
+      "description": "FIELD not step log. A reader must confirm gk_md5 == gk_plus1_md5 by eye.",
+      "required": [
+        "criterion",
+        "k",
+        "k_plus_1",
+        "gk_md5",
+        "gk_plus1_md5",
+        "gk_sha256",
+        "gk_plus1_sha256",
+        "md5_equal",
+        "sha256_equal",
+        "verified"
+      ],
+      "properties": {
+        "criterion": { "type": "string" },
+        "k": { "type": "integer", "minimum": 0 },
+        "k_plus_1": { "type": "integer", "minimum": 1 },
+        "gk_label": { "type": "string" },
+        "gk_plus1_label": { "type": "string" },
+        "gk_md5": { "type": "string", "minLength": 32, "maxLength": 32 },
+        "gk_plus1_md5": { "type": "string", "minLength": 32, "maxLength": 32 },
+        "gk_sha256": { "type": "string", "minLength": 64, "maxLength": 64 },
+        "gk_plus1_sha256": { "type": "string", "minLength": 64, "maxLength": 64 },
+        "md5_equal": { "type": "boolean" },
+        "sha256_equal": { "type": "boolean" },
+        "verified": { "type": "boolean" },
+        "eyeball_md5": { "type": "string" },
+        "eyeball_sha256": { "type": "string" }
+      }
+    },
+    "output_seed": {
+      "type": "object",
+      "required": ["path", "sha256", "md5", "bytes"],
+      "properties": {
+        "path": { "type": "string" },
+        "sha256": { "type": "string", "minLength": 64, "maxLength": 64 },
+        "md5": { "type": "string", "minLength": 32, "maxLength": 32 },
+        "bytes": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "environment": {
+      "type": "object",
+      "required": ["placement"],
+      "properties": {
+        "placement": {
+          "type": "string",
+          "enum": ["slurm", "local-locked", "check-only", "unknown"]
+        },
+        "hostname": { "type": "string" },
+        "slurm_partition": { "type": "string" },
+        "slurm_time": { "type": "string" },
+        "slurm_job_id": { "type": "string" },
+        "slurm_nodelist": { "type": "string" }
+      }
+    },
+    "checks": {
+      "type": "object",
+      "properties": {
+        "canonical_compiler_gate": {
+          "type": "string",
+          "enum": ["pass", "fail", "skip"]
+        },
+        "verify_lean_seed": {
+          "type": "string",
+          "enum": ["pass", "fail", "skip"]
+        }
+      }
+    },
+    "limits": {
+      "type": "object",
+      "required": ["provenance_note"],
+      "properties": {
+        "provenance_note": { "type": "string" }
+      }
+    }
+  }
+}

--- a/scripts/dev/refresh_lean_seed.sh
+++ b/scripts/dev/refresh_lean_seed.sh
@@ -34,6 +34,15 @@
 #   SOUNIO_SEED_REFRESH_EXECUTE=1 bash scripts/dev/refresh_lean_seed.sh --execute --via-slurm
 #   SOUNIO_SEED_REFRESH_EXECUTE=1 bash scripts/dev/refresh_lean_seed.sh --execute --local-locked
 #
+# OUTPUT
+# ------
+# --execute always emits a SeedReceipt (JSON + human .txt) under
+# artifacts/seed-refresh/ (and under the stage out/ dir). A procedure says work
+# ran; the receipt lets someone verify it was done *well* months later without
+# re-running. Fixed point is a FIELD (gk_md5 and gk_plus1_md5 side by side),
+# not a step log. See docs/ops/LEAN_SINGLE_SEED_REFRESH.md §2.5b and
+# docs/ops/SEED_RECEIPT.schema.json.
+#
 # DO NOT use sbatch. Use scripts/dev/slurm_srun_minimal.sh (srun). See
 # docs/ops/SLURM_LAUNCH_REPAIR_2026-08-17.md — sbatch is held for this submitter;
 # cluster hardware is up; held jobs are corpses, not capacity.
@@ -51,10 +60,14 @@ GATE="scripts/ci/canonical_compiler_gate.sh"
 VERIFY="scripts/ci/verify_lean_seed.sh"
 SRUN="scripts/dev/slurm_srun_minimal.sh"
 LOCK="scripts/dev/souc-build-lock.sh"
+RECEIPT_PY="scripts/dev/write_seed_receipt.py"
+RECEIPT_OUT_DEFAULT="artifacts/seed-refresh"
 
 # OrangeFS is visible on compute nodes; /workspace is not.
 ORANGEFS_ROOT="${SOUNIO_SEED_ORANGEFS_ROOT:-/orangefs/training/sounio/seed-refresh}"
 STAGE_DIR="${SOUNIO_SEED_STAGE_DIR:-}"
+RECEIPT_OUT="${SOUNIO_SEED_RECEIPT_OUT:-$RECEIPT_OUT_DEFAULT}"
+VERIFY_RECEIPT_PATH=""
 
 MODE="print"
 VIA="none"          # none | slurm | local-locked
@@ -68,7 +81,7 @@ SLURM_TIME="${SOUNIO_SEED_SLURM_TIME:-00:45:00}"
 FOLKLORE_COST_OPEN_PRS_MD5_ONLY=1
 
 usage() {
-  sed -n '2,45p' "$0" | sed 's/^# \?//'
+  sed -n '2,55p' "$0" | sed 's/^# \?//'
   cat <<EOF
 
 Modes:
@@ -76,6 +89,8 @@ Modes:
   --check            Run canonical_compiler_gate + verify_lean_seed on this tree.
   --stage            Stage SRC+SEED (+ optional linux bootstrap) onto OrangeFS.
   --execute          Run the derive chain. Requires SOUNIO_SEED_REFRESH_EXECUTE=1.
+                     Always writes a SeedReceipt (JSON + .txt).
+  --verify-receipt P Validate an existing SeedReceipt JSON (fixed_point by eye).
   --cost             Print the open-PR cost number of unwritten folklore and exit.
 
 Execute placement (with --execute):
@@ -86,6 +101,7 @@ Environment:
   SOUNIO_SEED_REFRESH_EXECUTE=1   required with --execute
   SOUNIO_SEED_STAGE_DIR=PATH      reuse an existing stage directory
   SOUNIO_SEED_ORANGEFS_ROOT=PATH  default $ORANGEFS_ROOT
+  SOUNIO_SEED_RECEIPT_OUT=PATH    default $RECEIPT_OUT_DEFAULT
   SOUNIO_SEED_MAX_GENS=N          default $MAX_GENS
   SOUNIO_SEED_SLURM_PARTITION=…   default $SLURM_PARTITION
   SOUNIO_SEED_SLURM_TIME=…        default $SLURM_TIME
@@ -95,6 +111,7 @@ Never:
   sbatch                          broken for openvscode-server (held corpses)
   cp … bin/souc                   bin/souc is the Madaros WRAPPER, not the seed
   commit generation 1             only genN where genN == genN+1 is shippable
+  claim success without SeedReceipt fixed_point.verified == true
 EOF
 }
 
@@ -102,6 +119,7 @@ die() { echo "[refresh-lean-seed] FAIL: $*" >&2; exit 1; }
 note() { echo "[refresh-lean-seed] $*"; }
 
 md5_of() { md5sum "$1" | awk '{print $1}'; }
+sha256_of() { sha256sum "$1" | awk '{print $1}'; }
 
 require_inputs() {
   [[ -f "$SRC" ]]  || die "missing $SRC"
@@ -178,14 +196,22 @@ EOF
 #     test -f out/SETTLED.md5 || exit 1
 #     cp -f out/gK.elf bin/souc-lean-single-x86_64 && chmod +x bin/souc-lean-single-x86_64
 
-## 7. Post-install M2+M3 (still required; DDC optional after)
+## 7. Post-install M2+M3 + SeedReceipt (still required; DDC optional after)
 #     bash scripts/ci/canonical_compiler_gate.sh     # M2
 #     bash scripts/ci/verify_lean_seed.sh            # M2+M3
+#     # --execute always writes:
+#     #   artifacts/seed-refresh/SeedReceipt-<utc>.json
+#     #   artifacts/seed-refresh/SeedReceipt-<utc>.txt
+#     # fixed_point is a FIELD — gk_md5 and gk_plus1_md5 side by side:
+#     #   gk_md5:       <H>
+#     #   gk_plus1_md5: <H>     # must match by eye or receipt proves nothing
+#     bash scripts/dev/refresh_lean_seed.sh --verify-receipt artifacts/seed-refresh/SeedReceipt.latest.json
 #   Commit message MUST contain:
 #     settle: gK==g{K+1} md5=<H>     # M1 — no line, no merge
+#     receipt: artifacts/seed-refresh/SeedReceipt-<utc>.json
 #     canonical: committed==self-compile==<H>
 #     placement: srun/cpu-ops
-#   NOT enough: "md5 changed" / "newer binary" / "make build ran"
+#   NOT enough: "md5 changed" / "newer binary" / "make build ran" / "procedure exited 0"
 
 ## 8. Commit + post-merge
 #     git add bin/souc-lean-single-x86_64 && git commit …
@@ -274,64 +300,9 @@ run_stage() {
   echo "$STAGE_DIR"
 }
 
-# ── derive loop (the actual folklore body) ──────────────────────────────────
-# Runs inside WORK_ROOT which must contain SRC and a starting ELF at SEED path.
-derive_fixed_point() {
-  local work_root="$1"
-  local start_elf="$2"   # absolute path to g0
-  local out_dir="$work_root/out"
-  mkdir -p "$out_dir"
-  ulimit -s "$STACK_KB" 2>/dev/null || true
-
-  local src="$work_root/$SRC"
-  [[ -f "$src" ]] || die "derive: missing $src"
-  [[ -x "$start_elf" ]] || die "derive: missing executable start $start_elf"
-
-  local prev="$start_elf"
-  local prev_md5
-  prev_md5="$(md5_of "$prev")"
-  note "g0 md5=$prev_md5  path=$prev"
-
-  local i=1
-  local cand=""
-  local cand_md5=""
-  while [[ "$i" -le "$MAX_GENS" ]]; do
-    cand="$out_dir/g${i}.elf"
-    note "compiling g${i}: $(basename "$prev") → $(basename "$cand")"
-    if ! "$prev" "$src" "$cand" >"$out_dir/g${i}.log" 2>&1; then
-      tail -20 "$out_dir/g${i}.log" >&2 || true
-      die "g${i} compile failed (see $out_dir/g${i}.log)"
-    fi
-    chmod +x "$cand"
-    cand_md5="$(md5_of "$cand")"
-    note "g${i} md5=$cand_md5  bytes=$(wc -c <"$cand")"
-    if [[ "$cand_md5" == "$prev_md5" && "$i" -ge 2 ]]; then
-      # prev was already a fixed point; ship prev (which equals cand)
-      note "SETTLED at g$((i-1))==g${i}  md5=$cand_md5"
-      echo "$cand"
-      return 0
-    fi
-    # special-case i==1: g0→g1 may differ; continue
-    prev="$cand"
-    prev_md5="$cand_md5"
-    i=$((i + 1))
-  done
-
-  # After loop, check last two generations if we produced >=2
-  if [[ -x "$out_dir/g$((MAX_GENS-1)).elf" && -x "$out_dir/g${MAX_GENS}.elf" ]]; then
-    local a b
-    a="$(md5_of "$out_dir/g$((MAX_GENS-1)).elf")"
-    b="$(md5_of "$out_dir/g${MAX_GENS}.elf")"
-    if [[ "$a" == "$b" ]]; then
-      note "SETTLED at g$((MAX_GENS-1))==g${MAX_GENS} md5=$a"
-      echo "$out_dir/g${MAX_GENS}.elf"
-      return 0
-    fi
-  fi
-  die "did not reach fixed point within MAX_GENS=$MAX_GENS (see $out_dir)"
-}
-
-# Refined settle: after each new gen i>=2, compare g{i-1} vs g{i}
+# ── derive loop ─────────────────────────────────────────────────────────────
+# Writes out/gens.tsv (gen\\tmd5\\tsha256\\tpath), out/SETTLED.md5, out/SETTLED.k,
+# out/seed.elf. Prints path to settled ELF on stdout (last line).
 derive_fixed_point_v2() {
   local work_root="$1"
   local start_elf="$2"
@@ -342,11 +313,14 @@ derive_fixed_point_v2() {
   local src="$work_root/$SRC"
   [[ -f "$src" && -x "$start_elf" ]] || die "derive_v2: bad inputs"
 
-  # g0 is start; produce g1.. until g{n}==g{n+1}
+  local gens_tsv="$out_dir/gens.tsv"
+  : >"$gens_tsv"
+
   local -a md5s=()
   local -a paths=()
   paths[0]="$start_elf"
   md5s[0]="$(md5_of "$start_elf")"
+  printf 'g0\t%s\t%s\t%s\n' "${md5s[0]}" "$(sha256_of "$start_elf")" "$start_elf" >>"$gens_tsv"
   note "g0 md5=${md5s[0]}  path=${paths[0]}"
 
   local i=1
@@ -361,10 +335,11 @@ derive_fixed_point_v2() {
     chmod +x "$cand"
     paths[$i]="$cand"
     md5s[$i]="$(md5_of "$cand")"
+    printf 'g%d\t%s\t%s\t%s\n' "$i" "${md5s[$i]}" "$(sha256_of "$cand")" "$cand" >>"$gens_tsv"
     note "g${i} md5=${md5s[$i]}  bytes=$(wc -c <"$cand")"
     if [[ "$i" -ge 2 && "${md5s[$i]}" == "${md5s[$((i-1))]}" ]]; then
-      note "SETTLED: g$((i-1)) == g${i}  md5=${md5s[$i]}"
-      # Also prove the gate property: settled ELF self-reproduces once more
+      local k=$((i - 1))
+      note "SETTLED: g${k} == g${i}  md5=${md5s[$i]}"
       local repro="$out_dir/repro.elf"
       if ! "$cand" "$src" "$repro" >"$out_dir/repro.log" 2>&1; then
         tail -20 "$out_dir/repro.log" >&2 || true
@@ -376,12 +351,42 @@ derive_fixed_point_v2() {
       [[ "$repro_md5" == "${md5s[$i]}" ]] \
         || die "settled md5 ${md5s[$i]} != self-repro $repro_md5 (not a fixed point)"
       note "SELF-REPRO ok md5=$repro_md5"
+      printf '%s\n' "${md5s[$i]}" >"$out_dir/SETTLED.md5"
+      printf '%s\n' "$k" >"$out_dir/SETTLED.k"
+      cp -f "$cand" "$out_dir/seed.elf"
+      chmod +x "$out_dir/seed.elf"
       printf '%s\n' "$cand"
       return 0
     fi
     i=$((i + 1))
   done
   die "no fixed point within MAX_GENS=$MAX_GENS — dump: ${md5s[*]}"
+}
+
+emit_seed_receipt() {
+  # Args via env-style locals set by caller:
+  #   _gens_tsv _source _input_seed _output_seed _settle_k _placement
+  #   _canon_status _verify_status  (pass|fail|skip)
+  local out_dir="${1:-$RECEIPT_OUT}"
+  mkdir -p "$out_dir"
+  [[ -f "$RECEIPT_PY" ]] || die "missing $RECEIPT_PY"
+  python3 "$RECEIPT_PY" \
+    --out-dir "$out_dir" \
+    --gens-tsv "$_gens_tsv" \
+    --source "$_source" \
+    --input-seed "$_input_seed" \
+    --output-seed "$_output_seed" \
+    --settle-k "$_settle_k" \
+    --placement "${_placement:-unknown}" \
+    --slurm-partition "${_slurm_partition:-}" \
+    --slurm-time "${_slurm_time:-}" \
+    --slurm-job-id "${_slurm_job_id:-}" \
+    --slurm-nodelist "${_slurm_nodelist:-}" \
+    --hostname "${_hostname:-$(hostname 2>/dev/null || true)}" \
+    --git-commit "$(git rev-parse HEAD 2>/dev/null || true)" \
+    --git-branch "$(git branch --show-current 2>/dev/null || echo detached)" \
+    --canonical-gate "${_canon_status:-skip}" \
+    --verify-lean-seed "${_verify_status:-skip}"
 }
 
 install_seed() {
@@ -412,8 +417,9 @@ run_execute() {
   Print the recipe with: bash scripts/dev/refresh_lean_seed.sh --print"
 
   require_inputs
-  local work_root=""
-  local start_elf=""
+  local out_meta=""   # directory holding gens.tsv / SETTLED.*
+  local input_seed_abs=""
+  local placement=""
 
   case "$VIA" in
     slurm)
@@ -422,22 +428,32 @@ run_execute() {
         STAGE_DIR="$(run_stage | tail -1)"
       fi
       [[ -d "$STAGE_DIR" ]] || die "stage dir missing: $STAGE_DIR"
-      work_root="$STAGE_DIR"
-      start_elf="$STAGE_DIR/$SEED"
+      input_seed_abs="$STAGE_DIR/$SEED"
+      # Snapshot input seed hashes before overwrite risk
+      cp -f "$STAGE_DIR/$SEED" "$STAGE_DIR/out/input_seed.elf" 2>/dev/null || {
+        mkdir -p "$STAGE_DIR/out"
+        cp -f "$STAGE_DIR/$SEED" "$STAGE_DIR/out/input_seed.elf"
+      }
+      placement="slurm"
       note "launching derive on Slurm via $SRUN (partition=$SLURM_PARTITION)"
       # shellcheck disable=SC2016
       bash "$SRUN" --partition="$SLURM_PARTITION" --time="$SLURM_TIME" -- "
         set -euo pipefail
         ulimit -s $STACK_KB || true
         cd '$STAGE_DIR'
-        # inline minimal derive so the node needs no /workspace
         SRC='$SRC'
         SEED='$SEED'
         OUT=out
         mkdir -p \"\$OUT\"
+        : >\"\$OUT/gens.tsv\"
         prev=\"\$SEED\"
         prev_md5=\$(md5sum \"\$prev\" | awk '{print \$1}')
-        echo \"[slurm-derive] g0 md5=\$prev_md5\"
+        prev_sha=\$(sha256sum \"\$prev\" | awk '{print \$1}')
+        printf 'g0\\t%s\\t%s\\t%s\\n' \"\$prev_md5\" \"\$prev_sha\" \"\$prev\" >>\"\$OUT/gens.tsv\"
+        echo \"[slurm-derive] g0 md5=\$prev_md5 hostname=\$(hostname) job=\${SLURM_JOB_ID:-} node=\${SLURM_NODELIST:-}\"
+        echo \"\$(hostname)\" >\"\$OUT/slurm.hostname\"
+        echo \"\${SLURM_JOB_ID:-}\" >\"\$OUT/slurm.job_id\"
+        echo \"\${SLURM_NODELIST:-}\" >\"\$OUT/slurm.nodelist\"
         i=1
         while [ \"\$i\" -le $MAX_GENS ]; do
           cand=\"\$OUT/g\${i}.elf\"
@@ -447,9 +463,10 @@ run_execute() {
           }
           chmod +x \"\$cand\"
           cand_md5=\$(md5sum \"\$cand\" | awk '{print \$1}')
+          cand_sha=\$(sha256sum \"\$cand\" | awk '{print \$1}')
+          printf 'g%d\\t%s\\t%s\\t%s\\n' \"\$i\" \"\$cand_md5\" \"\$cand_sha\" \"\$cand\" >>\"\$OUT/gens.tsv\"
           echo \"[slurm-derive] g\${i} md5=\$cand_md5\"
           if [ \"\$i\" -ge 2 ] && [ \"\$cand_md5\" = \"\$prev_md5\" ]; then
-            # self-repro check
             \"\$cand\" \"\$SRC\" \"\$OUT/repro.elf\" >\"\$OUT/repro.log\" 2>&1
             chmod +x \"\$OUT/repro.elf\"
             repro_md5=\$(md5sum \"\$OUT/repro.elf\" | awk '{print \$1}')
@@ -457,11 +474,13 @@ run_execute() {
               echo \"[slurm-derive] FAIL self-repro \$repro_md5 != \$cand_md5\" >&2
               exit 1
             }
+            k=\$((i - 1))
             echo \"\$cand_md5\" >\"\$OUT/SETTLED.md5\"
+            echo \"\$k\" >\"\$OUT/SETTLED.k\"
             echo \"\$cand\" >\"\$OUT/SETTLED.path\"
             cp -f \"\$cand\" \"\$OUT/seed.elf\"
             chmod +x \"\$OUT/seed.elf\"
-            echo \"[slurm-derive] SETTLED g\$((i-1))==g\${i} md5=\$cand_md5\"
+            echo \"[slurm-derive] SETTLED g\${k}==g\${i} md5=\$cand_md5\"
             exit 0
           fi
           prev=\"\$cand\"
@@ -471,44 +490,94 @@ run_execute() {
         echo \"[slurm-derive] FAIL no fixed point in $MAX_GENS gens\" >&2
         exit 1
       "
-      [[ -f "$STAGE_DIR/out/SETTLED.md5" ]] \
-        || die "M1 FAIL: slurm derive produced no SETTLED.md5 — refuse install"
-      local settled_md5
-      settled_md5="$(tr -d '[:space:]' <"$STAGE_DIR/out/SETTLED.md5")"
-      note "slurm settled md5=$settled_md5 (M1)"
+      [[ -f "$STAGE_DIR/out/SETTLED.md5" && -f "$STAGE_DIR/out/gens.tsv" ]] \
+        || die "M1 FAIL: slurm derive produced no SETTLED.md5/gens.tsv — refuse install"
+      note "slurm settled md5=$(tr -d '[:space:]' <"$STAGE_DIR/out/SETTLED.md5") (M1)"
       install_seed "$STAGE_DIR/out/seed.elf" "$ROOT_DIR/$SEED" "$STAGE_DIR/out/SETTLED.md5"
+      out_meta="$STAGE_DIR/out"
+      input_seed_abs="$STAGE_DIR/out/input_seed.elf"
+      [[ -f "$input_seed_abs" ]] || input_seed_abs="$STAGE_DIR/$SEED"
       ;;
     local-locked)
       note "LOCAL-LOCKED path — holds souc-build-lock; can stress the pod"
-      work_root="$ROOT_DIR"
-      start_elf="$ROOT_DIR/$SEED"
-      local cand settled_file
-      settled_file="$ROOT_DIR/out/SETTLED.md5"
+      placement="local-locked"
       mkdir -p "$ROOT_DIR/out"
-      cand="$(bash "$LOCK" bash -c "
+      cp -f "$ROOT_DIR/$SEED" "$ROOT_DIR/out/input_seed.elf"
+      input_seed_abs="$ROOT_DIR/out/input_seed.elf"
+      bash "$LOCK" bash -c "
         set -euo pipefail
-        $(declare -f note die md5_of derive_fixed_point_v2)
+        $(declare -f note die md5_of sha256_of derive_fixed_point_v2)
         ROOT_DIR='$ROOT_DIR'
         SRC='$SRC'
         MAX_GENS='$MAX_GENS'
         STACK_KB='$STACK_KB'
-        c=\$(derive_fixed_point_v2 '$work_root' '$start_elf')
-        md5sum \"\$c\" | awk '{print \$1}' > '$settled_file'
-        printf '%s\n' \"\$c\"
-      ")"
-      [[ -f "$settled_file" ]] || die "M1 FAIL: local derive wrote no SETTLED.md5"
-      install_seed "$cand" "$ROOT_DIR/$SEED" "$settled_file"
+        derive_fixed_point_v2 '$ROOT_DIR' '$ROOT_DIR/out/input_seed.elf' >/dev/null
+      "
+      [[ -f "$ROOT_DIR/out/SETTLED.md5" && -f "$ROOT_DIR/out/gens.tsv" ]] \
+        || die "M1 FAIL: local derive wrote no SETTLED.md5/gens.tsv"
+      install_seed "$ROOT_DIR/out/seed.elf" "$ROOT_DIR/$SEED" "$ROOT_DIR/out/SETTLED.md5"
+      out_meta="$ROOT_DIR/out"
       ;;
     *)
       die "--execute requires --via-slurm or --local-locked"
       ;;
   esac
 
+  local canon_status=fail verify_status=fail
   note "post-install verification"
-  (cd "$ROOT_DIR" && bash "$GATE")
-  (cd "$ROOT_DIR" && bash "$VERIFY")
-  note "EXECUTE PASS — commit $SEED when ready"
+  if (cd "$ROOT_DIR" && bash "$GATE"); then canon_status=pass; else canon_status=fail; fi
+  if (cd "$ROOT_DIR" && bash "$VERIFY"); then verify_status=pass; else verify_status=fail; fi
+  if [[ "${SOUNIO_SEED_DDC:-0}" == "1" ]]; then
+    note "DDC leg"
+    SOUNIO_SEED_DDC=1 bash "$VERIFY" || verify_status=fail
+  fi
+  [[ "$canon_status" == "pass" && "$verify_status" == "pass" ]] \
+    || die "post-install gates failed (canonical=$canon_status verify=$verify_status) — seed installed but NOT receipt-clean"
+
+  local settle_k
+  settle_k="$(tr -d '[:space:]' <"$out_meta/SETTLED.k")"
+  _gens_tsv="$out_meta/gens.tsv"
+  _source="$ROOT_DIR/$SRC"
+  # Prefer pre-chain snapshot of input seed
+  _input_seed="$input_seed_abs"
+  _output_seed="$ROOT_DIR/$SEED"
+  _settle_k="$settle_k"
+  _placement="$placement"
+  _slurm_partition="$SLURM_PARTITION"
+  _slurm_time="$SLURM_TIME"
+  _slurm_job_id=""
+  _slurm_nodelist=""
+  _hostname="$(hostname 2>/dev/null || true)"
+  if [[ -f "$out_meta/slurm.job_id" ]]; then
+    _slurm_job_id="$(tr -d '[:space:]' <"$out_meta/slurm.job_id")"
+  fi
+  if [[ -f "$out_meta/slurm.nodelist" ]]; then
+    _slurm_nodelist="$(tr -d '[:space:]' <"$out_meta/slurm.nodelist")"
+  fi
+  if [[ -f "$out_meta/slurm.hostname" ]]; then
+    _hostname="$(tr -d '[:space:]' <"$out_meta/slurm.hostname")"
+  fi
+  _canon_status="$canon_status"
+  _verify_status="$verify_status"
+
+  # Receipt in artifacts/ and next to stage out/
+  emit_seed_receipt "$RECEIPT_OUT"
+  if [[ "$out_meta" != "$RECEIPT_OUT" ]]; then
+    emit_seed_receipt "$out_meta" || true
+  fi
+
+  note "EXECUTE PASS — commit $SEED + SeedReceipt when ready"
   note "md5=$(md5_of "$ROOT_DIR/$SEED")"
+  note "receipt_dir=$RECEIPT_OUT (also see SeedReceipt.latest.json)"
+  note "fixed_point field: open the .txt and confirm gk_md5 == gk_plus1_md5 by eye"
+}
+
+run_verify_receipt() {
+  local p="${VERIFY_RECEIPT_PATH:-}"
+  [[ -n "$p" ]] || die "--verify-receipt requires a path"
+  [[ -f "$p" ]] || die "receipt not found: $p"
+  [[ -f "$RECEIPT_PY" ]] || die "missing $RECEIPT_PY"
+  python3 "$RECEIPT_PY" --verify-receipt "$p"
 }
 
 # ── argv ────────────────────────────────────────────────────────────────────
@@ -519,12 +588,24 @@ while [[ $# -gt 0 ]]; do
     --check) MODE=check; shift ;;
     --stage) MODE=stage; shift ;;
     --execute) MODE=execute; shift ;;
+    --verify-receipt)
+      MODE=verify-receipt
+      VERIFY_RECEIPT_PATH="${2:-}"
+      [[ -n "$VERIFY_RECEIPT_PATH" ]] || die "--verify-receipt needs PATH"
+      shift 2
+      ;;
+    --verify-receipt=*)
+      MODE=verify-receipt
+      VERIFY_RECEIPT_PATH="${1#*=}"
+      shift
+      ;;
     --cost) MODE=cost; shift ;;
     --via-slurm) VIA=slurm; shift ;;
     --local-locked) VIA=local-locked; shift ;;
     --stage-dir=*) STAGE_DIR="${1#*=}"; shift ;;
     --partition=*) SLURM_PARTITION="${1#*=}"; shift ;;
     --time=*) SLURM_TIME="${1#*=}"; shift ;;
+    --receipt-out=*) RECEIPT_OUT="${1#*=}"; shift ;;
     *) die "unknown arg: $1 (see --help)" ;;
   esac
 done
@@ -535,5 +616,6 @@ case "$MODE" in
   check)  run_check ;;
   stage)  run_stage >/dev/null; note "STAGE_DIR=$STAGE_DIR" ;;
   execute) run_execute ;;
+  verify-receipt) run_verify_receipt ;;
   *) die "bad mode $MODE" ;;
 esac

--- a/scripts/dev/write_seed_receipt.py
+++ b/scripts/dev/write_seed_receipt.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Emit a SeedReceipt for a lean_single seed refresh.
+
+A procedure says work ran. A receipt lets someone verify it was done *well*
+months later without re-running the chain.
+
+Fixed point is a *field*, not a narrative step:
+  fixed_point.gk_md5 and fixed_point.gk_plus1_md5 must be identical by eye.
+
+Usage:
+  python3 scripts/dev/write_seed_receipt.py \\
+    --out-dir artifacts/seed-refresh \\
+    --gens-tsv path/to/gens.tsv \\
+    --source path \\
+    --input-seed path \\
+    --output-seed path \\
+    --settle-k N \\
+    --placement slurm|local-locked \\
+    [--slurm-partition P] [--slurm-time T] [--slurm-job-id J] [--hostname H] \\
+    [--git-commit C] [--git-branch B] \\
+    [--canonical-gate pass|fail|skip] [--verify-lean-seed pass|fail|skip] \\
+    [--schema-version 1]
+
+gens.tsv columns (tab-separated, no header required if 4 cols):
+  gen  md5  sha256  path
+  gen may be g0, g1, … or 0, 1, …
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SCHEMA_VERSION = 1
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def md5_file(path: Path) -> str:
+    h = hashlib.md5()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def parse_gens_tsv(path: Path) -> list[dict]:
+    rows: list[dict] = []
+    text = path.read_text(encoding="utf-8")
+    for line_no, raw in enumerate(text.splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) < 3:
+            raise SystemExit(f"gens.tsv line {line_no}: need gen md5 sha256 [path], got {parts!r}")
+        gen_raw, md5, sha = parts[0].strip(), parts[1].strip(), parts[2].strip()
+        p = parts[3].strip() if len(parts) > 3 else ""
+        gen_label = gen_raw if gen_raw.startswith("g") else f"g{gen_raw}"
+        try:
+            gen_index = int(gen_label[1:])
+        except ValueError as e:
+            raise SystemExit(f"gens.tsv line {line_no}: bad gen {gen_raw!r}") from e
+        rows.append(
+            {
+                "gen": gen_label,
+                "gen_index": gen_index,
+                "md5": md5.lower(),
+                "sha256": sha.lower(),
+                "path": p,
+            }
+        )
+    rows.sort(key=lambda r: r["gen_index"])
+    return rows
+
+
+def build_fixed_point(gens: list[dict], settle_k: int) -> dict:
+    """settle_k is the index k such that g_k == g_{k+1} (both present)."""
+    by_i = {g["gen_index"]: g for g in gens}
+    if settle_k not in by_i or (settle_k + 1) not in by_i:
+        raise SystemExit(
+            f"settle-k={settle_k} requires g{settle_k} and g{settle_k + 1} in gens.tsv; "
+            f"have {[g['gen'] for g in gens]}"
+        )
+    gk = by_i[settle_k]
+    gk1 = by_i[settle_k + 1]
+    equal_md5 = gk["md5"] == gk1["md5"]
+    equal_sha = gk["sha256"] == gk1["sha256"]
+    verified = equal_md5 and equal_sha and bool(gk["md5"]) and bool(gk["sha256"])
+    return {
+        # Field, not a step log: a reader must confirm equality by eye.
+        "criterion": "md5(g_k) == md5(g_{k+1}) AND sha256(g_k) == sha256(g_{k+1})",
+        "k": settle_k,
+        "k_plus_1": settle_k + 1,
+        "gk_label": gk["gen"],
+        "gk_plus1_label": gk1["gen"],
+        "gk_md5": gk["md5"],
+        "gk_plus1_md5": gk1["md5"],
+        "gk_sha256": gk["sha256"],
+        "gk_plus1_sha256": gk1["sha256"],
+        "md5_equal": equal_md5,
+        "sha256_equal": equal_sha,
+        "verified": verified,
+        # Side-by-side block for human eyeball (duplicated in .txt):
+        "eyeball_md5": f"{gk['md5']}\n{gk1['md5']}",
+        "eyeball_sha256": f"{gk['sha256']}\n{gk1['sha256']}",
+    }
+
+
+def human_text(receipt: dict) -> str:
+    fp = receipt["fixed_point"]
+    env = receipt["environment"]
+    lines = [
+        "SeedReceipt",
+        f"schema_version: {receipt['schema_version']}",
+        f"receipt_utc: {receipt['receipt_utc']}",
+        f"git_commit: {receipt.get('git_commit') or ''}",
+        f"git_branch: {receipt.get('git_branch') or ''}",
+        "",
+        "## source (lean_single.sio)",
+        f"path: {receipt['source']['path']}",
+        f"sha256: {receipt['source']['sha256']}",
+        f"md5: {receipt['source']['md5']}",
+        f"bytes: {receipt['source']['bytes']}",
+        "",
+        "## input seed (g0 / bootstrap ELF used to start the chain)",
+        f"path: {receipt['input_seed']['path']}",
+        f"sha256: {receipt['input_seed']['sha256']}",
+        f"md5: {receipt['input_seed']['md5']}",
+        f"bytes: {receipt['input_seed']['bytes']}",
+        "",
+        "## generations",
+    ]
+    for g in receipt["generations"]:
+        lines.append(
+            f"  {g['gen']}: md5={g['md5']}  sha256={g['sha256']}  path={g.get('path') or ''}"
+        )
+    lines += [
+        "",
+        "## fixed_point (FIELD — confirm equality by eye; if you cannot, receipt proves nothing)",
+        f"criterion: {fp['criterion']}",
+        f"k: {fp['k']}",
+        f"k_plus_1: {fp['k_plus_1']}",
+        f"gk_label: {fp['gk_label']}",
+        f"gk_plus1_label: {fp['gk_plus1_label']}",
+        "--- md5 side-by-side (must be identical) ---",
+        f"gk_md5:       {fp['gk_md5']}",
+        f"gk_plus1_md5: {fp['gk_plus1_md5']}",
+        f"md5_equal: {str(fp['md5_equal']).lower()}",
+        "--- sha256 side-by-side (must be identical) ---",
+        f"gk_sha256:       {fp['gk_sha256']}",
+        f"gk_plus1_sha256: {fp['gk_plus1_sha256']}",
+        f"sha256_equal: {str(fp['sha256_equal']).lower()}",
+        f"verified: {str(fp['verified']).lower()}",
+        "",
+        "## output seed (installed / to commit)",
+        f"path: {receipt['output_seed']['path']}",
+        f"sha256: {receipt['output_seed']['sha256']}",
+        f"md5: {receipt['output_seed']['md5']}",
+        f"bytes: {receipt['output_seed']['bytes']}",
+        "",
+        "## environment",
+        f"placement: {env.get('placement') or ''}",
+        f"hostname: {env.get('hostname') or ''}",
+        f"slurm_partition: {env.get('slurm_partition') or ''}",
+        f"slurm_time: {env.get('slurm_time') or ''}",
+        f"slurm_job_id: {env.get('slurm_job_id') or ''}",
+        f"slurm_nodelist: {env.get('slurm_nodelist') or ''}",
+        "",
+        "## post checks",
+        f"canonical_compiler_gate: {receipt['checks'].get('canonical_compiler_gate')}",
+        f"verify_lean_seed: {receipt['checks'].get('verify_lean_seed')}",
+        "",
+        "## what this receipt does NOT prove",
+        receipt["limits"]["provenance_note"],
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def verify_receipt_file(path: Path) -> int:
+    """Exit 0 if fixed_point fields match by equality; 1 otherwise."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    fp = data.get("fixed_point") or {}
+    errors = []
+    if not fp.get("verified"):
+        errors.append("fixed_point.verified is not true")
+    if fp.get("gk_md5") != fp.get("gk_plus1_md5"):
+        errors.append(
+            f"md5 mismatch by eye:\n  gk_md5:       {fp.get('gk_md5')}\n  gk_plus1_md5: {fp.get('gk_plus1_md5')}"
+        )
+    if fp.get("gk_sha256") != fp.get("gk_plus1_sha256"):
+        errors.append(
+            f"sha256 mismatch by eye:\n  gk_sha256:       {fp.get('gk_sha256')}\n  gk_plus1_sha256: {fp.get('gk_plus1_sha256')}"
+        )
+    if errors:
+        print(f"[seed-receipt] FAIL {path}", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+    print(f"[seed-receipt] PASS fixed_point verified by eye fields in {path}")
+    print(f"  gk_md5:       {fp.get('gk_md5')}")
+    print(f"  gk_plus1_md5: {fp.get('gk_plus1_md5')}")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--verify-receipt", metavar="PATH", help="validate an existing SeedReceipt JSON")
+    ap.add_argument("--out-dir", type=Path, help="directory for SeedReceipt-*.json and .txt")
+    ap.add_argument("--gens-tsv", type=Path, help="generation table")
+    ap.add_argument("--source", type=Path)
+    ap.add_argument("--input-seed", type=Path)
+    ap.add_argument("--output-seed", type=Path)
+    ap.add_argument("--settle-k", type=int, help="k where g_k == g_{k+1}")
+    ap.add_argument("--placement", choices=("slurm", "local-locked", "check-only", "unknown"), default="unknown")
+    ap.add_argument("--slurm-partition", default="")
+    ap.add_argument("--slurm-time", default="")
+    ap.add_argument("--slurm-job-id", default="")
+    ap.add_argument("--slurm-nodelist", default="")
+    ap.add_argument("--hostname", default="")
+    ap.add_argument("--git-commit", default="")
+    ap.add_argument("--git-branch", default="")
+    ap.add_argument("--canonical-gate", default="skip", choices=("pass", "fail", "skip"))
+    ap.add_argument("--verify-lean-seed", default="skip", choices=("pass", "fail", "skip"))
+    ap.add_argument("--schema-version", type=int, default=SCHEMA_VERSION)
+    args = ap.parse_args()
+
+    if args.verify_receipt:
+        return verify_receipt_file(Path(args.verify_receipt))
+
+    required = [
+        args.out_dir,
+        args.gens_tsv,
+        args.source,
+        args.input_seed,
+        args.output_seed,
+        args.settle_k,
+    ]
+    if any(x is None for x in required):
+        ap.error("emit mode requires --out-dir --gens-tsv --source --input-seed --output-seed --settle-k")
+
+    source = args.source.resolve()
+    in_seed = args.input_seed.resolve()
+    out_seed = args.output_seed.resolve()
+    for p in (source, in_seed, out_seed, args.gens_tsv):
+        if not p.is_file():
+            raise SystemExit(f"missing file: {p}")
+
+    gens = parse_gens_tsv(args.gens_tsv)
+    fp = build_fixed_point(gens, args.settle_k)
+    if not fp["verified"]:
+        raise SystemExit(
+            "refusing to emit receipt: fixed_point not verified "
+            f"(md5_equal={fp['md5_equal']} sha256_equal={fp['sha256_equal']})"
+        )
+
+    utc = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    receipt = {
+        "schema": "sounio.SeedReceipt",
+        "schema_version": args.schema_version,
+        "receipt_utc": utc,
+        "git_commit": args.git_commit,
+        "git_branch": args.git_branch,
+        "source": {
+            "path": str(source),
+            "sha256": sha256_file(source),
+            "md5": md5_file(source),
+            "bytes": source.stat().st_size,
+        },
+        "input_seed": {
+            "path": str(in_seed),
+            "sha256": sha256_file(in_seed),
+            "md5": md5_file(in_seed),
+            "bytes": in_seed.stat().st_size,
+            "role": "g0_start_of_chain",
+        },
+        "generations": gens,
+        "fixed_point": fp,
+        "output_seed": {
+            "path": str(out_seed),
+            "sha256": sha256_file(out_seed),
+            "md5": md5_file(out_seed),
+            "bytes": out_seed.stat().st_size,
+        },
+        "environment": {
+            "placement": args.placement,
+            "hostname": args.hostname or os.uname().nodename,
+            "slurm_partition": args.slurm_partition,
+            "slurm_time": args.slurm_time,
+            "slurm_job_id": args.slurm_job_id or os.environ.get("SLURM_JOB_ID", ""),
+            "slurm_nodelist": args.slurm_nodelist or os.environ.get("SLURM_NODELIST", ""),
+        },
+        "checks": {
+            "canonical_compiler_gate": args.canonical_gate,
+            "verify_lean_seed": args.verify_lean_seed,
+        },
+        "limits": {
+            "provenance_note": (
+                "This receipt proves the installed ELF is a self-reproducing fixed point "
+                "of the recorded source bytes (g_k == g_{k+1}, self-repro). It does NOT by "
+                "itself prove the ELF was *derived from* that source rather than substituted "
+                "from another generation that happens to self-reproduce the same source. "
+                "canonical_compiler_gate.sh checks md5(committed)==md5(self-compile) — "
+                "stability, not provenance. Provenance (ELF came FROM this source via this "
+                "chain) is what the generation table + input_seed hashes are for; a future "
+                "gate should require a SeedReceipt, not only the self-repro equality."
+            )
+        },
+    }
+
+    # Consistency: output seed must match settled generation hash
+    settled_md5 = fp["gk_md5"]
+    if receipt["output_seed"]["md5"] != settled_md5:
+        raise SystemExit(
+            f"output seed md5 {receipt['output_seed']['md5']} != settled gk_md5 {settled_md5}"
+        )
+
+    out_dir = args.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    base = out_dir / f"SeedReceipt-{stamp}"
+    json_path = base.with_suffix(".json")
+    txt_path = base.with_suffix(".txt")
+    json_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    txt_path.write_text(human_text(receipt), encoding="utf-8")
+
+    # Also write a stable "latest" pointer in the out dir when under stage/out
+    latest_json = out_dir / "SeedReceipt.latest.json"
+    latest_txt = out_dir / "SeedReceipt.latest.txt"
+    latest_json.write_text(json_path.read_text(encoding="utf-8"), encoding="utf-8")
+    latest_txt.write_text(txt_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    print(f"[seed-receipt] wrote {json_path}")
+    print(f"[seed-receipt] wrote {txt_path}")
+    print(f"[seed-receipt] fixed_point.verified={fp['verified']}")
+    print(f"[seed-receipt] gk_md5:       {fp['gk_md5']}")
+    print(f"[seed-receipt] gk_plus1_md5: {fp['gk_plus1_md5']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Amendment on top of the lean_single seed refresh recipe (#1894): `--execute` no longer ends with “procedure exited 0”. It always emits a **SeedReceipt**.

### Procedure vs receipt

| | says | proves months later |
|---|---|---|
| Procedure | work ran | nothing durable |
| **SeedReceipt** | — | source bytes, input seed, gen chain, settle equality, Slurm env |

### Fixed point is a field

```text
--- md5 side-by-side (must be identical) ---
gk_md5:       <H>
gk_plus1_md5: <H>
```

If a reader cannot confirm equality by eye, the receipt proves nothing.
`bash scripts/dev/refresh_lean_seed.sh --verify-receipt PATH` fails closed on mismatch.

### What lands

- `scripts/dev/write_seed_receipt.py` — emit JSON + human `.txt`; `--verify-receipt`
- `docs/ops/SEED_RECEIPT.schema.json` — schema v1
- `scripts/dev/refresh_lean_seed.sh` — always writes receipt on `--execute`; records gens.tsv + Slurm job/host
- `docs/ops/LEAN_SINGLE_SEED_REFRESH.md` §2.5b

### Trust-anchor gap (recorded, not closed)

`canonical_compiler_gate` checks **self-repro stability** (`md5(ELF) == md5(ELF(source))`).
It does **not** prove the ELF was **derived from** that source rather than substituted from another generation that happens to self-reproduce it. The receipt’s generation table + `input_seed` hashes are the provenance trail; a future gate should require a SeedReceipt. Called out in `limits.provenance_note`.

No live seed rebuild in this PR.

## Test plan

- [x] Synthetic emit: side-by-side md5/sha256 identical → `verified: true`
- [x] `--verify-receipt` PASS on good receipt; FAIL when `gk_plus1_md5` mangled
- [x] `bash -n scripts/dev/refresh_lean_seed.sh`
- [ ] CI Contracts green
