### PR TITLE
docs(audit): cost the 11 unbudgeted claim-numeric gates; mark empty greens

### DIFF
--- a/docs/audit/CI_GATE_BUDGET_2026-08-18.tsv
+++ b/docs/audit/CI_GATE_BUDGET_2026-08-18.tsv
@@ -1,38 +1,53 @@
-gate	family	kind	elapsed_sec	rc	capped	polarity	propose_wire	note
-dissertation_confidence_gate_gate.sh	dissertation	gate_cost	1	0	no	green	yes	Contribution 2. Remeasured 0.693 s wall on 6098da3e82, rc=0. date+s first pass was 0–1 s.
-dissertation_frontend_parity_gate.sh	dissertation	gate_cost	2	0	no	green	yes	PBPK14 dual-Sounio 14/14 + Node product arm. Remeasured 1.942 s wall on 6098da3e82, rc=0.
-dissertation_dossier_gate.sh	dissertation	gate_cost	1	1	no	red	no	4 fails: dossier_smoke check/compile; binary not executable; no PASS dossier_smoke.
-dissertation_pbpk28_parity_gate.sh	dissertation	gate_cost	9	1	no	red	no	case7 semaglutide ref: E175 private fn + E008 bergman_glucose_insulin return type. Madaros preflight rc=1.
-dissertation_pbpk_hessian_gate.sh	dissertation	gate_cost	5	1	no	red	no	var_o1 golden 2.050168e-7 vs runtime 0.000000 (zero GUM variance). Mutates hessian CSV if left dirty.
-dissertation_pbpk_suite_gate.sh	dissertation	gate_cost	110	1	no	red	no	Default souc-seq-leansingle.sh (do not pin Madaros). 52/53 PASS; FAIL pbpk28_rapamycin_clinical rc=1 (90 s timeout). PEND semaglutide clinical. SOUNIO_DPS_GATE_SKIP=1 is vacuous skip — not used here.
-168_biology_validation_gate.sh	forgotten	gate_cost	5	0	no	green	no	Cheap green; not a dissertation candidate.
-claim_native_gate.sh	forgotten	timeout-cap	180	124	yes	capped	no	>=180 s. Partial N2 PASS. Not finished under cap.
-compile_fail_harness_contract_gate.sh	forgotten	gate_cost	1	0	no	green	no	Cheap green; harness contract, not dissertation.
-ffi_posix_builtin_gate.sh	forgotten	rebuild	180	124	yes	capped	no	NOT a slow gate. kind=rebuild: unless SOUNIO_GATE_SOUC is set, the script runs build_modular_madaros.sh before any witness. The 180 s cap with empty stdout is the accidental self-compile, not the POSIX reframe/execution arms. Wiring this to Contracts would bill every PR a Madaros rebuild.
-kretikos_kaxi_fmad_invariance_gate.sh	forgotten	skip-vacuous	0	0	no	skip-vacuous	no	SKIPPED (no CUDA). Green is not a measurement. kind=skip-vacuous.
-kretikos_kaxi_phase_j_aggregate_gate.sh	forgotten	gate_cost	3	0	no	green	no	6/0 PASS. Cheap; not dissertation.
-kretikos_kaxi_round_mode_gate.sh	forgotten	gate_cost	75	1	no	red	no	PTX golden rm kernel missing add.rm/sub.rm/mul.rm.f64.
-madaros_f128_f256_ladder_gate.sh	forgotten	gate_cost	4	1	no	red	no	V0-A E218 still active. Known: wiring this reds every PR.
-madaros_f128_f256_v0c_wire_gate.sh	forgotten	gate_cost	1	1	no	red	no	V0-C scaffold, external wire corpus unconsumed.
-madaros_f128_f256_v0d_softfloat_gate.sh	forgotten	gate_cost	0	1	no	red	no	V0-D scaffold, softfloat hard corpus unconsumed.
-madaros_imported_ep_var_preserve_gate.sh	forgotten	gate_cost	7	1	no	red	no	bin/madaros SIGSEGV during run. Do not wire.
-madaros_ols_fixed_e2e_gate.sh	forgotten	gate_cost	2	0	no	green	no	Cheap green; not dissertation.
-madaros_print_f64_negative_gate.sh	forgotten	gate_cost	2	0	no	green	no	Named leftover. Cheap; not dissertation.
-madaros_zero_provenance_failclosed_gate.sh	forgotten	gate_cost	2	0	no	green	no	Cheap green; not dissertation.
-mir_instr_capacity_coherence_gate.sh	forgotten	gate_cost	0	0	no	green	no	Source-text coherence check. Cheap; not dissertation.
-mli_s3_bit_identity_gate.sh	forgotten	gate_cost	5	0	no	green	no	Named leftover. Cheap; not dissertation.
-native_capacity_tiers_gate.sh	forgotten	gate_cost	0	1	no	red	no	label_tier_4096_below_ir_max_instrs_16384.
-octonion_probes_gate.sh	forgotten	gate_cost	1	0	no	green	no	Cheap green; not dissertation.
-oopsla2027_paper_gate.sh	forgotten	gate_cost	0	1	no	red	no	OOPSLA2027_PAPER_VERDICT INCOMPLETE.
-paper168_cocycle_subspace_gate.sh	forgotten	timeout-cap	180	124	yes	capped	no	>=180 s. Partial PASS k8/k9. Not finished under cap.
-paper_168_theorem_claims_gate.sh	forgotten	gate_cost	0	1	no	red	no	ModuleNotFoundError: numpy. Vacuous-red on this pod; not a Contracts candidate.
-run_pass_output_gate.sh	forgotten	gate_cost	53	0	no	green	no	219 checked vs committed baseline (25 mismatches already in baseline). 53 s — too dear for Contracts; not dissertation.
-self_falsifying_compilation_line_gate.sh	forgotten	gate_cost	1	0	no	green	no	SUBSTRATE_LIVE corpus-bound. Cheap; not dissertation. Rungs below are red or incomplete.
-self_falsifying_compilation_line_r11_gate.sh	forgotten	gate_cost	0	1	no	red	no	ModuleNotFoundError: numpy.
-self_falsifying_compilation_line_r17_gate.sh	forgotten	gate_cost	0	1	no	red	no	SURFACE_ONLY__NOT_CERTIFIED.
-self_falsifying_compilation_line_r2_gate.sh	forgotten	gate_cost	0	1	no	red	no	INCOMPLETE.
-self_falsifying_compilation_line_r4_gate.sh	forgotten	gate_cost	46	1	no	red	no	known correction daa0635d0 no longer lands in a graded bucket.
-self_falsifying_compilation_line_r5_gate.sh	forgotten	gate_cost	0	1	no	red	no	INCOMPLETE.
-self_falsifying_compiler_gate.sh	forgotten	timeout-cap	180	124	yes	capped	no	>=180 s. Partial F1_SURFACE PASS. Not finished under cap.
-stdlib_source_byte_ceiling_gate.sh	forgotten	gate_cost	4	0	no	green	no	Named leftover. Cheap; not dissertation.
-witness_based_compilation_paper_gate.sh	forgotten	gate_cost	0	0	no	green	no	DRAFT_TOKEN_BOUND. Cheap; not dissertation.
+# leftover snapshot measured on d3ea284caf / 6098da3e82. claim-numeric 11 + hardware-skip census measured on 665f412bd9 (origin/main).
+# polarity green on leftover rows is pass-measured. skip-vacuous is rc=0 that did not measure. measured=no means elapsed_sec is the cost of not measuring.
+gate	family	kind	elapsed_sec	rc	capped	polarity	measured	propose_wire	note
+dissertation_confidence_gate_gate.sh	dissertation	gate_cost	1	0	no	green	yes	yes	Contribution 2. Remeasured 0.693 s wall on 6098da3e82, rc=0. date+s first pass was 0–1 s.
+dissertation_frontend_parity_gate.sh	dissertation	gate_cost	2	0	no	green	yes	yes	PBPK14 dual-Sounio 14/14 + Node product arm. Remeasured 1.942 s wall on 6098da3e82, rc=0.
+dissertation_dossier_gate.sh	dissertation	gate_cost	1	1	no	red	yes	no	4 fails: dossier_smoke check/compile; binary not executable; no PASS dossier_smoke.
+dissertation_pbpk28_parity_gate.sh	dissertation	gate_cost	9	1	no	red	yes	no	case7 semaglutide ref: E175 private fn + E008 bergman_glucose_insulin return type. Madaros preflight rc=1.
+dissertation_pbpk_hessian_gate.sh	dissertation	gate_cost	5	1	no	red	yes	no	var_o1 golden 2.050168e-7 vs runtime 0.000000 (zero GUM variance). Mutates hessian CSV if left dirty.
+dissertation_pbpk_suite_gate.sh	dissertation	gate_cost	110	1	no	red	yes	no	Default souc-seq-leansingle.sh (do not pin Madaros). 52/53 PASS; FAIL pbpk28_rapamycin_clinical rc=1 (90 s timeout). PEND semaglutide clinical. SOUNIO_DPS_GATE_SKIP=1 is vacuous skip — not used here.
+168_biology_validation_gate.sh	forgotten	gate_cost	5	0	no	green	yes	no	Cheap green; not a dissertation candidate.
+claim_native_gate.sh	forgotten	timeout-cap	180	124	yes	capped	no	no	>=180 s. Partial N2 PASS. Not finished under cap.
+compile_fail_harness_contract_gate.sh	forgotten	gate_cost	1	0	no	green	yes	no	Cheap green; harness contract, not dissertation.
+ffi_posix_builtin_gate.sh	forgotten	rebuild	180	124	yes	capped	no	no	NOT a slow gate. kind=rebuild: unless SOUNIO_GATE_SOUC is set, the script runs build_modular_madaros.sh before any witness. The 180 s cap with empty stdout is the accidental self-compile, not the POSIX reframe/execution arms. Wiring this to Contracts would bill every PR a Madaros rebuild.
+kretikos_kaxi_fmad_invariance_gate.sh	forgotten	skip-vacuous	0	0	no	skip-vacuous	no	no	SKIPPED (no CUDA). Green is not a measurement. kind=skip-vacuous.
+kretikos_kaxi_phase_j_aggregate_gate.sh	forgotten	gate_cost	3	0	no	green	yes	no	6/0 PASS. Cheap; not dissertation.
+kretikos_kaxi_round_mode_gate.sh	forgotten	gate_cost	75	1	no	red	yes	no	PTX golden rm kernel missing add.rm/sub.rm/mul.rm.f64.
+madaros_f128_f256_ladder_gate.sh	forgotten	gate_cost	4	1	no	red	yes	no	V0-A E218 still active. Known: wiring this reds every PR.
+madaros_f128_f256_v0c_wire_gate.sh	forgotten	gate_cost	1	1	no	red	yes	no	V0-C scaffold, external wire corpus unconsumed.
+madaros_f128_f256_v0d_softfloat_gate.sh	forgotten	gate_cost	0	1	no	red	yes	no	V0-D scaffold, softfloat hard corpus unconsumed.
+madaros_imported_ep_var_preserve_gate.sh	forgotten	gate_cost	7	1	no	red	yes	no	bin/madaros SIGSEGV during run. Do not wire.
+madaros_ols_fixed_e2e_gate.sh	forgotten	gate_cost	2	0	no	green	yes	no	Cheap green; not dissertation.
+madaros_print_f64_negative_gate.sh	forgotten	gate_cost	2	0	no	green	yes	no	Named leftover. Cheap; not dissertation.
+madaros_zero_provenance_failclosed_gate.sh	forgotten	gate_cost	2	0	no	green	yes	no	Cheap green; not dissertation.
+mir_instr_capacity_coherence_gate.sh	forgotten	gate_cost	0	0	no	green	yes	no	Source-text coherence check. Cheap; not dissertation.
+mli_s3_bit_identity_gate.sh	forgotten	gate_cost	5	0	no	green	yes	no	Named leftover. Cheap; not dissertation.
+native_capacity_tiers_gate.sh	forgotten	gate_cost	0	1	no	red	yes	no	label_tier_4096_below_ir_max_instrs_16384.
+octonion_probes_gate.sh	forgotten	gate_cost	1	0	no	green	yes	no	Cheap green; not dissertation.
+oopsla2027_paper_gate.sh	forgotten	gate_cost	0	1	no	red	yes	no	OOPSLA2027_PAPER_VERDICT INCOMPLETE.
+paper168_cocycle_subspace_gate.sh	forgotten	timeout-cap	180	124	yes	capped	no	no	>=180 s. Partial PASS k8/k9. Not finished under cap.
+paper_168_theorem_claims_gate.sh	forgotten	gate_cost	0	1	no	red	yes	no	ModuleNotFoundError: numpy. Vacuous-red on this pod; not a Contracts candidate.
+run_pass_output_gate.sh	forgotten	gate_cost	53	0	no	green	yes	no	219 checked vs committed baseline (25 mismatches already in baseline). 53 s — too dear for Contracts; not dissertation.
+self_falsifying_compilation_line_gate.sh	forgotten	gate_cost	1	0	no	green	yes	no	SUBSTRATE_LIVE corpus-bound. Cheap; not dissertation. Rungs below are red or incomplete.
+self_falsifying_compilation_line_r11_gate.sh	forgotten	gate_cost	0	1	no	red	yes	no	ModuleNotFoundError: numpy.
+self_falsifying_compilation_line_r17_gate.sh	forgotten	gate_cost	0	1	no	red	yes	no	SURFACE_ONLY__NOT_CERTIFIED.
+self_falsifying_compilation_line_r2_gate.sh	forgotten	gate_cost	0	1	no	red	yes	no	INCOMPLETE.
+self_falsifying_compilation_line_r4_gate.sh	forgotten	gate_cost	46	1	no	red	yes	no	known correction daa0635d0 no longer lands in a graded bucket.
+self_falsifying_compilation_line_r5_gate.sh	forgotten	gate_cost	0	1	no	red	yes	no	INCOMPLETE.
+self_falsifying_compiler_gate.sh	forgotten	timeout-cap	180	124	yes	capped	no	no	>=180 s. Partial F1_SURFACE PASS. Not finished under cap.
+stdlib_source_byte_ceiling_gate.sh	forgotten	gate_cost	4	0	no	green	yes	no	Named leftover. Cheap; not dissertation.
+witness_based_compilation_paper_gate.sh	forgotten	gate_cost	0	0	no	green	yes	no	DRAFT_TOKEN_BOUND. Cheap; not dissertation.
+fo_pk_struct_auc_thalf_driver_gate.sh	claim-numeric	gate_cost	1	1	no	red	yes	no	E137 undeclared second_order_mean. Published AUC Var 114.6 / t½ Var 0.249835 not reproduced. 1 s on 665f412bd9.
+functor_f_g2_covariance_gate.sh	claim-numeric	gate_cost	0	1	no	red	yes	no	ModuleNotFoundError: numpy. Vacuous-red on this pod; published 6/6 not re-checked. 0 s on 665f412bd9.
+kaxi_ptx_golden_gate.sh	claim-numeric	gate_cost	80	1	no	red	yes	no	0/318 PASS, 318 DROP rc=1 (kretikos emit failed vs supported goldens). Published 318/318 bit-identical is stale. 80 s on 665f412bd9.
+kretikos_kaxi_lse8_gate.sh	claim-numeric	skip-vacuous	0	0	no	skip-vacuous	no	no	SKIPPED (no ptxas). Selected, ran, measured nothing. Published 7/7. 0 s on 665f412bd9.
+kretikos_kaxi_phase_y_gate.sh	claim-numeric	skip-vacuous	1	0	no	skip-vacuous	no	no	SKIPPED (libcuda not found). Selected, ran, measured nothing. Published 3/3 GPU/CPU. 1 s on 665f412bd9.
+kretikos_kaxi_sinkhorn16_gate.sh	claim-numeric	skip-vacuous	0	0	no	skip-vacuous	no	no	SKIPPED (no ptxas). Selected, ran, measured nothing. Published 7/7. 0 s on 665f412bd9.
+native_v2_cpu_compiler_umbrella_gate.sh	claim-numeric	timeout-cap	180	124	yes	capped	no	no	>=180 s, died inside e2e_codegen_suite before writing gates.tsv rows. Published 12/12. Cap is not a measurement. Do not put this in a claim-root hot path.
+san_imagenet_fpga_dl380_gate.sh	claim-numeric	gate_cost	0	1	no	red	yes	no	ModuleNotFoundError: numpy. Vacuous-red; published 8/8 ~3 min CPU not re-checked. 0 s on 665f412bd9.
+sedenion_phi_injectivity_gate.sh	claim-numeric	gate_cost	1	1	no	red	yes	no	Python oracle PASS; Sounio T9/T10 E175 private cd_product_16 / oct64_norm_sq_components. Published 10/10 stale. 1 s on 665f412bd9.
+sounio_direct_driver_support_gate.sh	claim-numeric	gate_cost	16	0	no	pass-measured	yes	no	24/24 PASS. Only cheap green among the 11. 16 s wall on 665f412bd9.
+windows_pe_smoke_gate.sh	claim-numeric	gate_cost	0	2	no	red	yes	no	madaros unsupported option --target. Wine-absent skip never reached. Published 6/6 stale. 0 s on 665f412bd9.
+kretikos_kaxi_phase_w2_gate.sh	hardware-skip	skip-vacuous	0	0	no	skip-vacuous	no	no	SKIPPED (local nvidia-smi missing). Same empty-green class as fmad. Not one of the 11 claim-numeric gates. 0 s on 665f412bd9.
+kretikos_kaxi_phase_x_gate.sh	hardware-skip	skip-vacuous	0	0	no	skip-vacuous	no	no	SKIPPED (local nvidia-smi missing). Same empty-green class as fmad. Not one of the 11 claim-numeric gates. 0 s on 665f412bd9.


### PR DESCRIPTION
## Summary

- Codex-1 asked for the 11 unbudgeted claim-numeric gates in the leftover budget format, before writing a claim-root.
- Measured on `665f412bd9` (`origin/main` at run). Receipt: `docs/audit/CI_GATE_BUDGET_2026-08-18.tsv`.
- New column **`measured`**: `yes` = the gate produced a measurement; `no` = elapsed seconds are the cost of not measuring.
- New polarity **`pass-measured`** for a green that actually ran the science. **`skip-vacuous`** is a selected gate that exited 0 without measuring (log, duration, conclusion=success).

Does **not** wire anything.

## The 11

| Gate | s | rc | polarity | measured | What happened |
|---|---:|---:|---|---|---|
| `fo_pk_struct_auc_thalf_driver_gate.sh` | 1 | 1 | red | yes | E137 `second_order_mean` |
| `functor_f_g2_covariance_gate.sh` | 0 | 1 | red | yes | numpy missing (vacuous-red) |
| `kaxi_ptx_golden_gate.sh` | **80** | 1 | red | yes | 0/318; published 318/318 is stale |
| `kretikos_kaxi_lse8_gate.sh` | 0 | 0 | skip-vacuous | **no** | SKIPPED (no ptxas) |
| `kretikos_kaxi_phase_y_gate.sh` | 1 | 0 | skip-vacuous | **no** | SKIPPED (libcuda not found) |
| `kretikos_kaxi_sinkhorn16_gate.sh` | 0 | 0 | skip-vacuous | **no** | SKIPPED (no ptxas) |
| `native_v2_cpu_compiler_umbrella_gate.sh` | **180** | 124 | capped | **no** | died in `e2e_codegen_suite` |
| `san_imagenet_fpga_dl380_gate.sh` | 0 | 1 | red | yes | numpy missing (vacuous-red) |
| `sedenion_phi_injectivity_gate.sh` | 1 | 1 | red | yes | Python PASS; Sounio E175 |
| `sounio_direct_driver_support_gate.sh` | **16** | 0 | pass-measured | yes | 24/24. Only cheap green |
| `windows_pe_smoke_gate.sh` | 0 | 2 | red | yes | `--target` unsupported |

## How many other empty greens?

Confirmed skip-vacuous on this CPU-only pod (exit 0, measured nothing):

1. `kretikos_kaxi_fmad_invariance_gate.sh` (already in the leftover snapshot)
2. `kretikos_kaxi_lse8_gate.sh`
3. `kretikos_kaxi_phase_y_gate.sh`
4. `kretikos_kaxi_sinkhorn16_gate.sh`
5. `kretikos_kaxi_phase_w2_gate.sh` (not one of the 11)
6. `kretikos_kaxi_phase_x_gate.sh` (not one of the 11)

**Five besides fmad.** None of them are in `.github/` today. A claim-root that treats rc=0 as `CURRENT_PASS` would invent that green.

`kretikos_kaxi_phase_z_assoc_gate.sh` printed SKIPPED on the GPU arm and still measured 3 CPU claims. That is not empty. Do not count it.

## Claim-root cost implication

Already-budgeted serial floor was **131 s** (110 of that is the PBPK suite).

The 11 add **80 s** of real red work (kaxi golden) + **16 s** of the one cheap green + **180 s** of umbrella cap that produced no receipt. If the claim-root pays the umbrella to revalidate a published 12/12, it already costs more than the gates it would validate. That is the wrong design.

Preflight of receipts stays the cheap path. Do not select skip-vacuous gates as a green class.

## Test plan

- [x] Sequential run, env scrubbed, `SOUNIO_GATE_SOUC` pinned to this worktree
- [x] 11/11 have a row; `measured` distinguishes pass-measured from skip-vacuous
- [x] Extra hardware-skip census: two more empty greens (w2, x)
- [ ] Docs registry / Contracts on this PR (appends an existing audit TSV)