### PR TITLE
test: lean_single is not a GUM oracle — pin three Madaros-right splits

### DIFF
--- a/tests/run-pass/lean_is_not_oracle_add.sio
+++ b/tests/run-pass/lean_is_not_oracle_add.sio
@@ -1,0 +1,27 @@
+//@ run-pass
+//@ requires: madaros
+//@ expect-stdout: LEAN_WRONG 4.000000
+//@ expect-stdout: MADAROS_RIGHT 5.000000
+//@ expect-stdout: OBSERVED 5.000000
+//@ expect-stdout: LEAN_IS_NOT_ORACLE_ADD_OK
+//@ description: JCGM 100:2008 §5.1.2 independent sum. u=2 and u=1 ⇒ var(a+b)=5. Madaros prints 5. lean_single prints 4 (drops the second channel) on the inline peel. Same-file helper add in gum_cross_function still prints 5 on both — do not confuse the two.
+
+fn main() -> i64 with IO, Mut, Epistemic {
+    let k1: Knowledge<f64> = measure(100.0, uncertainty: 2.0)
+    let k2: Knowledge<f64> = measure(50.0, uncertainty: 1.0)
+    let a = k1.value
+    let b = k2.value
+    let v = variance_of(a + b)
+    println("LEAN_WRONG 4.000000")
+    println("MADAROS_RIGHT 5.000000")
+    print("OBSERVED ")
+    print_f64(v)
+    println("")
+    if v > 4.9 && v < 5.1 {
+        println("LEAN_IS_NOT_ORACLE_ADD_OK")
+        0
+    } else {
+        println("LEAN_IS_NOT_ORACLE_ADD_REGRESSED")
+        1
+    }
+}

--- a/tests/run-pass/lean_is_not_oracle_product.sio
+++ b/tests/run-pass/lean_is_not_oracle_product.sio
@@ -1,0 +1,27 @@
+//@ run-pass
+//@ requires: madaros
+//@ expect-stdout: LEAN_WRONG 0.002500
+//@ expect-stdout: MADAROS_RIGHT 0.032500
+//@ expect-stdout: OBSERVED 0.032500
+//@ expect-stdout: LEAN_IS_NOT_ORACLE_PRODUCT_OK
+//@ description: GUM Var(a*b)=b²·Va+a²·Vb. a=2 b=3 u=0.05 ⇒ 0.0325. Madaros prints 0.0325. lean_single prints 0.0025. The older madaros_gum_independent_product.sio still prints PASS on lean with the wrong number — that is not a pin.
+
+fn main() -> i64 with IO, Mut, Epistemic {
+    let ka: Knowledge<f64> = measure(2.0, uncertainty: 0.05)
+    let kb: Knowledge<f64> = measure(3.0, uncertainty: 0.05)
+    let a = ka.value
+    let b = kb.value
+    let v = variance_of(a * b)
+    println("LEAN_WRONG 0.002500")
+    println("MADAROS_RIGHT 0.032500")
+    print("OBSERVED ")
+    print_f64(v)
+    println("")
+    if v > 0.032 && v < 0.033 {
+        println("LEAN_IS_NOT_ORACLE_PRODUCT_OK")
+        0
+    } else {
+        println("LEAN_IS_NOT_ORACLE_PRODUCT_REGRESSED")
+        1
+    }
+}

--- a/tests/run-pass/lean_is_not_oracle_scale2.sio
+++ b/tests/run-pass/lean_is_not_oracle_scale2.sio
@@ -1,0 +1,32 @@
+//@ run-pass
+//@ requires: madaros
+//@ expect-stdout: LEAN_WRONG 0.002500
+//@ expect-stdout: MADAROS_RIGHT 0.010000
+//@ expect-stdout: OBSERVED 0.010000
+//@ expect-stdout: LEAN_IS_NOT_ORACLE_SCALE2_OK
+//@ description: GUM var(2x)=4·var(x). measure(2.0, u=0.05) ⇒ var=0.0025; scale2 ⇒ 0.01. Madaros prints 0.01. lean_single prints 0.0025 (no scale). lean_single is not an oracle. If Madaros is "fixed" to 0.0025 this test fails.
+
+// The receipt counter-example: tests/run-pass/madaros_gum_fo_interproc.sio
+// is PASS on Madaros (s2=0.010000) and FAIL on lean_single (s2=0.002500),
+// but it lives in vacuous_expect_baseline so a Madaros regression to 0.0025
+// is silent on the seed suite. This file pins both numbers in expect-stdout.
+
+fn scale2(x: f64) -> f64 { 2.0 * x }
+
+fn main() -> i64 with IO, Mut, Epistemic {
+    let k: Knowledge<f64> = measure(2.0, uncertainty: 0.05)
+    let x = k.value
+    let v = variance_of(scale2(x))
+    println("LEAN_WRONG 0.002500")
+    println("MADAROS_RIGHT 0.010000")
+    print("OBSERVED ")
+    print_f64(v)
+    println("")
+    if v > 0.009 && v < 0.011 {
+        println("LEAN_IS_NOT_ORACLE_SCALE2_OK")
+        0
+    } else {
+        println("LEAN_IS_NOT_ORACLE_SCALE2_REGRESSED")
+        1
+    }
+}


### PR DESCRIPTION
## Why

Yesterday the fleet learned to treat `lean_single` as the reference. The additive-matrix receipt already said it is **not a universal oracle**, with one counter-example: `madaros_gum_fo_interproc` is `scale2=0.01` on Madaros (correct GUM) and `0.0025` on lean. That sentence lived in a document. If someone "fixed" Madaros to agree with lean, nobody would notice — and we would have regressed toward being correct.

These tests make the opposite case suite-visible.

## What landed

Three files. Each prints **both** numbers as literals and an `OBSERVED` line from `print_f64`. `expect-stdout` holds the lean-wrong value, the Madaros-right value, and `OBSERVED` equal to the Madaros-right value. The process exits 1 unless the observed value is the GUM number.

| Test | Law | Madaros | lean_single |
|---|---|---:|---:|
| `lean_is_not_oracle_scale2.sio` | `var(2x) = 4·var(x)`; `u=0.05` | **0.010000** | 0.002500 |
| `lean_is_not_oracle_product.sio` | `Var(a·b) = b²Va + a²Vb`; `a=2,b=3,u=0.05` | **0.032500** | 0.002500 |
| `lean_is_not_oracle_add.sio` | JCGM 100:2008 §5.1.2; `u=2,1` | **5.000000** | 4.000000 |

One counter-example is an anecdote. Three independently re-measured GUM splits are a pattern: lean keeps a single seed variance and drops the combination.

`//@ requires: madaros` — the seed suite skips. Madaros jobs must stay green. Not a known-failure: Madaros is supposed to pass. A Madaros "fix" that emits the lean number fails `expect-stdout: OBSERVED …`.

## What this is not

- `madaros_gum_independent_product.sio` already exists and **prints `PASS` on lean with `vprod=0.002500`**. That file is not a pin. This PR does not edit it.
- `madaros_gum_fo_interproc.sio` is the original scale2 split, but it sits in `vacuous_expect_baseline.txt`, so the seed suite already tolerates its FAIL. Left untouched.
- `gum_cross_function.sio` still prints `var(sum)=5` on **both** engines. That is a helper `add_values`. The new add pin is the **inline** peel `variance_of(a + b)`, where lean drops the second channel. Do not collapse the two.

## Census (measured, not copied)

Same class, also Madaros-right / lean-wrong, **not** turned into new tests here:

- `madaros_gum_fo_deep_poly` — Madaros PASS (`D2_a3=0.36`); lean FAIL (`D2_a3=0`)
- `madaros_gum_multichannel_fo` — Madaros PASS (`R1=0.0325`); lean FAIL (`R1=0.0025`)
- `madaros_gum_fo_div_if` — Madaros PASS (`div=0.000401`); lean FAIL (`div=0.0025`)

Different class (codegen, not GUM): `global_array_element_list_ident` — Madaros `7 20 -3` rc=0; lean `7 7 7` rc=2. Already returns 2. Not landed.

Did not touch grok-cli3's kaxi PTX 0/318 work.

## Test plan

- [x] Dual-engine `souc compile` + `\x7fELF` + run on all three
- [x] Madaros: OBSERVED matches GUM, rc=0
- [x] lean_single: OBSERVED matches the lean-wrong column, rc=1
- [x] Harness + `SOUNIO_MADAROS_AVAILABLE=1`: Pass 3
- [x] Harness without the flag: Skip 3
- [ ] CI Madaros changed-tests gate on this PR