### PR TITLE
feat(website): license live numerals; count the escapes

### DIFF
--- a/website/scripts/check-unguarded-numerals.mjs
+++ b/website/scripts/check-unguarded-numerals.mjs
@@ -1,25 +1,62 @@
 /**
- * Closed green-counts must not interpolate outside the throw functions.
- * A leak here means the kernel is a list of sites, not an invariant.
+ * License rule: classify who may assert, not which digits look like
+ * a ratio. A live page may print a measurement well only through
+ * claimFace / claimRefusal / suiteFaceParts, or through claimEscape.
  *
- * Closed: U1 251/251, U2 13/13, U3 7/7.
- * Archive and docs locales are not live faces.
+ * claimEscape is the visible door. The table prints on every run.
+ * Growing the table is a review signal. A silent skip is a refuse.
  *
- * NEXT STEP — do not do it in this change. Invert the rule.
- * A denylist of known numerals protects the past: it catches 7/7
- * because we already named 7/7. A new page can still write `{n}/{n}`
- * and ship. The step that closes that gap is a source rule: every
- * numeral on a live page must come from a function that can refuse
- * (`claimFace` / `claimRefusal` / `suiteFaceParts`). A list of
- * forbidden strings is not that rule. Do not grow CLOSED_PATTERNS
- * as if more entries were the invariant.
+ * Positive control: scripts/fixtures/mutant-unlicensed-fact.astro
+ * asserts a new fact (scienceLanes, 9/9) without license. The
+ * denylist misses it — confirmed before this rule shipped. If the
+ * mutant produces no finding, exit 1: POSITIVE CONTROL DEAD.
+ *
+ * DEBT: CLOSED_PATTERNS is the old denylist. It stays until the
+ * license rule is the sole finding on one green Website CI run on
+ * main AND the positive control still fires. Do not add rows. Two
+ * mechanisms for the same thing is how neither is owned. Retire
+ * this block in the first follow-up after that green — not in the
+ * same change that invents the rule.
  */
 import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 
-const root = path.resolve(process.cwd(), 'src');
+const websiteRoot = path.resolve(process.cwd());
+const srcRoot = path.join(websiteRoot, 'src');
+const mutantPath = path.join(websiteRoot, 'scripts/fixtures/mutant-unlicensed-fact.astro');
 
 const SKIP_DIR = new Set(['_archive', 'content', 'node_modules']);
+
+const ESCAPE_CLASSES = new Set(['inventory', 'literature', 'identity', 'threshold', 'version']);
+
+/**
+ * Fact wells. A new `{metrics.scienceLanes}` on a live page must
+ * fail until it is licensed. Tailwind `w-1/2` is not a well.
+ * Do not add CLOSED_PATTERNS rows for new greens — add a well or
+ * a claimEscape.
+ */
+const WELLS = [
+  { id: 'metrics.stdlibInventoryFiles', re: /metrics\.stdlibInventoryFiles/ },
+  { id: 'metrics.scienceLanes', re: /metrics\.scienceLanes/ },
+  { id: 'metrics.hyperLanes', re: /metrics\.hyperLanes/ },
+  { id: 'metrics.fullTestSuite', re: /metrics\.fullTestSuite/ },
+  { id: 'metrics.selfHostedSourceLines', re: /metrics\.selfHostedSourceLines/ },
+  { id: 'metrics.selfHostedSourceFiles', re: /metrics\.selfHostedSourceFiles/ },
+  { id: 'metrics.stdlibReliabilityGate.pass', re: /metrics\.stdlibReliabilityGate\.(pass|total|fail)/ },
+  { id: 'proof.stdlib.activeModuleEntrypoints', re: /proof(?:Hub)?\.stdlib\.activeModuleEntrypoints/ },
+  { id: 'proof.stdlib.hyperPassCount', re: /proof(?:Hub)?\.stdlib\.hyperPassCount/ },
+  { id: 'proof.stdlib.hyperTotalCount', re: /proof(?:Hub)?\.stdlib\.hyperTotalCount/ },
+  { id: 'proof.stdlib.scienceStatus', re: /proof(?:Hub)?\.stdlib\.scienceStatus/ },
+  { id: 'proof.gpu.attestedTargetCount', re: /proof(?:Hub)?\.gpu\.attestedTargetCount/ },
+  { id: 'proof.gpu.publicPassCount', re: /proof(?:Hub)?\.gpu\.publicPassCount/ },
+  { id: 'proof.gpu.publicCheckCount', re: /proof(?:Hub)?\.gpu\.publicCheckCount/ },
+  { id: 'proof.release.version', re: /proof(?:Hub)?\.release\.version/ },
+  { id: 'fullSuite.pass', re: /fullSuite\.(pass|total)/ },
+  { id: 'full.pass', re: /\bfull\.(pass|total)\b/ },
+  { id: 'stdlib.pass', re: /\bstdlib\.(pass|total)\b/ },
+  { id: 'versions.checkedArtifact', re: /versions\.checkedArtifact/ },
+  { id: 'versions.readmeBadge', re: /versions\.readmeBadge/ },
+];
 
 const CLOSED_PATTERNS = [
   { id: 'U2-13/13', re: /\b13\s*\/\s*13\b/ },
@@ -31,7 +68,7 @@ const CLOSED_PATTERNS = [
   { id: 'raw-hyperLanes', re: /hyperLanes/ },
 ];
 
-const KERNEL_DIR = path.join(root, 'lib');
+const KERNEL_DIR = path.join(srcRoot, 'lib');
 
 async function walk(dir, out = []) {
   const entries = await readdir(dir, { withFileTypes: true });
@@ -51,34 +88,223 @@ async function walk(dir, out = []) {
 
 function isKernelFile(file) {
   const rel = path.relative(KERNEL_DIR, file);
-  if (rel.startsWith('..')) return false;
+  if (rel.startsWith('..') || rel.startsWith(`..${path.sep}`)) return false;
   return /Honesty|measurementClaim|proofData|artifactStatus/.test(rel);
 }
 
+function isClaimEscapesFile(file) {
+  return path.basename(file) === 'claimEscapes.ts';
+}
+
+function findMatchingParen(src, openIdx) {
+  let depth = 0;
+  let quote = null;
+  for (let i = openIdx; i < src.length; i += 1) {
+    const c = src[i];
+    if (quote) {
+      if (c === '\\') {
+        i += 1;
+        continue;
+      }
+      if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      quote = c;
+      continue;
+    }
+    if (c === '(') depth += 1;
+    else if (c === ')') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+function eachClaimEscapeCall(src, onCall) {
+  let i = 0;
+  while (i < src.length) {
+    const idx = src.indexOf('claimEscape(', i);
+    if (idx === -1) break;
+    const open = idx + 'claimEscape'.length;
+    const close = findMatchingParen(src, open);
+    if (close === -1) {
+      onCall({ start: idx, end: src.length, body: src.slice(idx), incomplete: true });
+      break;
+    }
+    onCall({ start: idx, end: close + 1, body: src.slice(idx, close + 1), incomplete: false });
+    i = close + 1;
+  }
+}
+
+function stripClassAttrs(src) {
+  return src.replace(/\s(?:class|className)=(?:"[^"]*"|'[^']*'|\{[^}]*\})/g, '');
+}
+
+function stripClaimEscapeCalls(src) {
+  const pieces = [];
+  let last = 0;
+  eachClaimEscapeCall(src, ({ start, end }) => {
+    pieces.push(src.slice(last, start));
+    pieces.push(' CLAIM_ESCAPE ');
+    last = end;
+  });
+  pieces.push(src.slice(last));
+  return pieces.join('');
+}
+
+function extractQuoted(body, key) {
+  const re = new RegExp(`${key}:\\s*['"]([^'"]+)['"]`);
+  const m = body.match(re);
+  return m ? m[1] : null;
+}
+
+function parseEscapes(src, file) {
+  const rows = [];
+  const errors = [];
+  const rel = path.relative(websiteRoot, file);
+  eachClaimEscapeCall(src, ({ body, incomplete }) => {
+    if (incomplete) {
+      errors.push(`${rel}: claimEscape call is unclosed`);
+      return;
+    }
+    const id = extractQuoted(body, 'id');
+    const cls = extractQuoted(body, 'class');
+    const reason = extractQuoted(body, 'reason');
+    if (!id || !cls || !reason) {
+      errors.push(`${rel}: claimEscape missing id, class, or reason`);
+      return;
+    }
+    if (!ESCAPE_CLASSES.has(cls)) {
+      errors.push(`${rel}: claimEscape ${id} has unknown class "${cls}"`);
+      return;
+    }
+    if (reason.trim().length < 20) {
+      errors.push(`${rel}: claimEscape ${id} reason is too short to audit`);
+      return;
+    }
+    rows.push({ file: rel, id, class: cls, reason: reason.trim() });
+  });
+  return { rows, errors };
+}
+
+function scanWells(src, file) {
+  const rel = path.relative(websiteRoot, file);
+  const findings = [];
+  for (const { id, re } of WELLS) {
+    if (re.test(src)) findings.push(`${id} ${rel}`);
+  }
+  return findings;
+}
+
+function scanDenylist(src, file) {
+  const rel = path.relative(websiteRoot, file);
+  const findings = [];
+  for (const { id, re } of CLOSED_PATTERNS) {
+    if (re.test(src)) findings.push(`${id} ${rel}`);
+  }
+  return findings;
+}
+
+function printEscapeTable(rows) {
+  const unique = new Map();
+  for (const row of rows) {
+    if (!unique.has(row.id)) unique.set(row.id, row);
+  }
+  console.log(`claimEscape table (${unique.size} ids, ${rows.length} annotated calls):`);
+  const sorted = [...unique.values()].sort((a, b) => a.class.localeCompare(b.class) || a.id.localeCompare(b.id));
+  for (const row of sorted) {
+    console.log(`  ${row.class.padEnd(11)} ${row.id.padEnd(32)} ${row.reason}`);
+  }
+}
+
 async function run() {
-  const files = [
-    ...(await walk(path.join(root, 'pages'))),
-    ...(await walk(path.join(root, 'components'))),
+  const liveFiles = [
+    ...(await walk(path.join(srcRoot, 'pages'))),
+    ...(await walk(path.join(srcRoot, 'components'))),
   ];
 
-  const leaks = [];
-  for (const file of files) {
-    if (isKernelFile(file)) continue;
-    const text = await readFile(file, 'utf8');
-    for (const { id, re } of CLOSED_PATTERNS) {
-      if (re.test(text)) {
-        leaks.push(`${id} ${path.relative(process.cwd(), file)}`);
+  const escapeFiles = [path.join(srcRoot, 'lib', 'claimEscapes.ts'), ...liveFiles];
+
+  const escapeRows = [];
+  const escapeErrors = [];
+  for (const file of escapeFiles) {
+    let text;
+    try {
+      text = await readFile(file, 'utf8');
+    } catch {
+      if (isClaimEscapesFile(file)) {
+        escapeErrors.push('claimEscapes.ts is missing — the escape table cannot be empty by deletion');
       }
+      continue;
+    }
+    const parsed = parseEscapes(text, file);
+    escapeRows.push(...parsed.rows);
+    escapeErrors.push(...parsed.errors);
+  }
+
+  printEscapeTable(escapeRows);
+
+  const unlicensed = [];
+  const denylistLeaks = [];
+  for (const file of liveFiles) {
+    if (isKernelFile(file) && !isClaimEscapesFile(file)) continue;
+    let text;
+    try {
+      text = await readFile(file, 'utf8');
+    } catch {
+      if (isClaimEscapesFile(file)) unlicensed.push('claimEscapes.ts missing');
+      continue;
+    }
+    const stripped = stripClaimEscapeCalls(stripClassAttrs(text));
+    unlicensed.push(...scanWells(stripped, file));
+    if (!isClaimEscapesFile(file)) {
+      denylistLeaks.push(...scanDenylist(text, file));
     }
   }
 
-  if (leaks.length > 0) {
-    console.error('Unguarded closed numerals:');
-    for (const row of leaks) console.error(`- ${row}`);
-    process.exit(1);
+  const mutantText = await readFile(mutantPath, 'utf8');
+  const mutantFindings = scanWells(stripClaimEscapeCalls(stripClassAttrs(mutantText)), mutantPath);
+
+  let failed = false;
+
+  if (escapeErrors.length > 0) {
+    failed = true;
+    console.error('claimEscape annotation errors:');
+    for (const row of escapeErrors) console.error(`- ${row}`);
   }
 
-  console.log('OK: closed numerals (U1/U2/U3) do not interpolate outside the kernel.');
+  if (unlicensed.length > 0) {
+    failed = true;
+    console.error('Unlicensed measurement wells:');
+    for (const row of unlicensed) console.error(`- ${row}`);
+  } else {
+    console.log('OK: live pages have no unlicensed measurement wells.');
+  }
+
+  if (mutantFindings.length === 0) {
+    failed = true;
+    console.error(
+      'POSITIVE CONTROL DEAD: mutant-unlicensed-fact.astro produced no unlicensed well. The instrument no longer sees a new fact.',
+    );
+  } else {
+    console.log(
+      `OK: positive control — mutant produced ${mutantFindings.length} unlicensed well(s) as required.`,
+    );
+  }
+
+  if (denylistLeaks.length > 0) {
+    failed = true;
+    console.error('Unguarded closed numerals (denylist debt):');
+    for (const row of denylistLeaks) console.error(`- ${row}`);
+  } else {
+    console.log(
+      'OK: denylist debt still silent on live pages. Retire CLOSED_PATTERNS after one green Website CI run on main where this license rule is the only finding and the positive control still fires.',
+    );
+  }
+
+  if (failed) process.exit(1);
 }
 
 await run();

--- a/website/scripts/fixtures/mutant-unlicensed-fact.astro
+++ b/website/scripts/fixtures/mutant-unlicensed-fact.astro
@@ -1,0 +1,13 @@
+---
+/**
+ * Positive control. Not a live page. Never mount this component.
+ *
+ * A new fact. The denylist only names greens already closed, so it
+ * will not see this file. If the license check produces no finding
+ * here, the instrument is dead: exit 1 with POSITIVE CONTROL DEAD.
+ */
+const n = 9;
+---
+
+<p>Unlicensed well: metrics.scienceLanes</p>
+<p>Unlicensed fact: {n}/{n}</p>

--- a/website/src/components/home/LivingLanguagePulse.astro
+++ b/website/src/components/home/LivingLanguagePulse.astro
@@ -2,6 +2,11 @@
 import { artifactStatus, publicContract } from '../../data/artifactStatus';
 import { getLocalizedPath } from '../../lib/i18n';
 import type { Locale } from '../../lib/i18n';
+import {
+  escapeCheckedArtifact,
+  escapeSelfHostedFiles,
+  escapeSelfHostedLineNote,
+} from '../../lib/claimEscapes';
 import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal } from '../../lib/stdlibReliabilityHonesty';
 
 interface Props {
@@ -157,17 +162,12 @@ const copy: Record<string, {
 };
 
 const d = copy[locale] ?? copy.en;
-const { metrics, versions, defaultWorkflow, honestStatus } = publicContract;
-const stdlib = metrics.stdlibReliabilityGate;
+const { defaultWorkflow, honestStatus } = publicContract;
 const reliabilityOk = reliabilityMayPrint();
-const sourceFileCount = metrics.selfHostedSourceFiles;
-const sourceLineCount = metrics.selfHostedSourceLines;
 const parsedGeneratedDate = new Date(artifactStatus.generatedAt);
 const generatedDate = Number.isNaN(parsedGeneratedDate.getTime())
   ? artifactStatus.generatedAt.slice(0, 10)
   : parsedGeneratedDate.toISOString().slice(0, 10);
-const reliabilityPercent =
-  reliabilityOk && stdlib.total > 0 ? Math.round((stdlib.pass / stdlib.total) * 100) : null;
 const localeCodes = ['pt', 'el', 'zh', 'zh-hk', 'ja', 'es'];
 const localizedDocs = import.meta.glob('../../content/docs/{pt,el,zh,zh-hk,ja,es}/**/*.{md,mdx}', { eager: true });
 const englishDocs = import.meta.glob('../../content/docs/en/**/*.{md,mdx}', { eager: true });
@@ -194,11 +194,7 @@ const localizedFamilyNote =
     expectedShowcasesCount > 0 ? `showcases ${localizedShowcasesCount}/${expectedShowcasesCount}` : 'showcases no data',
     expectedTutorialsCount > 0 ? `tutorials ${localizedTutorialsCount}/${expectedTutorialsCount}` : 'tutorials no data',
   ].join(' · ');
-const reliabilityValue = reliabilityOk
-  ? reliabilityPercent == null
-    ? 'no data'
-    : `${reliabilityPercent}%`
-  : '—';
+const reliabilityValue = reliabilityOk ? reliabilityFace() : '—';
 const reliabilityNote = reliabilityOk
   ? reliabilityFace()
   : reliabilityRefusal();
@@ -212,14 +208,14 @@ const signals = [
   },
   {
     label: 'Checked artifact',
-    value: versions.checkedArtifact,
+    value: escapeCheckedArtifact(),
     note: defaultWorkflow.launcher,
     state: d.bounded,
   },
   {
     label: 'Self-hosted source',
-    value: sourceFileCount == null ? 'inventory pending' : `${sourceFileCount}`,
-    note: sourceLineCount == null ? 'line count unavailable' : `${sourceLineCount.toLocaleString('en-US')} lines`,
+    value: escapeSelfHostedFiles(),
+    note: escapeSelfHostedLineNote(),
     state: d.moving,
   },
   {

--- a/website/src/components/home/NumbersSection.astro
+++ b/website/src/components/home/NumbersSection.astro
@@ -1,23 +1,23 @@
 ---
 import { publicContract } from "../../data/artifactStatus";
 import { getLocaleFromUrl } from "../../lib/i18n";
+import {
+  escapeCheckedArtifact,
+  escapeFullSuite,
+  escapePbpkDemoCount,
+  escapeReadmeBadge,
+  escapeSelfHostedLines,
+  escapeStdlibInventoryFiles,
+  escapeVancomycinEpsilon,
+  readmeBadgeDiffers,
+} from "../../lib/claimEscapes";
 import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal, reliabilityShortRefusal } from "../../lib/stdlibReliabilityHonesty";
 
 const locale = getLocaleFromUrl(Astro.url);
-const { metrics, bootstrap, versions } = publicContract;
-const full = metrics.fullTestSuite;
+const { bootstrap } = publicContract;
 const reliabilityOk = reliabilityMayPrint();
 const reliabilityShown = reliabilityOk ? reliabilityFace() : reliabilityShortRefusal();
 const reliabilityLabel = reliabilityOk ? undefined : reliabilityRefusal();
-const selfHostedLines = metrics.selfHostedSourceLines;
-const stdlibFiles = metrics.stdlibInventoryFiles;
-
-function formatLines(n: number | null): string {
-  if (n == null) return "—";
-  if (n >= 1_000_000) return `${Math.round(n / 100_000) / 10}M`;
-  if (n >= 1000) return `${Math.round(n / 1000)}K`;
-  return String(n);
-}
 
 const t = {
   en: {
@@ -145,7 +145,7 @@ const d = t[locale] || t.en;
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-8 max-w-4xl mx-auto">
       <div class="text-center">
         <div class="text-3xl sm:text-4xl md:text-5xl font-extrabold text-[var(--color-accent-gold-soft)] tracking-tight mb-2">
-          ε ≥ 0.82
+          {escapeVancomycinEpsilon()}
         </div>
         <div class="text-xs sm:text-sm text-[var(--color-text-secondary)]">{d.scVancomycin}</div>
         <p class="text-[0.75rem] text-[var(--color-text-tertiary)] mt-1 max-w-[22ch] mx-auto">{d.scVancomycinDetail}</p>
@@ -153,7 +153,7 @@ const d = t[locale] || t.en;
 
       <div class="text-center">
         <div class="text-3xl sm:text-4xl md:text-5xl font-extrabold text-[var(--color-text-primary)] tracking-tight mb-2">
-          2
+          {escapePbpkDemoCount()}
         </div>
         <div class="text-xs sm:text-sm text-[var(--color-text-secondary)]">{d.scPbpk}</div>
         <p class="text-[0.75rem] text-[var(--color-text-tertiary)] mt-1 max-w-[22ch] mx-auto">{d.scPbpkDetail}</p>
@@ -173,22 +173,22 @@ const d = t[locale] || t.en;
 <section class="py-6 md:py-8 bg-[color-mix(in_srgb,var(--color-bg-alt)_85%,transparent)] border-y border-[var(--glass-border)]" data-for-audience="technical">
   <div class="container">
     <p class="text-center text-[0.78rem] text-[var(--color-text-tertiary)] mb-6 max-w-2xl mx-auto">
-      {d.topBanner} {versions.checkedArtifact}
-      {versions.readmeBadge && versions.readmeBadge !== versions.checkedArtifact
-        ? ` (${d.readmeBadge} ${versions.readmeBadge})`
+      {d.topBanner} {escapeCheckedArtifact()}
+      {readmeBadgeDiffers()
+        ? ` (${d.readmeBadge} ${escapeReadmeBadge()})`
         : ""}
     </p>
     <div class="grid grid-cols-2 md:grid-cols-4 gap-8 max-w-5xl mx-auto">
       <div class="text-center">
         <div class="text-3xl sm:text-4xl md:text-5xl lg:text-7xl font-extrabold text-[var(--color-text-primary)] tracking-tight mb-2 overflow-hidden text-ellipsis whitespace-nowrap">
-          {formatLines(selfHostedLines)}
+          {escapeSelfHostedLines()}
         </div>
         <div class="text-xs sm:text-sm text-[var(--color-text-secondary)]">{d.selfHostedLoc}</div>
       </div>
 
       <div class="text-center">
         <div class="text-3xl sm:text-4xl md:text-5xl lg:text-7xl font-extrabold text-[var(--color-text-primary)] tracking-tight mb-2 overflow-hidden text-ellipsis whitespace-nowrap">
-          {stdlibFiles ?? "—"}
+          {escapeStdlibInventoryFiles()}
         </div>
         <div class="text-xs sm:text-sm text-[var(--color-text-secondary)]">{d.stdlibFiles}</div>
       </div>
@@ -202,7 +202,7 @@ const d = t[locale] || t.en;
 
       <div class="text-center">
         <div class="text-3xl sm:text-4xl md:text-5xl lg:text-7xl font-extrabold text-[var(--color-text-primary)] tracking-tight mb-2 overflow-hidden text-ellipsis whitespace-nowrap">
-          {full ? `${full.pass}/${full.total}` : "—"}
+          {escapeFullSuite("—")}
         </div>
         <div class="text-xs sm:text-sm text-[var(--color-text-secondary)]">{d.fullSuite}</div>
       </div>

--- a/website/src/components/home/ProofStrip.astro
+++ b/website/src/components/home/ProofStrip.astro
@@ -1,6 +1,12 @@
 ---
 import { getLocalizedPath, type Locale } from '../../lib/i18n';
 import { getProofData } from '../../lib/proofData';
+import {
+  escapeActiveEntrypoints,
+  escapeAttestedTargets,
+  escapeReleaseVersion,
+  escapeScienceStatus,
+} from '../../lib/claimEscapes';
 import { gpuFace, gpuMayPrint, gpuRefusal, gpuShortRefusal } from '../../lib/gpuPublicHonesty';
 import { hyperFace, hyperMayPrint, hyperRefusal, hyperShortRefusal } from '../../lib/stdlibHyperHonesty';
 import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal, reliabilityShortRefusal } from '../../lib/stdlibReliabilityHonesty';
@@ -14,7 +20,7 @@ const proof = getProofData();
 
 const items = [
   {
-    value: `v${proof.release.version}`,
+    value: escapeReleaseVersion(),
     label: proof.release.statusLabel,
     detail: proof.release.generatedAtUtc ? `Provenance checked ${proof.release.generatedAtUtc.slice(0, 10)}` : 'Provenance tracked in-tree',
   },
@@ -22,21 +28,21 @@ const items = [
     value: reliabilityMayPrint() ? reliabilityFace() : reliabilityShortRefusal(),
     label: 'stdlib reliability fixtures passing',
     detail: reliabilityMayPrint()
-      ? `${proof.stdlib.activeModuleEntrypoints} active module entrypoints`
+      ? `${escapeActiveEntrypoints()} active module entrypoints`
       : reliabilityRefusal(),
   },
   {
     value: gpuMayPrint() ? gpuFace() : gpuShortRefusal(),
     label: 'public GPU contract checks passing',
     detail: gpuMayPrint()
-      ? `${proof.gpu.attestedTargetCount} attested binary targets`
+      ? `${escapeAttestedTargets()} attested binary targets`
       : gpuRefusal(),
   },
   {
     value: hyperMayPrint() ? hyperFace() : hyperShortRefusal(),
     label: 'required hyper lanes passing',
     detail: hyperMayPrint()
-      ? `science runtime status: ${proof.stdlib.scienceStatus}`
+      ? `science runtime status: ${escapeScienceStatus()}`
       : hyperRefusal(),
   },
 ];

--- a/website/src/components/playground/PlaygroundEditor.tsx
+++ b/website/src/components/playground/PlaygroundEditor.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, type KeyboardEvent } from 'react';
 import { publicContract } from '../../data/artifactStatus';
+import { claimEscape } from '../../lib/measurementClaim';
 
 interface PlaygroundEditorProps {
   initialCode?: string;
@@ -448,7 +449,12 @@ export default function PlaygroundEditor({ initialCode, theme = 'dark' }: Playgr
       </div>
 
       <div className="flex items-center justify-between px-4 py-2 bg-[var(--color-navy-900)] text-white/60 text-xs font-mono border-t border-white/10">
-        <span>Sounio v{publicContract.versions.checkedArtifact}</span>
+        <span>Sounio v{claimEscape({
+          id: 'checked-artifact-version',
+          class: 'version',
+          reason: 'Compiler launcher version string from the public contract. Identity, not a green-count.',
+          text: publicContract.versions.checkedArtifact,
+        })}</span>
         <span>{wasmApi?.version ? wasmApi.version() : 'WASM'}</span>
       </div>
     </div>

--- a/website/src/components/status/FeatureStatusPanel.astro
+++ b/website/src/components/status/FeatureStatusPanel.astro
@@ -1,10 +1,19 @@
 ---
 import { publicContract, artifactStatus } from "../../data/artifactStatus";
 import ArtifactStatusTable from "./ArtifactStatusTable.astro";
+import {
+  escapeCheckedArtifact,
+  escapeFullSuite,
+  escapeReadmeBadge,
+  escapeScienceLanes,
+  escapeStdlibInventoryFiles,
+  fullSuitePublished,
+  readmeBadgeDiffers,
+} from "../../lib/claimEscapes";
 import { hyperFace, hyperMayPrint, hyperRefusal } from "../../lib/stdlibHyperHonesty";
 import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal } from "../../lib/stdlibReliabilityHonesty";
 
-const { versions, defaultWorkflow, metrics } = publicContract;
+const { defaultWorkflow } = publicContract;
 const reliabilityShown = reliabilityMayPrint() ? reliabilityFace() : reliabilityRefusal();
 ---
 
@@ -27,35 +36,35 @@ const reliabilityShown = reliabilityMayPrint() ? reliabilityFace() : reliability
         <tbody class="text-[var(--color-text-secondary)]">
           <tr class="border-b border-[var(--glass-border)]">
             <td class="py-3 pr-4 font-medium text-[var(--color-text-primary)]">Checked launcher</td>
-            <td class="py-3"><code>souc {versions.checkedArtifact}</code> via <code>{defaultWorkflow.launcher}</code></td>
+            <td class="py-3"><code>souc {escapeCheckedArtifact()}</code> via <code>{defaultWorkflow.launcher}</code></td>
           </tr>
           <tr class="border-b border-[var(--glass-border)]">
             <td class="py-3 pr-4 font-medium text-[var(--color-text-primary)]">Default workflow</td>
             <td class="py-3">{defaultWorkflow.backend} — {defaultWorkflow.summary}</td>
           </tr>
-          {versions.readmeBadge && versions.readmeBadge !== versions.checkedArtifact && (
+          {readmeBadgeDiffers() && (
             <tr class="border-b border-[var(--glass-border)]">
               <td class="py-3 pr-4 font-medium text-[var(--color-text-primary)]">README badge</td>
-              <td class="py-3"><code>{versions.readmeBadge}</code> (may lead checked artifact during release reconciliation)</td>
+              <td class="py-3"><code>{escapeReadmeBadge()}</code> (may lead checked artifact during release reconciliation)</td>
             </tr>
           )}
           <tr class="border-b border-[var(--glass-border)]">
             <td class="py-3 pr-4 font-medium text-[var(--color-text-primary)]">Stdlib reliability gate</td>
             <td class="py-3">{reliabilityShown}</td>
           </tr>
-          {metrics.fullTestSuite && (
+          {fullSuitePublished() && (
             <tr class="border-b border-[var(--glass-border)]">
               <td class="py-3 pr-4 font-medium text-[var(--color-text-primary)]">Full test suite (README)</td>
-              <td class="py-3">{metrics.fullTestSuite.pass} / {metrics.fullTestSuite.total} tests pass</td>
+              <td class="py-3">{escapeFullSuite()} tests pass</td>
             </tr>
           )}
           <tr class="border-b border-[var(--glass-border)]">
             <td class="py-3 pr-4 font-medium text-[var(--color-text-primary)]">Stdlib inventory</td>
-            <td class="py-3">{metrics.stdlibInventoryFiles ?? "—"} <code>.sio</code> files in reliability inventory</td>
+            <td class="py-3">{escapeStdlibInventoryFiles()} <code>.sio</code> files in reliability inventory</td>
           </tr>
           <tr class="border-b border-[var(--glass-border)]">
             <td class="py-3 pr-4 font-medium text-[var(--color-text-primary)]">Science lanes</td>
-            <td class="py-3">{metrics.scienceLanes} lanes — see <code>artifacts/stdlib/stdlib_science_pipeline_status.v1.json</code></td>
+            <td class="py-3">{escapeScienceLanes()} lanes — see <code>artifacts/stdlib/stdlib_science_pipeline_status.v1.json</code></td>
           </tr>
           <tr>
             <td class="py-3 pr-4 font-medium text-[var(--color-text-primary)]">Hyper lanes</td>

--- a/website/src/lib/claimEscapes.ts
+++ b/website/src/lib/claimEscapes.ts
@@ -1,0 +1,183 @@
+/**
+ * Counted escapes. Each id is a numeral that is not a MeasurementClaim.
+ * The check prints this table on every run. Growing the table is a
+ * review signal — do not hide a new well by adding a silent skip.
+ */
+import { publicContract } from '../data/artifactStatus';
+import { claimEscape } from './measurementClaim';
+import { getProofData } from './proofData';
+
+function formatLines(n: number | null): string {
+  if (n == null) return '—';
+  if (n >= 1_000_000) return `${Math.round(n / 100_000) / 10}M`;
+  if (n >= 1000) return `${Math.round(n / 1000)}K`;
+  return String(n);
+}
+
+export function fullSuitePublished(): boolean {
+  return publicContract.metrics.fullTestSuite != null;
+}
+
+export function readmeBadgeDiffers(): boolean {
+  const { readmeBadge, checkedArtifact } = publicContract.versions;
+  return Boolean(readmeBadge && readmeBadge !== checkedArtifact);
+}
+
+export function escapeStdlibInventoryFiles(): string {
+  const n = publicContract.metrics.stdlibInventoryFiles;
+  return claimEscape({
+    id: 'stdlib-inventory-files',
+    class: 'inventory',
+    reason: 'File count from the May reliability sync. Not a gate outcome.',
+    text: n == null ? '—' : String(n),
+  });
+}
+
+export function escapeScienceLanes(): string {
+  return claimEscape({
+    id: 'science-lanes',
+    class: 'inventory',
+    reason: 'Lane count from the science pipeline JSON. Inventory, not a remasure.',
+    text: String(publicContract.metrics.scienceLanes),
+  });
+}
+
+export function escapeSelfHostedLines(): string {
+  return claimEscape({
+    id: 'self-hosted-source-lines',
+    class: 'inventory',
+    reason: 'Compiler LOC from the May sync. Not a gate outcome or remasure.',
+    text: formatLines(publicContract.metrics.selfHostedSourceLines),
+  });
+}
+
+export function escapeSelfHostedFiles(): string {
+  const n = publicContract.metrics.selfHostedSourceFiles;
+  return claimEscape({
+    id: 'self-hosted-source-files',
+    class: 'inventory',
+    reason: 'Self-hosted file count from the May sync. Inventory, not a green.',
+    text: n == null ? 'inventory pending' : String(n),
+  });
+}
+
+export function escapeSelfHostedLineNote(): string {
+  const n = publicContract.metrics.selfHostedSourceLines;
+  return claimEscape({
+    id: 'self-hosted-source-line-note',
+    class: 'inventory',
+    reason: 'Companion line-count note for the self-hosted file inventory.',
+    text: n == null ? 'line count unavailable' : `${n.toLocaleString('en-US')} lines`,
+  });
+}
+
+export function escapeFullSuite(unpublished = '—'): string {
+  const full = publicContract.metrics.fullTestSuite;
+  return claimEscape({
+    id: 'readme-full-suite',
+    class: 'inventory',
+    reason: 'README snapshot field. Null on current main — not a remasure and not a gate green.',
+    text: full ? `${full.pass}/${full.total}` : unpublished,
+  });
+}
+
+export function escapeFullSuiteSentence(): string {
+  const full = publicContract.metrics.fullTestSuite;
+  return claimEscape({
+    id: 'readme-full-suite-sentence',
+    class: 'inventory',
+    reason: 'README snapshot sentence. Empty while the field is unpublished.',
+    text: full ? ` The README full-suite snapshot is ${full.pass}/${full.total} tests pass.` : '',
+  });
+}
+
+export function escapeFullSuiteInline(): string {
+  const full = publicContract.metrics.fullTestSuite;
+  return claimEscape({
+    id: 'readme-full-suite-inline',
+    class: 'inventory',
+    reason: 'README snapshot inline on /language. Empty while unpublished.',
+    text: full ? ` README full-suite snapshot: ${full.pass}/${full.total}.` : '',
+  });
+}
+
+export function escapeCheckedArtifact(): string {
+  return claimEscape({
+    id: 'checked-artifact-version',
+    class: 'version',
+    reason: 'Compiler launcher version string from the public contract. Identity, not a green-count.',
+    text: publicContract.versions.checkedArtifact,
+  });
+}
+
+export function escapeReadmeBadge(): string {
+  return claimEscape({
+    id: 'readme-badge-version',
+    class: 'version',
+    reason: 'README badge string. Identity during release reconciliation, not a green-count.',
+    text: publicContract.versions.readmeBadge ?? '',
+  });
+}
+
+export function escapeReleaseVersion(): string {
+  return claimEscape({
+    id: 'release-provenance-version',
+    class: 'version',
+    reason: 'Release provenance version from proofData. Identity, not a gate numeral.',
+    text: `v${getProofData().release.version}`,
+  });
+}
+
+export function escapeActiveEntrypoints(): string {
+  return claimEscape({
+    id: 'stdlib-active-entrypoints',
+    class: 'inventory',
+    reason: 'Module entrypoint inventory from proofData. Not a reliability gate numeral.',
+    text: String(getProofData().stdlib.activeModuleEntrypoints),
+  });
+}
+
+export function escapeAttestedTargets(): string {
+  return claimEscape({
+    id: 'gpu-attested-targets',
+    class: 'inventory',
+    reason: 'Attested binary target count from proofData. Inventory next to the GPU refusal, not the 13-count.',
+    text: String(getProofData().gpu.attestedTargetCount),
+  });
+}
+
+export function escapeScienceStatus(): string {
+  return claimEscape({
+    id: 'science-runtime-status',
+    class: 'identity',
+    reason: 'Science pipeline status word from proofData. A label, not a green-count.',
+    text: getProofData().stdlib.scienceStatus,
+  });
+}
+
+export function escapeVancomycinEpsilon(): string {
+  return claimEscape({
+    id: 'ashp-vancomycin-epsilon',
+    class: 'literature',
+    reason: 'ASHP 2020 §8.3 threshold cited as literature. Not a remasured gate numeral.',
+    text: 'ε ≥ 0.82',
+  });
+}
+
+export function escapePbpkDemoCount(): string {
+  return claimEscape({
+    id: 'pbpk-demo-count',
+    class: 'inventory',
+    reason: 'Count of interactive dissertation demos on the site. Not a gate outcome.',
+    text: '2',
+  });
+}
+
+export function escapeOctonion168(): string {
+  return claimEscape({
+    id: 'octonion-168-theorem',
+    class: 'literature',
+    reason: 'Paper identity (the 168 theorem). Not a site measurement or gate outcome.',
+    text: '168',
+  });
+}

--- a/website/src/lib/measurementClaim.ts
+++ b/website/src/lib/measurementClaim.ts
@@ -15,10 +15,20 @@
  * `bin/souc` and `souc-linux-x86_64-gpu` are launchers, not engines.
  * Do not invent Madaros or lean_single from a path.
  *
- * NEXT STEP — not this change. `check-unguarded-numerals.mjs` is a
- * denylist of closed greens. That protects the past. The invariant
- * is the inverse: a live page may print a numeral only by calling a
- * function that can refuse. Growing the denylist is not that step.
+ * The site does not classify digits. It classifies who has license
+ * to assert. Three surfaces:
+ *   1. claimFace / claimRefusal — a MeasurementClaim that may print.
+ *   2. Unlicensed wells — a live page reading metrics.* / proof.*
+ *      without (1) or (3) fails the check.
+ *   3. claimEscape — a numeral that is not a scientific assertion.
+ *      Annotated, counted, printed as a table on every check run.
+ * Without (3), (1) and (2) push people to turn the script off.
+ * A silent skip is a door. A counted escape is a measurement.
+ *
+ * The CLOSED_PATTERNS denylist is debt. Do not grow it. Retire it
+ * after the license rule is the sole green on one Website CI run
+ * on main and the positive control still fires. Two mechanisms
+ * for the same thing is how neither is owned.
  */
 
 export const COMPILER_ENGINES = ['Madaros', 'lean_single'] as const;
@@ -105,4 +115,55 @@ export function claimFace(
 
 export function claimRefusal(c: MeasurementClaim, noun: string): string {
   return `${noun} · ${reachabilityFace(c)} · artifact ${c.measuredAt.slice(0, 10)} · engine unnamed`;
+}
+
+export const ESCAPE_CLASSES = ['inventory', 'literature', 'identity', 'threshold', 'version'] as const;
+export type EscapeClass = (typeof ESCAPE_CLASSES)[number];
+
+export type ClaimEscape = {
+  id: string;
+  class: EscapeClass;
+  reason: string;
+  text: string;
+};
+
+const escapeRegistry: ClaimEscape[] = [];
+
+function isEscapeClass(value: string): value is EscapeClass {
+  return (ESCAPE_CLASSES as readonly string[]).includes(value);
+}
+
+/**
+ * Mark a numeral that is not a MeasurementClaim. Returns the text
+ * without going through claimFace — this is not a green.
+ *
+ * id, class, and reason are required. The check parses every call
+ * and prints the table on every run. Growing the table is a review
+ * signal. An unannotated skip is a refuse.
+ */
+export function claimEscape(spec: ClaimEscape): string {
+  if (typeof spec.id !== 'string' || spec.id.trim().length === 0) {
+    throw new Error('claimEscape: id is required');
+  }
+  if (!isEscapeClass(spec.class)) {
+    throw new Error(
+      `claimEscape: class must be one of ${ESCAPE_CLASSES.join(', ')} (got ${String(spec.class)})`,
+    );
+  }
+  if (typeof spec.reason !== 'string' || spec.reason.trim().length < 20) {
+    throw new Error(
+      'claimEscape: reason must say why this numeral is not a MeasurementClaim (≥ 20 characters)',
+    );
+  }
+  escapeRegistry.push({
+    id: spec.id.trim(),
+    class: spec.class,
+    reason: spec.reason.trim(),
+    text: spec.text,
+  });
+  return spec.text;
+}
+
+export function claimEscapeTable(): readonly ClaimEscape[] {
+  return escapeRegistry.slice();
 }

--- a/website/src/pages/about/index.astro
+++ b/website/src/pages/about/index.astro
@@ -1,13 +1,16 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getLocaleFromUrl, getLocalizedPath, loadTranslations } from '../../lib/i18n';
-import { publicContract } from '../../data/artifactStatus';
+import {
+  escapeCheckedArtifact,
+  escapeFullSuite,
+  escapeOctonion168,
+  escapeStdlibInventoryFiles,
+} from '../../lib/claimEscapes';
 import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal, reliabilityShortRefusal } from '../../lib/stdlibReliabilityHonesty';
 
 const locale = getLocaleFromUrl(Astro.url);
 const t = await loadTranslations(locale);
-const { metrics, versions } = publicContract;
-const full = metrics.fullTestSuite;
 const reliabilityOk = reliabilityMayPrint();
 
 const aboutBreadcrumbSchema = {
@@ -105,9 +108,9 @@ const aboutBreadcrumbSchema = {
           <p>
             Demetrios is a medical student and researcher at PUC-SP and S&atilde;o Leopoldo Mandic,
             specialising in biomaterials and regenerative medicine. With published work on Ollivier-Ricci
-            curvature for complex networks and a submitted paper on octonion algebra (the 168 theorem),
+            curvature for complex networks and a submitted paper on octonion algebra (the {escapeOctonion168()} theorem),
             he created Sounio to bridge the gap between scientific rigour and computational practice &mdash;
-            building the entire language, compiler, and standard library from scratch since December 2025 (souc {versions.checkedArtifact}).
+            building the entire language, compiler, and standard library from scratch since December 2025 (souc {escapeCheckedArtifact()}).
           </p>
           <p>
             The name &ldquo;Sounio&rdquo; reflects both personal heritage and architectural philosophy: Cape Sounion (&Sigma;&omicron;&upsilon;&nu;&iota;&omicron;),
@@ -121,9 +124,9 @@ const aboutBreadcrumbSchema = {
         <h2 class="stats-heading">Project at a Glance</h2>
         <ul class="stats-list">
           <li><span class="stat-number">3,224</span><span class="stat-label">commits</span></li>
-          <li><span class="stat-number">{metrics.stdlibInventoryFiles ?? "—"}</span><span class="stat-label">stdlib .sio files</span></li>
+          <li><span class="stat-number">{escapeStdlibInventoryFiles()}</span><span class="stat-label">stdlib .sio files</span></li>
           <li><span class="stat-number">{reliabilityOk ? reliabilityFace() : reliabilityShortRefusal()}</span><span class="stat-label">{reliabilityOk ? 'stdlib reliability gate' : reliabilityRefusal()}</span></li>
-          <li><span class="stat-number">{full ? `${full.pass}/${full.total}` : "—"}</span><span class="stat-label">full suite</span></li>
+          <li><span class="stat-number">{escapeFullSuite("—")}</span><span class="stat-label">full suite</span></li>
           <li><span class="stat-number">1,000+</span><span class="stat-label">e-graph rewrite rules</span></li>
           <li><span class="stat-number">86K</span><span class="stat-label">max parameters (O-SSM)</span></li>
         </ul>

--- a/website/src/pages/language.astro
+++ b/website/src/pages/language.astro
@@ -8,13 +8,13 @@ import E219DiagnosticExhibit from '../components/language/E219DiagnosticExhibit.
 import { getLocaleFromUrl, getLocalizedPath, loadTranslations } from '../lib/i18n';
 import { publicContract } from '../data/artifactStatus';
 import HonestStatusSection from '../components/status/HonestStatusSection.astro';
+import { escapeFullSuiteInline } from '../lib/claimEscapes';
 import { gpuFace, gpuMayPrint, gpuRefusal } from '../lib/gpuPublicHonesty';
 import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal } from '../lib/stdlibReliabilityHonesty';
 
 const locale = getLocaleFromUrl(Astro.url);
 const t = await loadTranslations(locale);
-const { bootstrap, metrics } = publicContract;
-const fullSuite = metrics.fullTestSuite;
+const { bootstrap } = publicContract;
 const reliabilityShown = reliabilityMayPrint() ? reliabilityFace() : reliabilityRefusal();
 
 const languageBreadcrumbSchema = {
@@ -477,7 +477,7 @@ let weight: kg = 78.5
           <div class="glass rounded-[var(--radius-xl)] p-[1.1rem] grid gap-[0.5rem]">
             <h3 class="text-[1rem] font-[680] text-[var(--color-text-primary)]">Test gate snapshot</h3>
             <p class="text-[0.88rem] text-[var(--color-text-secondary)] leading-[1.65]">
-              Stdlib reliability gate: <strong class="text-[var(--color-text-primary)]">{reliabilityShown}</strong>{fullSuite ? ` README full-suite snapshot: ${fullSuite.pass}/${fullSuite.total}.` : ""} See <a href={getLocalizedPath('/proof#test-gate', locale)} class="text-[var(--color-accent-gold-soft)] hover:underline">/proof §4</a>.
+              Stdlib reliability gate: <strong class="text-[var(--color-text-primary)]">{reliabilityShown}</strong>{escapeFullSuiteInline()} See <a href={getLocalizedPath('/proof#test-gate', locale)} class="text-[var(--color-accent-gold-soft)] hover:underline">/proof §4</a>.
             </p>
           </div>
 

--- a/website/src/pages/plan.astro
+++ b/website/src/pages/plan.astro
@@ -1,13 +1,11 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import { publicContract } from '../data/artifactStatus';
+import { escapeCheckedArtifact, escapeFullSuite, fullSuitePublished } from '../lib/claimEscapes';
 import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal } from '../lib/stdlibReliabilityHonesty';
 import { getLocaleFromUrl, getLocalizedPath, loadTranslations } from '../lib/i18n';
 
 const locale = getLocaleFromUrl(Astro.url);
 const t = await loadTranslations(locale);
-const { metrics, versions } = publicContract;
-const fullSuite = metrics.fullTestSuite;
 const reliabilityOk = reliabilityMayPrint();
 
 const planBreadcrumbSchema = {
@@ -66,14 +64,14 @@ const evidenceGates = [
   },
   {
     name: 'Full suite',
-    value: fullSuite ? `${fullSuite.pass}/${fullSuite.total}` : 'not published',
-    detail: fullSuite
+    value: escapeFullSuite('not published'),
+    detail: fullSuitePublished()
       ? 'Used as an evidence surface, not a decorative maturity claim.'
       : 'No full-suite artifact is present in the current public contract.',
   },
   {
     name: 'Checked artifact',
-    value: versions.checkedArtifact,
+    value: escapeCheckedArtifact(),
     detail: 'The site should expose compiler freshness without turning churn into anxiety.',
   },
   {

--- a/website/src/pages/proof.astro
+++ b/website/src/pages/proof.astro
@@ -6,6 +6,12 @@ import EpistemicGateExhibit from '../components/proof/EpistemicGateExhibit.astro
 import { getProofData } from '../lib/proofData';
 import { publicContract } from '../data/artifactStatus';
 import { getLocaleFromUrl, loadTranslations, getLocalizedPath } from '../lib/i18n';
+import {
+  escapeActiveEntrypoints,
+  escapeAttestedTargets,
+  escapeFullSuiteSentence,
+  escapeReleaseVersion,
+} from '../lib/claimEscapes';
 import { gpuFace, gpuMayPrint, gpuRefusal, gpuShortRefusal } from '../lib/gpuPublicHonesty';
 import { reliabilityFace, reliabilityMayPrint, reliabilityRefusal, reliabilityShortRefusal } from '../lib/stdlibReliabilityHonesty';
 
@@ -32,8 +38,7 @@ const proofBreadcrumbSchema = {
 };
 
 const proofHub = getProofData();
-const { bootstrap, metrics } = publicContract;
-const fullSuite = metrics.fullTestSuite;
+const { bootstrap } = publicContract;
 const reliabilityOk = reliabilityMayPrint();
 const reliabilityShown = reliabilityOk ? reliabilityFace() : reliabilityRefusal();
 
@@ -48,18 +53,18 @@ const proofOverviewCards = [
   {
     title: locale === 'pt' ? 'Fiabilidade stdlib' : 'Stdlib reliability',
     value: reliabilityOk ? reliabilityFace() : reliabilityShortRefusal(),
-    detail: `${proofHub.stdlib.activeModuleEntrypoints} active entrypoints`,
+    detail: `${escapeActiveEntrypoints()} active entrypoints`,
   },
   {
     title: locale === 'pt' ? 'Proveniência de release' : 'Release provenance',
-    value: `v${proofHub.release.version}`,
+    value: escapeReleaseVersion(),
     detail: proofHub.release.statusLabel,
   },
   {
     title: locale === 'pt' ? 'Contrato GPU público' : 'GPU public contract',
     value: gpuMayPrint() ? gpuFace() : gpuShortRefusal(),
     detail: gpuMayPrint()
-      ? `${proofHub.gpu.attestedTargetCount} attested binary targets`
+      ? `${escapeAttestedTargets()} attested binary targets`
       : gpuRefusal(),
   },
 ];
@@ -161,7 +166,7 @@ fn main() with IO {
           <span class="text-[0.72rem] font-[700] uppercase tracking-[0.08em] text-[var(--color-accent-gold-soft)]">Release attestation</span>
           <p class="text-[0.9rem] text-[var(--color-text-secondary)] leading-[1.65]">
             Published provenance reports <strong class="text-[var(--color-text-primary)]">{proofHub.release.status}</strong> for
-            <strong class="text-[var(--color-text-primary)]"> v{proofHub.release.version}</strong>.
+            <strong class="text-[var(--color-text-primary)]"> {escapeReleaseVersion()}</strong>.
           </p>
           {proofHub.release.assetUrl && (
             <p>
@@ -411,7 +416,7 @@ typecheck: failed`}</code></pre>
       </div>
 
       <p class="text-[0.95rem] text-[var(--color-text-secondary)] leading-[1.75]">
-        The committed stdlib reliability gate reports <strong class="text-[var(--color-text-primary)]">{reliabilityShown}</strong> (source: <code class="font-mono text-[0.85em]">{publicContract.metrics.stdlibReliabilityGate.artifact}</code>).{fullSuite ? ` The README full-suite snapshot is ${fullSuite.pass}/${fullSuite.total} tests pass.` : ""} If this page disagrees with README.md or the artifacts, those sources win.
+        The committed stdlib reliability gate reports <strong class="text-[var(--color-text-primary)]">{reliabilityShown}</strong> (source: <code class="font-mono text-[0.85em]">{publicContract.metrics.stdlibReliabilityGate.artifact}</code>).{escapeFullSuiteSentence()} If this page disagrees with README.md or the artifacts, those sources win.
       </p>
 
       <pre class="rounded-[var(--radius-lg)] bg-[#1e1e1e] text-[#d4d4d4] text-[0.88rem] font-mono p-[1rem] overflow-x-auto leading-relaxed border border-white/10"><code>{reliabilityOk


### PR DESCRIPTION
## Summary

The site no longer classifies digits. It classifies **who has license to assert**, and makes the rest auditable.

- **Wells, not values.** A live page may read `metrics.*` / `proof.*` / version identity only through `claimFace` / `claimRefusal` / `suiteFaceParts`, or through `claimEscape`. Tailwind `w-1/2` is invisible. A new `{metrics.scienceLanes}` fails until licensed.
- **`claimEscape` is the third element.** Annotated (`id`, `class`, `reason`), counted, printed as a table on **every** `check:routes` run. 17 ids today. Growing the table is a review signal. A silent skip is a door; a counted escape is a measurement.
- **Positive control first.** `website/scripts/fixtures/mutant-unlicensed-fact.astro` asserts a new fact the denylist does not name. Before this rule, `CLOSED_PATTERNS` missed it. After this rule, the check **must** find that well; if it does not, it exits `POSITIVE CONTROL DEAD`. The mutant is not a live page.
- **Denylist is debt.** `CLOSED_PATTERNS` was not grown. It stays until the license rule is the sole finding on one green Website CI run on `main` **and** the positive control still fires. Two mechanisms for the same thing is how neither is owned.

Inventory (U4), the 168 theorem (U14), ε ≥ 0.82 (U15), and version strings stop pretending to be `MeasurementClaim`. They do not disappear.

## What this does not close

Hardcoded toolchain assertions (`1000+`, `FAIL=0`, `1,000+` e-graph) are **not** wells. They are not escapes. They should become `MeasurementClaim` instances later — not a denylist row, not a silent skip. Docs-locale 251 and leftover-umbrella viewers are still outside this kernel.

## Test plan

- [x] Mutant written first; current denylist missed `metrics.scienceLanes` + `9/9`
- [x] New check failed the mutant (and the live wells) before migration
- [x] After wiring `claimEscape`, `npm run check:routes` — live wells clean, mutant still required-fail, escape table printed
- [x] `npm run check:astro` — 0 errors
- [x] `npm run check:i18n` — 7 locales match
- [ ] Website CI on this PR: `check:routes` prints the 17-id table and `POSITIVE CONTROL` OK
- [ ] Do not merge unless the founder says go