### PR TITLE
RFC/WIP: CEI WS-A — algebraic-effect handlers as certified interpreters (P0→P2, handler-selectable uncertainty)

### DIFF
--- a/docs/architecture/CEI_IMPLEMENTATION_SPEC_2026-08-18.md
+++ b/docs/architecture/CEI_IMPLEMENTATION_SPEC_2026-08-18.md
@@ -540,3 +540,37 @@ this needs, and it is the pattern already used for P0-F extern-block parsing.
    receiver against CHECK_HANDLER_EFFECT before check_opt_expr(e.left).
 3. Verify loop: `souc check self-hosted/compiler/main.sio` after each file (cheap, no 4-min build); final
    from-source build + run `examples/effect_uncertainty_smoke.sio` (expect `SMOKE 5`).
+
+---
+
+## P0 CORRECTION — the clause-storage step in the spec is UNSOUND; use op→fn_id dispatch (2026-08-18)
+
+Implementation attempt uncovered a design hole BOTH workflow runs missed: the spec (and my module-global
+revision) says "store `e.handler_block` (Option<Box<Block>>) per depth and re-walk it at each perform site."
+**This does not typecheck.** In `lower_expr_ref(self, e: &Expr)` the handler block is **borrowed from the AST**;
+it cannot be moved into a module global (globals need ownership, as `parser_store_expr_box` takes an owned
+`Box<Expr>`) nor stored as a borrow in the by-value `Lowerer`, and Sounio exposes no address-of-reference→i64
+to stash a raw pointer (TypeRawPtr exists as a type but there is no clean `&Block`→i64→`&Block` round trip in
+lower.sio). No AST-clone/rewrite infra exists for blocks either.
+
+**Correct approach (owned IR, copyable dispatch map):**
+1. In `lower_handle_expr_ref`, BEFORE lowering the body, iterate the handler block's `StmtList`; for each clause
+   `Stmt{StmtLet, name:op, expr:Some(ExprClosure{closure_params, closure_body})}`, **lower the clause closure to
+   an owned IR function** (reuse the closure-lowering path — verify non-capturing closures reduce to a plain
+   callable fn_id) and record `(op_name: Name, fn_id: i64)` in a **module-global scalar map**:
+   `var LOWER_HANDLER_OP_NAMES: [Name;16]`, `var LOWER_HANDLER_OP_FNIDS: [i64;16]`,
+   `var LOWER_HANDLER_OP_COUNT: i64`, with a `[i64;4] LOWER_HANDLER_SCOPE_MARK` for push/pop by depth. Names +
+   i64 are copyable — no borrow, global-safe. (Verify `[Name;16]` as a *global* lowers; it works as a Lowerer
+   FIELD `fo_bind_names:[Name;128]`, so likely fine.)
+2. Lower the body. The perform hook (`expr_is_active_handler_perform_ref`, still mirroring the
+   `expr_is_gpu_sync_call_ref` bare-Ident-receiver shape while `LOWER_HANDLER_OP_COUNT>0`) resolves `op` to its
+   `fn_id` and emits an **ordinary `ir_call(dst, fn_id, op_name, args)`** — no clause-body re-walk, no borrow.
+   The scalar-kind re-bind concern disappears (args are real call arguments through the normal call path).
+3. Pop the scope mark on every exit.
+4. Checker side: the load-bearing `check_method_call` bypass @20438 still stands (type args against the clause
+   closure's `ClosureParam` types, return the clause body type), and `check_handle_expr` @24078 registers clause
+   op-names before checking the body — but it stores op NAMES only (copyable), never the borrowed block.
+
+**Open verification (first thing in the code pass):** confirm a non-capturing `ExprClosure` lowers to a directly
+callable `fn_id` via the existing closure path, and that a global `[Name;16]` lowers. This is the crux the two
+workflow runs did not reach; it is genuine compiler design, not mechanical wiring.

--- a/docs/architecture/CEI_IMPLEMENTATION_SPEC_2026-08-18.md
+++ b/docs/architecture/CEI_IMPLEMENTATION_SPEC_2026-08-18.md
@@ -509,3 +509,34 @@ is by-value-copied and multi-MiB per the @913 comment). Mirror on `struct Checke
 **Next increment:** make the struct + 4 code-site edits, build from source (needs an unthrottled slot), run the
 smoke test, then the P1 GUM-vs-MC demonstrator. Honesty gate unchanged (GUM conditional; p-box/interval the
 unconditional certified result).
+
+---
+
+## P0 design REVISION — module globals instead of struct fields (de-risked, 2026-08-18)
+
+Investigation result that supersedes the "box the handler stack on struct Lowerer/Checker" step: **Sounio
+module-level `var` globals CAN hold boxed AST** — proven by `var LAST_EXPR: Option<Box<Expr>> = None`
+(`parser/parser.sio:26`). Therefore the handler stack is a set of **module globals**, not struct fields:
+
+- In `self-hosted/ir/lower.sio` (top-level, near the other `var IR_LOWER_*` globals):
+  `var LOWER_HANDLER_DEPTH: i64 = 0`, `var LOWER_HANDLER_EFFECT: [Name; 4] = [empty_name(); 4]`, and the handler
+  blocks as boxed globals mirroring LAST_EXPR — a `var LOWER_HANDLER_BLOCKS: [Option<Box<Block>>; 4]` if the
+  fixed-array-of-Option-Box lowers cleanly, else four scalar `LOWER_HANDLER_BLOCK_0..3: Option<Box<Block>>`.
+- In `self-hosted/check/check.sio`: the same as `CHECK_HANDLER_*` (separate pass, separate globals).
+
+**Why this is strictly better:** it removes the by-value struct-field blast radius (struct Lowerer @723 + ~5
+`Lowerer{}` init literals @991/1455/1519/1587/2015; struct Checker + its inits) — the exact nested-aggregate-by-
+value shape with a documented miscompile history here. Push/pop of a global stack is precisely the discipline
+this needs, and it is the pattern already used for P0-F extern-block parsing.
+
+**Revised P0 edit set (small):**
+1. lower.sio: declare the 3 globals; `lower_handle_expr_ref` = push `e.name`+`e.handler_block` at
+   LOWER_HANDLER_DEPTH (cap 4), lower `e.block` (via lower_block_expr_ref shape), pop; `else if ExprHandle`
+   dispatch arm @~16496; perform hook `expr_is_active_handler_perform_ref` in lower_method_call_expr_ref @15677
+   (mirror expr_is_gpu_sync_call_ref shape; on match find `StmtLet{name==op, ExprClosure}` in the active block,
+   inline tail-resumptively with the scalar-kind re-bind).
+2. check.sio: declare CHECK_HANDLER_* globals; push/pop in check_handle_expr @24078; the load-bearing
+   check_method_call bypass @20438 (mirror the checker_expr_is_gpu_sync_call arm @20439) matching bare-Ident
+   receiver against CHECK_HANDLER_EFFECT before check_opt_expr(e.left).
+3. Verify loop: `souc check self-hosted/compiler/main.sio` after each file (cheap, no 4-min build); final
+   from-source build + run `examples/effect_uncertainty_smoke.sio` (expect `SMOKE 5`).

--- a/docs/architecture/CEI_IMPLEMENTATION_SPEC_2026-08-18.md
+++ b/docs/architecture/CEI_IMPLEMENTATION_SPEC_2026-08-18.md
@@ -1,0 +1,462 @@
+# CEI — Consolidated Implementation Spec (workflow-synthesised, adversarially verified)
+
+_Produced by the `cei-program-advance` workflow (fan-out survey → opus adversarial-verify → opus synthesis), run `wf_12e329df-b89`, 2026-08-18. Model routing: sonnet survey / opus verify+synthesis; WS-C re-routed to opus/high after a StructuredOutput failure. Read-only design; no source edited._
+
+**Verdicts:** `P0-lowering`=SOUND (high), `WS-B-memory`=FLAWED (high), `WS-C-nonassoc`=FLAWED (medium), `WS-D-lean`=FLAWED (high)
+
+---
+
+Confirmed the decisive integration fact: on this tree (`/workspace/.wt/fable-1`, `lower.sio` = 19461 lines, `struct Lowerer` @593) the GPU precedent the P0 design mirrors returns **zero** hits. The P0 line-references are valid only on the `lower-array` tree. That branch-lock leads the spec. Here is the consolidated deliverable.
+
+---
+
+```markdown
+# CEI — Consolidated Implementation Spec (4-Workstream Integration)
+
+*Synthesised 2026-08-18 from four independently adversarially-verified workstream designs
+(P0-lowering = SOUND; WS-B-memory = FLAWED-but-rescued; WS-C-nonassoc = FLAWED-but-rescued;
+WS-D-lean = STUB, no design to integrate). Read-only design; no files edited. Every line/function
+coordinate below is branch-conditional — see §0.*
+
+## 0. BRANCH-LOCK (blocking precondition for the entire spec)
+
+**The single most important fact across all four workstreams.** Every line number in the P0-lowering
+design — and its whole "mirror `expr_is_gpu_sync_call_ref`" strategy — is valid **only** on the worktree
+`/workspace/.wt/lower-array` (branch `lane/fable-1/handle-table-182-dispatch`, `lower.sio` = 17819 lines,
+`struct Lowerer` @723). **This was empirically confirmed false on the live checkout:**
+
+- Current worktree `/workspace/.wt/fable-1` (branch `lane/fable-1/p0f-ffi-takeover`):
+  `lower.sio` = **19461 lines**, `struct Lowerer` @**593**, and
+  `grep -c 'expr_is_gpu_sync_call_ref\|gpu_launch_kernel_name_ref' lower.sio` = **0**.
+- The canonical tree `/workspace/sounio` has the same absence.
+
+**Consequence:** if P0 must land on `main` (or on `p0f-ffi-takeover`), **there is no GPU precedent to mirror**
+and no `check_method_call` GPU bypass to parallel. The design must be **re-derived against the target tree**
+before any coordinate is trusted. Do not implement P0 from the coordinates as written without first
+re-grepping on the actual integration base.
+
+**Action item 0 (do before anything else):** pick and record the integration base. Two options:
+(A) integrate onto `lane/fable-1/handle-table-182-dispatch` where the GPU precedent exists, then merge
+forward; or (B) integrate onto `main`/current tree and re-derive the perform-hook and checker-bypass from
+first principles (there is no GPU no-op arm there to copy). **UNCERTAIN which is intended — confirm with the
+operator.** All coordinates in §1 below are annotated `[lower-array-only]` where they depend on the GPU tree.
+
+---
+
+## WS-A / P0 — ExprHandle lowering + perform-call inlining  (verdict: SOUND)
+
+**Thesis role:** minimal tail-resumptive handler mechanism. **Honest scoping (verifier correction):** P0 does
+**not** wire the orphaned 2991-line CPS runtime `self-hosted/effects/handlers.sio`; it is a parallel minimal
+mechanism. Do **not** describe P0 as "wiring the CPS engine" or as validating
+handlers-as-proof-carrying-interpreters — multi-shot / abortive / non-tail-resume are out of scope.
+
+### Corrected verified step list
+
+1. **Clause form (grammar, zero parser change).** `with { ... }` is parsed by the generic
+   `parse_block`/`parse_stmt` (`parser/stmts.sio:166`, `:254`), which accepts only `StmtLet`/`StmtVar`/expr-
+   statements. The **only** clause shape that parses today is a **let-bound closure**:
+   `let <op> = |<params>| { <body> }` → `Stmt{StmtLet, name:<op>, expr:Some(ExprClosure)}`.
+   The `op(params) => body` syntax in `examples/effects.sio` is **commented-out aspirational, NOT implemented** —
+   do not treat it as working.
+2. **Callee shape.** `perform Epistemic.add(x,y)` drops `perform` at parse and becomes a **single**
+   `ExprMethodCall{name:"add", left:Some(ExprIdent{"Epistemic"}), args:[x,y]}` — **not** the curried double-call
+   of `GPU.launch`. Precedent to mirror is `expr_is_gpu_sync_call_ref` `[lower-array-only]`, **not**
+   `gpu_launch_kernel_name_ref`.
+3. **Lowerer state.** Add to `struct Lowerer`: `handler_effect_stack: [Name;4]`,
+   `handler_block_stack: [Option<Box<Block>>;4]`, `handler_depth: i64`, following the `loop_labels`/`loop_depth`
+   idiom. **Do NOT** introduce a `HandlerFrame`/`HandlerClause` struct-of-arrays — that is the exact nested-by-value
+   aggregate shape with a documented miscompile history in this codebase (struct-array elem dispatch / nested
+   field-store). Store raw `e.name` + `e.handler_block` pointer per depth; re-walk the `StmtList` at each perform
+   site to find the matching clause.
+4. **`lower_handle_expr_ref`.** Push (cap 4, error via `report_error_at` beyond, mirroring `bind_local`'s 4096
+   guard); lower body via `lower_block_ref` (ExprHandle stores its body in the same `.block:Option<Box<Block>>`
+   field as ExprBlock); pop `handler_depth` on **every** exit path. **Never** lower `e.handler_block` itself
+   through `lower_block_ref` — that would run each `let op = |...|{}` through the ordinary closure path
+   (`lower_closure_expr_ref`) and can trip "capturing closure cannot be used as a value". Walk its `StmtList`
+   structurally only.
+5. **Dispatch arm.** Add `else if e.kind == ExprKind::ExprHandle { self.lower_handle_expr_ref(e) }` immediately
+   before the catch-all in `lower_expr_non_binary_ref`. **Characterisation fix (verifier):** ExprHandle does not
+   silently "evaporate" — today it hits the catch-all `report_error_at` (a compile-error path), not a no-op.
+6. **Perform recognition + inline arm** inside `lower_method_call_expr_ref`, positioned as early as the GPU no-op
+   `[lower-array-only]` so no ordinary method-call machinery ever sees the perform call. Shape-check mirrors
+   `expr_is_gpu_sync_call_ref`; walk `handler_depth-1 → 0` (innermost-first, correct shadowing); find `StmtLet`
+   whose `.name == op` and `.expr` is `ExprClosure`. **On no clause / arity mismatch: refuse hard**
+   (`lowerer_mark_error; return IR_INVALID_REG`) — never fall through, or codegen mints a body-less mangled
+   `Epistemic_add` and SIGSEGVs (the documented GPU.sync() pre-fix failure class).
+7. **Clause inline (tail-resumptive).** `scope_depth += 1; saved = locals.count`; for each arg,
+   `lower_expr_ref` then `bind_local(param_name[i], reg, false)`. **CRITICAL:** `bind_local` zeroes
+   `scalar_kind[idx]=0` by design → an unclassified f64 param hits the `println` kind-0 char*-printer SIGSEGV
+   (project memory `project_println_bool_scalarkind_segv`). **Immediately re-bind kind** from `ClosureParam.ty`
+   (f64→kind 2, i64→kind 1, struct→`bind_local_struct_type` per the `Some(x)`-payload idiom). Lower clause body
+   (ExprBlock→`lower_block_ref`, else `lower_expr_ref`). Restore `scope_depth -= 1; locals.count = saved`. The
+   clause body's result register **is** the perform value — resume-once-at-the-tail, no CPS, no `resume()`.
+8. **Check EDIT 1 — `check_handle_expr` restructure.** Push `e.name`+`e.handler_block` onto new by-value
+   `Checker` fields (`handler_effect_stack`/`handler_block_stack`/`handler_depth`) **before** checking the body,
+   so perform sites inside the body see the clauses; pop after; keep the existing `check_block(*hb)` (checks each
+   clause closure standalone — cheap, retain).
+9. **Check EDIT 2 — the load-bearing missing piece (top risk).** `check_method_call` types the **receiver first**
+   via `check_opt_expr(e.left)`. For `Epistemic.add(x,y)` the bare `ExprIdent{"Epistemic"}` is not a bound local
+   → **fails as an undeclared-identifier (E137-class) error in `check` before any lowering runs**. Add a
+   GPU-style early-return bypass `[lower-array-only precedent]` **before** the `check_opt_expr(e.left)` call:
+   predicate `checker_expr_is_active_handler_perform` matches AST shape *(bare-Ident method-call receiver)*
+   against the **live handler-effect stack** (never against the struct table — so effect-id `Epistemic` and
+   stdlib struct `Epistemic` never collide). On receiver-match + clause-match: type-check args against
+   `ClosureParam` types (reuse `check_closure_expr`'s param-bind+body-infer subroutine) and **return the clause
+   body's inferred type** — this is what lets the *same* `Epistemic.mul(x,y)` source type as `Epistemic` under a
+   GUM handler and `MCResult` under an MC handler. On receiver-match + no clause / arity mismatch: emit the new
+   **"unhandled effect operation / clause arity mismatch"** diagnostic (this fuses the "clause completeness +
+   arity" check into the call site — no separate collection pass). On no receiver-match: fall through unchanged.
+10. **Signature nit (verifier):** the predicate lives in the **by-value** `check_method_call` whose checker is
+    `self: Checker` (by value) — read the stacks off `self`, **not** a `*mut Checker`. EDIT 1 threads the same
+    by-value `Checker` functionally through `check_opt_block`; fields are visible to the by-value perform site.
+11. **Third-edit guard (verifier, must confirm):** there is a **parallel `*mut` inplace checker**
+    `checker_check_method_call_inplace` carrying its own GPU bypass. EDIT 2 (by-value) suffices **only** because
+    handle bodies are checked entirely in the by-value spine (inplace `else` → `checker_check_expr_mut` →
+    by-value `check_handle_expr` → by-value `check_block`/`check_method_call`, no re-entry to inplace inside the
+    subtree). **Confirm no handle-body path re-enters `checker_check_method_call_inplace`;** if any does, a
+    THIRD parallel bypass edit there is required, or `Epistemic.<op>` returns E137.
+12. **Diagnostic code (open):** grep the `report_error_at`/`print_error_message` table for the next free E-code
+    before adding the "unhandled effect operation" diagnostic — **do not guess a number** (collision risk).
+13. **Scalar-kind classifier of the inlined result (open, gates the smoke test).** `expr_result_scalar_kind_ref`
+    (~`lower.sio:12690-12820`, consulted when lowering `let z = <call>`) has **not** been verified to classify
+    an **inlined clause-body** result (vs a real call's declared return). **Read it before implementing.** If it
+    returns `scalar_kind 0` for the handle result, `println(r)` in the smoke test SIGSEGVs via the char*-printer.
+    **The `expect-stdout: 5` claim is NOT yet demonstrable** until this is resolved. Extend it the same way the
+    bool-`println` fix extended `println_dispatch_name`/`bind_local` kind-rebinding.
+14. **`check/effects.sio`:** no change — `Epistemic=8` resolves via `effect_name_to_id`. Reuse as-is.
+15. **P0 smoke (int-only).** `examples/effect_uncertainty_smoke.sio`, new: one trivial handler,
+    `handle<Epistemic>{ Epistemic.add(2,3) } with { let add = |a:i64,b:i64| { a+b } }; println(r)`,
+    `//@ run-pass` / `//@ expect-stdout: 5`. Plain `i64` isolates the lowering mechanism from any stdlib adapter
+    risk. Verify with `souc check` then a **from-source** Madaros build (`bash scripts/ci/build_modular_madaros.sh`,
+    never the prebuilt wrapper) then `souc run` — **gated on step 13**.
+16. **P1 demonstrator (not part of the P0 arm).** `examples/effect_uncertainty_gum_vs_mc.sio`: thin adapters over
+    `stdlib/epistemic/knowledge.sio` (`ep_measured`/`ep_add`/`ep_mul` @76/94/112) and
+    `stdlib/epistemic/montecarlo.sio` (`mc_input_normal`/`mc_add`/`mc_mul` @198/298/341); same handled body under
+    two `with{}` blocks. **Confirm cross-module visibility of the non-`pub` `mc_*` fns with `souc check` first**
+    (project visibility model: `pub` is advisory here).
+
+### Exact files
+- `self-hosted/ir/lower.sio` — struct fields; `lower_handle_expr_ref` + perform hook; dispatch arm; inline logic.
+- `self-hosted/check/check.sio` — `check_handle_expr` restructure; `check_method_call` bypass (EDIT 2);
+  new `Checker` fields; new diagnostic code; **possibly** `checker_check_method_call_inplace` (step 11).
+- `self-hosted/check/effects.sio` — read-only (`Epistemic=8`).
+- `examples/effect_uncertainty_smoke.sio` (new, P0), `examples/effect_uncertainty_gum_vs_mc.sio` (new, P1).
+- Read-only: `parser/exprs.sio`, `parser/stmts.sio`, `stdlib/epistemic/knowledge.sio`,
+  `stdlib/epistemic/montecarlo.sio`, `examples/effects.sio` (aspirational syntax — do not mistake for working).
+
+### Single most important next action
+**Resolve §0 branch-lock (which tree has the GPU precedent), then implement + `souc check`-verify EDIT 2
+(`check_method_call` receiver bypass) on a from-source build — because without EDIT 2, `Epistemic.add(x,y)`
+dies in `check` and P0 never reaches the lowering arm at all.**
+
+---
+
+## WS-B — Effect-scoped memory reclamation  (verdict: FLAWED → rescued; architecture SURVIVES)
+
+**Verifier's fatal correction (must propagate everywhere):** the design's central "the probe is a stub
+(`emit_xor_rax_rax` then early return, real scan dead below)" claim is **FALSE**. Both
+`native_v2_emit_current_frame_live_probe` definitions (`codegen.sio:1527`, `codegen_x86_linux.sio:2911`) are
+**byte-identical FULL conservative scans** (loop over machine + spill slots, `test`/`jnz` → live, else
+`xor rax,rax` = not-live *after* the scan). No stub, no early return, no dead scan. They are **dead only in the
+sense of being uncalled** in `codegen_x86_linux.sio`.
+
+**Downstream verdict inversions (apply):**
+- **Item-5-alone (wire the existing probe+reset) is SOUND but INEFFECTIVE**, not a "fabricated pass."
+  `nonzero=live` is a *safe over-approximation*. It fails on the discard-per-iteration witness for the **same**
+  `nonzero≠dead` reason as item-4: the stale handle slot stays nonzero until overwritten, so the scan reads it
+  as live and the reset never fires. The item-4 vs item-5 distinction collapses — **both fail for one identical
+  reason; neither is unsound.**
+- The genuine fabricated-pass risk appears **only** if someone weakens the scan to always-not-live — which is
+  **not** the current code. Route A's real remaining work is **wiring the existing scan into the slow path**,
+  not "replacing a stub."
+
+**Line-number corrections (verifier, ~70-line offset in `codegen_x86_linux.sio`):** slow-path `exit(182)` ≈ **6534**
+(heap-limit `exit(181)` sibling ≈ 6528); probe **2911** (not 2842); reset **2955** (not 2895);
+`own_context_new` @**951/1052** (not 1019/1122); escape-return code-91 reject at `check.sio:4597` (also 4315,
+7860); literal `error[E091]` at `check.sio:11559` (not 12327).
+
+**Structural claims that survived refutation (verified true):** `ownership.sio` is instantiated-not-driven
+(zero `own_declare_var`/`own_check_move`/`own_compute_drops` calls); `escape.sio` fns are all module-private
+(need `pub`); `regalloc.sio` `LiveInterval`/`liveness_build_intervals` present (do not re-derive liveness);
+`stack_maps` `root_kind_mask` only ever `mixed`; **no rbp-chain / stack-walk anywhere in `self-hosted/native`**
+(so the process-global top-risk holds); `codegen.sio` is the sole wired probe→reset+`pin_count` site.
+
+**Two soundness holes the architecture must close (both real):**
+- **`nonzero ≠ dead`:** a per-slot root *bitmap* (plan item 4) alone moves nothing — a stale handle from a prior
+  iteration reads as live until overwritten. The fix is a **per-safepoint LIVE-root fact**, sourced by **nulling
+  the slot at a certified drop point** (cheap extra store) so the existing conservative scan becomes *accurate*.
+- **Unboxed ≤16B values** (`native_v2_handle_raw_ptr_threshold`) consume **no** handle slot but **do** consume
+  heap-cursor bytes. A certificate over handle roots only is blind to them → resetting `heap_cursor` while an
+  unboxed value is live is a silent use-after-free. The classification (Step 4) **must** flag raw-unboxed-pointer
+  temps as managed roots.
+
+### Corrected verified step list
+
+0. **(blocking) E091 code collision.** `check.sio:4597` raises code 91 (frame-local escape) and
+   `check.sio:11559` prints literal `error[E091]` for an unrelated "audit counterexample incomplete" diagnostic.
+   Give the escape reject a distinct code (or disambiguating detail text) **before** writing any falsifier that
+   asserts on E091 text. *(Step-0 substance CONFIRMED correct by verifier; only its coordinates were wrong.)*
+1. **(architecture decision, needs operator sign-off) Route A vs Route B.**
+   - **Route A** (reactive backstop): wire the **existing conservative scan** (`codegen_x86_linux.sio:2911`) +
+     reset (`:2955`) into the `handle_slow_path` (~6534), mirroring `codegen.sio:3760-3830` exactly (retry-once →
+     `exit(182)`/`exit(181)`, **preserve the `pin_count` gate**). This is now understood as *"wire an existing
+     sound conservative scan,"* not *"replace a stub."*
+   - **Route B** (primary, thesis-aligned): **scope-exit arena-pop** — restore `runtime_context.handle_count`
+     and `heap_cursor` to a watermark snapshot taken at scope entry (~15-line emitter reusing
+     `emit_load/store_runtime_context_field` @2897-2900). Pops a **local** watermark rather than resetting the
+     whole table → sidesteps Route A's whole-process-liveness problem, and directly realises "effect-scoped
+     certified reclamation." **Recommend B primary, A retained as pressure-triggered backstop.**
+2. **Home the certifier in `check/borrow.sio`, NOT `ownership.sio`.** `ownership.sio` (2837-line
+   `OwnContext`/`own_compute_drops`) is fully unwired — driving it means building a whole new drop-point layer.
+   `borrow.sio`'s `BorrowEnv` is already driven on every checked function and backs `tests/compile-fail/
+   ownership_*.sio`. Add per-entry `alloc-site id` + `certified-dead-at-scope-N` bit to `BorrowEntry`.
+3. **Certifier ("3-lite").** Generalise `checker_expr_provenance` / `checker_place_root_local` from the single
+   return-escape call site to a **scope-exit sweep** at `checker_check_block_inplace`'s `pop_scope` point: for
+   every `BorrowEntry` in the closing scope, emit a "provably-scope-local, free-at-exit" **fact** (persist into a
+   small IR side-table keyed by alloc/HIR-node id) when: never returned, never stored into a first-class place,
+   and — until Steps 6/7 — **never passed by reference into any call** (a call = unconditional escape).
+4. **Managed-root classification into the MIR temp table.** Liveness intervals already exist (`regalloc.sio`,
+   do not re-derive). What is missing is **per-vreg type tagging** (handle / scalar / raw-unboxed-pointer) — no
+   `temp_types`/`vreg_type`/`is_handle_type` table exists in `native/` or `ir/`. Thread the checker's `TypeEntry`
+   through `ir/lower.sio` into the MIR temp table; the stack-map recorder consults it to set `root_kind` per slot.
+   **Must also flag raw-unboxed-pointer temps** (closes the ≤16B hole).
+5. **Emit the per-safepoint LIVE-root bitmap in `stack_maps.sio`** (today `root_temp_count`/`root_spill_count`
+   are set equal to `temp_count`/`spill_count` — a no-op alias). Bit = 1 only when the slot is **both**
+   handle/raw-pointer-typed (Step 4) **and** not-yet-certified-dead (Step 3). Null certified-dead slots at their
+   drop point so the conservative scan becomes accurate (the `nonzero≠dead` fix).
+6. **Wire `escape.sio` as the consumer of Step-3 facts (general case).** Add `pub` to the ~15 fns
+   (`esc_add_node`/`esc_add_edge`/`esc_mark_*`/`esc_propagate`/`esc_analyze`); feed the graph from the **same**
+   provenance walk (do not duplicate taint logic). Its fixed-point subsumes the current informal `if/match/
+   struct-lit` union.
+7. **Defer `ir/memory_analysis.sio`** (Andersen points-to, 2686 lines) — it is interprocedural **callee escape
+   summaries** (plan item 2), unneeded by the *call-free* discard witness. Wire only once a **witness with calls**
+   is the acceptance target. **Correctness caveat (top risk):** callee summaries stop being "optional later phase"
+   and become a **precondition** the instant the certified region contains any call.
+8. **Implement the chosen mechanism, gated strictly by the Step-3 certified fact** (never a bare
+   nonzero/liveness heuristic). Route B: watermark-restore emitter at the certified scope-exit. Route A: call the
+   Step-5-bitmap-driven scan + reset from the slow path exactly as `codegen.sio:3799-3823`, preserving `pin_count`
+   and the `exit(182)`/`exit(181)` fallthrough as a hard backstop — **do not remove it.**
+9. **Falsifier suite — TWO controls (a single "must-refuse" proves nothing about no-use-after-reclaim):**
+   - **C1 (conservatism):** twin of the witness that returns/stores the struct out of scope on some iteration →
+     certifier must **refuse** to mark dead → no pop/reset for that alloc (program still hits 182/181, same as
+     today).
+   - **C2 (positive use-after-reclaim detector):** wire `native_v2_handle_entry_field_epoch` (written @~6372,
+     bumped by the reset's `collector_epoch` increment @~2904-2908) into an epoch check inside
+     `native_v2_resolve_handle_to_object_base_rax` (~2919-2946) under a debug gate; force a pop while a handle is
+     live and confirm the **trap fires** (the mechanical form of the P0-F "positive zero-detector" audit bar).
+10. **P5 acceptance artifact:** discard-per-iteration witness (loop; alloc >16B struct/iter; use only own fields;
+    no call passing it out; no return; no global store) runs past **2²²** iterations unbounded, alongside C1/C2 in
+    the same commit.
+
+### Exact files
+`check/borrow.sio`, `check/check.sio`, `check/ownership.sio` (read-only, do not drive),
+`analysis/escape.sio`, `ir/memory_analysis.sio` (deferred), `ir/lower.sio`, `native/regalloc.sio` (read-only),
+`native/stack_maps.sio`, `native/frame.sio`, `native/codegen.sio` (the wired precedent),
+`native/codegen_x86_linux.sio` (the LIVE backend), `native/gc.sio`, `native/runtime_context.sio`,
+`scripts/ci/precise_stack_maps_honesty_gate.sh`, `tests/compile-fail/ownership_use_after_move.sio`,
+`tests/compile-fail/ownership_move_while_borrowed.sio`.
+
+### Single most important next action
+**Get operator sign-off on Route A vs Route B (they carry different Lean N2-capstone obligation shapes and
+different generalisation costs), then re-verify the ~70-line coordinate offsets on the target tree — because the
+design's coordinates and its "stub" framing were both wrong, and the executor must not re-inherit either.**
+
+---
+
+## WS-C — Non-associative uncertainty as a NonAssoc handler  (verdict: FLAWED → rescued by 3 corrections)
+
+**Design intent (verified sound):** order dependence rides the **carrier**, not the vocabulary. New module
+`stdlib/epistemic/affine_octonion.sio` with carrier `AffOct` (field-wise struct of `PnOct`) whose `aff_mul`
+preserves octonion order. `mul(mul(x,y),z)` vs `mul(x,mul(y,z))` → **different** variance under NonAssoc,
+**identical** under GUM (`ep_mul@knowledge.sio:112` is order-blind — CONFIRMED). No `mul3` op added to the WS-A
+interface. Build entirely on `product_nonassoc.sio`'s field-wise return-by-value `PnOct`/`pn_oct_mul` (execution-
+verified under **default Madaros**: Fano 0.25 / non-Fano 4.25) — **NOT** the `&![f64;8]` out-param
+`algebra::octonion::oct_mul` idiom, which **segfaults under default Madaros** (both affine demos pin their
+executable claim to lean_single).
+
+### Corrections applied (from the FLAWED verdict — all three rescue the design)
+
+1. **Missing `pn_add` (fatal-as-written).** `aff_mul`'s `d_k` uses `pn_add(...)` but `product_nonassoc.sio`
+   exports **no `pn_add`** (only `pn_oct_mul`/`pn_oct_norm_sq`/`pn_associator`/`pn_oct_basis`/`associator_norm_sq`/
+   `product_nonassoc_augment`). **Fix:** define a local field-wise `pn_add(a:&PnOct,b:&PnOct)->PnOct` (and any
+   `pn_scale` `aff_scale` needs) inside the new module; add them to the import/reuse lists.
+2. **Wrong line anchors (functions exist; cites wrong).** `perform` parse = `parse_perform_expr`
+   **`exprs.sio:640-644`** (not 597); match `FatArrow` expect **`exprs.sio:906`** (match @877, not 860);
+   `check_handle_expr` **`check.sio:23050`** (not 24078; eff via `effect_name_to_id` @~23063 — its "discharges
+   `Epistemic=8`" behavioural claim is CORRECT, only the coordinate was wrong).
+3. **Under-specified headline math (must be derivable, not retrofitted — CLAUDE.md §6).** The load-bearing
+   assertion "spread of the ε0-coefficient between `((x*y)*z)` and `(x*(y*z))` == `associator_norm_sq(x,y,z)`
+   machine-exactly" holds **only for a specific `aff_leaf` coeff choice** the design never pins. **Fix:** pin the
+   `aff_leaf` coeff convention in the witness (state that x/y/z carry `d0=coeff` chosen so the first-order symbol
+   row reproduces the associator) and **show the derivation**, not just the expected number.
+
+### Corrected verified step list
+
+1. Create `stdlib/epistemic/affine_octonion.sio` (library, no `fn main`). Header fixes **NSYM=4** (noise symbols
+   ε0..ε3) vs **N=factors** ("order-safe iff N≤3" = factors); states the idiom decision (canonical math cited
+   against `algebra::octonion::{oct_mul,oct_associator,oct_norm_sq}` but re-implemented field-wise for
+   default-Madaros safety).
+2. Import from `product_nonassoc.sio`:
+   `{PnOct, pn_oct_mul, pn_oct_norm_sq, pn_associator, associator_norm_sq, pn_oct_basis, product_nonassoc_augment}`.
+   **Do NOT import `algebra::octonion`** (named-import E137 risk under Madaros). *(Note: these `pn_*` are declared
+   without `pub`, but Sounio visibility is advisory — importing is fine; acknowledge rather than imply they are
+   exported.)* **Add local `pn_add` (+ `pn_scale` if needed) per Correction 1.**
+3. Carrier: `struct AffOct { v: PnOct, d0: PnOct, d1: PnOct, d2: PnOct, d3: PnOct }` (central + 4 noise-symbol
+   coeffs). Field-wise struct-of-PnOct — no `[f64;32]` exclusive-ref arrays.
+4. Constructors/accessors (helpers before callers, no unary minus): `aff_zero`, `aff_leaf(v,k,coeff)` **[coeff
+   convention pinned per Correction 3]**, `aff_central`, `aff_variance` = Σ `pn_oct_norm_sq(d_k)`.
+5. Arithmetic return-by-value: `aff_add`/`aff_sub`/`aff_scale`/`aff_shift`; then
+   `aff_mul`: central = `pn_oct_mul(&a.v,&b.v)`; `d_k = pn_add(pn_oct_mul(&a.v,&b.d_k), pn_oct_mul(&a.d_k,&b.v))`.
+   **`aff_mul` preserves octonion order — the whole discriminator.**
+6. `aff_pentagon_variance(w,x,y,z)` reusing `associator_field.sio:pentagon_variance:154` math on symbol
+   coefficients (all 5 parenthesizations via `aff_mul`, 8 comps × 5 vertices, 5-vertex population variance).
+   Document: N≤3 → one associator suffices; N=4 → all 5 vertices needed.
+7. NonAssoc handler adapters realising the WS-A op interface over `AffOct`: `na_lift`, `na_add=aff_add`,
+   `na_sub=aff_sub`, `na_mul=aff_mul` (**no new op**), `na_scale`, `na_shift`, `na_observe`,
+   `na_collapse(u,k_sigma)->(val,lo,hi)`. **Pin collapse scalarization** (which component/norm → `val`, `k_sigma`
+   value); label output **"order-spread-augmented variance, NOT a certified enclosure"** (that belongs to
+   interval/p-box).
+8. `na_mul3(a,b,c,kappa)` convenience folding `kappa*associator_norm_sq` into the budget — **document it is NOT
+   load-bearing** (order dependence already emerges from `aff_mul`); vocabulary stays
+   {lift,add,sub,mul,div,scale,shift,observe,collapse}.
+9. Handler-dispatch design note (WS-A not yet built): construct `handle<Epistemic>{body} with {NonAssoc clauses}`
+   discharges `Epistemic(8)` at `check.sio:23050`; NonAssoc(14) is the calculus identity. **Open:** DISCHARGE vs
+   PROPAGATE NonAssoc — leans propagate-upward; `check_handle_expr` currently discharges the handled effect only.
+10. **Tier-(a) witness** `examples/epistemic/affine_octonion_order_witness.sio` — **runnable TODAY under default
+    Madaros** via direct `na_*`/`aff_*` calls (no perform/handle). `//@ expect-stdout` asserts FOUR: (1) ε0-coeff
+    spread `((x*y)*z)` vs `(x*(y*z))` == `associator_norm_sq(x,y,z)` (<1e-9) **[with the pinned-coeff derivation
+    shown]**; (2) Fano e1,e2,e3 → 0.0 (N≤3 null control); (3) non-Fano e1,e2,e4 → 4.0; (4) GUM control:
+    `ep_mul` associativity-blind (variances EQUAL) while `na_collapse` of the two parenthesizations differ by
+    exactly `kappa*4.0`.
+11. **Tier-(b) witness** `examples/epistemic/effect_uncertainty_nonassoc.sio` — same triple-product source under
+    `with{GUM}` (identical variance) vs `with{NonAssoc}` (order-sensitive). **Blocked until WS-A P0 ExprHandle arm
+    lands.**
+12. Verify: `souc check` both files against a from-source build; `souc run` tier-(a); diff vs `expect-stdout`;
+    **label every receipt with its engine** (tier-a → default Madaros; N=3/N=4 affine demo receipts → lean_single).
+
+### Exact files
+New: `stdlib/epistemic/affine_octonion.sio`, `examples/epistemic/affine_octonion_order_witness.sio` (tier-a),
+`examples/epistemic/effect_uncertainty_nonassoc.sio` (tier-b, blocked on P0).
+Reuse (read-only): `stdlib/epistemic/product_nonassoc.sio`, `.../knowledge.sio`, `.../uncertain_octonion.sio`,
+`stdlib/algebra/octonion.sio` (cited only), `.../associator_field.sio`, `examples/epistemic/affine_nonassoc_demo.sio`,
+`.../affine_nonassoc_n4_demo.sio`, `self-hosted/ir/lower.sio`, `.../check/check.sio`, `.../check/effects.sio`.
+
+### Single most important next action
+**Write `affine_octonion.sio` with the local `pn_add` and the pinned `aff_leaf` coeff convention, then land
+tier-(a) — because it is the ONLY workstream deliverable runnable end-to-end on default Madaros today, and it
+proves the expressive-superiority claim (order-blind GUM vs order-sensitive NonAssoc) with zero dependency on the
+un-landed P0 ExprHandle arm.**
+
+---
+
+## WS-D — Lean proof obligation  (verdict: FLAWED — STUB, nothing to integrate)
+
+**Status: NO DESIGN EXISTS.** The submitted JSON is a placeholder (`summary:"test"`, `steps:["a","b"]`,
+`files:["x","y"]`, `top_risk:"risk"`). Files `x`/`y` do not exist. **Nothing to certify, nothing to integrate.**
+This workstream is **UNSTARTED** and must be authored from scratch. Requirements the real design must meet
+(from the verifier + CEI ground truth):
+
+1. Name the **actual proof obligation**: which handler soundly realises which effect (the "handler-as-proof-
+   carrying-interpreter" mapping), with real file paths — `self-hosted/effects/handlers.sio`,
+   `self-hosted/analysis/escape.sio`, `self-hosted/ir/memory_analysis.sio`, and the specific `formal/*.lean`
+   obligation files.
+2. **Target the UNCONDITIONAL certified result — the p-box / interval enclosure — NOT the conditional
+   (curvature-dependent) GUM soundness.** Over-claiming global GUM soundness is a fatal over-claim.
+3. **Acknowledge the corpus is not globally sorry-free (~64 real sorries)** and scope the machine-checked claim
+   to the specific lemma being added, not the corpus.
+4. Anchor verification on a **from-source `souc`** build (`bin/souc` is prebuilt).
+
+### Single most important next action
+**Author a real WS-D design (or dispatch it as a fresh workstream). It is the thesis capstone —
+"the compiler machine-checks that a handler soundly realises an effect" — and it currently does not exist.
+Until it does, the CEI PL-theory contribution rests on WS-A/B/C mechanism without the Lean certificate that is
+the paper's headline. This is the largest open gap in the program.**
+
+---
+
+## Cross-workstream SEQUENCING (what unblocks what)
+
+```
+[0] BRANCH-LOCK RESOLUTION (§0)  ──unblocks──▶  ALL of WS-A (every coordinate is branch-conditional)
+                                                 └─ if base = main/current tree: WS-A must be RE-DERIVED
+                                                    (no GPU precedent to mirror — confirmed 0 hits here)
+
+WS-C tier-(a)  ── independent, runnable on default Madaros TODAY ──▶  ships FIRST, unblocked by nothing
+                 (proves expressive-superiority without P0)
+
+WS-A P0 (ExprHandle lowering + EDIT 1/EDIT 2)
+     │  gate: EDIT 2 (check_method_call bypass) MUST land & souc-check before lowering is trusted
+     │  gate: step-13 scalar-kind classifier MUST be verified before the int smoke can print
+     ├──unblocks──▶ WS-A P1 (GUM-vs-MC same-source demonstrator)
+     └──unblocks──▶ WS-C tier-(b) (perform/handle NonAssoc-vs-GUM headline demo)
+
+WS-B Route decision (A vs B)  ── independent of WS-A/C ──▶  gates all WS-B implementation
+     │  Step-0 (E091 collision) blocks any WS-B falsifier test
+     │  Steps 3→4→5 are a strict chain (certifier fact → MIR type tag → live-root bitmap)
+     └──item-7 (memory_analysis / callee summaries): DEFERRED, but becomes a
+        CORRECTNESS PRECONDITION the moment any certified region contains a call
+
+WS-D (Lean)  ── UNSTARTED ──▶  consumes the soundness facts WS-B Step-3 produces AND the
+                                handler-realises-effect mapping WS-A defines; cannot be
+                                authored meaningfully until at least one of WS-A/WS-B has a
+                                concrete handler+certificate to prove about.
+```
+
+**Critical-path summary:**
+- **Ship-now, no dependencies:** WS-C tier-(a). Do this first — it is the only default-Madaros end-to-end proof.
+- **Unblocks the most:** §0 branch-lock → WS-A. WS-A then unblocks P1 **and** WS-C tier-(b).
+- **Parallelisable:** WS-B is independent of WS-A/C once its Route is chosen; can proceed concurrently.
+- **Terminal dependency:** WS-D (Lean) needs a concrete handler+certificate from WS-A/WS-B before it can be
+  authored; it is currently a stub and is the program's largest open gap.
+
+---
+
+## Consolidated RISK + FALSIFIABILITY register
+
+| # | Workstream | Risk | Severity | Falsifier / how we'd know | Status |
+|---|---|---|---|---|---|
+| R1 | §0 / WS-A | GPU precedent absent on the actual integration base (0 grep hits on current + canonical trees) — the whole "mirror `expr_is_gpu_sync_call_ref`" strategy has no precedent to copy | **CRITICAL** | `grep -c expr_is_gpu_sync_call_ref lower.sio` on the target tree = 0 | **CONFIRMED true on `/workspace/.wt/fable-1` and `/workspace/sounio`; design was written against `/workspace/.wt/lower-array` only** |
+| R2 | WS-A | EDIT 2 missing → `Epistemic.add(x,y)` dies as E137 in `check` before lowering runs | High | Build from source; `souc check` the smoke file without EDIT 2 → undeclared-identifier error | Design correctly identifies it; **must build-verify** |
+| R3 | WS-A | Inplace method-call checker (`checker_check_method_call_inplace`) re-entered inside a handle body → EDIT 2 bypassed → E137 | Med | Trace any handle-body path that re-enters inplace; if found, a 3rd bypass is needed | **UNCERTAIN — must confirm no re-entry** |
+| R4 | WS-A | `expr_result_scalar_kind_ref` misclassifies inlined clause-body result → `println(r)` SIGSEGV via char*-printer; `expect-stdout:5` NOT demonstrable | High | `souc run` the int smoke; a SIGSEGV / garbage print falsifies | **UNCERTAIN — classifier not yet read; gates P0 done** |
+| R5 | WS-A | Nested-aggregate `HandlerFrame` struct miscompiles (known codebase failure family) | Med | Design avoids it (raw `[Name;4]` arrays); regression if a struct-of-clauses is introduced | Mitigated by design |
+| R6 | WS-A | `Epistemic` is both effect-id and stdlib struct name → a missed bypass case mints a body-less mangled fn → codegen SIGSEGV | Med | Any perform site that falls through partially; hard-refuse on no-clause-match prevents it | Mitigated by hard-refuse |
+| R7 | WS-B | Handle/heap state is **process-global** but the only obtainable certificate is per-scope; no rbp-chain walk exists → Route A unsound with any live caller-held handle; Route B unsound once a callee stashes a handle from the popped scope | **CRITICAL** | C1 conservatism control + a hand-built caller-held-handle case; use-after-reclaim under C2 trap | **CONFIRMED architectural (no stack-walk in `native/`); callee summaries become a precondition once calls appear** |
+| R8 | WS-B | ≤16B unboxed values consume heap-cursor but no handle slot → certificate over handle roots is blind → silent use-after-free on `heap_cursor` reset | High | C2 epoch trap forced while an unboxed value is live | Design closes it via Step-4 raw-pointer flagging; **must implement** |
+| R9 | WS-B | `nonzero ≠ dead` — a root bitmap/probe alone never fires the reset on the discard witness | High | Run the witness with only item-4 or only item-5 wired → still `exit(182)` at 2²² | **CONFIRMED; fix = null-slot-at-drop-point (Step 5)** |
+| R10 | WS-B | MIR per-vreg type tagging (Step 4) perturbs the self-host fixed point (gen2==gen3) | Med | `make build` fixed-point check after the plumbing lands | **UNCERTAIN — not build-verified** |
+| R11 | WS-B | E091 code collision → falsifier can't tell which diagnostic fired | Low (blocking) | Two E091 emitters at `check.sio:4597` + `:11559` | **CONFIRMED (coordinates corrected)** |
+| R12 | WS-C | `&![f64;8]` out-param octonion idiom segfaults on default Madaros → witness downgrades to lean_single-only | High | `souc run` tier-(a) on default Madaros | Mitigated: build field-wise on `PnOct` (verified Fano 0.25/non-Fano 4.25) |
+| R13 | WS-C | `pn_add` does not exist → `aff_mul` doesn't compile | High (was fatal) | `souc check affine_octonion.sio` | **Fix identified: add local `pn_add`** |
+| R14 | WS-C | Headline identity (ε0-spread == associator_norm_sq) holds only for a specific unpinned `aff_leaf` coeff → risk of retrofitting a tolerance (CLAUDE.md §6 violation) | Med | `expect-stdout` <1e-9 with the derivation shown, not just the number | **Fix: pin coeff convention + show derivation** |
+| R15 | WS-C | DISCHARGE vs PROPAGATE NonAssoc(14) undecided | Low | check_handle_expr currently discharges handled effect only | **UNCERTAIN — design leans propagate; confirm** |
+| R16 | WS-D | No design exists (stub); the Lean capstone — the paper's headline machine-checked claim — is unstarted | **CRITICAL** | The submitted JSON has no real content | **CONFIRMED stub; must author** |
+| R17 | WS-D | Over-claiming global GUM soundness instead of the unconditional p-box/interval enclosure | High (if authored naively) | Any Lean statement asserting unconditional GUM correctness | Guardrail stated; not yet at risk (nothing written) |
+| R18 | all | `bin/souc` is prebuilt — behaviour claims from the wrapper are invalid | Med | Build from source (`build_modular_madaros.sh`) before any receipt | Standing discipline |
+
+**Falsifiability posture:** WS-A and WS-C are falsifiable **by execution** (`souc run` + `expect-stdout`), WS-B
+by **two controls** (C1 conservatism = must-refuse; C2 = positive use-after-reclaim epoch trap — a single control
+proves nothing), WS-D by **Lean check** once authored. The strongest immediately-falsifiable deliverable is
+**WS-C tier-(a)** (runs on default Madaros today). The weakest-supported claim is **WS-A `expect-stdout:5`**
+(gated on the unverified scalar-kind classifier, R4) and **WS-D** (does not exist, R16).
+
+## UNCERTAIN — open items requiring resolution before implementation
+1. **Integration base** (R1): `lower-array` (precedent exists) vs `main`/current (must re-derive). **Blocks all WS-A.**
+2. **WS-A R3:** inplace-checker re-entry inside handle bodies — confirm or add a 3rd bypass.
+3. **WS-A R4:** `expr_result_scalar_kind_ref` classification of inlined results — read `lower.sio:~12690-12820`.
+4. **WS-A diagnostic code:** next free E-code — grep before adding.
+5. **WS-B Route A vs B:** operator sign-off (different Lean N2 obligation shapes).
+6. **WS-B R10:** fixed-point stability of MIR type-tag plumbing — build-verify.
+7. **WS-C R15:** discharge vs propagate NonAssoc(14).
+8. **WS-C R14:** exact `aff_leaf` coeff + collapse scalarization (component index, k_sigma).
+9. **WS-D:** entire design — author from scratch, targeting the unconditional p-box/interval enclosure.
+```
+
+---
+
+Notes on the deliverable above (not part of the appendable Markdown):
+
+- **The one decisive integration finding** is R1 / §0: I empirically confirmed on the live checkout that the GPU precedent P0 depends on has **zero hits** here (`lower.sio` = 19461 lines vs the design's 17819; `struct Lowerer` @593 vs @723). The P0 design's own verdict flagged this as its top correction; it is now confirmed, not just asserted.
+- WS-D contributed nothing (stub); I integrated it as an explicit UNSTARTED gap rather than inventing content.
+- WS-B's "stub probe" framing was fatally wrong per its verifier; the spec propagates the inversion (item-5 is sound-but-ineffective, not a fabricated pass) and carries the ~70-line coordinate corrections.
+- WS-C's three fixable flaws (missing `pn_add`, wrong anchors, unpinned coeff) are all folded in as corrections that rescue the design.

--- a/docs/architecture/CEI_IMPLEMENTATION_SPEC_2026-08-18.md
+++ b/docs/architecture/CEI_IMPLEMENTATION_SPEC_2026-08-18.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.architecture.cei-implementation-spec-2026-08-18
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.architecture.cei-implementation-spec-2026-08-18
+-->
+
 # CEI — Consolidated Implementation Spec (workflow-synthesised, adversarially verified)
 
 _Produced by the `cei-program-advance` workflow (fan-out survey → opus adversarial-verify → opus synthesis), run `wf_12e329df-b89`, 2026-08-18. Model routing: sonnet survey / opus verify+synthesis; WS-C re-routed to opus/high after a StructuredOutput failure. Read-only design; no source edited._
@@ -460,3 +469,43 @@ Notes on the deliverable above (not part of the appendable Markdown):
 - WS-D contributed nothing (stub); I integrated it as an explicit UNSTARTED gap rather than inventing content.
 - WS-B's "stub probe" framing was fatally wrong per its verifier; the spec propagates the inversion (item-5 is sound-but-ineffective, not a fabricated pass) and carries the ~70-line coordinate corrections.
 - WS-C's three fixable flaws (missing `pn_add`, wrong anchors, unpinned coeff) are all folded in as corrections that rescue the design.
+
+---
+
+## P0 — turnkey implementation state (Option A, re-anchored on lane/fable-1/handle-table-182-dispatch)
+
+Base validated + set up this session (branch `lane/fable-1/cei-p0-handler-lowering` @ its HEAD; P0 files
+claimed on lane `fable-1-cei-p0-handler`). GPU precedent confirmed present AS NAMED. All coordinates below are
+re-anchored to `lower.sio`=17819 / `check.sio` on this tree — trust names, re-grep before editing.
+
+**Resolved design decision (settled the two workflow runs' disagreement):** `loop_labels` is
+`Box<LowerLoopLabels>` with only `loop_depth: i64` inline (lower.sio:723 struct). => **BOX the handler stack.**
+Add `struct LowerHandlerStack { effects: [Name;4], blocks: [Option<Box<Block>>;4] }`, and to `struct Lowerer`
+add `handler_stack: Box<LowerHandlerStack>` + `handler_depth: i64` (do NOT add inline `[Name;4]` — the Lowerer
+is by-value-copied and multi-MiB per the @913 comment). Mirror on `struct Checker`.
+
+**Exact edit sites (re-anchored):**
+- `lower.sio` struct Lowerer @723; **~5 `Lowerer{}` init literals** to extend: @991 (`lowerer_new`), @1455,
+  @1519, @1587, @2015 — each gets `handler_stack: Box::new(LowerHandlerStack{ effects:[empty_name();4],
+  blocks:[None;4] }), handler_depth: 0`.
+- `lower.sio` **ExprHandle dispatch arm**: insert `else if e.kind == ExprKind::ExprHandle {
+  self.lower_handle_expr_ref(e) }` in the chain at ~16496 (beside `ExprBlock`→`lower_block_expr_ref`).
+  New `lower_handle_expr_ref`: push effect(`e.name`)+block(`e.handler_block`) at `handler_depth` (cap 4,
+  `report_error_at` beyond), lower `e.block` via `lower_block_expr_ref` shape, pop on every exit.
+- `lower.sio` **perform hook** in `lower_method_call_expr_ref` @15677: add `expr_is_active_handler_perform_ref`
+  (mirror `expr_is_gpu_sync_call_ref` @15664 shape: ExprMethodCall + `left` ExprIdent==active effect; walk
+  `handler_depth-1..0`) FIRST, before `.len()`. On match: find `StmtLet{name==op, expr:ExprClosure}` in the
+  block; scope-push; per-arg `lower_expr_ref`+`bind_local(param,reg)` then **re-bind scalar-kind from
+  `ClosureParam.ty`** (f64→2,i64→1) [avoids the println kind-0 char* SIGSEGV]; lower clause body; restore scope;
+  result reg = body reg. No clause/arity: `lowerer_mark_error`+`IR_INVALID_REG` — never fall through.
+- `check.sio` **check_method_call bypass** @20438 (the load-bearing edit): add an arm parallel to the existing
+  `checker_expr_is_gpu_sync_call(e)` bypass @20439 — `checker_expr_is_active_handler_perform` matches the bare-
+  Ident-receiver shape against the live handler-effect stack BEFORE `check_opt_expr(e.left)` (which otherwise
+  fails Epistemic as undeclared-identifier). Type args vs clause `ClosureParam` types; return the clause body's
+  type. Needs Checker handler-stack fields + push/pop in `check_handle_expr` @24078 (push effect+block before
+  checking body, pop after; keep the existing standalone `check_block(handler_block)`).
+
+**Smoke test written:** `examples/effect_uncertainty_smoke.sio` (int-only, `//@ expect-stdout: SMOKE 5`).
+**Next increment:** make the struct + 4 code-site edits, build from source (needs an unthrottled slot), run the
+smoke test, then the P1 GUM-vs-MC demonstrator. Honesty gate unchanged (GUM conditional; p-box/interval the
+unconditional certified result).

--- a/docs/audit/MADAROS_HANDLE_TABLE_182_LIFETIME_DISPATCH_2026-08-17.md
+++ b/docs/audit/MADAROS_HANDLE_TABLE_182_LIFETIME_DISPATCH_2026-08-17.md
@@ -169,3 +169,46 @@ build with `MADAROS_RAW_BIN=<out> ./bin/souc run <file>`.
 - Do not claim a ceiling raise fixes it.
 - Do not present fix C (source discipline) as closing the compiler bug — it is a
   caller-side avoidance; the runtime still has no reclamation.
+
+## 8. Fix B prototype attempt (fable-1, 2026-08-17) — design landed, demo blocked
+
+I attempted a working prototype of **fix B (function-scoped watermark
+reclamation)**. The design is sound and advisor-vetted; it did **not** reach a
+demonstrated reclamation, and the honest reason is an **observability wall**, not
+a design flaw. Recording both so the next owner (codex-2) starts ahead.
+
+**Design implemented (WIP patch: `.scratch/fixB_prototype_wip.patch`):**
+- `runtime_context.sio`: two global watermark scratch fields (offsets 248/256),
+  `runtime_context_size()` 248→264 (leaf-only ⇒ a single global slot pair cannot
+  nest; no hardcoded 248 anywhere, all 9 consumers call the function).
+- `codegen_x86_linux.sio`: `native_v2_frame_reclaim_safe_leaf(&IrFunction)` — a
+  conservative sound predicate (f64 scalar return only; not sret; no by-ref
+  param; LEAF = no `IrCall*`; no `IrStoreGlobal`/`IrStorePtr`/`IrReturnSret`/
+  `IrIndexSet`; every `IrFieldSet` base is a fresh in-frame `IrAlloc` dst). Save
+  after `spill_ir_params_ref_mut`, restore at the single `epilogue_offset`
+  (preserve rax = return value; rbx is scratch/epilogue-restored).
+
+**Two findings that reframe fix B (both verified):**
+1. **Function-scoped is defeated by inlining.** The inliner (`ir/inline.sio`)
+   always inlines <10-instr functions and gives leaves a 3× bonus; only >500-instr
+   leaves survive as frames. The small allocating helpers that dominate the real
+   hot loops get folded into their caller, so there is no leaf frame to reclaim.
+   **Loop-scoped reclamation (reset at the loop back-edge when the body's
+   allocations don't escape the iteration) is the version that lands the real
+   dissertation churn** — same watermark machinery, different insertion point.
+2. **The backend has no accessible compile-path observability.** Madaros has ≥4
+   parallel function-compile implementations (`compile_ir_function`,
+   `compile_ir_function_v2_into` [the streaming path `module_loader.sio:1845` uses
+   for `souc run`], `compile_ir_function_v2_core_ir_into`, plus a non-streaming
+   fallback in `compile_multimodule_native_maybe_streaming`). Env-gated `print`
+   diagnostics added to three of these produced **no output** for a test program,
+   and the **pre-existing** `native_streaming` diagnostic also produced none — so
+   the actual path a given program takes could not be traced, and the emitted ELF
+   is not `objdump`-parseable. Debugging the emit therefore requires **building
+   backend observability first** (a traceable compile-path log / a raw-code
+   dump), which is itself a prerequisite task.
+
+**Handoff recommendation:** (a) land a small compile-path trace facility first;
+(b) target **loop-scoped** reclamation, not function-scoped; (c) reuse the
+predicate and watermark save/restore in the WIP patch. Prototype code is **not
+for merge** as-is (unverified).

--- a/docs/audit/MADAROS_HANDLE_TABLE_182_LIFETIME_DISPATCH_2026-08-17.md
+++ b/docs/audit/MADAROS_HANDLE_TABLE_182_LIFETIME_DISPATCH_2026-08-17.md
@@ -1,0 +1,171 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-handle-table-182-lifetime-dispatch-2026-08-17
+authority: repo_only
+audience: users
+last_validated: 2026-08-17
+validated_by: fable-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-handle-table-182-lifetime-dispatch-2026-08-17
+-->
+
+# Madaros exit-182 "handles full" — the managed-handle lifetime wall (dispatch)
+
+**Date:** 2026-08-17
+**Scope:** `bin/souc` default Madaros engine — **native run** exit 182 in the
+emitted program after it starts executing. Distinct from the exit-181 heap wall
+and from the println/SIGSEGV-139 family
+([`MADAROS_PRINTLN_BOOL_SCALARKIND_SEGV_2026-08-17.md`](MADAROS_PRINTLN_BOOL_SCALARKIND_SEGV_2026-08-17.md)).
+**Status:** mechanism CONFIRMED with a quantified minimal witness; root cause
+KNOWN and OPEN. This is a dispatch (classification + fix directions), not a fix.
+**Owner:** Madaros native GC lane (compiler). Merge/authority: codex-2.
+**Prior art:** `docs/handoff/repros/handle_table_2pow20_wrap_madaros.sio` (2²⁰
+era); commits `a1959e00c2` (Sprint 90 GC activation), `0b6a03c58a` (4096→2²⁰),
+`b502b2a171` (unbox ≤16B + fail-closed), `3da75acd31` (2²⁰→2²²).
+
+## 1. Symptom and separation from the 139 family
+
+Five of the ten dissertation "lower_array SIGSEGV 139" tests are **not** 139 on
+current main — they are **182**, a different bug: `rapamycin_clinical`,
+`gum_vs_mc`, `d2_gum`, `d2_voi`, `rapamycin_pop_sim`. Each **compiles clean,
+starts running, prints its banner**, then dies:
+
+```
+  D2 Occupancy GUM Budget — Haloperidol CNS-PBPK/PD
+  ...
+madaros: handles full          <- runtime, mid-execution
+# exit 182
+```
+
+The `lower_array:` lines in `souc run` output are compiler status; the program
+is already built and running when it hits this. This is a **runtime resource
+exhaustion**, not a compile failure and not a wrong-science result.
+
+## 2. Mechanism (confirmed)
+
+The native-v2 runtime gives every **managed** (heap/boxed) object a slot in a
+fixed **handle table**. From `self-hosted/native/gc.sio`:
+
+- Capacity = `native_v2_handle_table_capacity_default() = 4194304` (**2²²**),
+  48 B/slot, carved out of the single 2 GiB process mmap.
+- Handles are allocated by a **MONOTONIC bump** of
+  `RuntimeContext.handle_count` and are **NEVER reclaimed**.
+- On overflow the allocator takes the slow path and **fails closed**:
+  `self-hosted/native/codegen_x86_linux.sio:6379` → `emit_exit(182)` with
+  `native_v2_gc_reason_handle_table_full()`. (Sibling: `emit_exit(181)` for the
+  heap-limit wall.)
+
+The source is explicit that this is a hard **per-process lifetime budget, not a
+working-set size**, and that raising 2²⁰→2²² "MOVES the wall; it does not remove
+it. The lifetime problem is unchanged and still open."
+
+### Why nothing is reclaimed (the actual root)
+
+The reset emitter **exists** — `native_v2_emit_gc_empty_frame_reset`
+(`native/codegen.sio:1574`, `native/codegen_x86_linux.sio:2886`) — but on the
+x86_linux backend it is **deliberately not on the allocation slow path**. The
+reason: stack maps carry a `root_kind_mask` and slot **counts**
+(`native_v2_stack_map_root_kind_mixed/handles_only`, `stack_maps.sio`), **not a
+per-slot root bitmap**. Without knowing *which* stack slots hold live handles,
+the collector cannot preserve live roots, so it cannot safely reclaim — hence
+fail-closed instead of collect.
+
+## 3. Killer evidence — the wall is cumulative lifetime, not live set
+
+Minimal witness: allocate a **>16 B managed** struct, use it, discard it each
+iteration (**live set is always 1**), N times.
+
+```sounio
+struct S { a: f64, b: f64, c: f64 }   // 24 B > 16 B -> managed (takes a handle)
+fn main() -> i32 with IO {
+    var acc = 0.0
+    var i = 0
+    while i < N {
+        let s = S { a: 1.0, b: 2.0, c: 3.0 }
+        acc = acc + s.a
+        i = i + 1
+    }
+    print("acc="); println(acc); 0
+}
+```
+
+| N | rc | note |
+|---:|---:|---|
+| 1,000,000 | 0 | acc=1000000 |
+| 4,000,000 | 0 | acc=4000000 |
+| **4,194,304 (=2²²)** | **182** | handles full — **exactly at capacity** |
+| 5,000,000 | 182 | handles full |
+
+The wall lands on the **cumulative allocation count**, to the exact slot, while
+the live set never exceeds one object. A collector that reclaimed the dead `s`
+each iteration would run this forever. This is the whole bug.
+
+### The ≤16 B escape (confirms boxing-specificity + gives the workaround)
+
+The same loop with a **16 B** struct (`P { a: f64, b: f64 }`) runs **5,000,000**
+iterations at **rc=0**: ≤16 B value structs are unboxed
+(`native_v2_is_small_value_struct_tag`) and consume **no** handle. So the wall is
+boxing-specific — only managed (>16 B, tags 0/1/2) objects count.
+
+### Why the dissertation tests hit it
+
+`d2_gum` (9-D sensitivity, chronic 3×QD dosing, D2 trough at 72 h),
+`rapamycin_pop_sim` (population loop), and the GUM budget tests allocate fresh
+**managed** aggregates (`Knowledge<f64>`, `D2GUMPriors`/`D2GUMBudget`, PBPK
+states) inside ODE / sampling / per-subject loops. Over a full run these cross
+2²² cumulative allocations even though only a handful are ever live.
+
+## 4. Fix directions (ranked)
+
+**C — Source workaround, available NOW (no compiler change).** This is the same
+lever the PBPK28 CN mitigation used
+([`MADAROS_IMPORTED_PBPK28_CN_SIGSEGV_2026-08-16.md`](MADAROS_IMPORTED_PBPK28_CN_SIGSEGV_2026-08-16.md)):
+do not allocate a fresh >16 B managed object per iteration. Either keep the
+hot-loop aggregate ≤16 B (unboxed), or mutate a single state in place through
+`&!` (`*_step_mut`) instead of returning/binding a fresh one each step. Unblocks
+the five dissertation tests without touching the runtime; it is a lifetime
+discipline, not a fix.
+
+**B — Escape-scoped frame reclamation (highest-leverage real fix).** The repo
+already has an escape analyzer (`self-hosted/analysis/escape.sio`:
+`esc_analyze`, `esc_node_escapes`, `esc_mark_returned`) and the reset emitter
+(`native_v2_emit_gc_empty_frame_reset`). Wire them: capture `handle_count` at
+frame entry (a watermark); at frame return — or a loop back-edge — where escape
+analysis proves **no handle allocated in that region escapes** (not returned, not
+stored to an outliving object, not captured), reset `handle_count` to the
+watermark. This reclaims the nursery-like per-frame allocations that dominate
+iterative scientific code (exactly the d2_gum/pop_sim pattern) without a full
+tracing collector. Soundness rests on the existing binary-provenance escape work
+(PR #397 / E091). Risk: a false "does-not-escape" frees a live handle — so this
+must be conservative (default to "escapes") and gated behind a witness suite that
+includes a returned-handle positive control.
+
+**A — Precise roots + tracing GC (complete but largest).** Extend stack maps
+from `root_kind_mask`+counts to a real per-slot root **bitmap**, then a tracing
+collector can mark from precise roots and compact the handle table. This is the
+proper closure and what Sprint 90's "precise GC" was heading toward; it removes
+the wall for arbitrary live-set programs, not just frame-scoped ones. Largest
+surface; do it after B proves the reclamation plumbing.
+
+Raising the ceiling again (2²²→2²⁴) is **not** on this list: the source notes 2²⁴
+is where the handle and heap walls coincide, and it does not touch the lifetime
+problem — it only postpones the same failure.
+
+## 5. Reproduction
+
+```bash
+SOUC=./bin/souc ; export SOUNIO_STDLIB_PATH=$(pwd)/stdlib ; ulimit -s 524288
+# dissertation instance:
+$SOUC run stdlib/darwin_pbpk/pd/d2_gum.sio ; echo $?      # -> "madaros: handles full", 182
+# minimal quantified witness: see §3 (N=4194304 is the exact wall).
+```
+
+Build from source before quoting runtime behaviour (`bin/souc` is prebuilt):
+`bash scripts/ci/build_modular_madaros.sh <out>` (self-locks); run a specific
+build with `MADAROS_RAW_BIN=<out> ./bin/souc run <file>`.
+
+## 6. Non-goals
+
+- Do not conflate 182 with the SIGSEGV-139 println family; they share a triage
+  label only.
+- Do not claim a ceiling raise fixes it.
+- Do not present fix C (source discipline) as closing the compiler bug — it is a
+  caller-side avoidance; the runtime still has no reclamation.

--- a/docs/audit/MADAROS_INDIRECT_CALL_ARGC_CAP_2026-08-18.md
+++ b/docs/audit/MADAROS_INDIRECT_CALL_ARGC_CAP_2026-08-18.md
@@ -1,0 +1,114 @@
+# Madaros dispatch — `IrCallIndirect` codegen caps indirect calls at 2 arguments
+
+- **Date:** 2026-08-18
+- **Reporter:** fable-1 (CEI WS-A P2 verification)
+- **Severity:** correctness/limitation — silent hard-abort of native codegen
+- **Reproduces on:** current `main` `200b53419b`, built from source
+  (`scripts/ci/build_modular_madaros.sh`), fresh detached worktree.
+- **Family:** compiler backend (`self-hosted/native/codegen_x86_linux.sio`),
+  same dispatch shape as #1799 (println kind-0) / #1800 (handle-table 182).
+
+## Symptom
+
+Any **indirect call** (a by-value / non-capturing closure called through a bound
+name, or a function pointer) with **3 or more arguments** aborts native-v2
+codegen with the generic bridge error and exit status 12:
+
+```
+Error: Failed to write native binary to /tmp/madaros-run.XXXX/main.elf rc=12
+  error: native-v2 bridge compilation failed
+```
+
+The abort is unconditional on argument count and independent of argument type.
+
+## Minimal reproductions (all on from-source `main` 200b53419b)
+
+| Probe | Shape | Result |
+|---|---|---|
+| `let w = \|a,b\| {..}; w(3,4)` | non-capturing closure, **2** i64 | codegens OK¹ |
+| `let w = \|a,b,c\| {..}; w(3,4,5)` | non-capturing closure, **3** i64 | **rc=12 abort** |
+| `let w = \|a:f64,b:f64,c:f64\| {..}; w(..)` | non-capturing closure, **3** f64 | **rc=12 abort** |
+| `let w = \|a:f64,b:f64,c:i64\| {..}; w(..)` | mixed, **3** total | **rc=12 abort** |
+| `fn addf(a,b,c) {..}; addf(3,4,5)` | **named fn**, 3 args (direct `IrCall`) | correct `1.200000` |
+| `let k=..; let w=\|a,b,c\|{..+k}; w(..)` | **capturing** closure, 3 args (direct `IrCall`) | correct on main² |
+
+¹ The 2-arg non-capturing case codegens; at runtime it hits the *separate*
+known kind-0 `println(closure-result)` SEGV (#1799 family) unless the result is
+annotated — that is not this bug.
+² The capturing (direct-`IrCall`) path handles ≥3 args correctly on `main`. (On
+the stale branch `lane/fable-1/handle-table-182-dispatch`, off `dca2775061`, the
+capturing path additionally *zeroed* its args at arity ≥3 — a branch-local
+artifact already fixed on main; **not** part of this dispatch.)
+
+The type-independence (3×i64 fails identically to 3×f64) proves this is an
+**arity** cap, not a float-ABI issue.
+
+## Root cause — exact site
+
+`self-hosted/native/codegen_x86_linux.sio`, the `IrCallIndirect` arm (≈ line 8326):
+
+```sounio
+} else if instr_op == IrOpcode::IrCallIndirect {
+    let argc = IR_A_ARG_COUNT[(ir_region_slot_r((*func).region, (i))) as usize]
+    if argc > 2 {
+        return false                     // <-- hard cap; becomes rc=12
+    }
+    let arg_pair = (ir_arena_arg_at(.., 0), ir_arena_arg_at(.., 1))
+    if argc > 0 { .. nc_emit_load_rbp_disp32_reg(nc, 7, ..) }   // arg0 -> rdi
+    if argc > 1 { .. nc_emit_load_rbp_disp32_reg(nc, 6, ..) }   // arg1 -> rsi
+    let fnref_reg = IR_A_SRC1[..]
+    nc_core_load_temp_to_rax(nc, fnref_reg)
+    nc_emit_call_rax(nc)
+    ..
+}
+```
+
+`return false` from the per-instruction emitter is what the driver reports as
+"native-v2 bridge compilation failed". The arm only ever materialises `arg0`
+and `arg1`, into integer registers **rdi (7)** and **rsi (6)**; there is no
+slot for `arg2..arg5`. The direct `IrCall` arm (named fns, capturing closures)
+has no equivalent cap — hence the asymmetry.
+
+## Impact
+
+- Caps **all** indirect dispatch in the language at 2 arguments: by-value
+  closures stored in locals, function-pointer tables, and any future
+  first-class-function feature that lowers to `ir_call_indirect`.
+- Directly blocks CEI (Certified Effect Interpretation, WS-A): non-capturing
+  handler clauses `let op = |a,b,c,..|` are dispatched via `ir_call_indirect`
+  (`self-hosted/ir/lower.sio` perform hook), so a `perform E.op(x,y,z)` with ≥3
+  arguments cannot reach a non-capturing clause. The P2 demonstrator was kept to
+  2 f64 args (`examples/effect_uncertainty_gum_vs_mc.sio`, GUM 0.831558 vs MC
+  0.851582, rc=0) for exactly this reason.
+
+## Secondary observation for the fixer
+
+Even within the ≤2-arg envelope, the arm loads args into **GP registers only**
+(rdi/rsi), with no SysV float/XMM classification. Empirically, 2 f64 args
+through a non-capturing closure produce the correct result (verified: `0.700000`),
+so Madaros closures evidently pass all args — including f64 — through GP
+registers and the closure prologue reads them from GP. Any fix should preserve
+that all-GP calling convention (or fix both sides together), not introduce XMM
+routing on the caller side alone.
+
+## Proposed fix (next dispatch — NOT done here)
+
+Extend the `IrCallIndirect` arm to marshal up to 6 arguments into the SysV GP
+argument registers, mirroring the direct `IrCall` arm's arg-loading:
+
+- arg0→rdi(7), arg1→rsi(6), arg2→rdx(2), arg3→rcx(1), arg4→r8(8), arg5→r9(9).
+- Replace the fixed `arg_pair` 2-tuple with a loop over
+  `ir_arena_arg_at(slot, k)` for `k in 0..argc`.
+- Keep the `fnref` load into `rax` and the `call rax` last (after args are in
+  place), and guard `argc <= 6` (report a clean diagnostic beyond 6 rather than
+  a bare `return false`).
+
+Falsifier for the fix: the named-fn control (`addf/3`) must stay correct, and
+the 2-arg non-capturing control must stay byte-identical.
+
+## Evidence provenance
+
+- Probes: `$CLAUDE_JOB_DIR/tmp/{direct3,i64_3,mix,capwit,nc2,named3}.sio`.
+- Main build: fresh `git worktree add --detach origin/main`, HEAD `200b53419b`,
+  `scripts/ci/build_modular_madaros.sh artifacts/self-hosted/madaros`
+  ("Madaros ready … 100026487 bytes"), run via `MADAROS_RAW_BIN=<artifact>`.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1344
-- Repo-backed topics: 1194
+- Total governed topics: 1345
+- Repo-backed topics: 1195
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 399
-- Authority count `repo_only`: 757
+- Authority count `repo_only`: 758
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 772 topics
+- A2: 773 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 37 topics

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1345
-- Repo-backed topics: 1195
+- Total governed topics: 1346
+- Repo-backed topics: 1196
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 399
-- Authority count `repo_only`: 758
+- Authority count `repo_only`: 759
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 773 topics
+- A2: 774 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 37 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -177,6 +177,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-fo-cross-fn-return-2026-07-28 | repo_only | docs/audit/MADAROS_FO_CROSS_FN_RETURN_2026-07-28.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-fo-gum-stack-2026-07-27 | repo_only | docs/audit/MADAROS_FO_GUM_STACK_2026-07-27.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-for-loop-lowering-2026-06-20 | repo_only | docs/audit/MADAROS_FOR_LOOP_LOWERING_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-handle-table-182-lifetime-dispatch-2026-08-17 | repo_only | docs/audit/MADAROS_HANDLE_TABLE_182_LIFETIME_DISPATCH_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-hardening-plan-2026-08-12 | repo_only | docs/audit/MADAROS_HARDENING_PLAN_2026-08-12.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-impl-method-two-roots-2026-06-23 | repo_only | docs/audit/MADAROS_IMPL_METHOD_TWO_ROOTS_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-impl-methods-three-layer-fix-2026-06-23 | repo_only | docs/audit/MADAROS_IMPL_METHODS_THREE_LAYER_FIX_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -25,6 +25,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.contributor.codebase-overview | repo_only | docs/codebase_overview.md | - | A5 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.architects-guide | repo_only | docs/ARCHITECTS_GUIDE.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.architecture.async-runtime | historical | docs/architecture/ASYNC_RUNTIME.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.architecture.cei-implementation-spec-2026-08-18 | repo_only | docs/architecture/CEI_IMPLEMENTATION_SPEC_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.architecture.compiler-maturity-blueprint | repo_only | docs/architecture/compiler-maturity-blueprint.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.architecture.cps-pipeline-integration | historical | docs/architecture/CPS_PIPELINE_INTEGRATION.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.architecture.cybernetics-api-reference | repo_only | docs/architecture/CYBERNETICS_API_REFERENCE.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -3535,6 +3535,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-handle-table-182-lifetime-dispatch-2026-08-17",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_HANDLE_TABLE_182_LIFETIME_DISPATCH_2026-08-17.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-hardening-plan-2026-08-12",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_HARDENING_PLAN_2026-08-12.md",

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -71,6 +71,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.architecture.cei-implementation-spec-2026-08-18",
+      "collection": "repo",
+      "repo_doc_path": "docs/architecture/CEI_IMPLEMENTATION_SPEC_2026-08-18.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.architecture.compiler-maturity-blueprint",
       "collection": "repo",
       "repo_doc_path": "docs/architecture/compiler-maturity-blueprint.md",

--- a/examples/effect_uncertainty_gum_vs_mc.sio
+++ b/examples/effect_uncertainty_gum_vs_mc.sio
@@ -1,16 +1,21 @@
 //@ run-pass
-// CEI WS-A P1/P2 — handler-selectable uncertainty semantics with data flowing
-// SOURCE -> HANDLER. The source performs Epistemic.width(xv,xu,yv,yu) with the
-// measurements; the with{} handler chooses the calculus for the 95% half-width of
-// z = x*y. First-order GUM drops the sigma_x^2*sigma_y^2 cross term a product
-// carries; Monte-Carlo captures it -> DIFFERENT bounds from identical source.
+// CEI WS-A P1/P2 — handler-selectable uncertainty semantics, data SOURCE -> HANDLER.
+// The source performs Epistemic.width(xu, yu) with the two measurement uncertainties
+// of x~N(1.0,xu), y~N(1.0,yu); each with{} handler chooses the calculus for the 95%
+// half-width of z = x*y. First-order GUM drops the sigma_x^2*sigma_y^2 cross term a
+// product carries; Monte-Carlo captures it -> DIFFERENT bounds from an identical source.
+// (Operating point xv=yv=1.0 is a clause constant; the uncertainties flow through the
+// perform. Threading >2 f64 args through a closure clause hits a codegen limit — see
+// docs/audit dispatch; two args is inside the proven envelope.)
 fn main() -> i32 with IO {
     println("z = x*y,  x~N(1.0,0.3), y~N(1.0,0.3)  -- 95% half-width, by handler:")
 
     let _g = handle<Epistemic> {
-        Epistemic.width(1.0, 0.3, 1.0, 0.3)
+        Epistemic.width(0.3, 0.3)
     } with {
-        let width = |xv: f64, xu: f64, yv: f64, yu: f64| {
+        let width = |xu: f64, yu: f64| {
+            let xv: f64 = 1.0
+            let yv: f64 = 1.0
             let var_z: f64 = yv * yv * xu * xu + xv * xv * yu * yu
             print("  GUM (delta):    ")
             println(1.96 * sqrt(var_z))
@@ -19,9 +24,11 @@ fn main() -> i32 with IO {
     }
 
     let _m = handle<Epistemic> {
-        Epistemic.width(1.0, 0.3, 1.0, 0.3)
+        Epistemic.width(0.3, 0.3)
     } with {
-        let width = |xv: f64, xu: f64, yv: f64, yu: f64| {
+        let width = |xu: f64, yu: f64| {
+            let xv: f64 = 1.0
+            let yv: f64 = 1.0
             var seed: i64 = 987654321
             var sum: f64 = 0.0
             var sumsq: f64 = 0.0
@@ -57,6 +64,6 @@ fn main() -> i32 with IO {
             0
         }
     }
-    println("Same source `Epistemic.width(1.0,0.3,1.0,0.3)`; only the with{} handler changed.")
+    println("Same source `Epistemic.width(0.3,0.3)`; only the with{} handler changed.")
     0
 }

--- a/examples/effect_uncertainty_gum_vs_mc.sio
+++ b/examples/effect_uncertainty_gum_vs_mc.sio
@@ -1,40 +1,27 @@
 //@ run-pass
-// CEI WS-A P1 — handler-selectable uncertainty semantics.
-// ONE source performs `Epistemic.width()`; the HANDLER chooses the calculus that
-// computes the 95% half-width of z = x*y, with x~N(1.0,0.3), y~N(1.0,0.3).
-// The GUM handler uses the first-order delta method; the Monte-Carlo handler
-// (JCGM 101 style) samples. First-order GUM drops the σx²·σy² cross term that a
-// product carries, so the two handlers report DIFFERENT bounds from identical
-// source — the point of Certified Effect Interpretation (N1).
+// CEI WS-A P1/P2 — handler-selectable uncertainty semantics with data flowing
+// SOURCE -> HANDLER. The source performs Epistemic.width(xv,xu,yv,yu) with the
+// measurements; the with{} handler chooses the calculus for the 95% half-width of
+// z = x*y. First-order GUM drops the sigma_x^2*sigma_y^2 cross term a product
+// carries; Monte-Carlo captures it -> DIFFERENT bounds from identical source.
 fn main() -> i32 with IO {
     println("z = x*y,  x~N(1.0,0.3), y~N(1.0,0.3)  -- 95% half-width, by handler:")
 
-    // ---- GUM handler: first-order delta method ----
     let _g = handle<Epistemic> {
-        Epistemic.width()
+        Epistemic.width(1.0, 0.3, 1.0, 0.3)
     } with {
-        let width = || {
-            let xv: f64 = 1.0
-            let xu: f64 = 0.3
-            let yv: f64 = 1.0
-            let yu: f64 = 0.3
+        let width = |xv: f64, xu: f64, yv: f64, yu: f64| {
             let var_z: f64 = yv * yv * xu * xu + xv * xv * yu * yu
-            let w: f64 = 1.96 * sqrt(var_z)
             print("  GUM (delta):    ")
-            println(w)
+            println(1.96 * sqrt(var_z))
             0
         }
     }
 
-    // ---- Monte-Carlo handler: JCGM 101 sampling (LCG + Irwin-Hall N(0,1)) ----
     let _m = handle<Epistemic> {
-        Epistemic.width()
+        Epistemic.width(1.0, 0.3, 1.0, 0.3)
     } with {
-        let width = || {
-            let xv: f64 = 1.0
-            let xu: f64 = 0.3
-            let yv: f64 = 1.0
-            let yu: f64 = 0.3
+        let width = |xv: f64, xu: f64, yv: f64, yu: f64| {
             var seed: i64 = 987654321
             var sum: f64 = 0.0
             var sumsq: f64 = 0.0
@@ -65,13 +52,11 @@ fn main() -> i32 with IO {
             let nf: f64 = n as f64
             let mean: f64 = sum / nf
             let var_z: f64 = sumsq / nf - mean * mean
-            let w: f64 = 1.96 * sqrt(var_z)
             print("  Monte-Carlo:    ")
-            println(w)
+            println(1.96 * sqrt(var_z))
             0
         }
     }
-
-    println("Same source `Epistemic.width()`; only the with{} handler changed.")
+    println("Same source `Epistemic.width(1.0,0.3,1.0,0.3)`; only the with{} handler changed.")
     0
 }

--- a/examples/effect_uncertainty_gum_vs_mc.sio
+++ b/examples/effect_uncertainty_gum_vs_mc.sio
@@ -1,0 +1,77 @@
+//@ run-pass
+// CEI WS-A P1 — handler-selectable uncertainty semantics.
+// ONE source performs `Epistemic.width()`; the HANDLER chooses the calculus that
+// computes the 95% half-width of z = x*y, with x~N(1.0,0.3), y~N(1.0,0.3).
+// The GUM handler uses the first-order delta method; the Monte-Carlo handler
+// (JCGM 101 style) samples. First-order GUM drops the σx²·σy² cross term that a
+// product carries, so the two handlers report DIFFERENT bounds from identical
+// source — the point of Certified Effect Interpretation (N1).
+fn main() -> i32 with IO {
+    println("z = x*y,  x~N(1.0,0.3), y~N(1.0,0.3)  -- 95% half-width, by handler:")
+
+    // ---- GUM handler: first-order delta method ----
+    let _g = handle<Epistemic> {
+        Epistemic.width()
+    } with {
+        let width = || {
+            let xv: f64 = 1.0
+            let xu: f64 = 0.3
+            let yv: f64 = 1.0
+            let yu: f64 = 0.3
+            let var_z: f64 = yv * yv * xu * xu + xv * xv * yu * yu
+            let w: f64 = 1.96 * sqrt(var_z)
+            print("  GUM (delta):    ")
+            println(w)
+            0
+        }
+    }
+
+    // ---- Monte-Carlo handler: JCGM 101 sampling (LCG + Irwin-Hall N(0,1)) ----
+    let _m = handle<Epistemic> {
+        Epistemic.width()
+    } with {
+        let width = || {
+            let xv: f64 = 1.0
+            let xu: f64 = 0.3
+            let yv: f64 = 1.0
+            let yu: f64 = 0.3
+            var seed: i64 = 987654321
+            var sum: f64 = 0.0
+            var sumsq: f64 = 0.0
+            let n: i64 = 40000
+            var i = 0
+            while i < n {
+                var ax: f64 = 0.0
+                var kx = 0
+                while kx < 12 {
+                    seed = (seed * 1103515245 + 12345) % 2147483648
+                    ax = ax + (seed as f64) / 2147483648.0
+                    kx = kx + 1
+                }
+                var ay: f64 = 0.0
+                var ky = 0
+                while ky < 12 {
+                    seed = (seed * 1103515245 + 12345) % 2147483648
+                    ay = ay + (seed as f64) / 2147483648.0
+                    ky = ky + 1
+                }
+                let x: f64 = xv + xu * (ax - 6.0)
+                let y: f64 = yv + yu * (ay - 6.0)
+                let z: f64 = x * y
+                sum = sum + z
+                sumsq = sumsq + z * z
+                i = i + 1
+            }
+            let nf: f64 = n as f64
+            let mean: f64 = sum / nf
+            let var_z: f64 = sumsq / nf - mean * mean
+            let w: f64 = 1.96 * sqrt(var_z)
+            print("  Monte-Carlo:    ")
+            println(w)
+            0
+        }
+    }
+
+    println("Same source `Epistemic.width()`; only the with{} handler changed.")
+    0
+}

--- a/examples/effect_uncertainty_gum_vs_mc.sio
+++ b/examples/effect_uncertainty_gum_vs_mc.sio
@@ -1,21 +1,19 @@
 //@ run-pass
-// CEI WS-A P1/P2 — handler-selectable uncertainty semantics, data SOURCE -> HANDLER.
-// The source performs Epistemic.width(xu, yu) with the two measurement uncertainties
-// of x~N(1.0,xu), y~N(1.0,yu); each with{} handler chooses the calculus for the 95%
-// half-width of z = x*y. First-order GUM drops the sigma_x^2*sigma_y^2 cross term a
-// product carries; Monte-Carlo captures it -> DIFFERENT bounds from an identical source.
-// (Operating point xv=yv=1.0 is a clause constant; the uncertainties flow through the
-// perform. Threading >2 f64 args through a closure clause hits a codegen limit — see
-// docs/audit dispatch; two args is inside the proven envelope.)
+// CEI WS-A P2/P3 — handler-selectable uncertainty semantics, ALL measurements
+// threaded SOURCE -> HANDLER. The source performs Epistemic.width(xv,xu,yv,yu)
+// with the full (value, uncertainty) pair for each of x~N(1.0,0.3), y~N(1.0,0.3);
+// each with{} handler chooses the calculus for the 95% half-width of z = x*y.
+// First-order GUM drops the sigma_x^2*sigma_y^2 cross term a product carries;
+// Monte-Carlo captures it -> DIFFERENT bounds from an identical 4-arg source.
+// (Enabled by the IrCallIndirect argc-cap fix — PR #1877 — which lifts the
+// 2-arg limit on indirect/closure calls, so a handler clause can take 4 f64 args.)
 fn main() -> i32 with IO {
     println("z = x*y,  x~N(1.0,0.3), y~N(1.0,0.3)  -- 95% half-width, by handler:")
 
     let _g = handle<Epistemic> {
-        Epistemic.width(0.3, 0.3)
+        Epistemic.width(1.0, 0.3, 1.0, 0.3)
     } with {
-        let width = |xu: f64, yu: f64| {
-            let xv: f64 = 1.0
-            let yv: f64 = 1.0
+        let width = |xv: f64, xu: f64, yv: f64, yu: f64| {
             let var_z: f64 = yv * yv * xu * xu + xv * xv * yu * yu
             print("  GUM (delta):    ")
             println(1.96 * sqrt(var_z))
@@ -24,11 +22,9 @@ fn main() -> i32 with IO {
     }
 
     let _m = handle<Epistemic> {
-        Epistemic.width(0.3, 0.3)
+        Epistemic.width(1.0, 0.3, 1.0, 0.3)
     } with {
-        let width = |xu: f64, yu: f64| {
-            let xv: f64 = 1.0
-            let yv: f64 = 1.0
+        let width = |xv: f64, xu: f64, yv: f64, yu: f64| {
             var seed: i64 = 987654321
             var sum: f64 = 0.0
             var sumsq: f64 = 0.0
@@ -64,6 +60,6 @@ fn main() -> i32 with IO {
             0
         }
     }
-    println("Same source `Epistemic.width(0.3,0.3)`; only the with{} handler changed.")
+    println("Same 4-arg source `Epistemic.width(1.0,0.3,1.0,0.3)`; only the with{} handler changed.")
     0
 }

--- a/examples/effect_uncertainty_smoke.sio
+++ b/examples/effect_uncertainty_smoke.sio
@@ -1,10 +1,12 @@
 //@ run-pass
 //@ expect-stdout: SMOKE 5
 // CEI WS-A P0 smoke: a handle<Epistemic> block whose body performs Epistemic.add,
-// dispatched (tail-resumptive) to the handler clause. Int-only, no uncertainty
-// libraries yet — proves parse -> check(bypass) -> lower(inline) -> native run.
+// dispatched (tail-resumptive) to the handler clause `add`. Proves parse ->
+// check(perform bypass) -> lower(clause-as-fn + indirect dispatch) -> native run.
+// The `: i64` annotation works around a pre-existing kind-0 println gap for call
+// results on this branch (unrelated to handlers; baseline closure calls hit it too).
 fn main() -> i32 with IO {
-    let r = handle<Epistemic> {
+    let r: i64 = handle<Epistemic> {
         Epistemic.add(2, 3)
     } with {
         let add = |a: i64, b: i64| { a + b }

--- a/examples/effect_uncertainty_smoke.sio
+++ b/examples/effect_uncertainty_smoke.sio
@@ -1,0 +1,15 @@
+//@ run-pass
+//@ expect-stdout: SMOKE 5
+// CEI WS-A P0 smoke: a handle<Epistemic> block whose body performs Epistemic.add,
+// dispatched (tail-resumptive) to the handler clause. Int-only, no uncertainty
+// libraries yet — proves parse -> check(bypass) -> lower(inline) -> native run.
+fn main() -> i32 with IO {
+    let r = handle<Epistemic> {
+        Epistemic.add(2, 3)
+    } with {
+        let add = |a: i64, b: i64| { a + b }
+    }
+    print("SMOKE ")
+    println(r)
+    0
+}

--- a/examples/effect_uncertainty_smoke.sio
+++ b/examples/effect_uncertainty_smoke.sio
@@ -1,12 +1,9 @@
 //@ run-pass
 //@ expect-stdout: SMOKE 5
-// CEI WS-A P0 smoke: a handle<Epistemic> block whose body performs Epistemic.add,
-// dispatched (tail-resumptive) to the handler clause `add`. Proves parse ->
-// check(perform bypass) -> lower(clause-as-fn + indirect dispatch) -> native run.
-// The `: i64` annotation works around a pre-existing kind-0 println gap for call
-// results on this branch (unrelated to handlers; baseline closure calls hit it too).
+// CEI WS-A smoke: handle<Epistemic>{ Epistemic.add(2,3) } dispatched to the clause.
+// No result annotation needed (P2: ExprHandle results carry scalar-kind).
 fn main() -> i32 with IO {
-    let r: i64 = handle<Epistemic> {
+    let r = handle<Epistemic> {
         Epistemic.add(2, 3)
     } with {
         let add = |a: i64, b: i64| { a + b }

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -7514,6 +7514,11 @@ fn checker_widen_current_effects_inplace(c: *mut Checker, extra: [i64; 8], extra
 var CHECKER_EFFECT_INFERENCE_ENABLED_ON: i64 = 0
 var CHECKER_EFFECT_INFERENCE_ENABLED_CHECKED: i64 = 0
 
+// CEI WS-A P0: > 0 while checking the body of a handle<E> block. The check_method_call
+// perform bypass uses this to type E.op(args) as a handler operation rather than
+// failing the effect name as an undeclared identifier. Twin of lower.sio LOWER_HANDLER_DEPTH.
+var CHECK_HANDLER_DEPTH: i64 = 0
+
 fn checker_effect_inference_enabled() -> bool with IO, Mut, Panic, Div {
     if CHECKER_EFFECT_INFERENCE_ENABLED_CHECKED == 0 {
         CHECKER_EFFECT_INFERENCE_ENABLED_CHECKED = 1
@@ -13941,6 +13946,29 @@ fn checker_expr_is_gpu_sync_call(e: Expr) -> bool with Mut, Panic, Div, Alloc, I
     }
     match e.left {
         Some(callee) => checker_expr_is_gpu_effect_field(*callee, make_name("sync")),
+        None => false,
+    }
+}
+
+// CEI WS-A: is this a handler perform — `E.op(args)` whose receiver is a bare
+// identifier naming a known effect (Epistemic, ...)? Such a call is not a method on
+// a value; inside a handle<E> block it dispatches to a handler clause.
+fn checker_expr_is_handler_perform(e: Expr) -> bool with Mut, Panic, Div, Alloc, IO {
+    if e.kind != ExprKind::ExprMethodCall { return false }
+    match e.left {
+        Some(base) => {
+            if (*base).kind != ExprKind::ExprIdent {
+                false
+            } else {
+                var buf: [i8; 64] = [0; 64]
+                var i: i64 = 0
+                while i < (*base).name.len && i < 64 {
+                    buf[i as usize] = (*base).name.buf[i as usize]
+                    i = i + 1
+                }
+                effect_name_to_id(buf, (*base).name.len) >= 0
+            }
+        }
         None => false,
     }
 }
@@ -20440,6 +20468,15 @@ impl Checker {
             let c_gpu = self.check_expr_list_no_type_no_linear_consume(e.args)
             return (c_gpu, ty_unit())
         }
+        // CEI WS-A: effect-handler perform. Inside a handle<E> block, `E.op(args)`
+        // (bare-Ident effect receiver) is a perform, not a method on a value. Type
+        // its args and yield the operation result type. P0 types it as i64; P1 will
+        // infer the clause's declared return type. Runs BEFORE the receiver is
+        // type-checked, which would otherwise fail the effect name as undeclared.
+        if CHECK_HANDLER_DEPTH > 0 && checker_expr_is_handler_perform(e) {
+            let c_perf = self.check_expr_list_no_type_no_linear_consume(e.args)
+            return (c_perf, ty_i64())
+        }
         // Method receiver evaluation should not eagerly consume linear values,
         // because receiver passing mode is method-signature dependent.
         var checker_for_base = self
@@ -24099,10 +24136,14 @@ impl Checker {
             }
         }
 
-        // Check the body block
+        // Check the body block (CEI WS-A: raise handler depth so performs inside it
+        // type through the check_method_call perform bypass instead of failing the
+        // effect name as an undeclared identifier).
+        CHECK_HANDLER_DEPTH = CHECK_HANDLER_DEPTH + 1
         let body_pair = c.check_opt_block(e.block)
         c = body_pair.0
         let body_ty = body_pair.1
+        CHECK_HANDLER_DEPTH = CHECK_HANDLER_DEPTH - 1
 
         // Restore original effects (handler discharges the effect)
         c.current_sig_id = 0 - 1

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -16982,6 +16982,15 @@ impl Lowerer {
                     }
                     lo.current_func = cf_box
                     lo = lo.bind_local((*plist).head.name, preg, false)
+                    // f64 closure params were never marked float — named-fn params get
+                    // ir_mark_float_reg (see lowerer_lower_fn_params_mut), closures did not,
+                    // so `|a:f64|{..}` read its arg from an integer reg and computed garbage
+                    // (-0.000000). Mark the param reg float + scalar-kind 2, mirroring the
+                    // named-fn path. Enables f64 to flow through handler-clause closures (CEI P2).
+                    if lower_type_expr_is_f64(&(*plist).head.ty) {
+                        lo = lo.emit(ir_mark_float_reg(preg))
+                        lo = lo.bind_local_scalar_kind((*plist).head.name, 2)
+                    }
                     params = &(*plist).tail
                 }
                 _ => break

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -292,6 +292,14 @@ var IR_INSTR_CENSUS_TOTAL: i64 = 0
 var IR_INSTR_CENSUS_MAX: i64 = 0
 var IR_INSTR_CENSUS_OVER: i64 = 0
 
+// CEI WS-A P0 (handled effects): > 0 while lowering inside a handle<E> block.
+// The perform hook (in lower_method_call_expr_ref) dispatches a call E.op(args)
+// to a bound handler clause fn only while this is set. A module global (not a
+// struct field) mirrors the LAST_EXPR / EXTERN_BLOCK precedent; lowering is
+// single-threaded so a global depth counter is a safe stack discipline.
+// See docs/architecture/CEI_IMPLEMENTATION_SPEC_2026-08-18.md.
+var LOWER_HANDLER_DEPTH: i64 = 0
+
 // Memoised: read_env allocates and the runtime allocator never reclaims,
 // so a gate evaluated at every call site leaks on every call. CHECKED is
 // separate from the value because "off" and "not yet read" are different.
@@ -15675,6 +15683,29 @@ impl Lowerer {
     }
 
     fn lower_method_call_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        // CEI WS-A: effect-handler perform dispatch. Inside a handle<E> block, a
+        // call E.op(args) whose op names a bound handler clause is lowered as an
+        // ordinary call to that clause's synthetic fn (tail-resumptive; no CPS).
+        // Mirrors the bound-closure call path in lower_call_expr_ref (@14906).
+        if LOWER_HANDLER_DEPTH > 0 {
+            match (*e).left {
+                Some(base) => {
+                    if (*base).kind == ExprKind::ExprIdent {
+                        let clause_fn = self.lookup_local_closure_fn_id((*e).name)
+                        if clause_fn >= 0 {
+                            let pair_pa: LowerExprArgsResult = self.lower_expr_args_ref(&(*e).args)
+                            let lo_pa = pair_pa.lowerer
+                            let args_pa: Option<Box<IrRegList>> = if pair_pa.count <= 0 { None } else { Some(Box::new(pair_pa.regs)) }
+                            let pair_pd = lo_pa.fresh_reg()
+                            let lo_pd = pair_pd.0
+                            let dst_pd = pair_pd.1
+                            return (lo_pd.emit(ir_call(dst_pd, clause_fn, (*e).name, args_pa, pair_pa.count)), dst_pd)
+                        }
+                    }
+                }
+                None => {}
+            }
+        }
         if self.expr_is_gpu_sync_call_ref(e) {
             // Unit. A plain integer zero -- emit_f64_const would mark the
             // register as float for a value that is never read.
@@ -16116,6 +16147,48 @@ impl Lowerer {
         }
     }
 
+    // CEI WS-A P0: lower `handle<E> { body } with { let op = |..| {..} ... }`.
+    // Lower each clause `let op = closure` as a normal let-statement in an enclosing
+    // scope (this registers op's synthetic closure fn_id via bind_local_closure_fn_id),
+    // then lower the body with LOWER_HANDLER_DEPTH raised so a `perform E.op(args)`
+    // (parsed as the call E.op(args)) dispatches to the clause fn. Clause bindings are
+    // discarded when the scope closes. Tail-resumptive; multi-shot resume is out of scope.
+    fn lower_handle_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        var lo = self
+        lo.scope_depth = lo.scope_depth + 1
+        let saved_local_count = lo.locals.count
+        let hb_opt: Option<Box<Block>> = (*e).handler_block
+        match hb_opt {
+            Some(hb) => {
+                var current = &(*hb).stmts
+                while true {
+                    match *current {
+                        Some(list) => {
+                            let stmt_ref = &(*list).head
+                            if (*stmt_ref).kind == StmtKind::StmtLet {
+                                let cp = lo.lower_let_stmt_ref(stmt_ref, false)
+                                lo = cp.0
+                            }
+                            current = &(*list).tail
+                        }
+                        _ => break
+                    }
+                }
+            }
+            None => {}
+        }
+        LOWER_HANDLER_DEPTH = LOWER_HANDLER_DEPTH + 1
+        let body_pair = lo.lower_block_expr_ref(e)
+        lo = body_pair.0
+        let result = body_pair.1
+        LOWER_HANDLER_DEPTH = LOWER_HANDLER_DEPTH - 1
+        if lo.scope_depth > 0 {
+            lo.scope_depth = lo.scope_depth - 1
+        }
+        lo.locals.count = saved_local_count
+        (lo, result)
+    }
+
     fn lower_return_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
         let pair = self.lower_opt_expr_ref(&e.left)
         let lo = pair.0
@@ -16493,6 +16566,8 @@ impl Lowerer {
             self.lower_loop_expr_ref(e)
         } else if e.kind == ExprKind::ExprForIn {
             self.lower_for_in_expr_ref(e)
+        } else if e.kind == ExprKind::ExprHandle {
+            self.lower_handle_expr_ref(e)
         } else if e.kind == ExprKind::ExprBlock {
             self.lower_block_expr_ref(e)
         } else if e.kind == ExprKind::ExprReturn {

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -12743,7 +12743,17 @@ impl Lowerer {
         } else {
             match s.expr {
                 Some(expr_box_sk) => {
-                    if (*expr_box_sk).kind == ExprKind::ExprIntLit {
+                    if (*expr_box_sk).kind == ExprKind::ExprIdent && lo.lookup_local_scalar_kind((*expr_box_sk).name) != 0 {
+                        // println scalar-kind fix (2026-08-17): `let b = a` copies a
+                        // scalar. The recorded scalar-kind of `a` is authoritative
+                        // (int/bool->1, float->2, string->3); propagate it so a later
+                        // `println(b)` dispatches correctly. Without this the copy left
+                        // b at kind 0 and println routed the value through the char*
+                        // printer -> strlen-as-pointer SIGSEGV (holds for int copies too,
+                        // not only bool). Guarded on !=0 so an unclassified ident still
+                        // falls through to the float/string positive checks below.
+                        lo = lo.bind_local_scalar_kind(s.name, lo.lookup_local_scalar_kind((*expr_box_sk).name))
+                    } else if (*expr_box_sk).kind == ExprKind::ExprIntLit {
                         lo = lo.bind_local_scalar_kind(s.name, 1)
                     } else if (*expr_box_sk).kind == ExprKind::ExprBoolTrue || (*expr_box_sk).kind == ExprKind::ExprBoolFalse {
                         lo = lo.bind_local_scalar_kind(s.name, 1)

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -10587,6 +10587,12 @@ impl Lowerer {
         if (*e).kind == ExprKind::ExprStringLit {
             return 3
         }
+        if (*e).kind == ExprKind::ExprHandle {
+            // CEI WS-A P0: a handle<E>{..} result is the operation result type, which
+            // P0 fixes as i64. Without this, `let r = handle{..}` leaves r at scalar-kind
+            // 0 and println(r) routes to the char* printer -> SIGSEGV (the #1799 family).
+            return 1
+        }
         if (*e).kind == ExprKind::ExprIdent {
             let local_sk = self.lookup_local_scalar_kind((*e).name)
             if local_sk != 0 {
@@ -15691,15 +15697,25 @@ impl Lowerer {
             match (*e).left {
                 Some(base) => {
                     if (*base).kind == ExprKind::ExprIdent {
-                        let clause_fn = self.lookup_local_closure_fn_id((*e).name)
-                        if clause_fn >= 0 {
+                        let op_reg = self.lookup_local((*e).name)
+                        if op_reg >= 0 {
+                            // A non-capturing clause `let op = |..| {..}` binds a fn-ref
+                            // register (ir_load_fn_ref); a capturing one sets closure_fn_id.
+                            // Dispatch the direct call for the latter, else indirect via
+                            // the fn-ref reg — mirroring lower_call_expr_ref's bound-closure
+                            // path (@14906 direct / @14900 indirect).
+                            let clause_fn = self.lookup_local_closure_fn_id((*e).name)
                             let pair_pa: LowerExprArgsResult = self.lower_expr_args_ref(&(*e).args)
                             let lo_pa = pair_pa.lowerer
                             let args_pa: Option<Box<IrRegList>> = if pair_pa.count <= 0 { None } else { Some(Box::new(pair_pa.regs)) }
                             let pair_pd = lo_pa.fresh_reg()
                             let lo_pd = pair_pd.0
                             let dst_pd = pair_pd.1
-                            return (lo_pd.emit(ir_call(dst_pd, clause_fn, (*e).name, args_pa, pair_pa.count)), dst_pd)
+                            if clause_fn >= 0 {
+                                return (lo_pd.emit(ir_call(dst_pd, clause_fn, (*e).name, args_pa, pair_pa.count)), dst_pd)
+                            } else {
+                                return (lo_pd.emit(ir_call_indirect(dst_pd, op_reg, args_pa, pair_pa.count)), dst_pd)
+                            }
                         }
                     }
                 }

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -2349,7 +2349,7 @@ fn lowerer_preseed_external_struct_items_mut(
                                                 // instead of a direct load, corrupting the value. Compute
                                                 // the real class from the field type, matching
                                                 // ir_fast_summary_register_struct_fields_owned.
-                                                is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_integer(&(*flist).head.ty) { 3 } else { 0 },
+                                                is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_integer(&(*flist).head.ty) { 3 } else if lower_type_expr_is_bool(&(*flist).head.ty) { 3 } else { 0 },
                                                 elem_type_name_id: ir_intern_name(lower_type_expr_array_elem_name(&(*flist).head.ty)),
                                                 word_scalar_array_len: lower_type_expr_word_scalar_array_len(&(*flist).head.ty),
                                                 named_type_name_id: ir_intern_name(lower_type_expr_named_type_name(&(*flist).head.ty)),
@@ -2535,7 +2535,7 @@ fn lowerer_preseed_external_items_into_acc_mut(
                                             entry.fields[fc as usize] = StructFieldEntry {
                                                 name_id: ir_intern_name((*flist).head.name),
                                                 index: fc,
-                                                is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_integer(&(*flist).head.ty) { 3 } else { 0 },
+                                                is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_integer(&(*flist).head.ty) { 3 } else if lower_type_expr_is_bool(&(*flist).head.ty) { 3 } else { 0 },
                                                 elem_type_name_id: ir_intern_name(ir_empty_name()),
                                                 word_scalar_array_len: lower_type_expr_word_scalar_array_len(&(*flist).head.ty),
                                                 named_type_name_id: ir_intern_name(lower_type_expr_named_type_name(&(*flist).head.ty)),
@@ -2627,7 +2627,7 @@ fn lowerer_register_struct_fields_direct_mut(
                     // over the same struct_layouts table; a mismatch here would leave the
                     // FIRST-registered field entry — the one actually found by name lookup —
                     // without the i64 marker).
-                    is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_integer(&(*flist).head.ty) { 3 } else { 0 },
+                    is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_integer(&(*flist).head.ty) { 3 } else if lower_type_expr_is_bool(&(*flist).head.ty) { 3 } else { 0 },
                     elem_type_name_id: ir_intern_name(lower_type_expr_array_elem_name(&(*flist).head.ty)),
                     word_scalar_array_len: lower_type_expr_word_scalar_array_len(&(*flist).head.ty),
                     named_type_name_id: ir_intern_name(lower_type_expr_named_type_name(&(*flist).head.ty)),
@@ -2684,7 +2684,7 @@ fn lowerer_register_struct_fields_mut(
                         name_id: ir_intern_name((*list).head.name),
                         index: field_idx,
                         // println i64-segfault fix: see note in lowerer_register_struct_fields_direct_mut.
-                        is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_integer(&(*list).head.ty) { 3 } else { 0 },
+                        is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_integer(&(*list).head.ty) { 3 } else if lower_type_expr_is_bool(&(*list).head.ty) { 3 } else { 0 },
                         elem_type_name_id: ir_intern_name(lower_type_expr_array_elem_name(&(*list).head.ty)),
                         word_scalar_array_len: lower_type_expr_word_scalar_array_len(&(*list).head.ty),
                         named_type_name_id: ir_intern_name(lower_type_expr_named_type_name(&(*list).head.ty)),
@@ -3501,7 +3501,7 @@ fn ir_fast_summary_register_struct_fields_owned(
                     name_id: ir_intern_name((*list).head.name),
                     index: idx,
                     // println i64-segfault fix: see note in lowerer_register_struct_fields_direct_mut.
-                    is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_integer(&(*list).head.ty) { 3 } else { 0 },
+                    is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_integer(&(*list).head.ty) { 3 } else if lower_type_expr_is_bool(&(*list).head.ty) { 3 } else { 0 },
                     elem_type_name_id: ir_intern_name(lower_type_expr_array_elem_name(&(*list).head.ty)),
                     word_scalar_array_len: lower_type_expr_word_scalar_array_len(&(*list).head.ty),
                     named_type_name_id: ir_intern_name(lower_type_expr_named_type_name(&(*list).head.ty)),
@@ -4067,6 +4067,12 @@ fn lowerer_lower_fn_params_mut(
                     lowerer_mark_local_scalar_kind_mut(lo, (*list).head.name, 2)
                 } else if lower_type_expr_is_integer(&(*list).head.ty) {
                     lowerer_mark_local_scalar_kind_mut(lo, (*list).head.name, 1)
+                } else if lower_type_expr_is_bool(&(*list).head.ty) {
+                    // println bool-segfault fix (2026-08-17): bool param → kind 1
+                    // (print_int, 1/0), mirroring the int-param case above so
+                    // println(b) does not route the bool value through the char*
+                    // printer. This is the load-bearing param path (path-A).
+                    lowerer_mark_local_scalar_kind_mut(lo, (*list).head.name, 1)
                 }
                 if lower_type_expr_is_ref_like(&(*list).head.ty) {
                     lowerer_mark_local_ref_mut(lo, (*list).head.name)
@@ -4554,6 +4560,22 @@ fn lower_type_expr_is_i64(te: &TypeExpr) -> bool with Mut, Panic, Div {
     true
 }
 
+// println bool-segfault fix (2026-08-17): a `bool` type mention. bool prints
+// via print_int (kind 1) — the literal path already lowers `true`/`false` as
+// IntLit=1 and prints 1/0 — so any positively-known bool return/field/local must
+// route to print_int too, not the char* printer that strlen's the bool value 1
+// as a pointer (SIGSEGV). See docs/audit/MADAROS_PRINTLN_BOOL_SCALARKIND_SEGV.
+fn lower_type_expr_is_bool(te: &TypeExpr) -> bool with Mut, Panic, Div {
+    if (*te).kind != TypeExprKind::TypeNamed { return false }
+    let seg = (*te).path.segments
+    if seg.head_len != 4 { return false }
+    if seg.head_buf[0] as i64 != 98 { return false }    // 'b'
+    if seg.head_buf[1] as i64 != 111 { return false }   // 'o'
+    if seg.head_buf[2] as i64 != 111 { return false }   // 'o'
+    if seg.head_buf[3] as i64 != 108 { return false }   // 'l'
+    true
+}
+
 // println i64-segfault fix: a callee's return type name (module.functions[..].
 // return_struct_name, populated for ANY TypeNamed return type via
 // lower_opt_type_named_name — not only actual structs) positively identifies a
@@ -4564,6 +4586,17 @@ fn lower_name_is_i64_type(n: Name) -> bool with Div {
     && n.buf[0] == 105 as i8   // 'i'
     && n.buf[1] == 54 as i8    // '6'
     && n.buf[2] == 52 as i8    // '4'
+}
+
+// println bool-segfault fix (2026-08-17): a callee's return type name that is
+// `bool`. Like lower_name_is_i64_type but for bool — used so a bool-returning
+// call routes println to print_int (kind 1) instead of the char* printer.
+fn lower_name_is_bool_type(n: Name) -> bool with Div {
+    n.len == 4
+    && n.buf[0] == 98 as i8    // 'b'
+    && n.buf[1] == 111 as i8   // 'o'
+    && n.buf[2] == 111 as i8   // 'o'
+    && n.buf[3] == 108 as i8   // 'l'
 }
 
 // "string" named type (packed *u8, null-terminated) — NOT a GC array handle.
@@ -10622,7 +10655,10 @@ impl Lowerer {
                     let callee_name = self.expr_to_callee_name_ref(&(*callee_expr))
                     let fn_id = lowerer_lookup_fn_id_by_name_ref(&self, callee_name)
                     if fn_id >= 0 && fn_id < self.module.fn_count {
-                        if lower_name_is_integer_type(self.module.functions[fn_id as usize].return_struct_name) {
+                        if lower_name_is_integer_type(self.module.functions[fn_id as usize].return_struct_name)
+                            || lower_name_is_bool_type(self.module.functions[fn_id as usize].return_struct_name) {
+                            // println bool-segfault fix (2026-08-17): a bool-returning
+                            // call is kind 1 (print_int, 1/0) — not the char* default.
                             return 1
                         }
                     }
@@ -10889,7 +10925,14 @@ impl Lowerer {
                             // with a new `3` marker for scalar-i64 fields (2 is already taken by
                             // f64-array). Existing consumers only test `== 1` / `== 2`, so this
                             // is inert for them; field_is_int_* below tests `== 3`.
-                            is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_integer(&(*list).head.ty) { 3 } else { 0 },
+                            // println bool-segfault fix (2026-08-17): a bool field
+                            // takes the same scalar-int marker (3) as integers, so
+                            // field_is_int_* classifies `s.ok` as kind 1 and println
+                            // routes it to print_int (1/0) instead of the char* printer
+                            // that would strlen the bool value 1 as a pointer (SIGSEGV).
+                            // Marker 3 is consumed only by field_is_int_* (println
+                            // dispatch), so this is inert for float/array/store paths.
+                            is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_integer(&(*list).head.ty) { 3 } else if lower_type_expr_is_bool(&(*list).head.ty) { 3 } else { 0 },
                             elem_type_name_id: ir_intern_name(lower_type_expr_array_elem_name(&(*list).head.ty)),
                             word_scalar_array_len: lower_type_expr_word_scalar_array_len(&(*list).head.ty),
                             named_type_name_id: ir_intern_name(lower_type_expr_named_type_name(&(*list).head.ty)),
@@ -11634,6 +11677,11 @@ impl Lowerer {
                         (*locals).scalar_kind[idx as usize] = if lower_type_expr_is_f64(&(*list).head.ty) {
                             2
                         } else if lower_type_expr_is_integer(&(*list).head.ty) {
+                            1
+                        } else if lower_type_expr_is_bool(&(*list).head.ty) {
+                            // println bool-segfault fix (2026-08-17): a bool param is
+                            // kind 1 (print_int, 1/0) like an int param, so println(b)
+                            // does not route the bool value through the char* printer.
                             1
                         } else {
                             0

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -12777,6 +12777,12 @@ impl Lowerer {
                         // Restricted to Call/MethodCall so an indexed struct element
                         // cannot be misclassified as int.
                         lo = lo.bind_local_scalar_kind(s.name, 1)
+                    } else if (*expr_box_sk).kind == ExprKind::ExprHandle {
+                        // CEI P2: `let r = handle<E>{..} with {..}` — classify r by the
+                        // handle result kind (expr_result_scalar_kind_ref: P0 i64; the clause
+                        // return type once inferred) so println(r) routes to print_int, not
+                        // the char* printer -> SIGSEGV. Drops the `: i64` annotation.
+                        lo = lo.bind_local_scalar_kind(s.name, lo.expr_result_scalar_kind_ref(&(*expr_box_sk)))
                     } else if ((*expr_box_sk).kind == ExprKind::ExprBinary || (*expr_box_sk).kind == ExprKind::ExprUnary) {
                         // `let y = x + 1` / `let y = 0 - x` without an integer annotation:
                         // expr_result_scalar_kind_ref now positively returns 1 for int

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -8185,23 +8185,41 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
                 nc_core_store_rax_to_temp(nc, IR_A_DST[(ir_region_slot_r((*func).region, (i))) as usize])
             }
         } else if instr_op == IrOpcode::IrCallIndirect {
+            // Marshal up to 6 args into the SysV GP arg registers (args 6+ go on
+            // the stack), mirroring the direct IrCall arm. The old code capped at
+            // 2 args (`if argc > 2 { return false }` -> "native-v2 bridge failed"),
+            // which silently blocked every indirect call (by-value closures, fn
+            // pointers) with >=3 arguments. fnref (call target) is loaded into rax
+            // LAST so the arg-register loads cannot clobber it. (Ported from the
+            // main fix, PR #1877 / lane/fable-1/indirect-call-argc-fix.)
             let argc = IR_A_ARG_COUNT[(ir_region_slot_r((*func).region, (i))) as usize]
-            if argc > 2 {
-                return false
-            }
-            let arg_pair = (ir_arena_arg_at(ir_region_slot_r((*func).region, (i)), 0), ir_arena_arg_at(ir_region_slot_r((*func).region, (i)), 1))
-            if argc > 0 {
-                if arg_pair.0 < 0 { return false }
-                nc_emit_load_rbp_disp32_reg(nc, 7, ir_slot_offset(arg_pair.0))
-            }
-            if argc > 1 {
-                if arg_pair.1 < 0 { return false }
-                nc_emit_load_rbp_disp32_reg(nc, 6, ir_slot_offset(arg_pair.1))
-            }
             let fnref_reg = IR_A_SRC1[(ir_region_slot_r((*func).region, (i))) as usize]
             if fnref_reg < 0 { return false }
+            if !nc_core_push_call_stack_args(nc, func, i, argc) { return false }
+            if argc > 0 {
+                if !nc_core_load_call_arg_into(nc, func, i, 0, 7) { return false }
+            }
+            if argc > 1 {
+                if !nc_core_load_call_arg_into(nc, func, i, 1, 6) { return false }
+            }
+            if argc > 2 {
+                if !nc_core_load_call_arg_into(nc, func, i, 2, 2) { return false }
+            }
+            if argc > 3 {
+                if !nc_core_load_call_arg_into(nc, func, i, 3, 1) { return false }
+            }
+            if argc > 4 {
+                if !nc_core_load_call_arg_into(nc, func, i, 4, 8) { return false }
+            }
+            if argc > 5 {
+                if !nc_core_load_call_arg_into(nc, func, i, 5, 9) { return false }
+            }
             nc_core_load_temp_to_rax(nc, fnref_reg)
             nc_emit_call_rax(nc)
+            let cleanup_bytes = nc_core_stack_call_cleanup_bytes(argc, 6)
+            if cleanup_bytes > 0 {
+                nc_emit_add_rsp_imm32(nc, cleanup_bytes)
+            }
             if IR_A_DST[(ir_region_slot_r((*func).region, (i))) as usize] >= 0 {
                 nc_core_store_rax_to_temp(nc, IR_A_DST[(ir_region_slot_r((*func).region, (i))) as usize])
             }


### PR DESCRIPTION
> **Draft / RFC — not for direct merge.** This branch is off an older base (`dca2775061`); `main` has since moved ~100 commits (including incoming wholesale codegen rewrites via #1717). It is published for **review and record** of the CEI research line. The one piece that is cleanly merge-ready to current `main` is extracted separately as **#1877** (the `IrCallIndirect` argc-cap fix).

## What this is

First end-to-end realization of **Certified Effect Interpretation (CEI)** in Sounio: algebraic-effect handlers dispatched natively, with the *same source* yielding *different certified uncertainty bounds* depending only on the `with{}` handler — the flagship WS-A claim (N1).

## Milestones on this branch

- **P0** — `handle<E>{ body } with { clauses }` lowering + checker `perform` bypass. `handle<Epistemic>{ Epistemic.add(2,3) } with { let add=|a,b|{a+b} }` → `SMOKE 5`. First handler-dispatched effect that executes natively. (`self-hosted/ir/lower.sio` ExprHandle arm + perform hook; `self-hosted/check/check.sio` handler-depth bypass.)
- **P1** — GUM-vs-Monte-Carlo demonstrator: one source, two handlers, two certified 95% half-widths of z=x·y (`0.831558` vs `0.851582` — the gap is the σ²ₓσ²ᵧ cross term GUM drops and MC keeps).
- **P2** — f64 measurements threaded **source→handler**. Now **unbounded**: `examples/effect_uncertainty_gum_vs_mc.sio` passes all four `(xv,xu,yv,yu)` through one `Epistemic.width(1.0,0.3,1.0,0.3)` perform into two clauses. Enabled by porting the argc-cap fix (#1877) onto this base.

## Supporting compiler fixes carried here

- `IrCallIndirect` 2-arg cap lifted → full SysV GP marshaling (the #1877 fix, ported to this base).
- f64 closure params marked float (`ir_mark_float_reg`) — were read from int regs → garbage.
- Cherry-picked #1799 kind-0 `println` fixes (bool classification + ident-copy scalar-kind propagation).

## Verification (from source; self-compile fixed-point held)

`examples/effect_uncertainty_smoke.sio` → `SMOKE 5`; `examples/effect_uncertainty_gum_vs_mc.sio` → GUM `0.831558` / MC `0.851582`, both handlers reading the identical 4-arg source.

## Honesty / scope

- GUM soundness is **conditional** (curvature side-condition); p-box/interval enclosure is the unconditional certified result. The demonstrator shows *handler-selectable semantics*, not a soundness proof — that is WS-D (Lean metatheory), not in this branch.
- Off an old base by design (the GPU-`perform` precedent this lowering extends lived there). A forward-port onto post-#1717 `main` is future work; treat this as the reference implementation + evidence, review-only.

Dispatch/design docs included: `docs/audit/MADAROS_INDIRECT_CALL_ARGC_CAP_2026-08-18.md`, `docs/architecture/CEI_IMPLEMENTATION_SPEC_2026-08-18.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)