### PR TITLE
fix(madaros): DCE deleted free fns reachable only via associated fns — empty-body ud2 traps

### DIFF
--- a/self-hosted/check/specializer.sio
+++ b/self-hosted/check/specializer.sio
@@ -1468,8 +1468,10 @@ fn spec_dce_scan_block(b: Block, marks: &! [i64; 16384], count: &! i64) with Mut
     }
 }
 
-// If item is a marked callable (top-level ItemFn or impl/trait method),
-// scan its body and extend the mark set. Returns true if any new hash
+// If item is a body the filter can delete (a top-level ItemFn), scan its
+// body only when it is marked. Impl and trait methods are never deleted by
+// the filter, so their bodies are scanned unconditionally — a retained body
+// must contribute its callees to the mark set. Returns true if any new hash
 // was inserted.
 fn spec_dce_scan_item_if_marked(
     it: Item,
@@ -1486,6 +1488,20 @@ fn spec_dce_scan_item_if_marked(
             }
         }
     } else if it.kind == ItemKind::ItemImpl {
+        // Method bodies are scanned UNCONDITIONALLY, not only when the bare
+        // method name is marked. The filter below never deletes an ItemImpl,
+        // and the dep body pass lowers every method of a kept impl, so a
+        // method body is retained even when nothing reachable calls it. A
+        // retained body's callees must therefore be marked, or the callee is
+        // deleted from the item list while the wrapper that calls it still
+        // lowers — the call then binds to an instr_count==0 stub and native
+        // codegen traps it (ud2). Measured 2026-08-19 on madaros_root2_associated_
+        // import: Epistemic::measured lowered with a real delegation body while
+        // ep_measured (called only from that impl) was filtered out — SIGILL
+        // rc=132; the same program runs green with SOUNIO_DISABLE_MM_DCE=1. The
+        // associated call could not mark "measured" either, because
+        // spec_call_expr_callee_name returns empty for multi-segment paths —
+        // so the gate could never open for this shape at all.
         match it.impl_def {
             Some(id) => {
                 var mcur = (*id).methods
@@ -1496,12 +1512,9 @@ fn spec_dce_scan_item_if_marked(
                         Some(mlist) => {
                             let mit = (*mlist).head
                             if mit.kind == ItemKind::ItemFn {
-                                let mh = ast_name_hash(mit.name)
-                                if spec_dce_hash_find(marks, *count, mh) {
-                                    match mit.fn_def {
-                                        Some(fd) => spec_dce_scan_block((*fd).body, marks, count)
-                                        None => {}
-                                    }
+                                match mit.fn_def {
+                                    Some(fd) => spec_dce_scan_block((*fd).body, marks, count)
+                                    None => {}
                                 }
                             }
                             mcur = (*mlist).tail
@@ -1512,6 +1525,9 @@ fn spec_dce_scan_item_if_marked(
             None => {}
         }
     } else if it.kind == ItemKind::ItemTrait {
+        // Same unconditional scan as ItemImpl above: the filter keeps
+        // ItemTrait whole, so a default-method body is retained and its
+        // callees must be marked.
         match it.trait_def {
             Some(td) => {
                 var mcur = (*td).methods
@@ -1522,12 +1538,9 @@ fn spec_dce_scan_item_if_marked(
                         Some(mlist) => {
                             let mit = (*mlist).head
                             if mit.kind == ItemKind::ItemFn {
-                                let mh = ast_name_hash(mit.name)
-                                if spec_dce_hash_find(marks, *count, mh) {
-                                    match mit.fn_def {
-                                        Some(fd) => spec_dce_scan_block((*fd).body, marks, count)
-                                        None => {}
-                                    }
+                                match mit.fn_def {
+                                    Some(fd) => spec_dce_scan_block((*fd).body, marks, count)
+                                    None => {}
                                 }
                             }
                             mcur = (*mlist).tail

--- a/stdlib/testmod/af_mod.sio
+++ b/stdlib/testmod/af_mod.sio
@@ -1,0 +1,23 @@
+//! stdlib/testmod/af_mod.sio — witness module for the spec_dce impl-scan
+//! hole. AfNum::quad delegates to the module-internal free fn af_twice,
+//! which no top-level test body references: before the impl/trait bodies
+//! were scanned unconditionally, spec_dce_filter_items deleted af_twice
+//! from this module's item list (nothing marked reached it) while the
+//! AfNum::quad wrapper still lowered with a real delegation body. The call
+//! then bound to an instr_count==0 stub — native codegen traps it (ud2,
+//! SIGILL rc=132). Pinned by
+//! tests/run-pass/madaros_assoc_fn_free_callee_body.sio.
+
+pub struct AfNum {
+    v: f64,
+}
+
+pub fn af_twice(x: f64) -> f64 {
+    x * 2.0
+}
+
+impl AfNum {
+    pub fn quad(v: f64) -> f64 with Mut, Panic {
+        af_twice(v)
+    }
+}

--- a/tests/run-pass/madaros_assoc_fn_free_callee_body.sio
+++ b/tests/run-pass/madaros_assoc_fn_free_callee_body.sio
@@ -1,0 +1,27 @@
+//@ run-pass
+//@ expect-stdout: AF_ASSOC_FREE_BODY_OK
+// A free fn reachable ONLY through an imported module's associated fn must
+// keep its body. spec_dce_scan_item_if_marked used to scan impl methods
+// only when the bare method name was marked, and associated calls
+// (AfNum::quad) mark nothing (spec_call_expr_callee_name returns empty for
+// multi-segment paths) — so af_twice was filtered out of the module's item
+// list while AfNum::quad still lowered a real call to it. The call bound to
+// an instr_count==0 stub and the program died on its ud2 (SIGILL rc=132).
+// Fixed 2026-08-19 by scanning impl/trait method bodies unconditionally:
+// the filter never deletes an ItemImpl, so a retained body's callees must
+// be marked. The printed marker is load-bearing — it only prints if
+// af_twice's body actually ran.
+
+use testmod::af_mod::{AfNum}
+
+fn main() -> i32 with IO, Mut, Panic {
+    let r = AfNum::quad(21.0)
+    print("AF_ASSOC_FREE_BODY r=")
+    print_f64(r)
+    print("\n")
+    if r == 42.0 {
+        print("AF_ASSOC_FREE_BODY_OK\n")
+        return 0
+    }
+    return 1
+}


### PR DESCRIPTION
## What

Multi-module reachability DCE deleted free functions that are reachable
only through an imported module's associated functions. The associated
wrapper lowered with a real delegation body; its callee was filtered out
of the module's item list first, so the call bound to an
`instr_count == 0` stub and native codegen trapped it (`ud2`, SIGILL
rc 132). Fix: `spec_dce_scan_item_if_marked` now scans impl and trait
method bodies **unconditionally** instead of only when the bare method
name is marked.

## Why the gate could never open (measured)

Two facts that only fit together one way:

1. The filter (`spec_dce_filter_items`) never deletes an `ItemImpl` — and
   the dep body pass lowers **every** method of a kept impl. So a method
   body is retained even when nothing marked calls it.
2. An associated call (`Epistemic::measured(...)`, `AfNum::quad(...)`)
   marks nothing at all: `spec_call_expr_callee_name` returns
   `empty_name()` for any multi-segment path, so `ExprCall` marking was
   silent for exactly the shape that reaches impl methods.

A retained body whose callees are unmarked is a contradiction: the body
lowers a call to a function the same pass just deleted. The callee comes
back as a name-only slot from `lowerer_find_or_add_fn_id_mut`
(lower.sio:2188-2208), `ir_module_resolve_call_target_fields` finds no
same-name body to rebind to, and `native_v2_empty_stub_would_fabricate`
(codegen_x86_linux.sio:1195) emits the trap.

Minimal 2-file repro on unpatched main (2026-08-19, from-source build of
6bce611b7b):

    // mymath.sio
    pub fn twice(x: f64) -> f64 { x * 2.0 }
    impl S { pub fn quad(v: f64) -> f64 with Mut, Panic { twice(v) } }

    use mymath::{S}
    print_f64(S::quad(21.0))    # rc 132, no output

Intervention, not correlation: the same program with
`SOUNIO_DISABLE_MM_DCE=1` prints `42.000000`, rc 0 — the DCE pass was the
only variable.

Sibling probes bracketing the hole (same module, same build):

| shape | unpatched | DCE off |
|---|---|---|
| main calls `twice` directly (ExprIdent) | 42.000000 | 42.000000 |
| `S::eight` self-contained body | 168.000000 | 168.000000 |
| pub fn `api` → internal `twice` | 42.000000 | 42.000000 |
| `S::thirtytwo` → `S::sixteen` (assoc→assoc) | 336.000000 | 336.000000 |
| **`S::quad` → internal `twice` (assoc→free)** | **SIGILL 132** | **42.000000** |
| assoc→free with `twice` also named in the `use` list | SIGILL 132 | 42.000000 |

The use list is irrelevant — module loading is textual and whole-file;
only the mark set decides, and nothing marked `twice`.

## Fix

Scan impl/trait method bodies unconditionally in
`spec_dce_scan_item_if_marked` (the ItemFn top-level gate is unchanged —
those items *can* be deleted, so marking still gates them). This aligns
the marker with the retention policy: whatever is always lowered must
always contribute its callees to the mark set. Over-retention is bounded
by the declared-function count (self-compile: 10705 declared vs
IR_MAX_FUNCS 16384), and the existing saturation refusal
("REFUSING to filter") still fires loudly rather than filtering against
an incomplete set.

## Test

`tests/run-pass/madaros_assoc_fn_free_callee_body.sio` +
`stdlib/testmod/af_mod.sio` pin the shape with a load-bearing marker:
`af_twice` is referenced by no top-level body, only by `AfNum::quad`'s
delegation, and the marker prints only if the computed value is 42.0.
Unpatched: rc 132. Patched: `AF_ASSOC_FREE_BODY_OK`.

`madaros_root2_associated_import` (the still-red half of #1886) goes
green for real this time — on 2026-08-16 builds its `ep_measured` callee
was an empty body compiled as `mov $0x0,%rax; ret` (measured by
disassembling the Aug-16 ELF: the printed `ROOT2_ASSOCIATED_IMPORT_OK`
came from `print`, not from `Epistemic::measured`, whose result was
unused), so its old pass was itself vacuous.

## Verification

All on from-source builds of the exact PR tip (rebased onto
e81b88f7bc), plus a same-base unpatched control:

- `scripts/ci/build_modular_madaros.sh`: green (both the pre-rebase and
  the rebased tip).
- Probes A-F + `madaros_root2_associated_import` + `door1_box_new_array_
  65536`: 8/8 green under the fix (B, E, root2 were SIGILL 132 on
  unpatched main).
- New pin test green under the suite harness with BOTH the default
  engine and `SOUNIO_TEST_SOUC_BIN=bin/souc-lean-single-x86_64`.
- Full run-pass corpus, both binaries, gate's own protocol:

  | | unpatched main | this PR |
  |---|---|---|
  | failures observed | 618 / 1761 | 611 / 1758 |
  | new vs 2026-08-13 baseline | 396 | 389 |

  Cross-diff of the two new-failure lists: **zero entries only under the
  fix** (no regressions); **7 entries only under unpatched**, all in the
  associated-fn/import family and all now green:

      madaros_assoc_fn_free_callee_body   (this PR's pin)
      madaros_dual_gum_knowledge
      madaros_knowledge_method_form
      madaros_root2_associated_import     (#1886, still-red half)
      madaros_root2_multimodule_method    (was SIGSEGV rc 139 on 2026-08-16 too)
      madaros_root2_multimodule_method_chain
      madaros_unknown_method_known_ok

  The ~389 remaining new-vs-baseline entries are identical under both
  binaries — main's own drift since the 2026-08-13 baseline refresh,
  pre-existing and untouched by this PR.

`docs` registry check: rc 0 on the tip.
