### PR TITLE
feat(lean): V2 invKraw client — Knowledge<mg> is usable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -750,6 +750,10 @@ jobs:
       # is the 390-gate class. Written before the step is scored.
       - name: V2 invKraw-Nat consumer (V1 mutant must fail first)
         run: bash scripts/ci/epistemic_measure_correspondence_gate.sh --lean-consume-invkraw
+      # Same ritual at T ≠ Nat. A green Lean Proofs job whose this step
+      # is skipped is the 390-gate class. Written before the step is scored.
+      - name: V2 invKraw-mg consumer (V1 mutant must fail first)
+        run: bash scripts/ci/epistemic_measure_correspondence_gate.sh --lean-consume-invkraw-mg
       - name: Build all default-target proof modules
         run: |
           cd formal/lean4

--- a/docs/audit/epistemic_calculus_spec_divergence/DISPATCH.md
+++ b/docs/audit/epistemic_calculus_spec_divergence/DISPATCH.md
@@ -199,12 +199,12 @@ consumer 3).** One importer ≠ V2 covered. Re-derive with the names in
 `EpistemicEffectsV2.lean` against every `EpistemicEffectsV2_*.lean`
 consumer, comments stripped:
 
-| Layer | After measure | After + kvalue | After + invKraw | Remainder |
-|---|---:|---:|---:|---:|
-| Named theorems (28) | 0 | 1 (`preservation`) | **2** (`+ invKraw`) | 26 |
-| `HasTy` rules (14) | 3 | 4 | **7** (`+ t_var, t_lam, t_app`) | 7 |
-| `Step` rules (19) | 1 | 2 | **2** | 17 |
-| `IsValue` rules (4) | 1 (`v_nat`) | 1 (`v_nat`) | **3** (`+ v_lam, v_kraw`) | 1 (`v_real`) |
+| Layer | After measure | After + kvalue | After + invKraw | After + mg | Remainder |
+|---|---:|---:|---:|---:|---:|
+| Named theorems | 0 | 1 (`preservation`) | **2** (`+ invKraw`) | **2** (same; `invKraw` again) | glue |
+| `HasTy` rules | 3 | 4 | **7** | **8** (`+ t_lit_mg`; now 15) | 7 |
+| `Step` rules (19) | 1 | 2 | **2** | **2** | 17 |
+| `IsValue` rules | 1 (`v_nat`) | 1 | **3** | **4** (`+ v_mg`; now 5) | 1 (`v_real`) |
 
 kvalue did **not** move `IsValue`. invKraw on the propagation witness
 does: the identity is `v_lam` and the reduct used as a CBV argument is
@@ -251,36 +251,51 @@ operation is either consumed or classified as a hole/glue.
 |---|---|---|---|
 | Introduce (`measure` / ctor) | `ty_knowledge(v_ty)` | Yes — V1 discards `v` | Consumed (round 1) |
 | Eliminate payload | `check_knowledge_unwrap` | Yes — V1 → `lit_real` | Consumed (round 2) |
-| Use as `Knowledge<T>` | pass / apply / let | Yes — V1 existential | Consumed (round 3) |
+| Use as `Knowledge<T>` | pass / apply / let | Yes — V1 existential | Consumed (round 3); T≠Nat in round 4 |
 | Eliminate metadata | `.epsilon` / `.confidence` | No — both → `Real` | Do not consume |
 | GUM `+` `*` | `ty_knowledge(left_inner, …)` | Hole — V2 pins Real, checker keeps `T` | Do not consume; see R3-adjacent |
 | Progress, weakening, lookup, shift, `int_sq_nonneg`, `gAddMeta_valid` | none | Glue | Do not consume |
 
-**Conclusion — discriminating set empty.** Fraction beside it:
-**2/28** theorems, **7/14** `HasTy`, **2/19** `Step`, **3/4**
-`IsValue`. Read 2/28 without that sentence and it looks like 93% is
-missing. The other 26 theorems are ones any implementation would
-satisfy. They do not separate V2 from V1. Three consumers exhausted
-the surfaces that do. This is a stop by measurement, not by fatigue,
-and it is not "V2 is covered": it is "the next Nat-shaped client
-would not discriminate".
+**Conclusion after rounds 1–3 — discriminating set empty at Nat.**
+Fraction beside it was **2/28** theorems, **7/14** `HasTy`,
+**2/19** `Step`, **3/4** `IsValue`. Read 2/28 without that sentence
+and it looks like 93% is missing. The other theorems are ones any
+implementation would satisfy. They do not separate V2 from V1.
+Three consumers exhausted the Nat-shaped surfaces that do.
 
-**What would make the discriminating set non-empty again.** Not a
-fourth `Knowledge<Nat>` consumer. Either:
+**What reopened the set (round 4, landed).** Not a fourth
+`Knowledge<Nat>` consumer. The second reopening clause: a client
+that uses `Knowledge` at a type other than Nat. The checker is
+generic (`ty_knowledge(v_ty)`). We had only consumed Nat. The
+payload the language ships is `Knowledge<mg>`.
+`EpistemicEffectsV2_invkraw_mg.lean` cites `invKraw` on
+`kraw (.lit_mg 500) m`. `tmg` was added to the shared `Ty` spine
+so the V1 mutant can write `Knowledge<mg>` and still fail because
+`t_kraw` pins Real, not because `tmg` is missing. `lit_mg` /
+`t_lit_mg` / `v_mg` are the V2 intro; they are new constructors,
+not new discriminating *reasons*. The unique named-theorem count
+stays 2 (`preservation`, `invKraw`).
+
+Do **not** clone measure or unwrap at mg. Those V1 mutants would
+fail for the same Real pin already scored at Nat. That would be
+the 93%-left mistake at the type-instance level.
+
+**What would make the discriminating set non-empty again.** Not
+another unit literal (`Knowledge<kg>`, `Knowledge<L>`). Either:
 
 1. A **new proposition in V2** whose V1 mutant fails for a
    payload/Real reason (a new rule, a new inversion, a new
    operational clause). Glue added tomorrow is still glue.
-2. A **client that uses `Knowledge` at a type other than Nat.**
-   The checker is generic (`ty_knowledge(v_ty)`). We only consumed
-   Nat. That second case is the next round, and it already has a
-   name: `Knowledge<T>` for `T ≠ Nat` — the inverted V1 witness at a
-   payload the language actually ships (a unit type in the spec,
-   `Knowledge<mg>`, not another literal `0 : Nat`).
+   `genMg` is glue for the new literal.
+2. A correspondence close of the GUM hole (`t_kadd` pins Real;
+   the checker keeps `T`) — that is R3-adjacent, not a consumer.
 
 Until one of those appears, do not add a consumer. If a proposed
 client's V1 mutant elaborates, that is the signal to stop, not to
-weaken the mutant.
+weaken the mutant. `tmg` on the shared spine is not spine
+extraction: V2 still imports `Ty` from the refuted module.
+The three extraction triggers in the deferred note below have
+not fired.
 
 **Landed (consumer 3).** `EpistemicEffectsV2_invkraw_nat.lean` cites
 `invKraw` and proves `kraw_nat_inverts_and_is_usable`. The
@@ -306,6 +321,32 @@ A job whose this step is skipped is the 390-gate class. The #1892 /
 #1883 verifications do not transfer: those heads did not have this
 step. If the invKraw mutant elaborates, the consumer must not be
 scored.
+
+**Landed (consumer 4).** `EpistemicEffectsV2_invkraw_mg.lean` cites
+`invKraw` at `Knowledge<mg>` and proves `kraw_mg_inverts_and_is_usable`.
+The `--lean-consume-invkraw-mg` arm builds that module only after
+`v1_imports_invkraw_mg.lean` fails.
+
+**Acceptance for the named invKraw-mg step (written before the step
+is scored).** A green Lean Proofs *job* is not evidence. The PR
+head must show this step as `success` and not `skipped`:
+
+```
+success  V2 invKraw-mg consumer (V1 mutant must fail first)
+```
+
+and that step's log must contain:
+
+```
+POSITIVE_CONTROL_FIRED: v1_imports_invkraw_mg rejected
+V2_CONSUMED: EpistemicEffectsV2_invkraw_mg built
+```
+
+and the mutant rejection must mention `Knowledge` / `tmg` / `treal`
+(payload/Real), not an unknown identifier `tmg`. A job whose this
+step is skipped is the 390-gate class. The #1909 / #1892 / #1883
+verifications do not transfer: those heads did not have this step.
+If the mg mutant elaborates, the consumer must not be scored.
 
 **Deferred — extract the shared spine (end condition).** A third
 module holding `Effect`, `Ty`, `EffectSet`, `TyCtx` would stop V2 from
@@ -392,15 +433,19 @@ consume `kadd` as if it were the next coverage target.
 1. R1 and R2 landed. R3 recorded and explicitly deferred, not silently dropped.
    R1's remaining *fact* (V2 had no importer) is closed by
    `EpistemicEffectsV2_measure_nat.lean`, not by the banner. That close is
-   an import edge, not metatheory coverage. After consumer 3 the
-   fraction is **2 of 28** named theorems (`preservation`, `invKraw`),
-   **7 of 14** `HasTy`, **2 of 19** `Step`, **3 of 4** `IsValue`.
-   The discriminating set in §5 R1 is empty (2/28 is not "93% left").
-   It re-opens only on a new V2 proposition or a `Knowledge<T>` client
-   with `T ≠ Nat`. Spine extraction stays deferred until one of the
-   three end conditions in §5 R1 — none has fired.
+   an import edge, not metatheory coverage. After consumer 4 the
+   cited named theorems are still **2** (`preservation`, `invKraw` —
+   the mg client re-cites `invKraw`, it does not add a third name),
+   **8 of 15** `HasTy` (`+ t_lit_mg`), **2 of 19** `Step`,
+   **4 of 5** `IsValue` (`+ v_mg`). The Nat-shaped discriminating
+   set stayed empty; the `T ≠ Nat` hole closed at `Knowledge<mg>`.
+   It re-opens only on a new V2 proposition or the GUM
+   correspondence hole (R3-adjacent). Spine extraction stays
+   deferred until one of the three end conditions in §5 R1 — none
+   has fired. Adding `tmg` to the shared `Ty` is not extraction.
 2. `Lean Proofs` green, with V1, V2, `EpistemicEffectsV2_measure_nat`,
-   `EpistemicEffectsV2_kvalue_nat`, and `EpistemicEffectsV2_invkraw_nat`
+   `EpistemicEffectsV2_kvalue_nat`, `EpistemicEffectsV2_invkraw_nat`,
+   and `EpistemicEffectsV2_invkraw_mg`
    all `@[default_target]`. Deleting
    V1 to make the problem disappear is **out of scope** — the refutation
    is a result worth keeping, and §1's theorems are its statement.

--- a/formal/lean4/EpistemicEffects.lean
+++ b/formal/lean4/EpistemicEffects.lean
@@ -125,10 +125,13 @@ theorem union_sub {a b c : EffectSet} (h₁ : a ⊆ₑ c) (h₂ : b ⊆ₑ c) :
 -- ================================================================
 
 /-- Object types. `tknow` wraps a base type with a GUM/confidence cell;
-    `tarrow` carries the callee's latent effects on the arrow. -/
+    `tarrow` carries the callee's latent effects on the arrow.
+    `tmg` is the milligram unit the language ships (`Knowledge<mg>`).
+    This calculus still cannot inhabit it: `t_kraw` pins `Real`. -/
 inductive Ty where
   | tnat
   | treal
+  | tmg
   | tknow  : Ty → Ty
   | tarrow : Ty → EffectSet → Ty → Ty
 

--- a/formal/lean4/EpistemicEffectsV2.lean
+++ b/formal/lean4/EpistemicEffectsV2.lean
@@ -36,6 +36,7 @@ def kvalid (m : KMeta) : Prop := 0 ≤ m.gumVar ∧ 0 ≤ m.conf ∧ m.conf ≤ 
 inductive Expr where
   | lit_nat  : Nat → Expr
   | lit_real : Int → Expr
+  | lit_mg   : Int → Expr    -- milligram quantity; integer scale, like lit_real
   | var      : Nat → Expr
   | lam      : Ty → EffectSet → Expr → Expr
   | app      : Expr → Expr → Expr
@@ -52,6 +53,7 @@ inductive Expr where
 inductive IsValue : Expr → Prop where
   | v_nat   : ∀ n, IsValue (.lit_nat n)
   | v_real  : ∀ z, IsValue (.lit_real z)
+  | v_mg    : ∀ z, IsValue (.lit_mg z)
   | v_lam   : ∀ T E e, IsValue (.lam T E e)
   | v_kraw  : ∀ {v} m, IsValue v → IsValue (.kraw v m)
 
@@ -59,6 +61,7 @@ inductive IsValue : Expr → Prop where
 inductive HasTy : TyCtx → Expr → Ty → EffectSet → Prop where
   | t_lit_nat  : ∀ Γ n, HasTy Γ (.lit_nat n) .tnat emptyE
   | t_lit_real : ∀ Γ z, HasTy Γ (.lit_real z) .treal emptyE
+  | t_lit_mg   : ∀ Γ z, HasTy Γ (.lit_mg z) .tmg emptyE
   | t_var      : ∀ Γ n T, lookupCtx Γ n = some T → HasTy Γ (.var n) T emptyE
   | t_lam      : ∀ Γ T₁ T₂ E body,
       HasTy (T₁ :: Γ) body T₂ E → HasTy Γ (.lam T₁ E body) (.tarrow T₁ E T₂) emptyE
@@ -104,6 +107,7 @@ def shift (cutoff : Nat) (d : Int) : Expr → Expr
         | .negSucc dn => .var (k - (dn + 1))
   | .lit_nat n => .lit_nat n
   | .lit_real z => .lit_real z
+  | .lit_mg z => .lit_mg z
   | .lam T E b => .lam T E (shift (cutoff + 1) d b)
   | .app f a => .app (shift cutoff d f) (shift cutoff d a)
   | .measure e m => .measure (shift cutoff d e) m
@@ -119,6 +123,7 @@ def subst (n : Nat) (w : Expr) : Expr → Expr
   | .var k => if k = n then w else if k > n then .var (k - 1) else .var k
   | .lit_nat m => .lit_nat m
   | .lit_real z => .lit_real z
+  | .lit_mg z => .lit_mg z
   | .lam T E b => .lam T E (subst (n + 1) (shift 0 1 w) b)
   | .app f a => .app (subst n w f) (subst n w a)
   | .measure e m => .measure (subst n w e) m
@@ -172,6 +177,12 @@ theorem genReal {Γ e T E} (h : HasTy Γ e T E) {z} (he : e = .lit_real z) : T =
   | t_sub _ _ _ _ _ _ _ ih => exact ih he
   | _ => exact Expr.noConfusion he
 
+theorem genMg {Γ e T E} (h : HasTy Γ e T E) {z} (he : e = .lit_mg z) : T = .tmg := by
+  induction h with
+  | t_lit_mg => rfl
+  | t_sub _ _ _ _ _ _ _ ih => exact ih he
+  | _ => exact Expr.noConfusion he
+
 theorem genLam {Γ e T E S F b} (h : HasTy Γ e T E) (he : e = .lam S F b) :
     ∃ T₂, T = .tarrow S F T₂ := by
   induction h with
@@ -201,6 +212,7 @@ theorem canon_arrow {v S F T₂ E} (hv : IsValue v) (ht : HasTy [] v (.tarrow S 
   cases hv with
   | v_nat n  => exact Ty.noConfusion (genNat ht rfl)
   | v_real z => exact Ty.noConfusion (genReal ht rfl)
+  | v_mg z => exact Ty.noConfusion (genMg ht rfl)
   | v_lam T E0 e0 => exact ⟨T, E0, e0, rfl⟩
   | @v_kraw w m hp => rcases genKraw ht rfl with ⟨T', hT⟩; exact Ty.noConfusion hT
 
@@ -210,6 +222,7 @@ theorem canon_know {v T E} (hv : IsValue v) (ht : HasTy [] v (.tknow T) E) :
   | @v_kraw w m hp => exact ⟨w, m, rfl⟩
   | v_nat n  => exact Ty.noConfusion (genNat ht rfl)
   | v_real z => exact Ty.noConfusion (genReal ht rfl)
+  | v_mg z => exact Ty.noConfusion (genMg ht rfl)
   | v_lam T0 E0 e0 => rcases genLam ht rfl with ⟨T₂, hT⟩; exact Ty.noConfusion hT
 
 theorem canon_real {v E} (hv : IsValue v) (ht : HasTy [] v .treal E) :
@@ -217,6 +230,7 @@ theorem canon_real {v E} (hv : IsValue v) (ht : HasTy [] v .treal E) :
   cases hv with
   | v_real z => exact ⟨z, rfl⟩
   | v_nat n  => exact Ty.noConfusion (genNat ht rfl)
+  | v_mg z => exact Ty.noConfusion (genMg ht rfl)
   | v_lam T0 E0 e0 => rcases genLam ht rfl with ⟨T₂, hT⟩; exact Ty.noConfusion hT
   | @v_kraw w m hp => rcases genKraw ht rfl with ⟨T', hT⟩; exact Ty.noConfusion hT
 
@@ -225,6 +239,7 @@ theorem progress' {Γ e T E} (h : HasTy Γ e T E) (hΓ : Γ = []) :
   induction h with
   | t_lit_nat Γ n => exact Or.inl (.v_nat n)
   | t_lit_real Γ z => exact Or.inl (.v_real z)
+  | t_lit_mg Γ z => exact Or.inl (.v_mg z)
   | t_var Γ n T hlk => subst hΓ; simp [lookupCtx] at hlk
   | t_lam Γ T₁ T₂ E body _ => exact Or.inl (.v_lam _ _ _)
   | t_app Γ T₁ T₂ Ef Ec Ecaller f a hf ha _ _ ihf iha =>
@@ -310,6 +325,7 @@ theorem shift_value {v} (hv : IsValue v) : ∀ c d, IsValue (shift c d v) := by
   induction hv with
   | v_nat n => intro c d; exact .v_nat n
   | v_real z => intro c d; exact .v_real z
+  | v_mg z => intro c d; exact .v_mg z
   | v_lam T E e => intro c d; exact .v_lam _ _ _
   | v_kraw m hp ih => intro c d; exact .v_kraw m (ih c d)
 
@@ -317,6 +333,7 @@ theorem subst_value {w} (hw : IsValue w) : ∀ n u, IsValue (subst n u w) := by
   induction hw with
   | v_nat n => intro n' u; exact .v_nat n
   | v_real z => intro n' u; exact .v_real z
+  | v_mg z => intro n' u; exact .v_mg z
   | v_lam T E e => intro n' u; exact .v_lam _ _ _
   | v_kraw m hp ih => intro n' u; exact .v_kraw m (ih n' u)
 
@@ -367,6 +384,7 @@ theorem wellScoped {Γ e T E} (h : HasTy Γ e T E) :
   induction h with
   | t_lit_nat => intro c d _; rfl
   | t_lit_real => intro c d _; rfl
+  | t_lit_mg => intro c d _; rfl
   | t_var Γ n T hlk =>
     intro c d hc
     have hn : n < Γ.length := lookup_some_lt hlk
@@ -422,6 +440,7 @@ theorem weakening {Γ e T E} (h : HasTy Γ e T E) :
   induction h with
   | t_lit_nat Γ n => intro k τ; exact .t_lit_nat _ _
   | t_lit_real Γ z => intro k τ; exact .t_lit_real _ _
+  | t_lit_mg Γ z => intro k τ; exact .t_lit_mg _ _
   | t_var Γ n T hlk =>
     intro k τ
     by_cases hnk : n < k
@@ -496,6 +515,7 @@ theorem value_emptyE {Γ v T E} (hv : IsValue v) (h : HasTy Γ v T E) :
   cases hv with
   | v_nat n => rw [genNat h rfl]; exact .t_lit_nat _ _
   | v_real z => rw [genReal h rfl]; exact .t_lit_real _ _
+  | v_mg z => rw [genMg h rfl]; exact .t_lit_mg _ _
   | v_lam S F b => rcases invLam h rfl with ⟨T₂, hT, hb⟩; subst hT; exact .t_lam _ _ _ _ _ hb
   | @v_kraw w m hp =>
     rcases invKraw h rfl with ⟨T', hT, hwty, hwval, hk⟩; subst hT
@@ -506,6 +526,7 @@ theorem substClosed {v σ} (hv : HasTy [] v σ emptyE) {Γ0 e T E} (h : HasTy Γ
   induction h with
   | t_lit_nat Γ' n => intro Δ hΓ; exact .t_lit_nat _ _
   | t_lit_real Γ' z => intro Δ hΓ; exact .t_lit_real _ _
+  | t_lit_mg Γ' z => intro Δ hΓ; exact .t_lit_mg _ _
   | t_var Γ' n T' hlk =>
     intro Δ hΓ; subst hΓ
     by_cases h1 : n = Δ.length
@@ -561,6 +582,7 @@ theorem preservation' {Γ e T E} (h : HasTy Γ e T E) :
   induction h with
   | t_lit_nat Γ n => intro e' hs hΓ; cases hs
   | t_lit_real Γ z => intro e' hs hΓ; cases hs
+  | t_lit_mg Γ z => intro e' hs hΓ; cases hs
   | t_var Γ n T hlk => intro e' hs hΓ; cases hs
   | t_lam Γ T₁ T₂ E body _ => intro e' hs hΓ; cases hs
   | t_app Γ T₁ T₂ Ef Ec Ecaller f a hf ha hEf hEc ihf iha =>

--- a/formal/lean4/EpistemicEffectsV2_invkraw_mg.lean
+++ b/formal/lean4/EpistemicEffectsV2_invkraw_mg.lean
@@ -1,0 +1,66 @@
+import EpistemicEffectsV2
+
+/-!
+# V2 consumer — `invKraw` at `Knowledge<mg>`
+
+Consumers 1–3 used `Knowledge<Nat>`. The checker is generic
+(`ty_knowledge(v_ty)`); Nat was the only payload we consumed. V1's
+second refutation (`effect_preservation_existential_is_false`) is
+payload-blind: `f (kraw _)` with `f : Knowledge<T> → Knowledge<T>`
+is untypable for any `T ≠ Real`. The language actually ships a unit
+payload — `let m: Knowledge<mg> = measure(500.0, uncertainty: 2.5)`.
+
+This file cites `invKraw` on that payload. `tmg` lives on the shared
+`Ty` spine so a V1 mutant can write `Knowledge<mg>` and still fail
+for the Real pin, not a missing constructor. The instance is the
+identity applied to `kraw (.lit_mg 500) m`. The statement cannot
+be proved under `import EpistemicEffects` — the fixture
+`scripts/ci/fixtures/epistemic_measure_correspondence/v1_imports_invkraw_mg.lean`
+is that attempt, and must fail.
+
+This is not a fourth Nat-shaped client. It does not clone measure
+or unwrap at mg: those would fail in V1 for the same Real pin
+already scored. It closes the "T is only Nat" hole.
+
+No `sorry`. No `axiom`. No Mathlib.
+-/
+
+namespace Sounio.EpistemicEffectsV2
+
+open Sounio.EpistemicEffects (emptyE lookupCtx emptyE_sub subE_refl)
+
+def idKnowMg : Expr := .lam (.tknow .tmg) emptyE (.var 0)
+
+theorem id_know_mg_typed :
+    HasTy [] idKnowMg (.tarrow (.tknow .tmg) emptyE (.tknow .tmg)) emptyE :=
+  .t_lam _ _ _ _ _ (.t_var _ _ _ (by simp [lookupCtx]))
+
+theorem kraw_mg_typed (m : KMeta) (hm : kvalid m) :
+    HasTy [] (.kraw (.lit_mg 500) m) (.tknow .tmg) emptyE :=
+  .t_kraw _ _ _ _ (.t_lit_mg _ _) (.v_mg 500) hm
+
+theorem id_know_mg_is_value : IsValue idKnowMg :=
+  .v_lam _ _ _
+
+theorem kraw_mg_is_value (m : KMeta) :
+    IsValue (.kraw (.lit_mg 500) m) :=
+  .v_kraw m (.v_mg 500)
+
+/-- Cites `invKraw`. The payload of `kraw (.lit_mg 500) m` is `mg`,
+    and the identity applied to that value is typed `Knowledge<mg>`. -/
+theorem kraw_mg_inverts_and_is_usable
+    (m : KMeta) (hm : kvalid m) :
+    HasTy [] (.app idKnowMg (.kraw (.lit_mg 500) m)) (.tknow .tmg) emptyE
+    ∧ IsValue idKnowMg
+    ∧ IsValue (.kraw (.lit_mg 500) m)
+    ∧ (∃ T', T' = .tmg ∧ HasTy [] (.lit_mg 500) T' emptyE
+        ∧ IsValue (.lit_mg 500)) := by
+  have hk := kraw_mg_typed m hm
+  rcases invKraw hk rfl with ⟨T', hT, hv, hval, _⟩
+  injection hT with hTeq
+  subst hTeq
+  refine ⟨?app, id_know_mg_is_value, kraw_mg_is_value m,
+    ⟨.tmg, rfl, hv, hval⟩⟩
+  exact .t_app _ _ _ _ _ _ _ _ id_know_mg_typed hk (emptyE_sub _) (subE_refl _)
+
+end Sounio.EpistemicEffectsV2

--- a/formal/lean4/lakefile.lean
+++ b/formal/lean4/lakefile.lean
@@ -657,6 +657,11 @@ lean_lib «EpistemicEffectsV2_kvalue_nat» where
 @[default_target]
 lean_lib «EpistemicEffectsV2_invkraw_nat» where
 
+-- Fourth V2 importer: the inverted V1 witness at a payload the language
+-- ships. `f (kraw mg)` with `f : Knowledge<mg> → Knowledge<mg>` is typable.
+@[default_target]
+lean_lib «EpistemicEffectsV2_invkraw_mg» where
+
 -- Refusal as a first-class compilation outcome (E219 / P0-F). A well-typed
 -- program in the extern-call fragment produces a value or refuses; it never
 -- fabricates a zero. Models the historical stub-to-zero backend as a second

--- a/scripts/ci/epistemic_measure_correspondence_gate.sh
+++ b/scripts/ci/epistemic_measure_correspondence_gate.sh
@@ -15,11 +15,14 @@ KVALUE_CONSUMER_SOURCE="formal/lean4/EpistemicEffectsV2_kvalue_nat.lean"
 KVALUE_V1_MUTANT="scripts/ci/fixtures/epistemic_measure_correspondence/v1_imports_kvalue_nat.lean"
 INKRAW_CONSUMER_SOURCE="formal/lean4/EpistemicEffectsV2_invkraw_nat.lean"
 INKRAW_V1_MUTANT="scripts/ci/fixtures/epistemic_measure_correspondence/v1_imports_invkraw_nat.lean"
+INKRAW_MG_CONSUMER_SOURCE="formal/lean4/EpistemicEffectsV2_invkraw_mg.lean"
+INKRAW_MG_V1_MUTANT="scripts/ci/fixtures/epistemic_measure_correspondence/v1_imports_invkraw_mg.lean"
 ARTIFACT="${TMPDIR:-/tmp}/epistemic_measure_correspondence_gate.v1.json"
 RUN_POSITIVE_CONTROLS=1
 LEAN_CONSUME=0
 LEAN_CONSUME_KVALUE=0
 LEAN_CONSUME_INKRAW=0
+LEAN_CONSUME_INKRAW_MG=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -30,6 +33,7 @@ while [[ $# -gt 0 ]]; do
     --lean-consume) LEAN_CONSUME=1; shift ;;
     --lean-consume-kvalue) LEAN_CONSUME_KVALUE=1; shift ;;
     --lean-consume-invkraw) LEAN_CONSUME_INKRAW=1; shift ;;
+    --lean-consume-invkraw-mg) LEAN_CONSUME_INKRAW_MG=1; shift ;;
     *) echo "epistemic_measure_correspondence_gate: unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -312,6 +316,66 @@ run_lean_consume_invkraw() {
   echo "[epistemic-correspondence] V2_CONSUMED: EpistemicEffectsV2_invkraw_nat built"
 }
 
+run_lean_consume_invkraw_mg() {
+  local lean_dir="$ROOT_DIR/formal/lean4"
+  if ! command -v lake >/dev/null 2>&1; then
+    TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
+    record_failure "lake_missing"
+    return
+  fi
+
+  check_grep "invkraw_mg_consumer_imports_v2" \
+    '^import EpistemicEffectsV2$' "$INKRAW_MG_CONSUMER_SOURCE"
+  check_absent "invkraw_mg_consumer_must_not_import_v1_directly" \
+    '^import EpistemicEffects$' "$INKRAW_MG_CONSUMER_SOURCE"
+  check_grep "invkraw_mg_consumer_cites_invKraw" \
+    'invKraw hk rfl' "$INKRAW_MG_CONSUMER_SOURCE"
+  check_grep "invkraw_mg_consumer_names_the_propagation_witness" \
+    '^theorem kraw_mg_inverts_and_is_usable$' "$INKRAW_MG_CONSUMER_SOURCE"
+  check_grep "invkraw_mg_consumer_uses_tmg" \
+    '\.tknow \.tmg' "$INKRAW_MG_CONSUMER_SOURCE"
+  check_grep "invkraw_mg_v1_mutant_imports_v1" \
+    '^import EpistemicEffects$' "$INKRAW_MG_V1_MUTANT"
+  check_absent "invkraw_mg_v1_mutant_must_not_import_v2" \
+    '^import EpistemicEffectsV2$' "$INKRAW_MG_V1_MUTANT"
+  check_grep "invkraw_mg_v1_mutant_attempts_the_same_theorem" \
+    '^theorem kraw_mg_inverts_and_is_usable$' "$INKRAW_MG_V1_MUTANT"
+  check_grep "invkraw_mg_v1_mutant_uses_tmg" \
+    '\.tknow \.tmg' "$INKRAW_MG_V1_MUTANT"
+
+  if ! (cd "$lean_dir" && lake build EpistemicEffects) \
+      >"$WORK/lake-v1-invkraw-mg.log" 2>&1; then
+    TOTAL=$((TOTAL + 1)); FAILED=$((FAILED + 1))
+    record_failure "lake_build_v1_failed"
+    sed 's/^/[lake-v1] /' "$WORK/lake-v1-invkraw-mg.log" >&2
+    return
+  fi
+
+  # Arm 3 FIRST. If this mutant elaborates, arm 2 is measuring mention.
+  TOTAL=$((TOTAL + 1))
+  if (cd "$lean_dir" && lake env lean "$ROOT_DIR/$INKRAW_MG_V1_MUTANT") \
+      >"$WORK/v1-invkraw-mg-mutant.log" 2>&1; then
+    FAILED=$((FAILED + 1))
+    record_failure "positive_control_v1_import_invkraw_mg_was_not_rejected"
+    sed 's/^/[v1-invkraw-mg-mutant] /' "$WORK/v1-invkraw-mg-mutant.log" >&2
+    return
+  fi
+  PASSED=$((PASSED + 1))
+  echo "[epistemic-correspondence] POSITIVE_CONTROL_FIRED: v1_imports_invkraw_mg rejected"
+  sed 's/^/[v1-invkraw-mg-mutant] /' "$WORK/v1-invkraw-mg-mutant.log"
+
+  TOTAL=$((TOTAL + 1))
+  if ! (cd "$lean_dir" && lake build EpistemicEffectsV2_invkraw_mg) \
+      >"$WORK/lake-invkraw-mg-consumer.log" 2>&1; then
+    FAILED=$((FAILED + 1))
+    record_failure "v2_invkraw_mg_consumer_failed_to_build"
+    sed 's/^/[lake-invkraw-mg-consumer] /' "$WORK/lake-invkraw-mg-consumer.log" >&2
+    return
+  fi
+  PASSED=$((PASSED + 1))
+  echo "[epistemic-correspondence] V2_CONSUMED: EpistemicEffectsV2_invkraw_mg built"
+}
+
 if [[ "$LEAN_CONSUME" -eq 1 ]]; then
   if [[ ! -f "$CONSUMER_SOURCE" ]]; then
     TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
@@ -340,7 +404,7 @@ if [[ "$LEAN_CONSUME_KVALUE" -eq 1 && "$LEAN_CONSUME" -eq 0 ]]; then
   fi
 fi
 
-if [[ "$LEAN_CONSUME_INKRAW" -eq 1 && "$LEAN_CONSUME" -eq 0 && "$LEAN_CONSUME_KVALUE" -eq 0 ]]; then
+if [[ "$LEAN_CONSUME_INKRAW" -eq 1 && "$LEAN_CONSUME" -eq 0 && "$LEAN_CONSUME_KVALUE" -eq 0 && "$LEAN_CONSUME_INKRAW_MG" -eq 0 ]]; then
   if [[ ! -f "$INKRAW_CONSUMER_SOURCE" ]]; then
     TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
     record_failure "invkraw_consumer_source_missing:$INKRAW_CONSUMER_SOURCE"
@@ -354,7 +418,21 @@ if [[ "$LEAN_CONSUME_INKRAW" -eq 1 && "$LEAN_CONSUME" -eq 0 && "$LEAN_CONSUME_KV
   fi
 fi
 
-if [[ "$RUN_POSITIVE_CONTROLS" -eq 1 && "$NOT_RUN" -eq 0 && "$LEAN_CONSUME" -eq 0 && "$LEAN_CONSUME_KVALUE" -eq 0 && "$LEAN_CONSUME_INKRAW" -eq 0 ]]; then
+if [[ "$LEAN_CONSUME_INKRAW_MG" -eq 1 && "$LEAN_CONSUME" -eq 0 && "$LEAN_CONSUME_KVALUE" -eq 0 && "$LEAN_CONSUME_INKRAW" -eq 0 ]]; then
+  if [[ ! -f "$INKRAW_MG_CONSUMER_SOURCE" ]]; then
+    TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
+    record_failure "invkraw_mg_consumer_source_missing:$INKRAW_MG_CONSUMER_SOURCE"
+  fi
+  if [[ ! -f "$INKRAW_MG_V1_MUTANT" ]]; then
+    TOTAL=$((TOTAL + 1)); NOT_RUN=$((NOT_RUN + 1))
+    record_failure "invkraw_mg_v1_mutant_missing:$INKRAW_MG_V1_MUTANT"
+  fi
+  if [[ "$NOT_RUN" -eq 0 ]]; then
+    run_lean_consume_invkraw_mg
+  fi
+fi
+
+if [[ "$RUN_POSITIVE_CONTROLS" -eq 1 && "$NOT_RUN" -eq 0 && "$LEAN_CONSUME" -eq 0 && "$LEAN_CONSUME_KVALUE" -eq 0 && "$LEAN_CONSUME_INKRAW" -eq 0 && "$LEAN_CONSUME_INKRAW_MG" -eq 0 ]]; then
   CHECKER_MUTANT="scripts/ci/fixtures/epistemic_measure_correspondence/checker_fixed_f64.sio"
   MODEL_MUTANT="scripts/ci/fixtures/epistemic_measure_correspondence/model_fixed_treal.lean"
 

--- a/scripts/ci/fixtures/epistemic_measure_correspondence/v1_imports_invkraw_mg.lean
+++ b/scripts/ci/fixtures/epistemic_measure_correspondence/v1_imports_invkraw_mg.lean
@@ -1,0 +1,29 @@
+import EpistemicEffects
+open Sounio.EpistemicEffects
+
+/-
+  Positive control for the V2 `invKraw` consumer at `Knowledge<mg>`.
+  Same theorem name as `EpistemicEffectsV2_invkraw_mg.lean`, written
+  against the *refuted* calculus. `tmg` exists on the shared `Ty`
+  spine so this file does not fail by a missing constructor. V1's
+  `kraw` has no payload slot, so `t_kraw` types every cell at
+  `Knowledge<Real>` and `f (kraw k)` with
+  `f : Knowledge<mg> → Knowledge<mg>` cannot elaborate — `t_app`
+  wants `Knowledge<mg>`, `t_kraw` supplies `Knowledge<Real>`.
+  If `lake env lean` on this file exits 0, the consumer arm is
+  measuring mention, not use, and must not be added.
+-/
+
+theorem kraw_mg_inverts_and_is_usable
+    (k : KCell) (hk : kvalid k) :
+    HasTy [] (.app (.lam (.tknow .tmg) emptyE (.var 0)) (.kraw k))
+            (.tknow .tmg) emptyE
+    ∧ IsValue (.lam (.tknow .tmg) emptyE (.var 0))
+    ∧ (∃ T' : Ty, T' = Ty.tmg) :=
+  ⟨.t_app _ _ _ _ _ _ _ _
+      (.t_lam _ _ _ _ _ (.t_var _ _ _ (by simp [lookupCtx])))
+      (.t_kraw _ _ hk)
+      (emptyE_sub _)
+      (subE_refl _),
+   .v_lam _ _ _,
+   ⟨Ty.tmg, rfl⟩⟩


### PR DESCRIPTION
## Summary

- The Nat-shaped discriminating set was empty after #1923. This reopens it at `T ≠ Nat`: the inverted V1 witness at a payload the language ships (`Knowledge<mg>`), not another `0 : Nat`.
- `tmg` is on the shared `Ty` spine so the V1 mutant can write `Knowledge<mg>` and still fail because `t_kraw` pins Real (`Ty.treal.tknow` vs `Ty.tmg.tknow`), not because `tmg` is missing.
- `EpistemicEffectsV2_invkraw_mg.lean` cites `invKraw` on `kraw (.lit_mg 500) m`. Named CI step `V2 invKraw-mg consumer (V1 mutant must fail first)` → `--lean-consume-invkraw-mg`. Do not clone measure/unwrap at mg — same Real pin already scored.

A green Lean Proofs *job* is not evidence. This head must show:

```
success  V2 invKraw-mg consumer (V1 mutant must fail first)
```

and that step's log must contain:

```
POSITIVE_CONTROL_FIRED: v1_imports_invkraw_mg rejected
V2_CONSUMED: EpistemicEffectsV2_invkraw_mg built
```

Local gate on this head: `status=pass total=24 passed=24`. Mutant error is `Ty.treal.tknow` expected `Ty.tmg.tknow`.

## Test plan

- [ ] Named step `V2 invKraw-mg consumer (V1 mutant must fail first)` is **success**, not skipped, on this head
- [ ] Step log contains both `POSITIVE_CONTROL_FIRED: v1_imports_invkraw_mg rejected` and `V2_CONSUMED: EpistemicEffectsV2_invkraw_mg built`
- [ ] Mutant rejection mentions `tmg` / `treal` (payload/Real), not an unknown identifier
- [ ] Existing measure / kvalue / invKraw-Nat named steps still success
- [ ] No `sorry` / `axiom` / Mathlib

LLM-offload-review: xai / math-review on `EpistemicEffectsV2_invkraw_mg.lean` — all theorems [OK].