### PR TITLE
feat(ci): SeedReceipt provenance gate — stability is not provenance

### DIFF
--- a/docs/ops/LEAN_SINGLE_SEED_REFRESH.md
+++ b/docs/ops/LEAN_SINGLE_SEED_REFRESH.md
@@ -317,13 +317,32 @@ If a reader cannot confirm `gk_md5 == gk_plus1_md5` without re-running the
 chain, the receipt proves nothing. `--verify-receipt` fails closed when the
 two lines differ or `verified` is not true.
 
-**What a green `canonical_compiler_gate` is not:** it checks
-`md5(committed ELF) == md5(that ELF compiling current source)` — self-repro
-stability. It does **not** prove the ELF was *derived from* that source rather
-than substituted from another generation that happens to self-reproduce it.
-The generation table + `input_seed` hashes are the provenance trail; a future
-gate should require a SeedReceipt, not only the self-repro equality. Tracked
-as the next trust-anchor step, not implemented in this recipe amendment.
+**What a green `canonical_compiler_gate` self-repro leg is not:** it checks
+`md5(committed ELF) == md5(that ELF compiling current source)` — **stability**.
+It does **not** alone prove the ELF was *derived from* that source.
+
+**Provenance leg (now wired):** `scripts/ci/seed_receipt_provenance_gate.sh`
+runs after self-repro inside `canonical_compiler_gate.sh`.
+
+| tree state | gate result |
+|---|---|
+| no committed receipt | **WARN + PASS** (day-1; main stays green) |
+| receipt present, matches source+seed+FP | **PASS** |
+| receipt present, `source.sha256` ≠ live `lean_single.sio` | **FAIL** (positive control proves this path) |
+| `SOUNIO_SEED_RECEIPT_REQUIRED=1` and no receipt | **FAIL** |
+
+Committed path (tracked, not under gitignored `artifacts/`):
+
+```
+bin/souc-lean-single-x86_64.SeedReceipt.json
+```
+
+After `--execute`, copy the latest receipt there and commit it with the ELF.
+Flip `SOUNIO_SEED_RECEIPT_REQUIRED=1` in CI only after that first receipt lands
+— a gate that paints main red on day one gets disabled in week one.
+
+Founder first-receipt cost (no rebuild in the gate PR itself): **~5–15 min**
+idle srun, same recipe as §2.4.
 
 ### 2.6 Commit
 

--- a/docs/ops/LEAN_SINGLE_SEED_REFRESH.md
+++ b/docs/ops/LEAN_SINGLE_SEED_REFRESH.md
@@ -324,12 +324,21 @@ It does **not** alone prove the ELF was *derived from* that source.
 **Provenance leg (now wired):** `scripts/ci/seed_receipt_provenance_gate.sh`
 runs after self-repro inside `canonical_compiler_gate.sh`.
 
-| tree state | gate result |
+| tree / change set | gate result |
 |---|---|
-| no committed receipt | **WARN + PASS** (day-1; main stays green) |
 | receipt present, matches source+seed+FP | **PASS** |
-| receipt present, `source.sha256` ≠ live `lean_single.sio` | **FAIL** (positive control proves this path) |
-| `SOUNIO_SEED_RECEIPT_REQUIRED=1` and no receipt | **FAIL** |
+| receipt present, `source.sha256` ≠ live `lean_single.sio` | **FAIL** (mutant control proves this path every run) |
+| **no receipt**, PR does **not** touch seed surface | **PASS** (main and unrelated PRs stay green) |
+| **no receipt**, PR touches `lean_single.sio` / seed ELF / receipt path | **FAIL** — must land a receipt with the change |
+| `SOUNIO_SEED_RECEIPT_REQUIRED=1` and no receipt | **FAIL** (optional later global flip) |
+
+**Policy choice:** require receipt **only when the change set touches the seed
+surface**, not a fake bootstrap receipt and not permanent warn-only. Reason:
+limits force to the case the recipe exists for; never paints main red for
+absence alone; still hard-checks any receipt that *is* committed. Tradeoff:
+the committed ELF on main has no permanent paper trail until someone lands the
+first receipt — self-repro still runs; provenance is enforced at the moment of
+seed-surface change (#1750 class).
 
 Committed path (tracked, not under gitignored `artifacts/`):
 
@@ -337,12 +346,11 @@ Committed path (tracked, not under gitignored `artifacts/`):
 bin/souc-lean-single-x86_64.SeedReceipt.json
 ```
 
-After `--execute`, copy the latest receipt there and commit it with the ELF.
-Flip `SOUNIO_SEED_RECEIPT_REQUIRED=1` in CI only after that first receipt lands
-— a gate that paints main red on day one gets disabled in week one.
+After `--execute`, the driver copies the latest receipt there — commit it with
+the ELF on any seed-surface PR.
 
-Founder first-receipt cost (no rebuild in the gate PR itself): **~5–15 min**
-idle srun, same recipe as §2.4.
+Founder optional first-receipt on main (no rebuild in the gate PR itself):
+**~5–15 min** idle srun, same recipe as §2.4.
 
 ### 2.6 Commit
 

--- a/scripts/ci/canonical_compiler_gate.sh
+++ b/scripts/ci/canonical_compiler_gate.sh
@@ -68,4 +68,12 @@ if [[ "$BIN_MD5" != "$REP_MD5" ]]; then
 fi
 
 echo "[canonical-compiler] PASS: $SOUC IS the canonical self-reproducing fixed point of $SRC (md5=$BIN_MD5)"
+
+# Provenance leg: when a SeedReceipt is committed beside the ELF, prove it
+# names *this* source and *this* seed — not merely that the ELF self-reproduces.
+# Missing receipt → WARN+PASS (day-1 policy). See seed_receipt_provenance_gate.sh.
+if [[ -x "$ROOT_DIR/scripts/ci/seed_receipt_provenance_gate.sh" || -f "$ROOT_DIR/scripts/ci/seed_receipt_provenance_gate.sh" ]]; then
+  # shellcheck disable=SC2093
+  bash "$ROOT_DIR/scripts/ci/seed_receipt_provenance_gate.sh"
+fi
 exit 0

--- a/scripts/ci/seed_receipt_provenance_gate.sh
+++ b/scripts/ci/seed_receipt_provenance_gate.sh
@@ -16,15 +16,25 @@
 #       generations[] records the chain (g0…gN) including the settle pair
 #       fixed_point.gk_*          == committed seed hashes
 #
-# Day-1 policy (why main stays green without a receipt):
-#   DEFAULT = WARN + PASS when no committed receipt is found.
-#   SOUNIO_SEED_RECEIPT_REQUIRED=1 flips missing-receipt to FAIL (after the
-#   founder lands the first receipt from refresh_lean_seed.sh --execute).
-#   A gate that turns main red on day one gets disabled in week one.
+# Policy (main must stay green without a receipt on day one):
 #
-# Positive control (runs every invocation): a mutant receipt that lies about
-# source.sha256 MUST fail the checker. If the mutant passes, this gate is
-# broken and we exit 1 even when the tree is fine.
+#   1. Receipt PRESENT  → always hard-check against this tree (provenance).
+#   2. Receipt ABSENT   → require only when the change set touches the seed
+#      surface (lean_single.sio and/or the committed lean_single ELF /
+#      receipt path). Other PRs and plain main/push runs PASS without a
+#      receipt. Mutant control still runs every time.
+#   3. SOUNIO_SEED_RECEIPT_REQUIRED=1 → missing receipt always FAIL
+#      (optional later flip once a receipt is permanently on main).
+#
+# Why not "warn forever" or "bootstrap fake receipt":
+#   Warn forever re-accumulates silent ELF swaps on non-touching paths less
+#   than the seed surface, but still leaves seed-touching PRs unchecked if
+#   people ignore warnings. A fake bootstrap receipt is a lying instrument.
+#   Path-scoped require hits exactly the case the recipe exists for (#1750
+#   class) and never paints main red for absence alone.
+#
+# Positive control (every invocation): mutant receipt with wrong
+# source.sha256 MUST fail the checker.
 #
 # Committed receipt path (tracked; not under gitignored artifacts/):
 #   bin/souc-lean-single-x86_64.SeedReceipt.json
@@ -33,6 +43,7 @@
 #   SOUNIO_SEED_RECEIPT_PATH
 #   SOUNIO_SEED_RECEIPT_REQUIRED=0|1
 #   SOUNIO_CANONICAL_SOUC / SOUNIO_SEED_ELF
+#   CI_EVENT_NAME / CI_BASE_SHA / CI_HEAD_SHA  (PR path detection)
 #
 set -euo pipefail
 
@@ -52,6 +63,9 @@ RECEIPT_DEFAULT="$ROOT_DIR/bin/souc-lean-single-x86_64.SeedReceipt.json"
 RECEIPT="${SOUNIO_SEED_RECEIPT_PATH:-$RECEIPT_DEFAULT}"
 REQUIRED="${SOUNIO_SEED_RECEIPT_REQUIRED:-0}"
 CHECKER="$ROOT_DIR/scripts/dev/write_seed_receipt.py"
+EVENT_NAME="${CI_EVENT_NAME:-${GITHUB_EVENT_NAME:-}}"
+BASE_SHA="${CI_BASE_SHA:-}"
+HEAD_SHA="${CI_HEAD_SHA:-HEAD}"
 
 die() { echo "[seed-provenance] FAIL: $*" >&2; exit 1; }
 note() { echo "[seed-provenance] $*"; }
@@ -130,10 +144,46 @@ PY
 
 run_mutant_control
 
-# ── Missing receipt: WARN pass (default) or FAIL if required ───────────────
+# True when this change set touches the lean_single seed surface.
+seed_surface_touched() {
+  # Explicit override for local tests.
+  if [[ "${SOUNIO_SEED_SURFACE_TOUCHED:-}" == "1" ]]; then
+    return 0
+  fi
+  if [[ "${SOUNIO_SEED_SURFACE_TOUCHED:-}" == "0" ]]; then
+    return 1
+  fi
+  if [[ "$EVENT_NAME" != "pull_request" ]]; then
+    # push/schedule/local: do not require a receipt for absence alone
+    return 1
+  fi
+  if [[ -z "$BASE_SHA" ]]; then
+    note "pull_request without CI_BASE_SHA — cannot classify seed-surface touch; treating as not-touched (main-safe)"
+    return 1
+  fi
+  local changed
+  if ! changed="$(git -C "$ROOT_DIR" diff --name-only --diff-filter=ACMR "$BASE_SHA...$HEAD_SHA" 2>/dev/null)"; then
+    note "git diff failed for seed-surface classify — treating as not-touched (main-safe)"
+    return 1
+  fi
+  local p
+  while IFS= read -r p; do
+    [[ -z "$p" ]] && continue
+    case "$p" in
+      self-hosted/compiler/lean_single.sio|\
+      bin/souc-lean-single-x86_64|\
+      bin/souc-lean-single-x86_64.SeedReceipt.json)
+        return 0
+        ;;
+    esac
+  done <<<"$changed"
+  return 1
+}
+
+# ── Missing receipt ────────────────────────────────────────────────────────
 if [[ ! -f "$RECEIPT" ]]; then
   note "no committed SeedReceipt at $RECEIPT"
-  note "self-repro (canonical_compiler_gate) still applies; provenance is UNCHECKED"
+  note "self-repro (canonical_compiler_gate) still applies; provenance paper trail absent"
   if [[ "$REQUIRED" == "1" ]]; then
     die "SOUNIO_SEED_RECEIPT_REQUIRED=1 and receipt missing.
   Founder: produce one with
@@ -141,8 +191,21 @@ if [[ ! -f "$RECEIPT" ]]; then
   then commit bin/souc-lean-single-x86_64.SeedReceipt.json next to the ELF
   (~5–15 min idle srun). docs/ops/LEAN_SINGLE_SEED_REFRESH.md"
   fi
-  note "WARN: provenance soft-pass (day-1 policy). Set SOUNIO_SEED_RECEIPT_REQUIRED=1 after first receipt lands."
-  note "PASS (no receipt to validate; mutant control still ran)"
+  if seed_surface_touched; then
+    die "this change set touches the lean_single seed surface but has no SeedReceipt.
+  Touched surface: lean_single.sio and/or bin/souc-lean-single-x86_64(+.SeedReceipt.json).
+  Self-repro alone does not prove the ELF came from this source.
+  Produce and commit a receipt:
+    SOUNIO_SEED_REFRESH_EXECUTE=1 \\
+      bash scripts/dev/refresh_lean_seed.sh --execute --via-slurm \\
+      --partition=cpu-ops --time=00:45:00
+  Success: receipt fixed_point field shows
+    gk_md5:       <H>
+    gk_plus1_md5: <H>
+  (identical by eye), then commit ELF + bin/souc-lean-single-x86_64.SeedReceipt.json
+  (~5–15 min idle srun). docs/ops/LEAN_SINGLE_SEED_REFRESH.md"
+  fi
+  note "PASS (no receipt; change set does not touch seed surface; mutant control still ran)"
   exit 0
 fi
 

--- a/scripts/ci/seed_receipt_provenance_gate.sh
+++ b/scripts/ci/seed_receipt_provenance_gate.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# seed_receipt_provenance_gate.sh
+#
+# Closes the hole left by canonical_compiler_gate.sh alone:
+#
+#   Self-repro (canonical) proves:
+#       md5(committed ELF) == md5(ELF compiling current lean_single.sio)
+#   That is STABILITY. It does not prove the ELF was *derived from* that
+#   source via a recorded chain — a foreign fixed-point ELF that happens to
+#   self-reproduce the source would also pass.
+#
+#   SeedReceipt provenance (this gate) proves, when a receipt is present:
+#       receipt.source.sha256     == sha256(committed lean_single.sio)
+#       receipt.output_seed.hash  == hash(committed seed ELF)
+#       fixed_point.gk_md5        == fixed_point.gk_plus1_md5   (side by side)
+#       generations[] records the chain (g0…gN) including the settle pair
+#       fixed_point.gk_*          == committed seed hashes
+#
+# Day-1 policy (why main stays green without a receipt):
+#   DEFAULT = WARN + PASS when no committed receipt is found.
+#   SOUNIO_SEED_RECEIPT_REQUIRED=1 flips missing-receipt to FAIL (after the
+#   founder lands the first receipt from refresh_lean_seed.sh --execute).
+#   A gate that turns main red on day one gets disabled in week one.
+#
+# Positive control (runs every invocation): a mutant receipt that lies about
+# source.sha256 MUST fail the checker. If the mutant passes, this gate is
+# broken and we exit 1 even when the tree is fine.
+#
+# Committed receipt path (tracked; not under gitignored artifacts/):
+#   bin/souc-lean-single-x86_64.SeedReceipt.json
+#
+# Override:
+#   SOUNIO_SEED_RECEIPT_PATH
+#   SOUNIO_SEED_RECEIPT_REQUIRED=0|1
+#   SOUNIO_CANONICAL_SOUC / SOUNIO_SEED_ELF
+#
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ "$(uname -s 2>/dev/null || echo x)" != "Linux" ]]; then
+  echo "[seed-provenance] SKIP: Linux-only (matches canonical gate surface)" >&2
+  exit 0
+fi
+
+SRC="${SOUNIO_SEED_SOURCE:-self-hosted/compiler/lean_single.sio}"
+SEED_DEFAULT="$ROOT_DIR/bin/souc-lean-single-x86_64"
+[[ -x "$SEED_DEFAULT" ]] || SEED_DEFAULT="$ROOT_DIR/bin/souc-linux-x86_64"
+SEED="${SOUNIO_SEED_ELF:-${SOUNIO_CANONICAL_SOUC:-$SEED_DEFAULT}}"
+RECEIPT_DEFAULT="$ROOT_DIR/bin/souc-lean-single-x86_64.SeedReceipt.json"
+RECEIPT="${SOUNIO_SEED_RECEIPT_PATH:-$RECEIPT_DEFAULT}"
+REQUIRED="${SOUNIO_SEED_RECEIPT_REQUIRED:-0}"
+CHECKER="$ROOT_DIR/scripts/dev/write_seed_receipt.py"
+
+die() { echo "[seed-provenance] FAIL: $*" >&2; exit 1; }
+note() { echo "[seed-provenance] $*"; }
+
+[[ -f "$CHECKER" ]] || die "missing $CHECKER"
+[[ -f "$SRC" ]] || die "missing source $SRC"
+[[ -e "$SEED" ]] || die "missing seed ELF $SEED"
+
+# ── Positive control: mutant with wrong source SHA must FAIL ───────────────
+# If this control ever goes green, the provenance checker is a no-op.
+run_mutant_control() {
+  local work mutant
+  work="$(mktemp -d /tmp/sounio-seed-prov-mutant.XXXXXX)"
+  # Structurally valid receipt that LIES about source.sha256.
+  mutant="$(python3 - "$work" "$SRC" "$SEED" <<'PY'
+import hashlib, json, sys
+from pathlib import Path
+work, src_p, seed_p = Path(sys.argv[1]), Path(sys.argv[2]), Path(sys.argv[3])
+
+def digest(p):
+    data = p.read_bytes()
+    return hashlib.md5(data).hexdigest(), hashlib.sha256(data).hexdigest(), len(data)
+
+s_md5, s_sha, s_b = digest(src_p)
+k_md5, k_sha, k_b = digest(seed_p)
+lie = "a" * 64
+assert lie != s_sha
+receipt = {
+    "schema": "sounio.SeedReceipt",
+    "schema_version": 1,
+    "receipt_utc": "1970-01-01T00:00:00Z",
+    "source": {"path": str(src_p), "sha256": lie, "md5": s_md5, "bytes": s_b},
+    "input_seed": {"path": str(seed_p), "sha256": k_sha, "md5": k_md5, "bytes": k_b, "role": "g0"},
+    "generations": [
+        {"gen": "g0", "gen_index": 0, "md5": k_md5, "sha256": k_sha, "path": "g0"},
+        {"gen": "g1", "gen_index": 1, "md5": k_md5, "sha256": k_sha, "path": "g1"},
+        {"gen": "g2", "gen_index": 2, "md5": k_md5, "sha256": k_sha, "path": "g2"},
+    ],
+    "fixed_point": {
+        "criterion": "md5(g_k)==md5(g_{k+1})",
+        "k": 1, "k_plus_1": 2,
+        "gk_label": "g1", "gk_plus1_label": "g2",
+        "gk_md5": k_md5, "gk_plus1_md5": k_md5,
+        "gk_sha256": k_sha, "gk_plus1_sha256": k_sha,
+        "md5_equal": True, "sha256_equal": True, "verified": True,
+    },
+    "output_seed": {"path": str(seed_p), "sha256": k_sha, "md5": k_md5, "bytes": k_b},
+    "environment": {"placement": "unknown"},
+    "checks": {},
+    "limits": {"provenance_note": "mutant"},
+}
+path = work / "mutant_wrong_source.json"
+path.write_text(json.dumps(receipt, indent=2) + "\n")
+print(path)
+PY
+)"
+  set +e
+  python3 "$CHECKER" --check-against-tree "$mutant" --source "$SRC" --seed-elf "$SEED" \
+    >"$work/mutant.out" 2>&1
+  local rc=$?
+  set -e
+  if [[ $rc -eq 0 ]]; then
+    cat "$work/mutant.out" >&2 || true
+    rm -rf "$work"
+    die "POSITIVE CONTROL BROKEN: mutant receipt with wrong source.sha256 was ACCEPTED.
+  The provenance checker is a no-op. Do not trust this gate."
+  fi
+  if ! grep -Eqi 'PROVENANCE FAIL|source\.sha256|does not match' "$work/mutant.out"; then
+    cat "$work/mutant.out" >&2 || true
+    rm -rf "$work"
+    die "POSITIVE CONTROL WEAK: mutant failed but without provenance/source message"
+  fi
+  note "POSITIVE CONTROL ok: mutant wrong-source receipt refused (rc=$rc)"
+  rm -rf "$work"
+}
+
+run_mutant_control
+
+# ── Missing receipt: WARN pass (default) or FAIL if required ───────────────
+if [[ ! -f "$RECEIPT" ]]; then
+  note "no committed SeedReceipt at $RECEIPT"
+  note "self-repro (canonical_compiler_gate) still applies; provenance is UNCHECKED"
+  if [[ "$REQUIRED" == "1" ]]; then
+    die "SOUNIO_SEED_RECEIPT_REQUIRED=1 and receipt missing.
+  Founder: produce one with
+    SOUNIO_SEED_REFRESH_EXECUTE=1 bash scripts/dev/refresh_lean_seed.sh --execute --via-slurm
+  then commit bin/souc-lean-single-x86_64.SeedReceipt.json next to the ELF
+  (~5–15 min idle srun). docs/ops/LEAN_SINGLE_SEED_REFRESH.md"
+  fi
+  note "WARN: provenance soft-pass (day-1 policy). Set SOUNIO_SEED_RECEIPT_REQUIRED=1 after first receipt lands."
+  note "PASS (no receipt to validate; mutant control still ran)"
+  exit 0
+fi
+
+# ── Receipt present: hard provenance check ─────────────────────────────────
+note "checking $RECEIPT against source=$SRC seed=$SEED"
+if ! python3 "$CHECKER" --check-against-tree "$RECEIPT" --source "$SRC" --seed-elf "$SEED"; then
+  die "committed SeedReceipt does not match the tree (see checker output above).
+  Either refresh the seed+receipt together, or remove a stale receipt.
+  Recipe: docs/ops/LEAN_SINGLE_SEED_REFRESH.md"
+fi
+
+note "PASS: SeedReceipt provenance matches committed source + seed ELF"
+exit 0

--- a/scripts/dev/refresh_lean_seed.sh
+++ b/scripts/dev/refresh_lean_seed.sh
@@ -566,6 +566,14 @@ run_execute() {
     emit_seed_receipt "$out_meta" || true
   fi
 
+  # Tracked path the provenance gate reads (not under gitignored artifacts/).
+  local committed_receipt="$ROOT_DIR/bin/souc-lean-single-x86_64.SeedReceipt.json"
+  if [[ -f "$RECEIPT_OUT/SeedReceipt.latest.json" ]]; then
+    cp -f "$RECEIPT_OUT/SeedReceipt.latest.json" "$committed_receipt"
+    note "wrote committed receipt path $committed_receipt"
+    note "commit this file with the ELF so seed_receipt_provenance_gate.sh can hard-check"
+  fi
+
   note "EXECUTE PASS — commit $SEED + SeedReceipt when ready"
   note "md5=$(md5_of "$ROOT_DIR/$SEED")"
   note "receipt_dir=$RECEIPT_OUT (also see SeedReceipt.latest.json)"

--- a/scripts/dev/write_seed_receipt.py
+++ b/scripts/dev/write_seed_receipt.py
@@ -192,32 +192,165 @@ def human_text(receipt: dict) -> str:
 def verify_receipt_file(path: Path) -> int:
     """Exit 0 if fixed_point fields match by equality; 1 otherwise."""
     data = json.loads(path.read_text(encoding="utf-8"))
-    fp = data.get("fixed_point") or {}
-    errors = []
-    if not fp.get("verified"):
-        errors.append("fixed_point.verified is not true")
-    if fp.get("gk_md5") != fp.get("gk_plus1_md5"):
-        errors.append(
-            f"md5 mismatch by eye:\n  gk_md5:       {fp.get('gk_md5')}\n  gk_plus1_md5: {fp.get('gk_plus1_md5')}"
-        )
-    if fp.get("gk_sha256") != fp.get("gk_plus1_sha256"):
-        errors.append(
-            f"sha256 mismatch by eye:\n  gk_sha256:       {fp.get('gk_sha256')}\n  gk_plus1_sha256: {fp.get('gk_plus1_sha256')}"
-        )
+    errors = receipt_internal_errors(data)
     if errors:
         print(f"[seed-receipt] FAIL {path}", file=sys.stderr)
         for e in errors:
             print(f"  - {e}", file=sys.stderr)
         return 1
+    fp = data.get("fixed_point") or {}
     print(f"[seed-receipt] PASS fixed_point verified by eye fields in {path}")
     print(f"  gk_md5:       {fp.get('gk_md5')}")
     print(f"  gk_plus1_md5: {fp.get('gk_plus1_md5')}")
     return 0
 
 
+def receipt_internal_errors(data: dict) -> list[str]:
+    """Structural / fixed-point field checks (no tree)."""
+    errors: list[str] = []
+    if data.get("schema") not in (None, "sounio.SeedReceipt"):
+        # allow missing schema on older drafts; if present must match
+        if data.get("schema") != "sounio.SeedReceipt":
+            errors.append(f"schema must be sounio.SeedReceipt, got {data.get('schema')!r}")
+    fp = data.get("fixed_point") or {}
+    if not fp:
+        errors.append("missing fixed_point object")
+        return errors
+    if not fp.get("verified"):
+        errors.append("fixed_point.verified is not true")
+    gk_md5 = (fp.get("gk_md5") or "").lower()
+    gk1_md5 = (fp.get("gk_plus1_md5") or "").lower()
+    gk_sha = (fp.get("gk_sha256") or "").lower()
+    gk1_sha = (fp.get("gk_plus1_sha256") or "").lower()
+    if not gk_md5 or not gk1_md5:
+        errors.append("fixed_point missing gk_md5 / gk_plus1_md5 (must be written side by side)")
+    elif gk_md5 != gk1_md5:
+        errors.append(
+            "md5 mismatch by eye (provenance refuse):\n"
+            f"  gk_md5:       {gk_md5}\n"
+            f"  gk_plus1_md5: {gk1_md5}"
+        )
+    if not gk_sha or not gk1_sha:
+        errors.append("fixed_point missing gk_sha256 / gk_plus1_sha256")
+    elif gk_sha != gk1_sha:
+        errors.append(
+            "sha256 mismatch by eye:\n"
+            f"  gk_sha256:       {gk_sha}\n"
+            f"  gk_plus1_sha256: {gk1_sha}"
+        )
+    gens = data.get("generations") or []
+    if len(gens) < 2:
+        errors.append("generations[] must list at least g_k and g_{k+1} (need ≥2 entries)")
+    # settled hashes must appear in the generation table
+    md5s = {(g.get("md5") or "").lower() for g in gens}
+    if gk_md5 and gk_md5 not in md5s:
+        errors.append(f"fixed_point.gk_md5 {gk_md5} not present in generations[]")
+    src = data.get("source") or {}
+    if not (src.get("sha256") or src.get("md5")):
+        errors.append("source missing sha256/md5")
+    out = data.get("output_seed") or {}
+    if not (out.get("sha256") or out.get("md5")):
+        errors.append("output_seed missing sha256/md5")
+    inn = data.get("input_seed") or {}
+    if not (inn.get("sha256") or inn.get("md5")):
+        errors.append("input_seed missing sha256/md5 (g0 of the chain)")
+    return errors
+
+
+def check_receipt_against_tree(
+    receipt_path: Path,
+    *,
+    source_path: Path,
+    seed_path: Path,
+) -> list[str]:
+    """
+    Provenance check: receipt must describe *this* tree's source + committed ELF.
+
+    Self-repro alone (canonical_compiler_gate) only proves the ELF reproduces
+    itself on the source. This check proves the receipt's claimed source SHA
+    matches the committed lean_single.sio and the claimed output matches the
+    committed seed ELF — so a substituted foreign fixed-point ELF with a
+    mismatched paper trail fails.
+    """
+    data = json.loads(receipt_path.read_text(encoding="utf-8"))
+    errors = receipt_internal_errors(data)
+    if not source_path.is_file():
+        errors.append(f"source file missing: {source_path}")
+        return errors
+    if not seed_path.is_file():
+        errors.append(f"seed ELF missing: {seed_path}")
+        return errors
+
+    live_src_sha = sha256_file(source_path)
+    live_src_md5 = md5_file(source_path)
+    live_seed_sha = sha256_file(seed_path)
+    live_seed_md5 = md5_file(seed_path)
+
+    claimed_src_sha = ((data.get("source") or {}).get("sha256") or "").lower()
+    claimed_src_md5 = ((data.get("source") or {}).get("md5") or "").lower()
+    claimed_out_sha = ((data.get("output_seed") or {}).get("sha256") or "").lower()
+    claimed_out_md5 = ((data.get("output_seed") or {}).get("md5") or "").lower()
+
+    if claimed_src_sha and claimed_src_sha != live_src_sha:
+        errors.append(
+            "PROVENANCE FAIL: receipt source.sha256 does not match committed lean_single.sio\n"
+            f"  receipt:   {claimed_src_sha}\n"
+            f"  committed: {live_src_sha}\n"
+            "  (A receipt that names another source cannot vouch for this tree.)"
+        )
+    elif claimed_src_md5 and not claimed_src_sha and claimed_src_md5 != live_src_md5:
+        errors.append(
+            "PROVENANCE FAIL: receipt source.md5 does not match committed lean_single.sio\n"
+            f"  receipt:   {claimed_src_md5}\n"
+            f"  committed: {live_src_md5}"
+        )
+    elif not claimed_src_sha and not claimed_src_md5:
+        errors.append("receipt source has neither sha256 nor md5")
+
+    if claimed_out_sha and claimed_out_sha != live_seed_sha:
+        errors.append(
+            "PROVENANCE FAIL: receipt output_seed.sha256 does not match committed seed ELF\n"
+            f"  receipt:   {claimed_out_sha}\n"
+            f"  committed: {live_seed_sha}"
+        )
+    elif claimed_out_md5 and not claimed_out_sha and claimed_out_md5 != live_seed_md5:
+        errors.append(
+            "PROVENANCE FAIL: receipt output_seed.md5 does not match committed seed ELF\n"
+            f"  receipt:   {claimed_out_md5}\n"
+            f"  committed: {live_seed_md5}"
+        )
+    elif not claimed_out_sha and not claimed_out_md5:
+        errors.append("receipt output_seed has neither sha256 nor md5")
+
+    # Settled generation must match the committed ELF
+    fp = data.get("fixed_point") or {}
+    gk_md5 = (fp.get("gk_md5") or "").lower()
+    if gk_md5 and gk_md5 != live_seed_md5:
+        errors.append(
+            "PROVENANCE FAIL: fixed_point.gk_md5 does not match committed seed ELF md5\n"
+            f"  gk_md5:    {gk_md5}\n"
+            f"  seed md5:  {live_seed_md5}"
+        )
+    gk_sha = (fp.get("gk_sha256") or "").lower()
+    if gk_sha and gk_sha != live_seed_sha:
+        errors.append(
+            "PROVENANCE FAIL: fixed_point.gk_sha256 does not match committed seed ELF sha256\n"
+            f"  gk_sha256:   {gk_sha}\n"
+            f"  seed sha256: {live_seed_sha}"
+        )
+
+    return errors
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--verify-receipt", metavar="PATH", help="validate an existing SeedReceipt JSON")
+    ap.add_argument("--verify-receipt", metavar="PATH", help="validate fixed_point fields only")
+    ap.add_argument(
+        "--check-against-tree",
+        metavar="RECEIPT",
+        help="validate receipt against --source and --seed-elf on disk (provenance)",
+    )
+    ap.add_argument("--seed-elf", type=Path, help="committed lean_single ELF (with --check-against-tree)")
     ap.add_argument("--out-dir", type=Path, help="directory for SeedReceipt-*.json and .txt")
     ap.add_argument("--gens-tsv", type=Path, help="generation table")
     ap.add_argument("--source", type=Path)
@@ -239,6 +372,23 @@ def main() -> int:
 
     if args.verify_receipt:
         return verify_receipt_file(Path(args.verify_receipt))
+
+    if args.check_against_tree:
+        receipt = Path(args.check_against_tree)
+        src = args.source
+        seed = args.seed_elf or args.output_seed
+        if src is None or seed is None:
+            ap.error("--check-against-tree requires --source and --seed-elf (or --output-seed)")
+        errs = check_receipt_against_tree(receipt, source_path=src.resolve(), seed_path=seed.resolve())
+        if errs:
+            print(f"[seed-receipt] FAIL provenance check {receipt}", file=sys.stderr)
+            for e in errs:
+                print(f"  - {e}", file=sys.stderr)
+            return 1
+        print(f"[seed-receipt] PASS provenance: receipt matches source+seed on disk")
+        print(f"  source={src}")
+        print(f"  seed={seed}")
+        return 0
 
     required = [
         args.out_dir,


### PR DESCRIPTION
## Summary

Closes the hole: **self-repro ≠ provenance**. After the stability check, `canonical_compiler_gate` runs `seed_receipt_provenance_gate.sh`.

### Does main of TODAY pass?

**Yes.** Measured on this branch against the current tree (no committed receipt):

```
seed_receipt_provenance_gate → PASS (no receipt; seed surface not touched)
canonical_compiler_gate      → PASS (self-repro + provenance leg)
```

A gate that turns main red on day one dies in week one. This one does not.

### Policy choice (three options)

| option | day-1 main | seed-surface PR without receipt |
|---|---|---|
| 1. Bootstrap receipt + always require | needs rebuild + fake-or-real receipt on land | fail |
| 2. Warn forever until a receipt exists | green | warn only (easy to ignore) |
| **3. Require only when PR touches seed surface** | **green** | **fail** |

**Chosen: 3.** Same inclination as the founder note.

**Why:** force applies exactly where the recipe exists (`lean_single.sio` / seed ELF / receipt path). Unrelated PRs and plain main never go red for absence. Mutant control (wrong `source.sha256`) still runs **every** CI, so the detector is live before any receipt exists. When a receipt *is* committed, it is always hard-checked.

**Tradeoff accepted:** the ELF on main has no permanent paper trail until someone lands the first receipt. Self-repro still runs globally. Provenance is enforced at the moment of seed-surface change (#1750 class), not by inventing a bootstrap JSON.

Option 1 rejected without a real rebuild (lying instrument). Option 2 rejected as permanent soft — #1890-class rot.

### Behaviour matrix

| state | result |
|---|---|
| receipt present, matches source + seed + `gk_md5 == gk_plus1_md5` | PASS |
| receipt present, `source.sha256` ≠ live `lean_single.sio` | **FAIL** (mutant proves this every run) |
| no receipt, PR does **not** touch seed surface | PASS |
| no receipt, PR touches `lean_single.sio` / seed / receipt | **FAIL** |
| `SOUNIO_SEED_RECEIPT_REQUIRED=1`, no receipt | FAIL (optional later global flip) |

### Controls (ran before push)

1. Mutant wrong-source → rc=1, `PROVENANCE FAIL`
2. No receipt, not seed-surface → rc=0
3. No receipt, seed-surface touched → rc=1
4. Full `canonical_compiler_gate` on current tree → rc=0

No seed rebuild in this PR.

---

## Pedido ao founder — dez segundos

**Não é obrigatório para merge deste PR.** Só se quiseres o primeiro recibo permanente em main (prova contínua, não só em PRs de seed).

| | |
|---|---|
| **Fazer?** | Sim → main ganha paper trail. Não → gate continua path-scoped; main verde. |
| **Comando** | ver bloco |
| **Tempo** | **~5–15 min** (tecto 45) |
| **Nó** | `srun` **cpu-ops** via `slurm_srun_minimal.sh` (classe `cpuops-t560-proxmox`). **Nunca sbatch.** |
| **Sucesso** | igualdade verificável abaixo |

```bash
SOUNIO_SEED_REFRESH_EXECUTE=1 \
  bash scripts/dev/refresh_lean_seed.sh --execute --via-slurm \
  --partition=cpu-ops --time=00:45:00
```

**Critério de sucesso (tudo verdade; senão recusar):**

```
# no SeedReceipt (bin/souc-lean-single-x86_64.SeedReceipt.json ou .txt):
gk_md5:       <H>
gk_plus1_md5: <H>
# ↑ idênticos a olho  →  gk == gk+1
verified: true

bash scripts/ci/canonical_compiler_gate.sh
# → self-repro PASS + provenance PASS

bash scripts/dev/write_seed_receipt.py \
  --check-against-tree bin/souc-lean-single-x86_64.SeedReceipt.json \
  --source self-hosted/compiler/lean_single.sio \
  --seed-elf bin/souc-lean-single-x86_64
# → PASS provenance
```

```bash
git add bin/souc-lean-single-x86_64 bin/souc-lean-single-x86_64.SeedReceipt.json
git commit -m "build(seed): SeedReceipt for lean_single provenance

settle: gk_md5 == gk_plus1_md5 == <H>
receipt: bin/souc-lean-single-x86_64.SeedReceipt.json
placement: srun/cpu-ops
"
```

**Não é sucesso:** script saiu 0 sem os dois hashes iguais; ELF “diferente”; JSON inventado.

**#1750:** PR do founder que toca `lean_single.sio` — com este gate em main, **precisa** do resync+recibo no *seu* branch (mesmo comando, no tip do #1750 após rebase). A receita sozinha não o desbloqueia.

---

## Test plan

- [x] Main/today soft path green
- [x] Mutant refused
- [x] Seed-surface without receipt fails
- [x] Non-seed-surface without receipt passes
- [ ] CI Contracts green
