### PR TITLE
dead-code(native): remove seven measured-dead codegen bodies

### DIFF
--- a/self-hosted/native/codegen.sio
+++ b/self-hosted/native/codegen.sio
@@ -66,8 +66,6 @@ pub fn ERR_OK() -> i64 { 0 }
 pub fn ERR_BACKEND_NOT_IMPLEMENTED() -> i64 { 1 }
 fn ERR_INVALID_TARGET() -> i64 { 2 }
 fn ERR_INVALID_MATRIX() -> i64 { 3 }
-fn ERR_TRACE_WRITE_FAILED() -> i64 { 4 }
-fn ERR_TARGET_FLAGS_REQUIRE_NATIVE() -> i64 { 5 }
 
 fn TARGET_SOURCE_UNKNOWN() -> i64 { 0 }
 fn TARGET_SOURCE_EXPLICIT() -> i64 { 1 }
@@ -5129,7 +5127,6 @@ fn emit_entry_trampoline_windows_x86(nc: NativeCompiler, main_fn_index: i64) -> 
 fn MACOS_SYS_EXIT() -> i64 { 33554433 }       // 0x2000001
 fn MACOS_SYS_WRITE() -> i64 { 33554436 }      // 0x2000004
 fn MACOS_SYS_MMAP() -> i64 { 33554629 }       // 0x20000C5 (197)
-fn MACOS_SYS_OPEN() -> i64 { 33554437 }       // 0x2000005
 
 // macOS x86-64 entry trampoline — same System V ABI as Linux, different syscall numbers.
 fn emit_entry_trampoline_macos_x86(nc: NativeCompiler, main_fn_index: i64) -> NativeCompiler with Mut, Panic, Div {

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -100,14 +100,11 @@ fn MATRIX_AME() -> i64 { 6 }
 fn FORMAT_NONE() -> i64 { 0 }
 pub fn FORMAT_ELF64() -> i64 { 1 }
 fn FORMAT_MACHO64() -> i64 { 2 }
-fn FORMAT_PE64() -> i64 { 3 }
 
 pub fn ERR_OK() -> i64 { 0 }
 pub fn ERR_BACKEND_NOT_IMPLEMENTED() -> i64 { 1 }
 fn ERR_INVALID_TARGET() -> i64 { 2 }
 fn ERR_INVALID_MATRIX() -> i64 { 3 }
-fn ERR_TRACE_WRITE_FAILED() -> i64 { 4 }
-fn ERR_TARGET_FLAGS_REQUIRE_NATIVE() -> i64 { 5 }
 
 fn TARGET_SOURCE_UNKNOWN() -> i64 { 0 }
 pub(crate) fn TARGET_SOURCE_EXPLICIT() -> i64 { 1 }
@@ -10577,7 +10574,6 @@ fn emit_entry_trampoline_windows_x86(nc: NativeCompiler, main_fn_index: i64) -> 
 pub(crate) fn MACOS_SYS_EXIT() -> i64 { 33554433 }       // 0x2000001
 pub(crate) fn MACOS_SYS_WRITE() -> i64 { 33554436 }      // 0x2000004
 pub(crate) fn MACOS_SYS_MMAP() -> i64 { 33554629 }       // 0x20000C5 (197)
-fn MACOS_SYS_OPEN() -> i64 { 33554437 }       // 0x2000005
 
 // macOS x86-64 entry trampoline — same System V ABI as Linux, different syscall numbers.
 fn emit_entry_trampoline_macos_x86(nc: NativeCompiler, main_fn_index: i64) -> NativeCompiler with Mut, Panic, Div {


### PR DESCRIPTION
## Scope

Removes exactly seven source bodies proved unreachable:

- both copies of `ERR_TARGET_FLAGS_REQUIRE_NATIVE`
- both copies of `ERR_TRACE_WRITE_FAILED`
- both copies of `MACOS_SYS_OPEN`
- only the dead `codegen_x86_linux.sio` copy of `FORMAT_PE64`

The live `codegen.sio` `FORMAT_PE64`, all 21 live pairs, and the six flat-namespace occurrences remain unchanged. The apparent `7 + 21 = 28` mismatch is units: 7 dead bodies plus 43 live bodies equals 50 bodies across 25 pairs.

## Caller evidence

Measured on `main@665f412bd92ec969014387ef1cfbf77c8ccc2447` with ripgrep 15.2.0. `CALLERS = occurrences(NAME() - definitions(fn NAME()`, over active `self-hosted/`, `tests/`, and `examples/`; x86 attribution additionally enumerated every explicit x86 importer.

Positive control: `FORMAT_PE64` in `codegen.sio` produced `OCC=3 DEFS=1 CALLERS=2`, at lines 5888 and 6026. Each deleted body produced zero callers. The x86 `FORMAT_PE64` copy also had zero calls across all six external x86 importers. Full per-body evidence is in commit `8aba397f9`.

The previous reconstructed ELF proves only its own older snapshot. Deadness here was remeasured directly at the named main SHA. Later main movement was inspected: additions did not touch these names or their call sites.

## Verification

- Diff: exactly `2 files changed, 7 deletions`
- Madaros parent == candidate: `codegen.sio TOTAL=92 E175=61 E177=0`; x86 `TOTAL=0`
- lean_single parent == candidate: 65 and 2 unqualified error lines respectively
- `extern_builtin_mirror_gate.sh`: PASS, 40 names
- `e219_refusal_correspondence_gate.sh`: PASS 15/15; all three positive controls fired
- Slurm current-source build from clean `8aba397f94d4a1416b67467fd58d3bf0064a49d1`: `BUILD_RC=0`, 243 s
- rebuilt ELF SHA-256: `491a981fddd2bb8f971bb21d4495182b28d3e0dd54478ff30a435d91828e8a5c`; magic `7f454c46`
- rebuilt ELF: legacy codegen `92/61/0`; x86 codegen `0/0/0`

No fallback and no bare `souc <src> -o <out>` invocation were used.