### PR TITLE
fix(madaros): imported 1-2 arg helpers keep first-order variance

### DIFF
--- a/docs/audit/FO_IMPORT_BOUNDARY_PORT_2026-08-19.md
+++ b/docs/audit/FO_IMPORT_BOUNDARY_PORT_2026-08-19.md
@@ -1,0 +1,113 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.fo-import-boundary-port-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: grok-cli5
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.fo-import-boundary-port-2026-08-19
+-->
+
+# Semantic lane — first-order uncertainty across an imported helper
+
+This declaration precedes the compiler edit. It is the contract for WS-A1,
+authorized 2026-08-19. The axis is not the dissertation: `Knowledge<T>` is in
+121 stdlib+examples files and the uncertainty dies at the third function.
+
+```text
+Semantic-Lane-ID: WS-A1-fo-import-boundary-20260819
+Owner: grok-cli5
+Concept-IDs: SOUNIO-EPISTEMIC-NUMERIC-VALUE, SOUNIO-ORDERED-PATH-PROVENANCE
+Intent-Preserved: a incerteza atravessa uma fronteira de funcao sem ser apagada
+Transformation: A first-order uncertainty attached to an epistemic numeric
+  value remains attached when that value is produced by a pure 1- or 2-argument
+  helper defined in another compilation unit and consumed in the caller. Crossing
+  a module is an ordered path, not a license to drop the uncertainty axis.
+  Same-file 1-2 argument transfer is unchanged. Same-file or imported helpers
+  with three or more parameters remain outside this transformation.
+Types-Changed: none
+Effects-Changed: none
+IR-Changed: none (FO_XFER table already exists; this lane populates it from
+  loaded modules before seed body lower)
+Claims-Introduced: An imported 1- or 2-argument pure helper preserves
+  first-order variance across the call. Witness: tests/run-pass/gum_fo_import_boundary.sio
+  XPASS on Madaros.
+Claims-Forbidden: "a FO esta corrigida" while the arity >=3 hole remains open;
+  "o lean_single e o oraculo"; imported fo_css (5-arg) is fixed; same-file add3
+  is fixed; every Knowledge<T> number in the 121 files is now trustworthy.
+Assumptions: fo_register_pure_fn_transfer still skips >2 params; frontend
+  prepass must not be wiped by fo_xfer_global_reset on the bodies path;
+  DCE filter of imported items does not delete reachable 1-2 arg helpers.
+Write-Set: self-hosted/ir/lower.sio, self-hosted/compiler/module_frontend.sio,
+  this file, governance registry rows for this file
+Read-Set: tests/run-pass/gum_fo_import_boundary.sio,
+  tests/run-pass/gum_fo_arity3_boundary.sio,
+  tests/run-pass/gum_cross_function.sio,
+  tests/run-pass/lean_is_not_oracle_scale2.sio,
+  tests/run-pass/lean_is_not_oracle_product.sio,
+  tests/run-pass/lean_is_not_oracle_add.sio
+Positive-Witness: gum_fo_import_boundary (2-arg imported fo_add2, peel=5, imp=5)
+Negative-Witness: gum_fo_arity3_boundary (same-file add3 stays 0);
+  madaros_gum_fo_import combined pin stays red (calls 5-arg fo_css)
+Acceptance-Gate: Madaros compile+run of gum_fo_import_boundary exits 0 with
+  OBSERVED/IMP in (4.9, 5.1); harness XPASS under SOUNIO_XPAS_FATAL=1;
+  gum_cross_function still PASS; the three lean_is_not_oracle_* pins still PASS
+  on Madaros.
+Integration-Target: origin/main at 6f23dfe1da
+Authoritative-Only-If: the acceptance gate holds on an unpatched current-source
+  Madaros ELF. A lean_single pass of the import witness is not authority.
+```
+
+## Semantic-Outcome
+
+Recorded after the current-source Madaros ELF
+`artifacts/self-hosted/madaros` (100553240 bytes, built 2026-08-19T03:10:12Z
+from this worktree at 6f23dfe1da + the port) compiled and ran the read-set.
+
+```text
+Semantic-Outcome:
+Concept-Status-Before: an imported 1- or 2-argument pure helper returned a
+  numeric value whose first-order variance had been erased (IMP=0 while the
+  same-file peel of a+b was 5). Crossing a module was treated as a license
+  to drop SOUNIO-EPISTEMIC-NUMERIC-VALUE. The ordered path of the import
+  was not a provenance-preserving path.
+Concept-Status-After: the same imported helper (epistemic::fo::fo_add2)
+  returns the value with first-order variance still attached (IMP=5.000000,
+  PEEL=5.000000). Crossing a module is an ordered path that keeps the
+  uncertainty axis for 1- and 2-argument pure helpers.
+Distinctions-Added: module boundary != uncertainty erasure, for the 1-2
+  argument case only.
+Distinctions-Preserved: uncertainty != ignorance; compile success !=
+  runtime parity; arity >=3 still erases (ADD3=0); lean_single is not an
+  oracle (#1927 pins still print MADAROS_RIGHT).
+Distinctions-Erased: none
+Evidence-Run:
+  artifacts/self-hosted/madaros build+run:
+    gum_fo_import_boundary  PEEL=5.000000 IMP=5.000000 OK rc=0
+    gum_cross_function      var(sum)=5 var(scaled)=16 PASS rc=0
+    lean_is_not_oracle_scale2   OBSERVED=0.010000 OK rc=0
+    lean_is_not_oracle_product  OBSERVED=0.032500 OK rc=0
+    lean_is_not_oracle_add      OBSERVED=5.000000 OK rc=0
+    gum_fo_arity3_boundary  ADD2=5 ADD3=0 ZERO rc=1
+    gum_fo_across_call      CALL_var=0 ZERO rc=1
+  harness (SOUNIO_XPAS_FATAL=1, this ELF):
+    gum_fo_import_boundary  XPAS + XPAS_FATAL rc=1
+    gum_fo_arity3_boundary  known-failure (still red) rc=0
+    gum_cross_function      PASS
+    lean_is_not_oracle_*    PASS
+Fallback-Path: none used. Proof is the rebuilt current-source ELF, not
+  lean_single and not bin/madaros-linux-x86_64.
+Legacy-Kept: fo_register_pure_fn_transfer still skips >2 params
+  (self-hosted/ir/lower.sio:8698). fo_xfer_global_reset still runs on
+  items_mut / items_ref. bodies_ref and bodies_dedup do not reset.
+  known-failure tag on gum_fo_import_boundary left in place so the
+  #1910 gate accuses; dropping it is a one-line follow-up, not this
+  write-set. Witness files were not edited.
+Conflicting-Lanes: grok-cli2 WS-A2 (fo bytecode) claimed
+  MADAROS_FO_CALL_BOUNDARY_DISPATCH and fo_call_boundary_div.sio — not
+  this write-set. No coord conflict on lower.sio / module_frontend.sio.
+Next-Semantic-Interface: arity >=3 (same-file add3, imported fo_css).
+  That hole is open. This lane does not authorize lifting it.
+```
+
+The acceptance gate holds. Authoritative-Only-If is satisfied. The claim
+introduced is only the imported 1–2 argument case. FO is not fixed.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -128,6 +128,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.equivalence-theory-lean-obligations-2026-06-23 | repo_only | docs/audit/EQUIVALENCE_THEORY_LEAN_OBLIGATIONS_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.equivalence-theory-lean-persite-2026-06-23 | repo_only | docs/audit/EQUIVALENCE_THEORY_LEAN_PERSITE_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.extern-c-ffi-silent-noop-dispatch-2026-08-13 | repo_only | docs/audit/EXTERN_C_FFI_SILENT_NOOP_DISPATCH_2026-08-13.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.fo-import-boundary-port-2026-08-19 | repo_only | docs/audit/FO_IMPORT_BOUNDARY_PORT_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.fo-variance-across-fn-independent-verify-2026-08-18 | repo_only | docs/audit/FO_VARIANCE_ACROSS_FN_INDEPENDENT_VERIFY_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.frame-fix-7fa3c3524-dead-code-2026-06-16 | repo_only | docs/audit/FRAME_FIX_7fa3c3524_DEAD_CODE_2026-06-16.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.frame-fix-full-selfhosted-2026-06-16 | repo_only | docs/audit/FRAME_FIX_FULL_SELFHOSTED_2026-06-16.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2408,6 +2408,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.fo-import-boundary-port-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/FO_IMPORT_BOUNDARY_PORT_2026-08-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.fo-variance-across-fn-independent-verify-2026-08-18",
       "collection": "repo",
       "repo_doc_path": "docs/audit/FO_VARIANCE_ACROSS_FN_INDEPENDENT_VERIFY_2026-08-18.md",

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -11,7 +11,7 @@ use ir::opt_cleanup::{OcpCleanupModuleReceipt, opt_cleanup_module_inplace, OCP_S
 use io::env::{read_env}
 use io::trace::{io_trace_i64_string}
 use check::mod::{check_items_verdict_boot4, check_items_verdict_boot4_with_ontocache_sidecar, check_modules_verdict_boot4, check_program_epistemic_into, check_program_with_artifacts, checker_to_ir_epistemic_into, checker_apply_ir_metadata, checker_apply_ir_ontology_parameter_links_from_items}
-use ir::lower::{lower_hard_error_report, lower_program_to_ir_trace, lower_program_to_ir_with_epistemic_trace, lower_program_to_ir_summary_flat_owned_with_epistemic_ref, lower_program_bodies_from_summary_flat_with_epistemic_ref, lower_program_bodies_from_summary_with_epistemic_boxed_owned, lower_dep_program_items_into_acc_with_externs, lower_hard_error_reset, lower_hard_error_pending, ir_instr_census_report}
+use ir::lower::{lower_hard_error_report, lower_program_to_ir_trace, lower_program_to_ir_with_epistemic_trace, lower_program_to_ir_summary_flat_owned_with_epistemic_ref, lower_program_bodies_from_summary_flat_with_epistemic_ref, lower_program_bodies_from_summary_with_epistemic_boxed_owned, lower_dep_program_items_into_acc_with_externs, lower_hard_error_reset, lower_hard_error_pending, ir_instr_census_report, fo_preregister_program_items_multipass, fo_xfer_global_reset}
 use native::codegen_x86_linux::{compile_native_v2_preview_to_file, native_resolve_target, native_v2_builtin_id_for_name, native_v2_builtin_returns_float}
 use check::knowledge_context::{knowledge_context_validate_items, knowledge_context_validate_items_values_only}
 use resolve::mod::{resolve_modules}
@@ -5501,6 +5501,19 @@ fn module_frontend_lower_programs_array_direct_box(
     if module_frontend_loaded_ir_slot_capacity_exceeded(programs, loaded) {
         trace.last_stage = "lower_summary_error"
         return module_frontend_lower_direct_box_error(module_frontend_loaded_ir_slot_capacity_error(programs, loaded))
+    }
+    // FO multi-mod: register pure-fn transfers from *all* loaded modules before
+    // seed body lower, so user main FO-sees imported helpers (epistemic::fo, …).
+    // CRITICAL: copy Program to a local first. Nested field-address of large
+    // Program in a large array (&programs[i].items) is a lean_single residual
+    // that reads as Option::None (measured: fo_prereg none=1). Whole-Program
+    // by-value load then &prog.items is the proven A14-safe pattern.
+    fo_xfer_global_reset()
+    var fo_pi: i64 = 0
+    while fo_pi < loaded {
+        var prog = (*programs)[fo_pi as usize]
+        fo_preregister_program_items_multipass(&prog.items)
+        fo_pi = fo_pi + 1
     }
     print("lower_array: seed_begin\n")
     let seed_items = spec_dce_filter_with_global_marks((*programs)[0].items)

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -1908,6 +1908,10 @@ fn lowerer_lower_program_bodies_dedup_mut(
     // and seeding from the reset produced zero effect — verified with an
     // unconditional print that never fired, and with SOUNIO_LOWER_LIVE_TRACE
     // showing `fo_xfer_miss name=sin count=0`, an empty table at lookup time.
+    // Multi-pass FO pre-register for this dep's pure fns (reverse-order expand).
+    // Do not reset FO_XFER here: the frontend multi-mod prepass may already
+    // hold imported helpers.
+    lowerer_fo_preregister_pure_fns_multipass_mut(lo, items)
     var current = items
     while true {
         match *current {
@@ -4469,11 +4473,93 @@ fn lowerer_lower_impl_methods_mut(
     }
 }
 
+// Multi-pass FO pure-fn transfer registration.
+// Nested helper expand needs callees already in FO_XFER. Source order may put
+// callers first — one pass leaves them without FO; re-register until nested
+// expands see leaf helpers. Does not lift the >2-param skip.
+fn lowerer_fo_preregister_pure_fns_mut(
+    lo: &! Lowerer,
+    items: &Option<Box<ItemList>>
+) with Mut, Panic, Div, Alloc, IO {
+    var current = items
+    while true {
+        match *current {
+            Some(list) => {
+                let head = &(*list).head
+                if head.kind == ItemKind::ItemFn {
+                    let fn_def_opt_ref: &Option<Box<FnDef>> = &head.fn_def
+                    match *fn_def_opt_ref {
+                        Some(fd) => {
+                            let lo_x = (*lo).fo_register_pure_fn_transfer(head.name, &(*fd))
+                            (*lo) = lo_x
+                        }
+                        _ => {}
+                    }
+                } else if head.kind == ItemKind::ItemImpl {
+                    let impl_def_opt_ref: &Option<Box<ImplDef>> = &head.impl_def
+                    match *impl_def_opt_ref {
+                        Some(id) => {
+                            var mcur = &(*id).methods
+                            while true {
+                                match *mcur {
+                                    Some(mlist) => {
+                                        let mhead = &(*mlist).head
+                                        if mhead.kind == ItemKind::ItemFn {
+                                            let mfd_opt: &Option<Box<FnDef>> = &mhead.fn_def
+                                            match *mfd_opt {
+                                                Some(fd) => {
+                                                    let mangled = ir_mangle_method_name(head.name, mhead.name)
+                                                    let lo_x = (*lo).fo_register_pure_fn_transfer(mangled, &(*fd))
+                                                    (*lo) = lo_x
+                                                }
+                                                _ => {}
+                                            }
+                                        }
+                                        mcur = &(*mlist).tail
+                                    }
+                                    _ => break
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                current = &(*list).tail
+            }
+            _ => break
+        }
+    }
+}
+
+fn lowerer_fo_preregister_pure_fns_multipass_mut(
+    lo: &! Lowerer,
+    items: &Option<Box<ItemList>>
+) with Mut, Panic, Div, Alloc, IO {
+    // 4 passes: reverse-order chains of depth 3 close by pass 4.
+    var pass: i64 = 0
+    while pass < 4 {
+        lowerer_fo_preregister_pure_fns_mut(lo, items)
+        pass = pass + 1
+    }
+}
+
+// Multi-mod FO: register pure transfers for one program's items without body lower.
+// FO_XFER is global — call once per loaded module *before* seed body lower so
+// imported helpers (e.g. epistemic::fo::fo_add2) FO-transfer into user main.
+pub fn fo_preregister_program_items_multipass(
+    items: &Option<Box<ItemList>>
+) with Mut, Panic, Div, Alloc, IO {
+    var lo = lowerer_new()
+    lowerer_fo_preregister_pure_fns_multipass_mut(&! lo, items)
+}
+
 fn lowerer_lower_program_items_mut(
     lo: &! Lowerer,
     items: Option<Box<ItemList>>
 ) with Mut, Panic, Div, Alloc, IO {
     fo_xfer_global_reset()
+    // Pre-register FO transfers so reverse-order pure helpers expand nested calls.
+    lowerer_fo_preregister_pure_fns_multipass_mut(lo, &items)
     var current = items
     while true {
         match current {
@@ -11191,6 +11277,7 @@ impl Lowerer {
     fn lower_program_items_ref(self, items: &Option<Box<ItemList>>) -> Lowerer with Mut, Panic, Div, Alloc, IO {
         fo_xfer_global_reset()
         var lo = self
+        lowerer_fo_preregister_pure_fns_multipass_mut(&! lo, items)
         var current = items
         while true {
             match *current {
@@ -11400,6 +11487,9 @@ impl Lowerer {
 
     fn lower_program_bodies_ref(self, items: &Option<Box<ItemList>>) -> Lowerer with Mut, Panic, Div, Alloc, IO {
         var lo = self
+        // Do NOT fo_xfer_global_reset here: multi-mod prepass may have already
+        // registered imported pure helpers into the global FO_XFER table.
+        lowerer_fo_preregister_pure_fns_multipass_mut(&! lo, items)
         var current = items
         while true {
             match *current {


### PR DESCRIPTION
## Semantic lane

```text
Semantic-Lane-ID: WS-A1-fo-import-boundary-20260819
Owner: grok-cli5
Concept-IDs: SOUNIO-EPISTEMIC-NUMERIC-VALUE, SOUNIO-ORDERED-PATH-PROVENANCE
Intent-Preserved: a incerteza atravessa uma fronteira de funcao sem ser apagada
Transformation: A first-order uncertainty attached to an epistemic numeric
  value remains attached when that value is produced by a pure 1- or 2-argument
  helper defined in another compilation unit and consumed in the caller.
Claims-Introduced: An imported 1- or 2-argument pure helper preserves
  first-order variance across the call.
Claims-Forbidden: "a FO esta corrigida" while the arity >=3 hole remains open;
  "o lean_single e o oraculo".
Authoritative-Only-If: the acceptance gate holds on an unpatched current-source
  Madaros ELF. A lean_single pass of the import witness is not authority.
```

Full declaration and Semantic-Outcome: `docs/audit/FO_IMPORT_BOUNDARY_PORT_2026-08-19.md`.

## What this is

`Knowledge<T>` is in 121 stdlib+examples files and the uncertainty dies at the third function. This is the language differentiator failing at program scale. WS-A1 ports the import FO chain so a 1- or 2-argument imported helper does not erase first-order variance.

It is **not** "FO is fixed".

## What landed

- `self-hosted/ir/lower.sio`: multi-pass FO pre-register; call sites on `items_mut` / `items_ref` (after the existing reset) and on `bodies_ref` / `bodies_dedup` (**no** reset — that would wipe the frontend prepass). `fo_register_pure_fn_transfer` still skips `>2` params.
- `self-hosted/compiler/module_frontend.sio`: before `seed_begin`, reset then A14-safe `Program` copy + `fo_preregister_program_items_multipass` over loaded modules.

Not ported: arity lift; a907 `fo_xfer_global_reset` on `bodies_ref`; tip `fo_bc_impl_type_set`.

## Proof

Current-source ELF `artifacts/self-hosted/madaros` (100553240 bytes, 2026-08-19T03:10:12Z):

| Witness | Result |
|---|---|
| `gum_fo_import_boundary` | PEEL=5.000000 IMP=5.000000 OK **rc=0** |
| harness `SOUNIO_XPAS_FATAL=1` | **XPAS** + `XPAS_FATAL` **rc=1** |
| `gum_cross_function` | var(sum)=5 var(scaled)=16 **PASS** |
| `lean_is_not_oracle_scale2` | OBSERVED=0.010000 **PASS** |
| `lean_is_not_oracle_product` | OBSERVED=0.032500 **PASS** |
| `lean_is_not_oracle_add` | OBSERVED=5.000000 **PASS** |
| `gum_fo_arity3_boundary` | ADD2=5 ADD3=0 **still red** |
| `gum_fo_across_call` | CALL_var=0 **still red** |

## Follow-up, not this write-set

The `//@ known-failure` tag on `gum_fo_import_boundary.sio` is now a stale claim. It was left in place so the #1910 gate accuses. Dropping it is a one-line follow-up. Do not drop `gum_fo_arity3_boundary`.

## Claims this PR does not make

- FO is not fixed.
- lean_single is not the oracle (#1927).
- imported `fo_css` (5-arg) is not fixed.
- same-file `add3` is not fixed.
- the 121 `Knowledge<T>` files are not all trustworthy.