### PR TITLE
docs(honesty): mark published 318/318 as a May receipt, not a live pass

### DIFF
--- a/.agent-orchestration/coordination/6_lane_assignment.md
+++ b/.agent-orchestration/coordination/6_lane_assignment.md
@@ -71,16 +71,18 @@ from goldens.
      to confirm self-host fixed-point still green; rebuild only if
      fixed-point is broken or souc rejects current source.
   4. Run `bash scripts/ci/kaxi_ptx_capture.sh` to regenerate goldens.
-  5. Run `bash scripts/ci/kaxi_ptx_golden_gate.sh` — must show 318/318
-     PASS, 0 FAIL, 0 MISSING.
+  5. Run `bash scripts/ci/kaxi_ptx_golden_gate.sh`. The May 2026
+     closeout target was 318/318 PASS, 0 FAIL, 0 MISSING. That
+     number is stale. Live measurement 2026-08-18 (#1915): **0/318**,
+     rc=1, 80 s. Do not treat 318/318 as current health.
   6. Diff the regenerated goldens vs HEAD: if huge diff, ROLLBACK and
      classify as `compiler-semantics` Blocker (souc producing wrong PTX,
      not goldens being stale).
   7. Commit goldens; PR title `[lane-1] regenerate kaxi_ptx goldens vs
      post-Phase-Y emitter source`.
-- **Build target**: `bash scripts/ci/kaxi_ptx_golden_gate.sh` returns
-  rc=0, output line `PASS:    318` (or current N), `FAIL:    0`,
-  `MISSING: 0`.
+- **Build target (May 2026 closeout, stale):** `kaxi_ptx_golden_gate.sh`
+  rc=0, `PASS: 318`, `FAIL: 0`, `MISSING: 0`. Live 2026-08-18 (#1915):
+  rc=1, 0/318 PASS. Do not use 318/318 as a current pass criterion.
 - **Merge status**: merged via PR #95.
 
 ### Lane 2 — `dissertation-evidence` (Codex #1)

--- a/docs/audit/KAXI_PTX_TARGET_SM_AUDIT_2026-06-17.md
+++ b/docs/audit/KAXI_PTX_TARGET_SM_AUDIT_2026-06-17.md
@@ -9,6 +9,8 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.kaxi-ptx
 
 # K-AXI → PTX emitter correctness audit — 2026-06-17
 
+> The `ACCEPT=318/318` on this page is Slurm job 4311 (2026-06-17), a JIT-accept receipt, not the byte-compare golden gate. The golden gate on 2026-08-18 measured **0/318** PASS, rc=1, 80 s (#1915). Do not read this dated audit as current 318/318.
+
 Static, local audit of every `(pattern × mode)` PTX emitted by
 `./bin/kretikos kaxi-emit-ptx … --no-ptxas` (318 combos: 53 patterns × 6 modes).
 No GPU / ptxas required for these checks.

--- a/docs/research/subptx_buffer_refactor_investigation.md
+++ b/docs/research/subptx_buffer_refactor_investigation.md
@@ -11,6 +11,8 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.subpt
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+>
+> **Live golden-gate (not this page):** on 2026-08-18 `kaxi_ptx_golden_gate.sh` measured **0/318** PASS, rc=1, 80 s (`docs/audit/CI_GATE_BUDGET_2026-08-18.tsv`, #1915). The 318/318 rows below are a 2026-05-11 receipt. They are not a current measurement.
 <!-- docs:status-note:end -->
 
 # Sub-PTX buffer refactor — investigation finding
@@ -52,7 +54,7 @@ sites unchanged.
 
 | Kernel | Emission outcome |
 |---|---|
-| 318 PTX golden gate | PASS 318/318 unchanged |
+| 318 PTX golden gate | PASS 318/318 unchanged **(2026-05-11 receipt; live 2026-08-18 is 0/318, #1915)** |
 | LSE-8 gate | PASS 7/7 unchanged |
 | Sinkhorn-16, 2 iters | PASS, 657 KB PTX in 37s (was 13s — 3× slower from larger buffer copies) |
 | Sinkhorn-16, 4 iters | **segfault** at ~52s |
@@ -123,7 +125,7 @@ without functional change. The cap stays at 262144 (256 KB), Sinkhorn-
 < 2` body comment), and all gates remain green at their
 previously-committed state:
 
-- `kaxi_ptx_golden_gate.sh` PASS 318/318
+- `kaxi_ptx_golden_gate.sh` PASS 318/318 **(2026-05-11 receipt; live 2026-08-18 is 0/318, #1915)**
 - `kretikos_kaxi_lse8_gate.sh` PASS 7/7
 - `kretikos_kaxi_sinkhorn16_gate.sh` PASS 7/7
 - `kretikos_kaxi_fmad_invariance_gate.sh` PASS 18/18

--- a/docs/research/subptx_phase_h_complete.md
+++ b/docs/research/subptx_phase_h_complete.md
@@ -11,6 +11,8 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.subpt
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+>
+> **Live golden-gate (not this page):** on 2026-08-18 `kaxi_ptx_golden_gate.sh` measured **0/318** PASS, rc=1, 80 s (`docs/audit/CI_GATE_BUDGET_2026-08-18.tsv`, #1915). The 318/318 row below is a 2026-05-11 receipt. It is not a current measurement.
 <!-- docs:status-note:end -->
 
 # Sub-PTX Phase H complete — convergence-grade Sinkhorn unlocked
@@ -53,7 +55,7 @@ emitter body raised from 2 to 16.
 
 | Gate | Result | Note |
 |---|---|---|
-| `kaxi_ptx_golden_gate.sh` | PASS 318/318 byte-identical | Backward compat — streaming and accumulator emit the SAME bytes in the SAME order |
+| `kaxi_ptx_golden_gate.sh` | PASS 318/318 byte-identical **(2026-05-11 receipt; live 2026-08-18 is 0/318, #1915)** | Backward compat on that date — streaming and accumulator emit the SAME bytes in the SAME order |
 | `kretikos_kaxi_lse8_gate.sh` | PASS 7/7 | Small kernel sanity |
 | `kretikos_kaxi_sinkhorn16_gate.sh` | PASS 7/7 | At 16 iters: lands on analytic fixed point u = -7.08746, v ≈ 0; 3-run bit-deterministic |
 | `kretikos_kaxi_fmad_invariance_gate.sh` | PASS 18/18 | At the 5.26 MB PTX scale, ptxas refuses to fuse any of ~480k mul+add chains — `.rn` discipline holds |


### PR DESCRIPTION
## Summary

`kaxi_ptx_golden_gate.sh` is not an unguarded numeral. It is a **false** one: the live gate measures **0/318** (rc=1, 80 s, `measured=yes`, #1915) while three present-tense surfaces still said **318/318**.

This is a different class from 19/53. That count was right and unlabeled. This count is wrong.

## Where it was (and was not)

| Surface | 318/318 | License | Action |
|---|---|---|---|
| Live website (`pages/`, `components/`, `/honesty`) | **absent** | none — not a site claim | none |
| Public claim registry | absent | — | none |
| `docs/research/subptx_phase_h_complete.md` | PASS 318/318 byte-identical | none (historical banner, present-tense row) | marked as 2026-05-11 receipt vs live 0/318 |
| `docs/research/subptx_buffer_refactor_investigation.md` | two PASS 318/318 rows | none | same |
| `.agent-orchestration/coordination/6_lane_assignment.md` | "must show 318/318" | none (file still says **active**) | closeout target marked stale |
| `docs/audit/KAXI_PTX_TARGET_SM_AUDIT_2026-06-17.md` | ACCEPT=318/318 | dated JIT job 4311 — **not** the golden gate | banner: do not read as current golden 318/318 |
| `artifacts/omega/agent_handoff.log.md` | May closeout log | dated receipt | **left** — rewriting a log invents a second history |

Not a remasure. The 0/318 is cursor-2's #1915 row. Dated rows stay; they stop pretending to be now.

## What this does not do

Does not redesign the honesty label. The three states her table forces (unguarded / guarded-and-measured / guarded-but-empty) are noted, not implemented. `phase_z_assoc` is not an empty green — she refused to inflate that count; this PR does not add it.

## Test plan

- [x] `git grep 318/318 -- website` is empty
- [x] Present-tense research rows and the active lane assignment now name #1915 0/318
- [ ] Do not merge unless the founder says go