### PR TITLE
test(effects): derive archaeology from executable pairs

### DIFF
--- a/scripts/ci/effect_archaeology_gate.sh
+++ b/scripts/ci/effect_archaeology_gate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Derive the effect archaeology ladder from executable pass/refuse pairs.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INDEX="${SOUNIO_EFFECT_ARCHAEOLOGY_INDEX:-$ROOT_DIR/tests/effects/archaeology/index.tsv}"
+COMPILER="${SOUNIO_EFFECT_ARCHAEOLOGY_BIN:-$ROOT_DIR/bin/souc}"
+REPORT_ONLY="${SOUNIO_EFFECT_ARCHAEOLOGY_REPORT_ONLY:-0}"
+
+fail() {
+  echo "EFFECT_ARCHAEOLOGY_GATE_FAIL reason=$1" >&2
+  exit 1
+}
+
+[[ -f "$INDEX" ]] || fail "missing_index"
+[[ -x "$COMPILER" ]] || fail "missing_compiler"
+
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/sounio-effect-archaeology.XXXXXX")"
+trap 'rm -rf "$work_dir"' EXIT
+
+failures=0
+rows=0
+printf 'kind\tposition\tdeepest_named_layer\tpass_rc\trefuse_rc\texpected_diagnostic\n'
+
+while IFS=$'\t' read -r kind pass_fixture refuse_fixture expected_diag deepest_layer; do
+  [[ "$kind" == "kind" ]] && continue
+  [[ -z "$kind" ]] && continue
+  rows=$((rows + 1))
+
+  if [[ -z "$pass_fixture" || -z "$refuse_fixture" ]]; then
+    printf '%s\tGarden\t%s\tNA\tNA\t%s\n' "$kind" "$deepest_layer" "$expected_diag"
+    continue
+  fi
+
+  pass_path="$ROOT_DIR/$pass_fixture"
+  refuse_path="$ROOT_DIR/$refuse_fixture"
+  if [[ ! -f "$pass_path" || ! -f "$refuse_path" ]]; then
+    printf '%s\tGarden\t%s\tNA\tNA\t%s\n' "$kind" "$deepest_layer" "$expected_diag"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  set +e
+  "$COMPILER" run "$pass_path" >"$work_dir/${kind}.pass.log" 2>&1
+  pass_rc=$?
+  "$COMPILER" check "$refuse_path" >"$work_dir/${kind}.refuse.log" 2>&1
+  refuse_rc=$?
+  set -e
+
+  pass_has_diag=0
+  refuse_has_diag=0
+  grep -Fq "error[$expected_diag]" "$work_dir/${kind}.pass.log" && pass_has_diag=1
+  grep -Fq "error[$expected_diag]" "$work_dir/${kind}.refuse.log" && refuse_has_diag=1
+
+  position=Hypothesis
+  if ((pass_rc == 0)); then
+    if ((refuse_rc != 0 && refuse_has_diag == 1)); then
+      position=Claim-ready
+    elif ((refuse_rc == 0)); then
+      position=Executable
+      failures=$((failures + 1))
+      echo "EFFECT_ARCHAEOLOGY_XPASS kind=$kind fixture=$refuse_fixture" >&2
+    else
+      position=Executable
+      failures=$((failures + 1))
+      echo "EFFECT_ARCHAEOLOGY_WRONG_DIAGNOSTIC kind=$kind expected=$expected_diag" >&2
+    fi
+  elif ((refuse_rc != 0 && refuse_has_diag == 1 && pass_has_diag == 1)); then
+    position=Reserva
+  else
+    failures=$((failures + 1))
+    echo "EFFECT_ARCHAEOLOGY_PASS_REGRESSION kind=$kind fixture=$pass_fixture rc=$pass_rc" >&2
+  fi
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$kind" "$position" "$deepest_layer" "$pass_rc" "$refuse_rc" "$expected_diag"
+done <"$INDEX"
+
+echo "EFFECT_ARCHAEOLOGY_SUMMARY rows=$rows failures=$failures"
+if ((failures > 0)) && [[ "$REPORT_ONLY" != "1" ]]; then
+  exit 1
+fi

--- a/tests/effects/archaeology/alloc_pass.sio
+++ b/tests/effects/archaeology/alloc_pass.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Alloc { 7 }
+fn forwarding() -> i64 with Alloc { marked() }
+
+fn main() -> i32 with Alloc {
+    if forwarding() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/alloc_refuse.sio
+++ b/tests/effects/archaeology/alloc_refuse.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Alloc { 7 }
+fn drops_effect() -> i64 { marked() }
+
+fn main() -> i32 with Alloc {
+    if drops_effect() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/async_pass.sio
+++ b/tests/effects/archaeology/async_pass.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Async { 7 }
+fn forwarding() -> i64 with Async { marked() }
+
+fn main() -> i32 with Async {
+    if forwarding() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/async_refuse.sio
+++ b/tests/effects/archaeology/async_refuse.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Async { 7 }
+fn drops_effect() -> i64 { marked() }
+
+fn main() -> i32 with Async {
+    if drops_effect() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/audit_pass.sio
+++ b/tests/effects/archaeology/audit_pass.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Audit { 7 }
+fn forwarding() -> i64 with Audit { marked() }
+
+fn main() -> i32 with Audit {
+    if forwarding() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/audit_refuse.sio
+++ b/tests/effects/archaeology/audit_refuse.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Audit { 7 }
+fn drops_effect() -> i64 { marked() }
+
+fn main() -> i32 with Audit {
+    if drops_effect() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/chaotic_pass.sio
+++ b/tests/effects/archaeology/chaotic_pass.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Chaotic { 7 }
+fn forwarding() -> i64 with Chaotic { marked() }
+
+fn main() -> i32 with Chaotic {
+    if forwarding() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/chaotic_refuse.sio
+++ b/tests/effects/archaeology/chaotic_refuse.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Chaotic { 7 }
+fn drops_effect() -> i64 { marked() }
+
+fn main() -> i32 with Chaotic {
+    if drops_effect() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/div_pass.sio
+++ b/tests/effects/archaeology/div_pass.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Div { 7 }
+fn forwarding() -> i64 with Div { marked() }
+
+fn main() -> i32 with Div {
+    if forwarding() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/div_refuse.sio
+++ b/tests/effects/archaeology/div_refuse.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Div { 7 }
+fn drops_effect() -> i64 { marked() }
+
+fn main() -> i32 with Div {
+    if drops_effect() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/gpu_pass.sio
+++ b/tests/effects/archaeology/gpu_pass.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with GPU { 7 }
+fn forwarding() -> i64 with GPU { marked() }
+
+fn main() -> i32 with GPU {
+    if forwarding() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/gpu_refuse.sio
+++ b/tests/effects/archaeology/gpu_refuse.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with GPU { 7 }
+fn drops_effect() -> i64 { marked() }
+
+fn main() -> i32 with GPU {
+    if drops_effect() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/index.tsv
+++ b/tests/effects/archaeology/index.tsv
@@ -1,0 +1,17 @@
+kind	pass_fixture	refuse_fixture	expected_diagnostic	deepest_named_layer
+Alloc	tests/effects/archaeology/alloc_pass.sio	tests/effects/archaeology/alloc_refuse.sio	E035	HLIR
+Async	tests/effects/archaeology/async_pass.sio	tests/effects/archaeology/async_refuse.sio	E035	HLIR
+Audit	tests/effects/archaeology/audit_pass.sio	tests/effects/archaeology/audit_refuse.sio	E035	HLIR
+Chaotic	tests/effects/archaeology/chaotic_pass.sio	tests/effects/archaeology/chaotic_refuse.sio	E035	IR
+Div	tests/effects/archaeology/div_pass.sio	tests/effects/archaeology/div_refuse.sio	E035	HLIR
+GPU	tests/effects/archaeology/gpu_pass.sio	tests/effects/archaeology/gpu_refuse.sio	E035	IR
+IO	tests/effects/archaeology/io_pass.sio	tests/effects/archaeology/io_refuse.sio	E035	HLIR
+Learn	tests/effects/archaeology/learn_pass.sio	tests/effects/archaeology/learn_refuse.sio	E035	HLIR
+Mut	tests/effects/archaeology/mut_pass.sio	tests/effects/archaeology/mut_refuse.sio	E035	HLIR
+NonAssoc	tests/effects/archaeology/nonassoc_pass.sio	tests/effects/archaeology/nonassoc_refuse.sio	E035	HLIR
+Observe	tests/effects/archaeology/observe_pass.sio	tests/effects/archaeology/observe_refuse.sio	E035	HLIR
+Panic	tests/effects/archaeology/panic_pass.sio	tests/effects/archaeology/panic_refuse.sio	E035	HLIR
+Prob	tests/effects/archaeology/prob_pass.sio	tests/effects/archaeology/prob_refuse.sio	E035	IR
+Temporal	tests/effects/archaeology/temporal_pass.sio	tests/effects/archaeology/temporal_refuse.sio	E035	HLIR
+Witness	tests/effects/archaeology/witness_pass.sio	tests/effects/archaeology/witness_refuse.sio	E035	HLIR
+ZD	tests/effects/archaeology/zd_pass.sio	tests/effects/archaeology/zd_refuse.sio	E035	HLIR

--- a/tests/effects/archaeology/io_pass.sio
+++ b/tests/effects/archaeology/io_pass.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with IO { 7 }
+fn forwarding() -> i64 with IO { marked() }
+
+fn main() -> i32 with IO {
+    if forwarding() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/io_refuse.sio
+++ b/tests/effects/archaeology/io_refuse.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with IO { 7 }
+fn drops_effect() -> i64 { marked() }
+
+fn main() -> i32 with IO {
+    if drops_effect() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/learn_pass.sio
+++ b/tests/effects/archaeology/learn_pass.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Learn { 7 }
+fn forwarding() -> i64 with Learn { marked() }
+
+fn main() -> i32 with Learn {
+    if forwarding() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/learn_refuse.sio
+++ b/tests/effects/archaeology/learn_refuse.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Learn { 7 }
+fn drops_effect() -> i64 { marked() }
+
+fn main() -> i32 with Learn {
+    if drops_effect() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/mut_pass.sio
+++ b/tests/effects/archaeology/mut_pass.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Mut { 7 }
+fn forwarding() -> i64 with Mut { marked() }
+
+fn main() -> i32 with Mut {
+    if forwarding() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/mut_refuse.sio
+++ b/tests/effects/archaeology/mut_refuse.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Mut { 7 }
+fn drops_effect() -> i64 { marked() }
+
+fn main() -> i32 with Mut {
+    if drops_effect() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/nonassoc_pass.sio
+++ b/tests/effects/archaeology/nonassoc_pass.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with NonAssoc { 7 }
+fn forwarding() -> i64 with NonAssoc { marked() }
+
+fn main() -> i32 with NonAssoc {
+    if forwarding() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/nonassoc_refuse.sio
+++ b/tests/effects/archaeology/nonassoc_refuse.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with NonAssoc { 7 }
+fn drops_effect() -> i64 { marked() }
+
+fn main() -> i32 with NonAssoc {
+    if drops_effect() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/observe_pass.sio
+++ b/tests/effects/archaeology/observe_pass.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Observe { 7 }
+fn forwarding() -> i64 with Observe { marked() }
+
+fn main() -> i32 with Observe {
+    if forwarding() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/observe_refuse.sio
+++ b/tests/effects/archaeology/observe_refuse.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Observe { 7 }
+fn drops_effect() -> i64 { marked() }
+
+fn main() -> i32 with Observe {
+    if drops_effect() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/panic_pass.sio
+++ b/tests/effects/archaeology/panic_pass.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Panic { 7 }
+fn forwarding() -> i64 with Panic { marked() }
+
+fn main() -> i32 with Panic {
+    if forwarding() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/panic_refuse.sio
+++ b/tests/effects/archaeology/panic_refuse.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Panic { 7 }
+fn drops_effect() -> i64 { marked() }
+
+fn main() -> i32 with Panic {
+    if drops_effect() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/prob_pass.sio
+++ b/tests/effects/archaeology/prob_pass.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Prob { 7 }
+fn forwarding() -> i64 with Prob { marked() }
+
+fn main() -> i32 with Prob {
+    if forwarding() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/prob_refuse.sio
+++ b/tests/effects/archaeology/prob_refuse.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Prob { 7 }
+fn drops_effect() -> i64 { marked() }
+
+fn main() -> i32 with Prob {
+    if drops_effect() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/temporal_pass.sio
+++ b/tests/effects/archaeology/temporal_pass.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Temporal { 7 }
+fn forwarding() -> i64 with Temporal { marked() }
+
+fn main() -> i32 with Temporal {
+    if forwarding() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/temporal_refuse.sio
+++ b/tests/effects/archaeology/temporal_refuse.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Temporal { 7 }
+fn drops_effect() -> i64 { marked() }
+
+fn main() -> i32 with Temporal {
+    if drops_effect() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/witness_pass.sio
+++ b/tests/effects/archaeology/witness_pass.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Witness { 7 }
+fn forwarding() -> i64 with Witness { marked() }
+
+fn main() -> i32 with Witness {
+    if forwarding() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/witness_refuse.sio
+++ b/tests/effects/archaeology/witness_refuse.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with Witness { 7 }
+fn drops_effect() -> i64 { marked() }
+
+fn main() -> i32 with Witness {
+    if drops_effect() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/zd_pass.sio
+++ b/tests/effects/archaeology/zd_pass.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with ZD { 7 }
+fn forwarding() -> i64 with ZD { marked() }
+
+fn main() -> i32 with ZD {
+    if forwarding() == 7 { 0 } else { 1 }
+}

--- a/tests/effects/archaeology/zd_refuse.sio
+++ b/tests/effects/archaeology/zd_refuse.sio
@@ -1,0 +1,6 @@
+fn marked() -> i64 with ZD { 7 }
+fn drops_effect() -> i64 { marked() }
+
+fn main() -> i32 with ZD {
+    if drops_effect() == 7 { 0 } else { 1 }
+}


### PR DESCRIPTION
## Summary
- add pass/refuse fixtures for all 16 censused effects
- index only fixture paths, expected diagnostic, and deepest named layer
- derive Garden/Hypothesis/Reserva/Executable/Claim-ready at runtime
- make pass regressions, wrong diagnostics, and refusal XPASS fatal

## Current receipt
- report-only: 15 Claim-ready, Chaotic Hypothesis
- strict gate: FAIL_HONEST because chaotic_pass reaches native-v2 bridge rc=12
- synthetic refusal XPASS control: detected and strict rc=1
- unknown Teleport control remains check rc=0 on both propagated and dropped forms

## Base
Measured on main a4d44ec22c11b11c81186bb364839e33c731bdcf.