### PR TITLE
governance(ladder): Reserved — the fifth state, and the rule that found it

### DIFF
--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -589,6 +589,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.internal.concepts.epistemic-numeric-value | repo_only | docs/internal/concepts/epistemic-numeric-value.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.explicit-discharge | repo_only | docs/internal/concepts/explicit-discharge.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.hypercomplex-zero-divisor-evidence | repo_only | docs/internal/concepts/hypercomplex-zero-divisor-evidence.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.concepts.maturity-ladder | repo_only | docs/internal/concepts/MATURITY_LADDER.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.nonassociative-order | repo_only | docs/internal/concepts/nonassociative-order.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.ordered-path-provenance | repo_only | docs/internal/concepts/ordered-path-provenance.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.path-conditioned-partial-identification | repo_only | docs/internal/concepts/path-conditioned-partial-identification.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -13027,6 +13027,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.internal.concepts.maturity-ladder",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/concepts/MATURITY_LADDER.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.internal.concepts.nonassociative-order",
       "collection": "repo",
       "repo_doc_path": "docs/internal/concepts/nonassociative-order.md",

--- a/docs/internal/concepts/MATURITY_LADDER.md
+++ b/docs/internal/concepts/MATURITY_LADDER.md
@@ -1,0 +1,78 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.concepts.maturity-ladder
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: claude-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.concepts.maturity-ladder
+-->
+
+# Maturity Ladder — five states, and how to measure one
+
+The evidence progression in `FOUNDER_INTENT.md` and `docs/internal/garden/README.md`
+is `Garden -> Hypothesis -> Executable -> Claim-ready`. This document adds the
+rule that makes the ladder measurable, and the fifth state the archaeology of
+2026-08-19 found by failing.
+
+## The ladder is monotone
+
+    Claim-ready  =>  Executable  =>  Hypothesis  =>  Garden
+
+Each rung **requires** every rung beneath it. A kind cannot be `Claim-ready`
+without being `Executable`. If no program constructs it and passes, the
+highest reachable position is `Hypothesis`, however many refusals the
+compiler emits.
+
+This was not stated in the first archaeology protocol. A lane applied the
+four definitions independently, correctly, and reached a position the
+definitions permitted and the ladder does not: `TyF128` marked `Claim-ready`
+because Madaros refuses every use of it. The defect was in the protocol.
+
+## The fifth state: Reserved
+
+    Reserved   the name is taken, the system REFUSES every use with a NAMED
+               diagnostic, and no use passes. Fail-closed by decision,
+               semantics unimplemented.
+
+`Reserved` is **not** `Hypothesis`. In `Hypothesis` the system is passive: it
+does not know, and says nothing. In `Reserved` the system knows, acts, and
+says why it refuses.
+
+`Reserved` is **not** `Claim-ready`. Refusing everything is not
+discriminating. A kind that rejects the correct program and the incorrect one
+with the same diagnostic is not typing anything.
+
+`Reserved` is honest, and worth more than `Hypothesis`. It is declared
+waiting, not omission. It sits beside the ladder rather than on it: a
+`Reserved` kind has not failed to reach `Executable`, it has been held short
+of it on purpose.
+
+Measured instance: `TyF128` and `TyF256` under Madaros. `E218` on bind, on
+arithmetic, and on signature-only use.
+
+## The test that decides a position
+
+Write **two** programs: one that must pass and one that must fail.
+
+| correct program | wrong program | position |
+|---|---|---|
+| passes | passes | label — nothing is being typed |
+| **fails** | **fails** | **Reserved** |
+| passes | fails | **Claim-ready** — the only case that is |
+| passes | passes | `Executable`, not `Claim-ready` |
+
+**Without both programs there is no position above `Hypothesis`.** One
+program never decides. A single accepting witness cannot distinguish a type
+from a label; a single refusal cannot distinguish a type from a wall.
+
+## Why this belongs in governance, not in an audit
+
+`FOUNDER_INTENT.md` asks what information was made invisible so the system
+could look simpler. A four-state ladder was simpler than the language, and
+the price was a kind recorded at the wrong rung. The state existed and had
+even been observed — `f128/f256` had already been called "seed reservations"
+in the known-failure census hours earlier — but had no standing, so the
+observation could not be carried.
+
+When a measurement produces an impossible position, suspect the ruler before
+the measurement. The impossible position is a site.

--- a/docs/internal/concepts/README.md
+++ b/docs/internal/concepts/README.md
@@ -32,6 +32,10 @@ without a package manager, and consumed by
 - `garden`: captured intuition, not yet a formal model.
 - `hypothesis`: explicit formal or scientific question.
 - `executable`: implemented with a focused witness.
+- `reserved`: the name is taken and every surface **refuses** with a named
+  diagnostic; semantics unimplemented. Beside the ladder, not on it — held
+  short of `executable` on purpose, not failing to reach it. See
+  `MATURITY_LADDER.md`.
 - `integrated`: represented across every currently required layer.
 - `claim-ready`: evidence permits the scoped external claim.
 - `superseded`: retained for history; another concept is authoritative.

--- a/docs/internal/garden/README.md
+++ b/docs/internal/garden/README.md
@@ -42,6 +42,13 @@ Use these labels inside every seed:
 | `Hypothesis` | A precise direction that could become testable but is not yet proven. |
 | `Executable` | Backed by a repo command, test, gate, artifact, or implementation path. |
 | `Claim-ready` | Suitable for paper or public use only after explicit validation and review. |
+| `Reserved` | The name is taken and the system **refuses every use** with a named diagnostic, pending implementation. Beside the ladder, not on it. |
+
+The ladder is **monotone**: each state requires every state beneath it. A
+seed or kind cannot be `Claim-ready` without being `Executable`. `Reserved`
+sits beside the ladder — it has not failed to reach `Executable`, it is held
+short of it on purpose. See `docs/internal/concepts/MATURITY_LADDER.md` for
+the two-program test that decides a position.
 
 Most seeds should start as `Garden` or `Hypothesis`. A seed becomes
 `Executable` only when it names a concrete artifact or gate. A seed becomes


### PR DESCRIPTION
## What

Adds `docs/internal/concepts/MATURITY_LADDER.md`, adds `Reserved` to the
canonical ladder in `docs/internal/garden/README.md`, and adds `reserved` to
the status vocabulary in `docs/internal/concepts/README.md`.

## How it was found

The archaeology protocol stated the four states as **independent definitions**
and did not say they are cumulative. A lane applied them correctly and reached
a position the definitions permitted and the ladder does not:

> `TyF128` — **Claim-ready** — Madaros **refuses** any surface use with `E218`.
> Probes: bind, arith, signature-only — all rc=1 E218.

`F128` is refused *always*. There is no correct program that uses it. By the
literal rule it qualified; by the ladder it cannot, because `Claim-ready`
without `Executable` is not a position.

**The defect was in the protocol, not in the lane.**

## Monotonicity

    Claim-ready  =>  Executable  =>  Hypothesis  =>  Garden

If no program constructs the kind **and passes**, the highest reachable
position is `Hypothesis`, however many refusals the compiler emits.

## Reserved

The name is taken, the system **refuses every use** with a named diagnostic,
and no use passes. Fail-closed by decision, semantics unimplemented.

- **Not `Hypothesis`** — there the system is passive: it does not know and says
  nothing. Here it knows, acts, and says why it refuses.
- **Not `Claim-ready`** — refusing everything is not discriminating. A kind
  that rejects the correct program and the incorrect one with the same
  diagnostic is not typing anything.
- **Honest, and worth more than `Hypothesis`.** Declared waiting, not omission.
  It sits beside the ladder: held short of `Executable` on purpose, not failing
  to reach it.

Measured instance: `TyF128`/`TyF256` under Madaros — `E218` on bind, on
arithmetic, and on signature-only use.

## The two-program test

| correct | wrong | position |
|---|---|---|
| passes | passes | label — nothing is typed |
| **fails** | **fails** | **Reserved** |
| passes | fails | **Claim-ready** — the only case that is |
| passes | passes | `Executable` |

**Without both programs there is no position above `Hypothesis`.** One
accepting witness cannot distinguish a type from a label; one refusal cannot
distinguish a type from a wall.

## Noted while writing

The concept status vocabulary already carries **`integrated`** — *"represented
across every currently required layer"* — and **no concept has ever reached
it** (20 `executable`, 4 `hypothesis`, 0 `integrated`).

That state is exactly the founder ruling of 2026-08-19 that every type must
exist in every layer. The word was already there and empty.

## Gate

`scripts/dev/check_docs_registry.sh` passes with the full selftest.
Governance metadata synced after the docs were written, per the gate's own
instruction.