### PR TITLE
docs(audit): 46/51 thesis surfaces transitively traverse arity ≥3

### DIFF
--- a/docs/audit/MADAROS_FO_CALL_BOUNDARY_DISPATCH_2026-08-18.md
+++ b/docs/audit/MADAROS_FO_CALL_BOUNDARY_DISPATCH_2026-08-18.md
@@ -165,7 +165,11 @@ What the FO programme itself did when it outgrew 2 — **read, not ported**: it 
 
 ### Does skip → 4 or → 8 cover the dissertation?
 
-**No.**
+**No.** Two layers, both measured:
+
+**Layer A — files that lose variance today (Knowledge / `variance_of` after a call).** After the #1889 inline, `rapamycin_epistemic_adaptive` and `rapamycin_rk4_budget` are LIVE (`FAMILY_A_VAR_LIVE`). `rapamycin_iso_budget` peels `.value` on purpose; Budget64 is the ISO path. `rapamycin_epistemic_pbpk` / `rapamycin_gum_vs_mc` do not call `variance_of`. The only remaining FO-call zero on this slice is `gum_fo_across_call.sio`: **one helper, arity 3**, body nest+`−`+`/`. skip=4 would *admit* it to classification; the classifier still would not register the body. A ceiling bump does not turn that 0 into a live GUM var.
+
+**Layer B — helpers sitting in those files if the model is written as functions again.** In `rapamycin_rk4_budget.sio` the named RHS (called only from the plain finite-diff sim today) are `rhs_brain` **4**, `rhs_periph` **4**, `rhs_blood` **11**. `examples/dissertation_pbpk_rapamycin.sio` has `pbpk_rhs(y0,y1,y2)` arity **3**, but its uncertainty is hand-rolled finite-diff, not `variance_of`. Max arity on the Knowledge-shaped RHS is **11**. skip=8 still skips `rhs_blood`. Even skip=16 would still miss the body (nest / OpSub / OpDiv).
 
 | Thesis helper (Knowledge path vs plain) | Arity | Body | skip=4 | skip=8 |
 |---|---:|---|---|---|
@@ -181,6 +185,36 @@ Census of `fn` with arity > 2 in 41 thesis-ish `tests/run-pass` files (rapamycin
 Today’s thesis **numbers** are live because of inline, not because of the ceiling. If the model is written as functions again: a ceiling of 4 or 8 still misses `rhs_blood` (11) and still misses every body that is not id/scale/add/mul. A small skip bump is **not** a small fix with large thesis value. The large value needs the bytecode path (≤4 then 8 then 16) that the preserved FO programme already named — grok-cli5’s viability triage, not this lane.
 
 Naive lift risk: changing `return lo` to “collect 2 names and classify anyway” would make `id3` look like `id1` (correct) and `add3` look like `add2` (silent **under**-estimate). Worse than an honest 0 if nobody is looking.
+
+## 4c. How many thesis surfaces **traverse** arity ≥ 3 today (not: how many fail)
+
+Measured 2026-08-19 on `origin/main` `91be3a0959`. Method: parse `fn` defs + call sites, BFS from `main`, follow same-file calls **and** resolved `use` imports. A surface counts if any reachable helper has arity ≥ 3. That is **traverse**, not fail — a surface can traverse and still print a plausible number if the lost term is small or if uncertainty is not `variance_of` FO.
+
+Universe: the 51 entries in `TESTS` + `TESTS_SMOKE` of `scripts/ci/dissertation_pbpk_suite_gate.sh`.
+
+Filter “FO-shaped”: arity ≥ 3, not `print*` / `estate_set` / `ode_params_set` / `t_test*` / string params. Printers with 3 args are not the ceiling hole.
+
+| | Count |
+|---|---:|
+| Surfaces in the gate | **51** |
+| Traverse FO-shaped arity ≥ 3 from `main` (**transitive**) | **46** |
+| Do not traverse | **5** |
+
+The five that do **not** traverse: `rapamycin_epistemic_adaptive` (RHS inlined), `dissertation_tirzepatide_demo`, `dissertation_vancomycin_demo`, `halo_pgx_gate_pass`, `rapamycin_kaxi_fuse_prior`.
+
+Max arity reached on a traversing surface: **11** (`rhs_blood` on `rapamycin_rk4_budget`; `mc_auc_sd` on `gum_vs_mc`). Typical stack is tsit5 / BBB / oral runner (4–8).
+
+Re-derive:
+
+```bash
+python3 scripts/dev/thesis_fo_arity_traverse_census.py
+```
+
+**This is not a fail count.** Most of the 46 do not print `variance_of=0` today (Budget64, finite-diff, Knightian, hand-rolled GUM). They still **cross** a helper the FO catalog cannot see. If that helper ever carries peeled Knowledge, the 0 is silent.
+
+**Urgency:** 46/51 is not two surfaces. The bytecode port is not optional before September if any of those call chains is, or becomes, a Knowledge path. Adaptive is the exception (inlined), not the rule.
+
+Limitations of the walker: line comments only; method recv counted in arity; `use` resolved by path heuristic under `stdlib/`; ambiguous callee names flagged, not guessed.
 
 ## 5. What this does to a thesis
 

--- a/scripts/dev/thesis_fo_arity_traverse_census.py
+++ b/scripts/dev/thesis_fo_arity_traverse_census.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Transitive arity>2 helper traverse census for dissertation surfaces.
+
+Counts surfaces that REACH a helper with >=3 parameters from main,
+following same-file calls and resolved `use` imports. Not a fail count.
+
+Limitations (printed at the end):
+- comments stripped line-wise only (`//`), not block comments
+- method calls `recv.foo(` are resolved if a unique fn/method named foo
+  is in the loaded set; ambiguous names are flagged
+- does not expand macros / generated code
+"""
+from __future__ import annotations
+
+import re
+import sys
+from collections import defaultdict, deque
+from pathlib import Path
+
+ROOT = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
+
+# Builtins / runtime — not FO-transfer helpers.
+IGNORE_CALLS = {
+    "print", "println", "print_f64", "print_int", "print_char",
+    "measure", "variance_of", "uncertainty_of", "acknowledge",
+    "require_confidence", "assert", "panic", "abs", "sqrt",
+    "Some", "None", "Ok", "Err", "Box", "Some",
+}
+
+FN_DEF = re.compile(
+    r"^(?:pub(?:\(crate\))?\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\((.*?)\)",
+    re.S | re.M,
+)
+IMPL_FN = re.compile(
+    r"fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\((.*?)\)",
+    re.S,
+)
+USE_LINE = re.compile(
+    r"^use\s+([A-Za-z0-9_:]+)(?:::\{([^}]+)\})?",
+    re.M,
+)
+CALL = re.compile(r"(?<![\w.])([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+
+
+def strip_line_comments(text: str) -> str:
+    out = []
+    for line in text.splitlines():
+        if "//" in line:
+            # keep //@ annotations out of code anyway
+            line = line[: line.find("//")]
+        out.append(line)
+    return "\n".join(out)
+
+
+def arity_of(params: str) -> int:
+    params = params.strip()
+    if not params:
+        return 0
+    # drop nested parens content roughly
+    depth = 0
+    cleaned = []
+    for ch in params:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth = max(0, depth - 1)
+        elif depth == 0:
+            cleaned.append(ch)
+    parts = [p.strip() for p in "".join(cleaned).split(",") if p.strip()]
+    return len(parts)
+
+
+def extract_fns(text: str, path: str) -> dict[str, dict]:
+    code = strip_line_comments(text)
+    fns: dict[str, dict] = {}
+    for m in FN_DEF.finditer(code):
+        name, params = m.group(1), m.group(2)
+        start = m.end()
+        # body: from next { 
+        brace = code.find("{", start)
+        if brace < 0:
+            body = ""
+        else:
+            depth = 0
+            i = brace
+            while i < len(code):
+                if code[i] == "{":
+                    depth += 1
+                elif code[i] == "}":
+                    depth -= 1
+                    if depth == 0:
+                        body = code[brace + 1 : i]
+                        break
+                i += 1
+            else:
+                body = code[brace + 1 :]
+        calls = [c for c in CALL.findall(body) if c != name and c not in IGNORE_CALLS]
+        fns[name] = {
+            "arity": arity_of(params),
+            "calls": calls,
+            "path": path,
+            "params": " ".join(params.split()),
+        }
+    return fns
+
+
+def parse_uses(text: str) -> list[tuple[str, list[str]]]:
+    out = []
+    for m in USE_LINE.finditer(text):
+        prefix, group = m.group(1), m.group(2)
+        if group:
+            names = [n.strip() for n in group.split(",") if n.strip()]
+            out.append((prefix, names))
+        else:
+            # use foo::bar  → last segment is the name
+            names = [prefix.split("::")[-1]]
+            out.append((prefix, names))
+    return out
+
+
+def resolve_module(prefix: str) -> list[Path]:
+    """Map use prefix to candidate files under stdlib/ and examples/."""
+    parts = prefix.split("::")
+    cands = []
+    # stdlib/<parts>.sio or stdlib/<parts>/mod.sio or stdlib/<parts>/lib.sio
+    rel = Path(*parts)
+    for base in (ROOT / "stdlib", ROOT / "examples", ROOT / "tests" / "run-pass"):
+        p = base / rel
+        if p.with_suffix(".sio").is_file():
+            cands.append(p.with_suffix(".sio"))
+        if p.is_dir():
+            for name in ("lib.sio", "mod.sio"):
+                if (p / name).is_file():
+                    cands.append(p / name)
+            cands.extend(sorted(p.glob("*.sio")))
+        # darwin_pbpk lives under stdlib/darwin_pbpk
+        if parts[0] == "epistemic":
+            q = ROOT / "stdlib" / "epistemic" / (parts[-1] + ".sio") if len(parts) > 1 else ROOT / "stdlib" / "epistemic"
+            if q.is_file():
+                cands.append(q)
+            elif q.is_dir():
+                cands.extend(sorted(q.glob("*.sio")))
+    # unique
+    seen = set()
+    uniq = []
+    for c in cands:
+        if c.resolve() not in seen:
+            seen.add(c.resolve())
+            uniq.append(c)
+    return uniq
+
+
+def load_suite() -> list[tuple[str, Path]]:
+    gate = (ROOT / "scripts/ci/dissertation_pbpk_suite_gate.sh").read_text()
+    surfaces = []
+    for arr in ("TESTS", "TESTS_SMOKE"):
+        block = re.search(rf"^{arr}=\((.*?)^\)", gate, re.S | re.M)
+        if not block:
+            continue
+        for line in block.group(1).splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            # "name    path"
+            m = re.match(r'"(\S+)\s+(\S+)"', line)
+            if not m:
+                continue
+            name, rel = m.group(1), m.group(2)
+            p = ROOT / rel
+            if p.is_file():
+                surfaces.append((name, p))
+    return surfaces
+
+
+def main() -> None:
+    surfaces = load_suite()
+    cache: dict[Path, dict[str, dict]] = {}
+
+    def fns_of(path: Path) -> dict[str, dict]:
+        path = path.resolve()
+        if path not in cache:
+            cache[path] = extract_fns(path.read_text(encoding="utf-8", errors="replace"), str(path.relative_to(ROOT)))
+        return cache[path]
+
+    rows = []
+    for sname, spath in surfaces:
+        text = spath.read_text(encoding="utf-8", errors="replace")
+        local = extract_fns(text, str(spath.relative_to(ROOT)))
+        cache[spath.resolve()] = local
+
+        # import resolution: load candidate modules, merge named exports
+        imported: dict[str, dict] = {}
+        unresolved_use = []
+        for prefix, names in parse_uses(text):
+            mods = resolve_module(prefix)
+            if not mods:
+                unresolved_use.append(prefix)
+                continue
+            for n in names:
+                found = None
+                for mod in mods:
+                    fns = fns_of(mod)
+                    if n in fns:
+                        found = fns[n]
+                        break
+                if found:
+                    imported[n] = found
+                else:
+                    unresolved_use.append(f"{prefix}::{n}")
+
+        # universe for lookup: local overrides import
+        universe = dict(imported)
+        universe.update(local)
+
+        if "main" not in local:
+            rows.append((sname, "NO_MAIN", [], unresolved_use, []))
+            continue
+
+        # BFS from main
+        seen = set()
+        q = deque(["main"])
+        reachable = []
+        ambig = []
+        while q:
+            cur = q.popleft()
+            if cur in seen:
+                continue
+            seen.add(cur)
+            info = universe.get(cur)
+            if info is None:
+                continue
+            reachable.append((cur, info))
+            for callee in info["calls"]:
+                if callee in IGNORE_CALLS:
+                    continue
+                if callee in universe:
+                    q.append(callee)
+                else:
+                    # maybe unique across loaded cache?
+                    hits = []
+                    for fns in cache.values():
+                        if callee in fns:
+                            hits.append(fns[callee])
+                    if len(hits) == 1:
+                        universe[callee] = hits[0]
+                        q.append(callee)
+                    elif len(hits) > 1:
+                        ambig.append(callee)
+
+        hot = [(n, i) for n, i in reachable if n != "main" and i["arity"] >= 3]
+        max_a = max((i["arity"] for _, i in hot), default=0)
+        rows.append((sname, "OK", hot, unresolved_use, ambig, max_a, [n for n, _ in reachable if n != "main"]))
+
+    traverse = [r for r in rows if r[1] == "OK" and r[2]]
+    no_trav = [r for r in rows if r[1] == "OK" and not r[2]]
+    no_main = [r for r in rows if r[1] == "NO_MAIN"]
+
+    print(f"ROOT {ROOT}")
+    print(f"SURFACES {len(rows)}  TRAVERSE_ARITY_GE3 {len(traverse)}  NO_TRAVERSE {len(no_trav)}  NO_MAIN {len(no_main)}")
+    print()
+    print("=== TRAVERSE (from main, transitive, arity>=3) ===")
+    for r in sorted(traverse, key=lambda x: -x[5]):
+        sname, _, hot, uses, ambig, max_a, _ = r
+        bits = [f"{n}:{i['arity']}@{i['path']}" for n, i in sorted(hot, key=lambda x: -x[1]["arity"])]
+        print(f"{sname:32} max={max_a:2}  n_hot={len(hot):2}  {', '.join(bits[:8])}" + (" …" if len(bits) > 8 else ""))
+        if uses:
+            print(f"{'':32}  unresolved_use={uses[:6]}")
+        if ambig:
+            print(f"{'':32}  ambiguous_calls={sorted(set(ambig))[:6]}")
+
+    print()
+    print("=== NO TRANSITIVE ARITY>=3 FROM MAIN ===")
+    for r in no_trav:
+        print(f"  {r[0]}")
+
+    print()
+    print("=== NO MAIN ===")
+    for r in no_main:
+        print(f"  {r[0]}")
+
+    print()
+    print("LIMITATIONS: line comments only; method recv counted in arity;")
+    print("import resolve is path-heuristic under stdlib/; ambiguous names flagged.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Founder datum for whether the FO bytecode port is optional before September.

**46 of 51** dissertation-gate surfaces (`TESTS` + `TESTS_SMOKE`) **traverse** a helper with arity ≥ 3 from `main`, **transitively** (same-file calls + resolved `use` imports). That is not a fail count.

Five do not: `rapamycin_epistemic_adaptive` (inlined), `dissertation_tirzepatide_demo`, `dissertation_vancomycin_demo`, `halo_pgx_gate_pass`, `rapamycin_kaxi_fuse_prior`.

Max arity reached: **11** (`rhs_blood`, `mc_auc_sd`).

Method: `python3 scripts/dev/thesis_fo_arity_traverse_census.py` on `origin/main` `91be3a0959`. Not a grep of definitions. A 2-arg helper that calls a 4-arg helper counts.

Most of the 46 do not print `variance_of=0` today (Budget64 / finite-diff / Knightian). They still cross a helper the FO catalog cannot see. If that chain is or becomes a Knowledge path, the 0 is silent.

**46 is not two.** The port is not optional before September.

No `lower.sio`. No skip bump. Import/div port stays grok-cli5.
