### PR TITLE
refactor(compiler): split run_compiler_main_self_tests into 10 parts — clears the IR_MAX_INSTRS wall without raising any capacity

### DIFF
--- a/docs/audit/MADAROS_BOX_AUTODEREF_MAIN_REPRODUCTION_2026-08-17.md
+++ b/docs/audit/MADAROS_BOX_AUTODEREF_MAIN_REPRODUCTION_2026-08-17.md
@@ -300,3 +300,31 @@ recorded, so its definition looks dead and the sweep deletes live code,
 silently, at rc=0). Raising `IR_MAX_INSTRS` without raising `DCE_MAX_INSTRS`
 and every per-instruction context that stops at its own cap converts an
 honest refusal into silent miscompilation. That is a separate, larger task.
+
+The `IR_MAX_INSTRS` wall was then cleared WITHOUT raising any capacity
+(2026-08-18, branch `lane/empryo-1/normalize-byref-20260818`, source build
+SHA-256 `7ffc6c82…`). The compiler's own error message prescribed the fix:
+"split it into smaller functions". `run_compiler_main_self_tests`
+(`self-hosted/compiler/main.sio`, 5839-line body, 1163 independent test
+blocks) lowered to 33829 IR instructions — past the 16384 cap. Splitting it
+into ten part-functions (`compiler_main_self_tests_part_01..10`, ~116 blocks
+each) keeps every part far under the IR cap AND under the DCE/const-prop
+8192 caps, so every analysis pass stays complete on every part — no refusal,
+no truncation, and no capacity constant touched. `DCE_MAX_INSTRS`,
+`CP_MAX_INSTRS`, and every lateral array stay exactly where they are.
+
+Measured on the from-source split build:
+
+    fixed-point gate   GATE_RC=0, reached `check` as recorded.
+                       The 33829/IR_MAX_INSTRS wall is GONE (0 occurrences in
+                       the gen2 log). gen2 now progresses past typecheck into
+                       lowering before hitting a deeper, different SIGSEGV —
+                       a separate wall, not this one.
+    box_all_read_forms BOXMATRIX OK rc=0 — no regression
+    dce_reachability   all three arms pass
+    typecheck main.sio 80 errors before == 80 after (all pre-existing
+                       ontology E175); the split adds ZERO
+
+This is the safe stop point for the capacity question: the instruction wall
+did not need a raise, it needed the function split. Raising `IR_MAX_INSTRS`
+remains the wrong lever here, for the liveness-capacity reason above.

--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -22041,11 +22041,12 @@ fn compiler_main_test_dz_no_fold_or_outer() -> bool with Mut, Div, Panic {
     (IR_A_BIN_OP[(ir_region_slot_r(opt.region, (3))) as usize] as BinaryOp) != BinaryOp::OpBitXor
 }
 
-fn run_compiler_main_self_tests() -> i32 with IO, Mut, Panic, Div, Alloc {
-    var passed: i64 = 0
-    let total: i64 = 1156
-
-    println("=== compiler/main.sio self-tests ===")
+// Self-test dispatcher part 1/10: split out of run_compiler_main_self_tests
+// because the monolithic body lowered to 33829 IR instructions, past IR_MAX_INSTRS.
+// Each part stays far under the IR cap and under the DCE/const-prop 8192 caps,
+// so every analysis pass remains complete on every part (no refusal, no truncation).
+fn compiler_main_self_tests_part_01(passed_in: i64) -> i64 with IO, Mut, Panic, Div, Alloc {
+    var passed = passed_in
 
     // Feature A-1 (run FIRST: a pre-existing crash downstream of T1201 on this WIP
     // branch otherwise prevents these from being reached).
@@ -22868,6 +22869,15 @@ fn run_compiler_main_self_tests() -> i32 with IO, Mut, Panic, Div, Alloc {
     } else {
         println("  FAIL: T113 left-constant commutative SR: 2 * x → x << 1")
     }
+    passed
+}
+
+// Self-test dispatcher part 2/10: split out of run_compiler_main_self_tests
+// because the monolithic body lowered to 33829 IR instructions, past IR_MAX_INSTRS.
+// Each part stays far under the IR cap and under the DCE/const-prop 8192 caps,
+// so every analysis pass remains complete on every part (no refusal, no truncation).
+fn compiler_main_self_tests_part_02(passed_in: i64) -> i64 with IO, Mut, Panic, Div, Alloc {
+    var passed = passed_in
 
     if compiler_main_test_alg_comm_sr_3x_no_reduce() {
         println("  T114 OK: left-constant non-pow2 stays as OpMul (3 * x not reduced)")
@@ -23687,6 +23697,15 @@ fn run_compiler_main_self_tests() -> i32 with IO, Mut, Panic, Div, Alloc {
     } else {
         println("  FAIL: T226 Sprint 85: ir_opt_expands_local_reg_range")
     }
+    passed
+}
+
+// Self-test dispatcher part 3/10: split out of run_compiler_main_self_tests
+// because the monolithic body lowered to 33829 IR instructions, past IR_MAX_INSTRS.
+// Each part stays far under the IR cap and under the DCE/const-prop 8192 caps,
+// so every analysis pass remains complete on every part (no refusal, no truncation).
+fn compiler_main_self_tests_part_03(passed_in: i64) -> i64 with IO, Mut, Panic, Div, Alloc {
+    var passed = passed_in
 
     if compiler_main_test_native_v2_compile_preview_scalar() {
         println("  T227 OK: Sprint 85: native-v2 compile_preview produces valid ELF64 for scalar module")
@@ -24430,6 +24449,15 @@ fn run_compiler_main_self_tests() -> i32 with IO, Mut, Panic, Div, Alloc {
         println("  T337 OK: Sprint 104 Block AB: different ops no fold")
         passed = passed + 1
     } else { println("  FAIL: T337") }
+    passed
+}
+
+// Self-test dispatcher part 4/10: split out of run_compiler_main_self_tests
+// because the monolithic body lowered to 33829 IR instructions, past IR_MAX_INSTRS.
+// Each part stays far under the IR cap and under the DCE/const-prop 8192 caps,
+// so every analysis pass remains complete on every part (no refusal, no truncation).
+fn compiler_main_self_tests_part_04(passed_in: i64) -> i64 with IO, Mut, Panic, Div, Alloc {
+    var passed = passed_in
     if compiler_main_test_gvn_label_invalidates() {
         println("  T338 OK: Sprint 104 Block AB: label invalidates")
         passed = passed + 1
@@ -24918,6 +24946,15 @@ fn run_compiler_main_self_tests() -> i32 with IO, Mut, Panic, Div, Alloc {
         println("  T461 OK: Sprint 131 Block AS: ~x^~y→x^y")
         passed = passed + 1
     } else { println("  FAIL: T461") }
+    passed
+}
+
+// Self-test dispatcher part 5/10: split out of run_compiler_main_self_tests
+// because the monolithic body lowered to 33829 IR instructions, past IR_MAX_INSTRS.
+// Each part stays far under the IR cap and under the DCE/const-prop 8192 caps,
+// so every analysis pass remains complete on every part (no refusal, no truncation).
+fn compiler_main_self_tests_part_05(passed_in: i64) -> i64 with IO, Mut, Panic, Div, Alloc {
+    var passed = passed_in
     if compiler_main_test_xor_self_complement_zero() {
         println("  T462 OK: Sprint 131 Block AS: ~x^~x→0")
         passed = passed + 1
@@ -25419,6 +25456,15 @@ fn run_compiler_main_self_tests() -> i32 with IO, Mut, Panic, Div, Alloc {
         passed = passed + 1
         println("  T577 OK: Sprint 151 Block BM: or-base no xor-chain fold")
     } else { println("  FAIL: T577") }
+    passed
+}
+
+// Self-test dispatcher part 6/10: split out of run_compiler_main_self_tests
+// because the monolithic body lowered to 33829 IR instructions, past IR_MAX_INSTRS.
+// Each part stays far under the IR cap and under the DCE/const-prop 8192 caps,
+// so every analysis pass remains complete on every part (no refusal, no truncation).
+fn compiler_main_self_tests_part_06(passed_in: i64) -> i64 with IO, Mut, Panic, Div, Alloc {
+    var passed = passed_in
 
     // Sprint 152 Block BN: XOR self-recovery (T578-T583)
     if compiler_main_test_xor_self_recovery_basic() {
@@ -25923,6 +25969,15 @@ fn run_compiler_main_self_tests() -> i32 with IO, Mut, Panic, Div, Alloc {
         passed = passed + 1
         println("  T693 OK: Sprint 171 Block CG: r0+(r0*5) → r0*6 commutative")
     } else { println("  FAIL: T693") }
+    passed
+}
+
+// Self-test dispatcher part 7/10: split out of run_compiler_main_self_tests
+// because the monolithic body lowered to 33829 IR instructions, past IR_MAX_INSTRS.
+// Each part stays far under the IR cap and under the DCE/const-prop 8192 caps,
+// so every analysis pass remains complete on every part (no refusal, no truncation).
+fn compiler_main_self_tests_part_07(passed_in: i64) -> i64 with IO, Mut, Panic, Div, Alloc {
+    var passed = passed_in
     if compiler_main_test_cg_mul_add_large() {
         passed = passed + 1
         println("  T694 OK: Sprint 171 Block CG: (r0*99)+r0 → r0*100")
@@ -26371,6 +26426,15 @@ fn run_compiler_main_self_tests() -> i32 with IO, Mut, Panic, Div, Alloc {
         passed = passed + 1
         println("  T809 OK: Sprint 190 Block CZ: r0^(r1&7) no fold diff base")
     } else { println("  FAIL: T809") }
+    passed
+}
+
+// Self-test dispatcher part 8/10: split out of run_compiler_main_self_tests
+// because the monolithic body lowered to 33829 IR instructions, past IR_MAX_INSTRS.
+// Each part stays far under the IR cap and under the DCE/const-prop 8192 caps,
+// so every analysis pass remains complete on every part (no refusal, no truncation).
+fn compiler_main_self_tests_part_08(passed_in: i64) -> i64 with IO, Mut, Panic, Div, Alloc {
+    var passed = passed_in
     if compiler_main_test_cz_no_fold_rr_and() {
         passed = passed + 1
         println("  T810 OK: Sprint 190 Block CZ: r0^(r0&r1) no fold rr-and")
@@ -26873,6 +26937,15 @@ fn run_compiler_main_self_tests() -> i32 with IO, Mut, Panic, Div, Alloc {
         passed = passed + 1
         println("  T925 OK: Sprint 209 Block DS: ~(r0|r1) no fold plain OR")
     } else { println("  FAIL: T925") }
+    passed
+}
+
+// Self-test dispatcher part 9/10: split out of run_compiler_main_self_tests
+// because the monolithic body lowered to 33829 IR instructions, past IR_MAX_INSTRS.
+// Each part stays far under the IR cap and under the DCE/const-prop 8192 caps,
+// so every analysis pass remains complete on every part (no refusal, no truncation).
+fn compiler_main_self_tests_part_09(passed_in: i64) -> i64 with IO, Mut, Panic, Div, Alloc {
+    var passed = passed_in
 
     // Sprint 210 Block DT: OR-AND complement absorption (T926-T931)
     if compiler_main_test_dt_or_and_comp_basic() {
@@ -27375,6 +27448,15 @@ fn run_compiler_main_self_tests() -> i32 with IO, Mut, Panic, Div, Alloc {
         passed = passed + 1
         println("  T1079 OK: Sprint 235 Block ES: (r0&r1)+(r0^r2) no fold diff var")
     } else { println("  FAIL: T1079") }
+    passed
+}
+
+// Self-test dispatcher part 10/10: split out of run_compiler_main_self_tests
+// because the monolithic body lowered to 33829 IR instructions, past IR_MAX_INSTRS.
+// Each part stays far under the IR cap and under the DCE/const-prop 8192 caps,
+// so every analysis pass remains complete on every part (no refusal, no truncation).
+fn compiler_main_self_tests_part_10(passed_in: i64) -> i64 with IO, Mut, Panic, Div, Alloc {
+    var passed = passed_in
     if compiler_main_test_es_no_fold_sub_outer() {
         passed = passed + 1
         println("  T1080 OK: Sprint 235 Block ES: (r0&r1)-(r0^r1) no fold sub outer")
@@ -27877,6 +27959,24 @@ fn run_compiler_main_self_tests() -> i32 with IO, Mut, Panic, Div, Alloc {
         passed = passed + 1
         println("  T967 OK: Sprint 216 Block DZ: (r0|r1)|(r0&r1) no fold OR outer")
     } else { println("  FAIL: T967") }
+    passed
+}
+
+fn run_compiler_main_self_tests() -> i32 with IO, Mut, Panic, Div, Alloc {
+    var passed: i64 = 0
+    let total: i64 = 1156
+
+    println("=== compiler/main.sio self-tests ===")
+    passed = compiler_main_self_tests_part_01(passed)
+    passed = compiler_main_self_tests_part_02(passed)
+    passed = compiler_main_self_tests_part_03(passed)
+    passed = compiler_main_self_tests_part_04(passed)
+    passed = compiler_main_self_tests_part_05(passed)
+    passed = compiler_main_self_tests_part_06(passed)
+    passed = compiler_main_self_tests_part_07(passed)
+    passed = compiler_main_self_tests_part_08(passed)
+    passed = compiler_main_self_tests_part_09(passed)
+    passed = compiler_main_self_tests_part_10(passed)
 
     println("")
     println("compiler/main tests: " + int_to_string(passed) + "/" + int_to_string(total) + " passed")


### PR DESCRIPTION
## Summary

`run_compiler_main_self_tests` (`self-hosted/compiler/main.sio`, 5839-line body, 1163 independent test blocks) lowered to **33829 IR instructions** — past `IR_MAX_INSTRS=16384`. That was the rung-gen2 wall named in the Box audit doc. The compiler's own error message prescribed the fix: *"split it into smaller functions"*. This does exactly that.

## Why split, not raise

Raising `IR_MAX_INSTRS` is the wrong lever here, for the reason the audit doc and `irfunction_instr_capacity_coherence_gate.sh` both name: `DCE_MAX_INSTRS=8192` caps liveness, and a truncated liveness analysis is a WRONG analysis (silent miscompile). Splitting sidesteps the whole question:

- Each part (~116 blocks) stays far under the IR cap **and** under the DCE/const-prop 8192 caps, so every per-instruction analysis pass stays complete on every part — no refusal, no truncation.
- `DCE_MAX_INSTRS`, `CP_MAX_INSTRS`, and every lateral array stay exactly where they are.

## The split is mechanical and provably safe

- 1163 depth-0 blocks, each an independent `if compiler_main_test_*` mutating only `passed`.
- No block references `total`; all 1164 test functions are defined before the dispatcher (no forward refs).
- Body is brace-balanced with no braces in strings.
- Ten part-functions `compiler_main_self_tests_part_01..10` thread `passed` through; the dispatcher keeps the banner, the total, and the summary/exit-code logic unchanged.

## Measured (from-source split build SHA-256 `7ffc6c82…`)

- **fixed-point gate**: `GATE_RC=0`, reached `check` as recorded. The 33829/`IR_MAX_INSTRS` wall is **GONE** (0 occurrences in the gen2 log). gen2 now progresses past typecheck into lowering before a deeper, different SIGSEGV — a separate wall, not this one.
- **box_all_read_forms**: `BOXMATRIX OK` rc=0 — no regression
- **dce_reachability**: all three arms pass
- **typecheck main.sio**: 80 errors before == 80 after (all pre-existing ontology E175); the split adds ZERO

## Not done here

`IR_MAX_INSTRS` is NOT raised. The deeper gen2 SIGSEGV (now in lowering, past typecheck) is a separate wall and a separate task.