### PR TITLE
test: pin FO-across-boundary as known-failure (import and arity ≥3)

### DIFF
--- a/tests/run-pass/gum_fo_arity3_boundary.sio
+++ b/tests/run-pass/gum_fo_arity3_boundary.sio
@@ -1,0 +1,39 @@
+//@ run-pass
+//@ requires: madaros
+//@ known-failure: Madaros loses first-order variance across a same-file helper with ≥3 f64 params. Observed 2026-08-18: souc compile rc=0, \x7fELF, run rc=1; variance_of(add3(a,b,c))=0 while locals are 4/1/9 and add2 of the same seeds is 5. Not print rounding. Not a regression — fo_register_pure_fn_transfer skips >2 params since 990168abc2 (2026-07-26). Remove when the arity cap lifts. XPASS under #1910 is the detector.
+//@ expect-stdout: GUM_FO_ARITY3_BOUNDARY_OK
+//@ description: XPASS detector for the ≥3-arg hole. Same file, so import cannot hide a successful arity fix.
+
+fn add2(x: f64, y: f64) -> f64 with Mut {
+    let r = x + y
+    return r
+}
+
+fn add3(x: f64, y: f64, z: f64) -> f64 with Mut {
+    let r = x + y + z
+    return r
+}
+
+fn main() -> i64 with IO, Mut, Epistemic {
+    let k1: Knowledge<f64> = measure(100.0, uncertainty: 2.0)
+    let k2: Knowledge<f64> = measure(50.0, uncertainty: 1.0)
+    let k3: Knowledge<f64> = measure(10.0, uncertainty: 3.0)
+    let a = k1.value
+    let b = k2.value
+    let c = k3.value
+    let v2 = variance_of(add2(a, b))
+    let v3 = variance_of(add3(a, b, c))
+    print("ADD2 ")
+    print_f64(v2)
+    println("")
+    print("ADD3 ")
+    print_f64(v3)
+    println("")
+    if v2 > 4.9 && v2 < 5.1 && v3 > 13.9 && v3 < 14.1 {
+        println("GUM_FO_ARITY3_BOUNDARY_OK")
+        0
+    } else {
+        println("GUM_FO_ARITY3_BOUNDARY_ZERO")
+        1
+    }
+}

--- a/tests/run-pass/gum_fo_import_boundary.sio
+++ b/tests/run-pass/gum_fo_import_boundary.sio
@@ -1,0 +1,29 @@
+//@ run-pass
+//@ requires: madaros
+//@ known-failure: Madaros loses first-order variance across an imported helper, including 1–2 f64 args. Observed 2026-08-18: souc compile rc=0, \x7fELF, run rc=1; variance_of(fo_add2(a,b))=0 while same-file peel of a+b is 5.0. Not print rounding. Not a regression — import FO never landed on main (d9fe77669a). Remove when imported FO lands. XPASS under #1910 is the detector.
+//@ expect-stdout: GUM_FO_IMPORT_BOUNDARY_OK
+//@ description: XPASS detector for the surgical import-FO port. 2-arg only, so arity ≥3 cannot hide a successful import fix.
+
+use epistemic::fo::{fo_add2}
+
+fn main() -> i64 with IO, Mut, Epistemic {
+    let k1: Knowledge<f64> = measure(100.0, uncertainty: 2.0)
+    let k2: Knowledge<f64> = measure(50.0, uncertainty: 1.0)
+    let a = k1.value
+    let b = k2.value
+    let peel = variance_of(a + b)
+    let imp = variance_of(fo_add2(a, b))
+    print("PEEL ")
+    print_f64(peel)
+    println("")
+    print("IMP ")
+    print_f64(imp)
+    println("")
+    if peel > 4.9 && peel < 5.1 && imp > 4.9 && imp < 5.1 {
+        println("GUM_FO_IMPORT_BOUNDARY_OK")
+        0
+    } else {
+        println("GUM_FO_IMPORT_BOUNDARY_ZERO")
+        1
+    }
+}

--- a/tests/run-pass/madaros_gum_fo_import.sio
+++ b/tests/run-pass/madaros_gum_fo_import.sio
@@ -1,4 +1,6 @@
 //@ run-pass
+//@ requires: madaros
+//@ known-failure: Madaros loses FO on imported helpers; this file also calls 5-arg fo_css so it stays red until BOTH the import wall and the ≥3-arg cap close. Observed 2026-08-18: compile rc=0, run rc=1, v_imp_mul=0 v_peel_mul=0.25. Was hidden as VXFAIL in vacuous_expect_baseline. Combined pin — the XPASS detectors are gum_fo_import_boundary.sio (2-arg import) and gum_fo_arity3_boundary.sio (same-file add3).
 //@ expect-stdout: MADAROS_GUM_FO_IMPORT_PASS
 
 // Multi-mod FO: imported pure helpers from epistemic::fo must FO-transfer
@@ -12,7 +14,7 @@ fn abs_f(x: f64) -> f64 {
     return x
 }
 
-fn main() with IO, Mut, Div, Epistemic {
+fn main() -> i64 with IO, Mut, Div, Epistemic {
     let ka: Knowledge<f64> = measure(2.0, uncertainty: 0.1)
     let kb: Knowledge<f64> = measure(3.0, uncertainty: 0.2)
     let a = ka.value
@@ -54,7 +56,9 @@ fn main() with IO, Mut, Div, Epistemic {
         && v_imp_css > 0.1
     if ok {
         print("MADAROS_GUM_FO_IMPORT_PASS\n")
+        0
     } else {
         print("MADAROS_GUM_FO_IMPORT_FAIL\n")
+        1
     }
 }

--- a/tests/vacuous_expect_baseline.txt
+++ b/tests/vacuous_expect_baseline.txt
@@ -143,7 +143,6 @@ tests/run-pass/madaros_gum_fo_deep_field.sio
 tests/run-pass/madaros_gum_fo_eight_param.sio
 tests/run-pass/madaros_gum_fo_field_call.sio
 tests/run-pass/madaros_gum_fo_if_helper.sio
-tests/run-pass/madaros_gum_fo_import.sio
 tests/run-pass/madaros_gum_fo_impure_ctor.sio
 tests/run-pass/madaros_gum_fo_knowledge_ops.sio
 tests/run-pass/madaros_gum_fo_let_bytecode.sio


### PR DESCRIPTION
## Why

#1912 measured that Madaros loses first-order variance across a function boundary when the callee has **≥3 f64 params** or is **imported**. That lived in a receipt. This PR puts it in the suite as a failing test with an honest known-failure.

This is valuable even if the surgical import port never happens. The defect becomes CI-visible instead of a document someone has to go read.

#1910 (open) will make XPASS fail the gate. The day someone closes the FO hole, the matching witness passes, the gate fires, and the repository notices the block dropped. The witness stops being documentation and becomes detection.

Not a regression. Import FO never landed on main (`d9fe77669a`). The arity cap is original (`990168abc2`, 2026-07-26).

## What landed

| File | Role |
|---|---|
| `tests/run-pass/gum_fo_import_boundary.sio` | **Import detector.** 2-arg `fo_add2` only. Peel of `a+b` is 5.0; imported call is 0 on Madaros. An import-only port cannot hide behind the arity cap. |
| `tests/run-pass/gum_fo_arity3_boundary.sio` | **Arity detector.** Same-file `add2` + `add3`. Import cannot hide an arity fix. `add2` is the 1–2-arg canary (must stay 5.0). |
| `tests/run-pass/madaros_gum_fo_import.sio` | Combined pin. Also calls 5-arg `fo_css`, so it stays red until **both** holes close. Now returns 1 on FAIL (was rc=0 while printing FAIL). |
| `tests/vacuous_expect_baseline.txt` | Drop the VXFAIL that was swallowing the combined pin. |

Each known-failure states the observed rc and the real reason (FO lost at the boundary: ≥3 args or import).

`//@ requires: madaros` is required: lean_single already passes the arity-3 witness (ADD3=14), so without the tag a seed-suite run would XPASS today and lie about Madaros. The seed full-test-suite will skip these. They run on any job that sets `SOUNIO_MADAROS_AVAILABLE` (this PR's changed-tests gate; later #1910's known-failure recheck).

## Measured on this branch (unpatched Madaros)

| Witness | peel / ADD2 | imported / ADD3 | run rc |
|---|---:|---:|---:|
| import boundary | 5.0 | 0.0 | 1 |
| arity-3 boundary | 5.0 | 0.0 | 1 |
| combined import pin | peel_mul 0.25 | imp_mul 0 | 1 |

Harness with `SOUNIO_MADAROS_AVAILABLE=1`: Known failures 3, Pass 0. Without the flag: Skip 3. `gum_cross_function` (same-file 1–2 arg) still PASS on both engines.

## Out of scope

- No compiler port. `lower.sio` and `module_frontend.sio` are untouched.
- Does not take grok-cli2's `gum_fo_across_call` / `fo_call_boundary_*` files.
- Does not edit grok-cli3's harness (#1910).

## Test plan

- [x] Dual-engine compile+run of both new witnesses (Madaros ELF, `\x7fELF`, rc=1)
- [x] Combined pin now exits 1
- [x] Harness classifies all three as known-failure under Madaros
- [x] `gum_cross_function` still PASS
- [ ] CI changed-tests / Madaros gate on this PR