### PR TITLE
test(typekind): family C — two programs in-repo, position derived

### DIFF
--- a/scripts/ci/typekind_archaeology_c.sh
+++ b/scripts/ci/typekind_archaeology_c.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Derive family-C TypeKind positions from tests/typekind/c/index.tsv (PROTOCOLO v3).
+# Position is NOT stored. Empty pass+refuse => Garden.
+#
+# Ghost identity/inner files under tests/typekind/c/ are attempts, not fixtures.
+# They must stay behaviour-identical to NoSuchType. Divergence means the kind
+# is no longer a label — fill index pass/refuse then, not before.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+INDEX="${1:-$ROOT_DIR/tests/typekind/c/index.tsv}"
+COMPILER="${SOUNIO_TYPEKIND_ARCHAEOLOGY_BIN:-$ROOT_DIR/bin/souc}"
+C_DIR="$ROOT_DIR/tests/typekind/c"
+
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+unset SOUC_BIN SOUNIO_SOUC_BIN SOUNIO_SOUC_ENGINE || true
+export MADAROS_STACK_KB="${MADAROS_STACK_KB:-524288}"
+ulimit -s 1048576 2>/dev/null || true
+
+fail() {
+  echo "TYPEKIND_ARCHAEOLOGY_C_FAIL reason=$1" >&2
+  exit 1
+}
+
+[[ -f "$INDEX" ]] || fail "missing_index path=$INDEX"
+[[ -x "$COMPILER" ]] || fail "missing_compiler path=$COMPILER"
+[[ -d "$C_DIR" ]] || fail "missing_c_dir path=$C_DIR"
+
+check_rc() {
+  local src="$1" log="$2"
+  set +e
+  "$COMPILER" check "$src" >"$log" 2>&1
+  local rc=$?
+  set -e
+  printf '%s' "$rc"
+}
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/sounio-typekind-c.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+# --- control: NoSuchType ghost pair must both check ---
+ghost_id="$C_DIR/NoSuchType.ghost_identity.sio"
+ghost_inner="$C_DIR/NoSuchType.ghost_inner.sio"
+[[ -f "$ghost_id" && -f "$ghost_inner" ]] || fail "missing_ghost_control"
+gid_rc="$(check_rc "$ghost_id" "$work/ghost_id.log")"
+gin_rc="$(check_rc "$ghost_inner" "$work/ghost_inner.log")"
+[[ "$gid_rc" == "0" ]] || fail "ghost_identity_control_failed rc=$gid_rc"
+[[ "$gin_rc" == "0" ]] || fail "ghost_inner_control_failed rc=$gin_rc"
+
+layer_of() {
+  local kind="$1"
+  local ty="Ty${kind}"
+  local texpr="Type${kind}"
+  local hlir="HlirType${kind}"
+  local deepest="none"
+  if grep -qE "TypeKind::${ty}\b" self-hosted/check/types.sio 2>/dev/null; then
+    deepest="checker"
+  fi
+  if grep -qE "TypeExprKind::${texpr}\b" self-hosted/parser/ast.sio 2>/dev/null; then
+    deepest="parser"
+  fi
+  # parser names TypeExpr; if both parser and checker, parser is shallower
+  # deepest = last layer that still names it. Recompute in depth order.
+  deepest="none"
+  grep -qE "TypeExprKind::${texpr}\b" self-hosted/parser/ast.sio 2>/dev/null && deepest="parser"
+  grep -qE "TypeKind::${ty}\b" self-hosted/check/types.sio 2>/dev/null && deepest="checker"
+  grep -qE "${hlir}\b" self-hosted/hlir/*.sio 2>/dev/null && deepest="hlir"
+  grep -qE "TypeKind::${ty}\b|${hlir}\b" self-hosted/ir/*.sio 2>/dev/null && deepest="ir"
+  grep -qE "${hlir}\b|TypeKind::${ty}\b" self-hosted/native/*.sio self-hosted/llvm/*.sio 2>/dev/null && deepest="codegen"
+  printf '%s' "$deepest"
+}
+
+echo "TYPEKIND_ARCHAEOLOGY_C sha_main=$(git rev-parse HEAD) compiler=$COMPILER"
+printf 'kind\tposition\tdeepest_named_layer\tghost_id_rc\tghost_inner_rc\tpass_fixture\trefuse_fixture\n'
+
+failures=0
+rows=0
+
+while IFS=$'\t' read -r kind pass_fixture refuse_fixture expected_diag deepest_layer || [[ -n "${kind:-}" ]]; do
+  [[ -z "${kind:-}" ]] && continue
+  [[ "$kind" == \#* ]] && continue
+  [[ "$kind" == "kind" ]] && continue
+
+  rows=$((rows + 1))
+  pass_fixture="${pass_fixture:-}"
+  refuse_fixture="${refuse_fixture:-}"
+  expected_diag="${expected_diag:-}"
+  deepest_layer="${deepest_layer:-}"
+  [[ "$pass_fixture" == "-" ]] && pass_fixture=""
+  [[ "$refuse_fixture" == "-" ]] && refuse_fixture=""
+  [[ "$expected_diag" == "-" ]] && expected_diag=""
+
+  computed="$(layer_of "$kind")"
+  if [[ -n "$deepest_layer" && "$computed" != "$deepest_layer" ]]; then
+    echo "TYPEKIND_ARCHAEOLOGY_C_FAIL reason=layer_drift kind=$kind indexed=$deepest_layer computed=$computed" >&2
+    failures=$((failures + 1))
+  fi
+
+  id_sio="$C_DIR/${kind}.ghost_identity.sio"
+  inner_sio="$C_DIR/${kind}.ghost_inner.sio"
+  id_rc="NA"
+  inner_rc="NA"
+  if [[ -f "$id_sio" ]]; then
+    id_rc="$(check_rc "$id_sio" "$work/${kind}.id.log")"
+  fi
+  if [[ -f "$inner_sio" ]]; then
+    inner_rc="$(check_rc "$inner_sio" "$work/${kind}.inner.log")"
+  fi
+
+  # Divergence from NoSuchType: the name is no longer a label.
+  if [[ "$id_rc" != "NA" && "$id_rc" != "$gid_rc" ]]; then
+    echo "TYPEKIND_ARCHAEOLOGY_C_FAIL reason=ghost_identity_diverged kind=$kind rc=$id_rc (NoSuchType rc=$gid_rc) — fill index pass/refuse; this kind is no longer a label" >&2
+    failures=$((failures + 1))
+  fi
+  if [[ "$inner_rc" != "NA" && "$inner_rc" != "$gin_rc" ]]; then
+    echo "TYPEKIND_ARCHAEOLOGY_C_FAIL reason=ghost_inner_diverged kind=$kind rc=$inner_rc (NoSuchType rc=$gin_rc) — fill index pass/refuse; this kind started discriminating" >&2
+    failures=$((failures + 1))
+  fi
+
+  position="Garden"
+  if [[ -n "$pass_fixture" && -n "$refuse_fixture" ]]; then
+    echo "TYPEKIND_ARCHAEOLOGY_C_FAIL reason=unexpected_indexed_pair kind=$kind — family C has no constructing program; do not index the ghost pair" >&2
+    failures=$((failures + 1))
+    position="INVALID"
+  fi
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$kind" "$position" "${deepest_layer:-$computed}" "$id_rc" "$inner_rc" \
+    "$pass_fixture" "$refuse_fixture"
+done < "$INDEX"
+
+[[ "$rows" -ge 12 ]] || fail "too_few_rows n=$rows (family C is 12 kinds)"
+
+if [[ "$failures" -gt 0 ]]; then
+  fail "failures=$failures"
+fi
+
+echo "TYPEKIND_ARCHAEOLOGY_C_OK rows=$rows ghost_control=NoSuchType"

--- a/tests/typekind/c/ConditionalDist.ghost_identity.sio
+++ b/tests/typekind/c/ConditionalDist.ghost_identity.sio
@@ -1,0 +1,7 @@
+//@ typekind-attempt
+//@ kind: ConditionalDist
+//@ not-indexed: ghost-identical to NoSuchType.identity — not a TypeKind construction
+// The program that would construct TyConditionalDist if the kind were wired.
+// Today this compiles as ty_named("ConditionalDist"), same as NoSuchType.
+fn id(x: ConditionalDist<f64>) -> ConditionalDist<f64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/ConditionalDist.ghost_inner.sio
+++ b/tests/typekind/c/ConditionalDist.ghost_inner.sio
@@ -1,0 +1,8 @@
+//@ typekind-attempt
+//@ kind: ConditionalDist
+//@ not-indexed: ghost-identical to NoSuchType.inner — not a TypeKind refusal
+// The program that would violate TyConditionalDist (inner mismatch) if the kind discriminated.
+// Today this compiles. When it starts failing with a named TyConditionalDist diagnostic,
+// fill index pass/refuse with a real constructor + this file as refuse.
+fn coerce(x: ConditionalDist<f64>) -> ConditionalDist<i64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/Distribution.ghost_identity.sio
+++ b/tests/typekind/c/Distribution.ghost_identity.sio
@@ -1,0 +1,7 @@
+//@ typekind-attempt
+//@ kind: Distribution
+//@ not-indexed: ghost-identical to NoSuchType.identity — not a TypeKind construction
+// The program that would construct TyDistribution if the kind were wired.
+// Today this compiles as ty_named("Distribution"), same as NoSuchType.
+fn id(x: Distribution<f64>) -> Distribution<f64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/Distribution.ghost_inner.sio
+++ b/tests/typekind/c/Distribution.ghost_inner.sio
@@ -1,0 +1,8 @@
+//@ typekind-attempt
+//@ kind: Distribution
+//@ not-indexed: ghost-identical to NoSuchType.inner — not a TypeKind refusal
+// The program that would violate TyDistribution (inner mismatch) if the kind discriminated.
+// Today this compiles. When it starts failing with a named TyDistribution diagnostic,
+// fill index pass/refuse with a real constructor + this file as refuse.
+fn coerce(x: Distribution<f64>) -> Distribution<i64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/ELBO.ghost_bound.sio
+++ b/tests/typekind/c/ELBO.ghost_bound.sio
@@ -1,0 +1,7 @@
+//@ typekind-attempt
+//@ kind: ELBO
+//@ not-indexed: bound inversion — would be the refuse if TyELBO enforced epsilon
+// Today rc=0. If this starts failing with a named diagnostic while identity
+// still passes, the kind is beginning to type.
+fn coerce(x: ELBO<f64, 2>) -> ELBO<f64, 1> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/ELBO.ghost_identity.sio
+++ b/tests/typekind/c/ELBO.ghost_identity.sio
@@ -1,0 +1,7 @@
+//@ typekind-attempt
+//@ kind: ELBO
+//@ not-indexed: ghost-identical to NoSuchType.identity — not a TypeKind construction
+// The program that would construct TyELBO if the kind were wired.
+// Today this compiles as ty_named("ELBO"), same as NoSuchType.
+fn id(x: ELBO<f64>) -> ELBO<f64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/ELBO.ghost_inner.sio
+++ b/tests/typekind/c/ELBO.ghost_inner.sio
@@ -1,0 +1,8 @@
+//@ typekind-attempt
+//@ kind: ELBO
+//@ not-indexed: ghost-identical to NoSuchType.inner — not a TypeKind refusal
+// The program that would violate TyELBO (inner mismatch) if the kind discriminated.
+// Today this compiles. When it starts failing with a named TyELBO diagnostic,
+// fill index pass/refuse with a real constructor + this file as refuse.
+fn coerce(x: ELBO<f64>) -> ELBO<i64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/Entropic.ghost_bound.sio
+++ b/tests/typekind/c/Entropic.ghost_bound.sio
@@ -1,0 +1,7 @@
+//@ typekind-attempt
+//@ kind: Entropic
+//@ not-indexed: bound inversion — would be the refuse if TyEntropic enforced epsilon
+// Today rc=0. If this starts failing with a named diagnostic while identity
+// still passes, the kind is beginning to type.
+fn coerce(x: Entropic<f64, 2>) -> Entropic<f64, 1> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/Entropic.ghost_identity.sio
+++ b/tests/typekind/c/Entropic.ghost_identity.sio
@@ -1,0 +1,7 @@
+//@ typekind-attempt
+//@ kind: Entropic
+//@ not-indexed: ghost-identical to NoSuchType.identity — not a TypeKind construction
+// The program that would construct TyEntropic if the kind were wired.
+// Today this compiles as ty_named("Entropic"), same as NoSuchType.
+fn id(x: Entropic<f64>) -> Entropic<f64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/Entropic.ghost_inner.sio
+++ b/tests/typekind/c/Entropic.ghost_inner.sio
@@ -1,0 +1,8 @@
+//@ typekind-attempt
+//@ kind: Entropic
+//@ not-indexed: ghost-identical to NoSuchType.inner — not a TypeKind refusal
+// The program that would violate TyEntropic (inner mismatch) if the kind discriminated.
+// Today this compiles. When it starts failing with a named TyEntropic diagnostic,
+// fill index pass/refuse with a real constructor + this file as refuse.
+fn coerce(x: Entropic<f64>) -> Entropic<i64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/KLBounded.ghost_bound.sio
+++ b/tests/typekind/c/KLBounded.ghost_bound.sio
@@ -1,0 +1,7 @@
+//@ typekind-attempt
+//@ kind: KLBounded
+//@ not-indexed: bound inversion — would be the refuse if TyKLBounded enforced epsilon
+// Today rc=0. If this starts failing with a named diagnostic while identity
+// still passes, the kind is beginning to type.
+fn coerce(x: KLBounded<f64, 2>) -> KLBounded<f64, 1> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/KLBounded.ghost_identity.sio
+++ b/tests/typekind/c/KLBounded.ghost_identity.sio
@@ -1,0 +1,7 @@
+//@ typekind-attempt
+//@ kind: KLBounded
+//@ not-indexed: ghost-identical to NoSuchType.identity — not a TypeKind construction
+// The program that would construct TyKLBounded if the kind were wired.
+// Today this compiles as ty_named("KLBounded"), same as NoSuchType.
+fn id(x: KLBounded<f64>) -> KLBounded<f64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/KLBounded.ghost_inner.sio
+++ b/tests/typekind/c/KLBounded.ghost_inner.sio
@@ -1,0 +1,8 @@
+//@ typekind-attempt
+//@ kind: KLBounded
+//@ not-indexed: ghost-identical to NoSuchType.inner — not a TypeKind refusal
+// The program that would violate TyKLBounded (inner mismatch) if the kind discriminated.
+// Today this compiles. When it starts failing with a named TyKLBounded diagnostic,
+// fill index pass/refuse with a real constructor + this file as refuse.
+fn coerce(x: KLBounded<f64>) -> KLBounded<i64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/MarkovChain.ghost_identity.sio
+++ b/tests/typekind/c/MarkovChain.ghost_identity.sio
@@ -1,0 +1,7 @@
+//@ typekind-attempt
+//@ kind: MarkovChain
+//@ not-indexed: ghost-identical to NoSuchType.identity — not a TypeKind construction
+// The program that would construct TyMarkovChain if the kind were wired.
+// Today this compiles as ty_named("MarkovChain"), same as NoSuchType.
+fn id(x: MarkovChain<f64>) -> MarkovChain<f64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/MarkovChain.ghost_inner.sio
+++ b/tests/typekind/c/MarkovChain.ghost_inner.sio
@@ -1,0 +1,8 @@
+//@ typekind-attempt
+//@ kind: MarkovChain
+//@ not-indexed: ghost-identical to NoSuchType.inner — not a TypeKind refusal
+// The program that would violate TyMarkovChain (inner mismatch) if the kind discriminated.
+// Today this compiles. When it starts failing with a named TyMarkovChain diagnostic,
+// fill index pass/refuse with a real constructor + this file as refuse.
+fn coerce(x: MarkovChain<f64>) -> MarkovChain<i64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/Martingale.ghost_identity.sio
+++ b/tests/typekind/c/Martingale.ghost_identity.sio
@@ -1,0 +1,7 @@
+//@ typekind-attempt
+//@ kind: Martingale
+//@ not-indexed: ghost-identical to NoSuchType.identity — not a TypeKind construction
+// The program that would construct TyMartingale if the kind were wired.
+// Today this compiles as ty_named("Martingale"), same as NoSuchType.
+fn id(x: Martingale<f64>) -> Martingale<f64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/Martingale.ghost_inner.sio
+++ b/tests/typekind/c/Martingale.ghost_inner.sio
@@ -1,0 +1,8 @@
+//@ typekind-attempt
+//@ kind: Martingale
+//@ not-indexed: ghost-identical to NoSuchType.inner — not a TypeKind refusal
+// The program that would violate TyMartingale (inner mismatch) if the kind discriminated.
+// Today this compiles. When it starts failing with a named TyMartingale diagnostic,
+// fill index pass/refuse with a real constructor + this file as refuse.
+fn coerce(x: Martingale<f64>) -> Martingale<i64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/MutualInfo.ghost_identity.sio
+++ b/tests/typekind/c/MutualInfo.ghost_identity.sio
@@ -1,0 +1,7 @@
+//@ typekind-attempt
+//@ kind: MutualInfo
+//@ not-indexed: ghost-identical to NoSuchType.identity — not a TypeKind construction
+// The program that would construct TyMutualInfo if the kind were wired.
+// Today this compiles as ty_named("MutualInfo"), same as NoSuchType.
+fn id(x: MutualInfo<f64>) -> MutualInfo<f64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/MutualInfo.ghost_inner.sio
+++ b/tests/typekind/c/MutualInfo.ghost_inner.sio
@@ -1,0 +1,8 @@
+//@ typekind-attempt
+//@ kind: MutualInfo
+//@ not-indexed: ghost-identical to NoSuchType.inner — not a TypeKind refusal
+// The program that would violate TyMutualInfo (inner mismatch) if the kind discriminated.
+// Today this compiles. When it starts failing with a named TyMutualInfo diagnostic,
+// fill index pass/refuse with a real constructor + this file as refuse.
+fn coerce(x: MutualInfo<f64>) -> MutualInfo<i64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/NoSuchType.ghost_identity.sio
+++ b/tests/typekind/c/NoSuchType.ghost_identity.sio
@@ -1,0 +1,5 @@
+//@ typekind-attempt
+//@ kind: NoSuchType
+//@ not-indexed: control — the ghost wall every unimplemented name shares
+fn id(x: NoSuchType<f64>) -> NoSuchType<f64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/NoSuchType.ghost_inner.sio
+++ b/tests/typekind/c/NoSuchType.ghost_inner.sio
@@ -1,0 +1,5 @@
+//@ typekind-attempt
+//@ kind: NoSuchType
+//@ not-indexed: control — inner mismatch still checks OK for a ghost name
+fn coerce(x: NoSuchType<f64>) -> NoSuchType<i64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/README.md
+++ b/tests/typekind/c/README.md
@@ -1,0 +1,57 @@
+# TypeKind archaeology — family C (probabilistic / information)
+
+**Protocol v3.** Position is **derived**, never stored.
+
+Assigned kinds: `Distribution` `Sample` `ConditionalDist` `Entropic`
+`MutualInfo` `KLBounded` `ELBO` `VariationalFamily` `MarkovChain` `SDE`
+`Martingale` `StationaryDist`.
+
+## Why the indexed pass/refuse columns are empty
+
+v1/v2 wrote **Hypothesis**: constructors and `compat.sio` rules exist in
+the checker; no program constructs `TypeKind::TyX`. Under v3 a kind
+without a pass+refuse pair is **Garden**. That is the conversion, not a
+loss: the handwritten Hypothesis was "we did not find a constructing
+program." The constructing program is what would fill `pass`.
+
+Do **not** fill the pair with:
+
+| program | what it does today |
+|---|---|
+| `fn id(x: Kind<f64>) -> Kind<f64> { x }` | rc=0 for Kind **and** for `NoSuchType` |
+| `let x: Kind<f64> = 1.0` | E001 expected Kind — same wall as `NoSuchType` |
+| `fn coerce(x: Kind<f64>) -> Kind<i64> { x }` | rc=0 — inner args ignored |
+
+Family G measured the same pair on `FairPrediction` / `NoSuchType`. If
+that pair were indexed, `NoSuchType` would derive Claim-ready. It is a
+label, not a type.
+
+`*.ghost_identity.sio` and `*.ghost_inner.sio` are the two programs the
+census already ran. They are **attempts**, not fixtures. When
+`ghost_inner` starts failing with a named diagnostic that
+`NoSuchType.ghost_inner` does not emit, fill `index.tsv` with a real
+constructor as `pass` and that file as `refuse`.
+
+Bounded kinds also keep `*.ghost_bound.sio` (`Kind<f64,2> -> Kind<f64,1>`).
+Today rc=0. That would be the refuse if `TyKLBounded` / `TyEntropic` /
+`TyELBO` enforced ε.
+
+## Deepest named layer
+
+All twelve die at **checker** (`TypeKind::TyX` in
+`self-hosted/check/types.sio`). There is no `TypeExprKind::TypeX` in
+the parser, no `HlirTypeX`, nothing in `self-hosted/ir/` or codegen.
+Token `sample` exists as a keyword; it does not produce `TySample`.
+
+Index rows use `-` for an empty path (bash `read` collapses consecutive tabs).
+`-` + `-` is Garden.
+
+## Run
+
+```bash
+bash scripts/ci/typekind_archaeology_c.sh
+```
+
+The script prints the derived table. It does not store positions.
+It also re-runs each ghost pair against `NoSuchType` and fails if a
+kind **diverges** (the type became real or Reserved).

--- a/tests/typekind/c/SDE.ghost_identity.sio
+++ b/tests/typekind/c/SDE.ghost_identity.sio
@@ -1,0 +1,7 @@
+//@ typekind-attempt
+//@ kind: SDE
+//@ not-indexed: ghost-identical to NoSuchType.identity — not a TypeKind construction
+// The program that would construct TySDE if the kind were wired.
+// Today this compiles as ty_named("SDE"), same as NoSuchType.
+fn id(x: SDE<f64>) -> SDE<f64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/SDE.ghost_inner.sio
+++ b/tests/typekind/c/SDE.ghost_inner.sio
@@ -1,0 +1,8 @@
+//@ typekind-attempt
+//@ kind: SDE
+//@ not-indexed: ghost-identical to NoSuchType.inner — not a TypeKind refusal
+// The program that would violate TySDE (inner mismatch) if the kind discriminated.
+// Today this compiles. When it starts failing with a named TySDE diagnostic,
+// fill index pass/refuse with a real constructor + this file as refuse.
+fn coerce(x: SDE<f64>) -> SDE<i64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/Sample.ghost_identity.sio
+++ b/tests/typekind/c/Sample.ghost_identity.sio
@@ -1,0 +1,7 @@
+//@ typekind-attempt
+//@ kind: Sample
+//@ not-indexed: ghost-identical to NoSuchType.identity — not a TypeKind construction
+// The program that would construct TySample if the kind were wired.
+// Today this compiles as ty_named("Sample"), same as NoSuchType.
+fn id(x: Sample<f64>) -> Sample<f64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/Sample.ghost_inner.sio
+++ b/tests/typekind/c/Sample.ghost_inner.sio
@@ -1,0 +1,8 @@
+//@ typekind-attempt
+//@ kind: Sample
+//@ not-indexed: ghost-identical to NoSuchType.inner — not a TypeKind refusal
+// The program that would violate TySample (inner mismatch) if the kind discriminated.
+// Today this compiles. When it starts failing with a named TySample diagnostic,
+// fill index pass/refuse with a real constructor + this file as refuse.
+fn coerce(x: Sample<f64>) -> Sample<i64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/StationaryDist.ghost_identity.sio
+++ b/tests/typekind/c/StationaryDist.ghost_identity.sio
@@ -1,0 +1,7 @@
+//@ typekind-attempt
+//@ kind: StationaryDist
+//@ not-indexed: ghost-identical to NoSuchType.identity — not a TypeKind construction
+// The program that would construct TyStationaryDist if the kind were wired.
+// Today this compiles as ty_named("StationaryDist"), same as NoSuchType.
+fn id(x: StationaryDist<f64>) -> StationaryDist<f64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/StationaryDist.ghost_inner.sio
+++ b/tests/typekind/c/StationaryDist.ghost_inner.sio
@@ -1,0 +1,8 @@
+//@ typekind-attempt
+//@ kind: StationaryDist
+//@ not-indexed: ghost-identical to NoSuchType.inner — not a TypeKind refusal
+// The program that would violate TyStationaryDist (inner mismatch) if the kind discriminated.
+// Today this compiles. When it starts failing with a named TyStationaryDist diagnostic,
+// fill index pass/refuse with a real constructor + this file as refuse.
+fn coerce(x: StationaryDist<f64>) -> StationaryDist<i64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/VariationalFamily.ghost_identity.sio
+++ b/tests/typekind/c/VariationalFamily.ghost_identity.sio
@@ -1,0 +1,7 @@
+//@ typekind-attempt
+//@ kind: VariationalFamily
+//@ not-indexed: ghost-identical to NoSuchType.identity — not a TypeKind construction
+// The program that would construct TyVariationalFamily if the kind were wired.
+// Today this compiles as ty_named("VariationalFamily"), same as NoSuchType.
+fn id(x: VariationalFamily<f64>) -> VariationalFamily<f64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/VariationalFamily.ghost_inner.sio
+++ b/tests/typekind/c/VariationalFamily.ghost_inner.sio
@@ -1,0 +1,8 @@
+//@ typekind-attempt
+//@ kind: VariationalFamily
+//@ not-indexed: ghost-identical to NoSuchType.inner — not a TypeKind refusal
+// The program that would violate TyVariationalFamily (inner mismatch) if the kind discriminated.
+// Today this compiles. When it starts failing with a named TyVariationalFamily diagnostic,
+// fill index pass/refuse with a real constructor + this file as refuse.
+fn coerce(x: VariationalFamily<f64>) -> VariationalFamily<i64> { x }
+fn main() -> i64 { 0 }

--- a/tests/typekind/c/index.tsv
+++ b/tests/typekind/c/index.tsv
@@ -1,0 +1,18 @@
+# TypeKind archaeology family C — probabilistic / information.
+# Position is NOT stored. Derive by running scripts/ci/typekind_archaeology_c.sh
+# columns: kind<TAB>pass<TAB>refuse<TAB>expect_diag<TAB>deepest_layer
+# Use '-' for an empty fixture path. '-' + '-' = Garden.
+# Do NOT replace '-' with ghost identity + E001-on-literal (NoSuchType would become Claim-ready).
+kind	pass	refuse	expect_diag	deepest_layer
+Distribution	-	-	-	checker
+Sample	-	-	-	checker
+ConditionalDist	-	-	-	checker
+Entropic	-	-	-	checker
+MutualInfo	-	-	-	checker
+KLBounded	-	-	-	checker
+ELBO	-	-	-	checker
+VariationalFamily	-	-	-	checker
+MarkovChain	-	-	-	checker
+SDE	-	-	-	checker
+Martingale	-	-	-	checker
+StationaryDist	-	-	-	checker


### PR DESCRIPTION
Protocol v3. Position is not in the commit. `bash scripts/ci/typekind_archaeology_c.sh` prints it.

## Conversion from the v2 Hypothesis table

All twelve kinds (Distribution Sample ConditionalDist Entropic MutualInfo KLBounded ELBO VariationalFamily MarkovChain SDE Martingale StationaryDist) had constructors in the checker and no constructing program. v3: a kind without a pass+refuse pair is Garden. That is the conversion.

The two programs already run are in `tests/typekind/c/*.ghost_*.sio`. They are **attempts**, not fixtures. Indexing `id(x: Kind<f64>)` + `let x: Kind<f64> = 1.0` (E001) would make `NoSuchType` Claim-ready — family G measured that pair.

When `ghost_inner` diverges from `NoSuchType.ghost_inner`, the gate fails and the pair can be filled.

Index `pass`/`refuse` are `-`. Deepest named layer: **checker**. Gate re-checks that against parser/HLIR/IR/codegen.

Did not touch `tests/typekind/index.tsv` or `scripts/ci/typekind_archaeology_gate.sh` (grok-cli4 claim).