### PR TITLE
concept(registry): SOUNIO-EPISTEMIC-ERASURE — the effect vocabulary has no word for loss

### DIFF
--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -587,6 +587,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.internal.concepts.dyadic-nonreduction | repo_only | docs/internal/concepts/dyadic-nonreduction.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.endogenous-observability | repo_only | docs/internal/concepts/endogenous-observability.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.epistemic-numeric-value | repo_only | docs/internal/concepts/epistemic-numeric-value.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.concepts.erasure | repo_only | docs/internal/concepts/erasure.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.exactness | repo_only | docs/internal/concepts/exactness.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.explicit-discharge | repo_only | docs/internal/concepts/explicit-discharge.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.hypercomplex-zero-divisor-evidence | repo_only | docs/internal/concepts/hypercomplex-zero-divisor-evidence.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -592,6 +592,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.internal.concepts.explicit-discharge | repo_only | docs/internal/concepts/explicit-discharge.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.hypercomplex-zero-divisor-evidence | repo_only | docs/internal/concepts/hypercomplex-zero-divisor-evidence.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.maturity-ladder | repo_only | docs/internal/concepts/MATURITY_LADDER.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.concepts.no-implicit-degradation | repo_only | docs/internal/concepts/no-implicit-degradation.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.nonassociative-order | repo_only | docs/internal/concepts/nonassociative-order.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.ordered-path-provenance | repo_only | docs/internal/concepts/ordered-path-provenance.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.path-conditioned-partial-identification | repo_only | docs/internal/concepts/path-conditioned-partial-identification.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -604,6 +605,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.internal.concepts.proof-carrying-rebracketing-protocol | repo_only | docs/internal/concepts/proof-carrying-rebracketing-protocol.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.proof-carrying-shift-robust-risk-transport | repo_only | docs/internal/concepts/proof-carrying-shift-robust-risk-transport.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.proof-carrying-statistical-coverage-empirical-binding | repo_only | docs/internal/concepts/proof-carrying-statistical-coverage-empirical-binding.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.concepts.provenance | repo_only | docs/internal/concepts/provenance.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.readme | repo_only | docs/internal/concepts/README.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.rebracketing-authority | repo_only | docs/internal/concepts/rebracketing-authority.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.reflexive-inquiry | repo_only | docs/internal/concepts/reflexive-inquiry.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -591,6 +591,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.internal.concepts.exactness | repo_only | docs/internal/concepts/exactness.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.explicit-discharge | repo_only | docs/internal/concepts/explicit-discharge.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.hypercomplex-zero-divisor-evidence | repo_only | docs/internal/concepts/hypercomplex-zero-divisor-evidence.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.concepts.justification | repo_only | docs/internal/concepts/justification.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.maturity-ladder | repo_only | docs/internal/concepts/MATURITY_LADDER.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.no-implicit-degradation | repo_only | docs/internal/concepts/no-implicit-degradation.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.nonassociative-order | repo_only | docs/internal/concepts/nonassociative-order.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -13073,6 +13073,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.internal.concepts.justification",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/concepts/justification.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.internal.concepts.maturity-ladder",
       "collection": "repo",
       "repo_doc_path": "docs/internal/concepts/MATURITY_LADDER.md",

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -13096,6 +13096,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.internal.concepts.no-implicit-degradation",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/concepts/no-implicit-degradation.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.internal.concepts.nonassociative-order",
       "collection": "repo",
       "repo_doc_path": "docs/internal/concepts/nonassociative-order.md",
@@ -13352,6 +13375,29 @@
       "topic_id": "repo.docs.internal.concepts.proof-carrying-statistical-coverage-empirical-binding",
       "collection": "repo",
       "repo_doc_path": "docs/internal/concepts/proof-carrying-statistical-coverage-empirical-binding.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.internal.concepts.provenance",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/concepts/provenance.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -12981,6 +12981,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.internal.concepts.erasure",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/concepts/erasure.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.internal.concepts.exactness",
       "collection": "repo",
       "repo_doc_path": "docs/internal/concepts/exactness.md",

--- a/docs/internal/concepts/erasure.md
+++ b/docs/internal/concepts/erasure.md
@@ -1,0 +1,125 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.concepts.erasure
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: claude-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.concepts.erasure
+-->
+
+# Epistemic Erasure
+
+Concept-ID: `SOUNIO-EPISTEMIC-ERASURE`
+
+Status: **Hypothesis** — designed by the founder in session on 2026-08-19,
+recorded here before implementation. No compiler surface implements it, and
+no fixture pair exists. Under the monotone maturity ladder
+(`MATURITY_LADDER.md`) this may not be described as Executable or
+Claim-ready until a correct program passes and a wrong program is refused.
+
+## Founder Intent
+
+Sounio's epistemic effect vocabulary points in one direction. `Observe`,
+`Learn`, `Witness`, `Prob` and `Audit` all name ways knowledge is **acquired**.
+Not one of them names the inverse.
+
+The founder's ruling, stated in session:
+
+> The compiler is not failing. The program was allowed to say it.
+
+The operation that destroys epistemic content is today legal, unmarked, and
+invisible. It is spelled `.value`.
+
+```sounio
+let k = measure(2.0, uncertainty: 2.0)
+let r = combinar(k.value, x, y)     // uncertainty gone, silently
+```
+
+`Knowledge` is a plain struct — `value`, `variance`, `confidence` — and is not
+linear. Dropping one requires nothing. `.value` yields an `f64`, and an `f64`
+has no uncertainty to lose, so every layer below behaves correctly while the
+claim quietly stops being a claim.
+
+## The erasure this prevents
+
+From `FOUNDER_INTENT.md`: *"a small or unresolved effect reported as zero"*.
+This is that erasure at its source, in the core epistemic type.
+
+It is important that the FO variance defect
+(`docs/audit/FO_VARIANCE_ACROSS_FN_INDEPENDENT_VERIFY_2026-08-18.md`, live on
+46 of 51 dissertation surfaces) is a **symptom, not the disease**. Repairing
+the codegen so variance survives a call does not make the line above safe: the
+projection still discards the uncertainty, and `0.000000` remains the honest
+answer to a question the program had already thrown away.
+
+## Design
+
+**Projection taints.** `k.value` does not yield a plain `f64`. It yields a
+value that remembers its uncertainty was discarded, and arithmetic over it
+stays marked. This is information-flow typing applied to uncertainty, and it
+is the only formulation that refuses the FO class **at compile time** rather
+than when someone runs the right witness.
+
+**The annotation burden falls on the claim, not the plumbing.** The programmer
+never writes the marked type; the checker infers it and stays silent.
+Functions that sum, iterate, sort or index declare nothing and keep saying
+`f64`. Only functions that **assert** something epistemic declare that they
+require clean input. Taint systems die on migration when every intermediate
+must be annotated; here the boundary set is small and is itself the
+specification of what counts as a claim in Sounio.
+
+**Declassification is an act, not a coercion.** Returning knowledge to a bare
+number requires `attest(v, uncertainty: u, because: <provenance>)` — an
+assertion someone signs, never a cast. Every site where uncertainty was
+restored by hand is therefore visible.
+
+## The four sinks
+
+A marked value is refused at exactly the four boundaries where a number stops
+being plumbing and becomes an assertion. The founder closed all four:
+
+1. **Reading uncertainty** — `variance_of`, `gum_k95`, confidence, coverage
+   interval. Asking the uncertainty of a value whose uncertainty was erased
+   returns `0.000000` today; it must refuse. This is the minimum: without it
+   the FO class can still print a zero that looks like a perfect measurement.
+2. **Leaving a public stdlib function** — the boundary where knowledge passes
+   from whoever computed it to whoever will use it without knowing how.
+3. **Compared against a test tolerance** — a test that passes by comparing a
+   value which already lost its uncertainty has validated the arithmetic and
+   pretended to validate the science. This is the sink that stops a green gate
+   from lying.
+4. **Printed or written out** — `println` of a value presented as a
+   measurement, or a write to a results file. After this the number leaves the
+   program and no reader can tell the uncertainty was erased.
+
+## Required Invariants
+
+- Projection out of an epistemic type is never silent. It either propagates a
+  mark or is refused; it does not yield an indistinguishable bare number.
+- A marked value is refused at all four sinks. Closing three is not a weaker
+  version of this concept; it is a different concept, because the open sink is
+  where the claim escapes.
+- Restoring uncertainty requires provenance. A function that attaches
+  uncertainty to a bare number without a source is a back door and must be
+  named as one.
+- The marked type is **inferred, never required in plumbing signatures**. A
+  design that forces intermediate functions to annotate has failed its own
+  adoption test regardless of soundness.
+- Repairing variance propagation does not close this concept. The two are
+  independent: FO is about whether the value survives; erasure is about
+  whether discarding it may be silent.
+
+## Claims Forbidden
+
+- Do not describe this as implemented, partially implemented, or as a
+  compiler behaviour. Nothing in `self-hosted/` reads this document.
+- Do not present the FO variance work as closing this concept, or this concept
+  as closing FO.
+- Do not quote the sink list as enforced anywhere. It is a design decision of
+  record, and its enforcement does not yet exist.
+
+## Related
+
+- `SOUNIO-EXACTNESS` — the sibling erasure: a decided fact narrowed to a
+  measurement. Both concern a qualitative property lost without a mark.
+- `MATURITY_LADDER.md` — why this document is Hypothesis and what would move it.

--- a/docs/internal/concepts/justification.md
+++ b/docs/internal/concepts/justification.md
@@ -1,0 +1,109 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.concepts.justification
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: claude-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.concepts.justification
+-->
+
+# Justification
+
+Concept-ID: `SOUNIO-JUSTIFICATION`
+
+Status: **Hypothesis** — decided by the founder in session on 2026-08-19. The
+mechanism that would connect a Sounio call site to a Lean obligation does not
+exist.
+
+## Founder Intent
+
+`SOUNIO-NO-IMPLICIT-DEGRADATION` requires that every epistemic loss carry a
+justification. This document fixes what a justification *is*.
+
+Founder ruling: the floor is a **proof obligation**. `because:` names a
+theorem in `formal/`, and the build fails if that theorem does not exist or
+does not close.
+
+The consequence is the ruling, not a side effect:
+
+> A justification that cannot be discharged as a proof does not belong in
+> `because:` at all.
+
+## Why prose was the wrong shape
+
+A justification written as a string is inert. The compiler cannot read it,
+cannot check it, and cannot tell when it stopped being true. It is a parallel
+record with nothing forcing it to agree with the code — the same failure class
+as a provenance ledger no value is bound to.
+
+The apparent objection is that some justifications are empirical
+(*"Kp is not measurable in vivo"*) and no compiler will ever decide them. The
+ruling dissolves this rather than conceding it: **that claim was never a
+justification for the mixture.** It explains why *that value* has
+literature origin. It belongs at the construction of the value, in its
+provenance, with citation, owner and date — not at the site where the value is
+combined.
+
+What remains at the act is whether *this combination* is valid. That is a
+theorem.
+
+## Why this is feasible
+
+The `formal/` contract — Lean proves **algorithmic** invariants; the paper
+proves probabilistic fidelity — is what makes the ruling implementable.
+
+The obligation for combining two epistemic values is **not** "GUM propagation
+is valid". That requires measure theory, requires Mathlib, and is the paper's
+work. The obligation is *"these two ancestor sets are disjoint"* — a finite,
+combinatorial, decidable fact **about the program**, provable with no Mathlib
+dependency.
+
+The theorem is about the program, not about the world. A rule written for a
+different reason turns out to be the precondition for this one.
+
+Measured 2026-08-19 on `origin/main`: `formal/` holds 182 `.lean` files;
+`sorry` appears as an actual tactic **3 times in one file**
+(`formal/lean4/SounioSedenionBipartite.lean`) — the other 165 hits are prose in
+docstrings stating "Zero sorry". Mathlib is imported by 5 files.
+
+## Required Invariants
+
+- The floor is a discharged proof. A justification that names no obligation,
+  or names one that does not close, is not a justification.
+- Empirical claims live in provenance, not in `because:`. Moving one into a
+  justification slot re-creates the inert string this concept exists to remove.
+- The obligation is about the program. An obligation that requires modelling
+  the world has been stated at the wrong layer and belongs to the paper.
+- A missing theorem fails the build. A justification whose obligation is
+  absent must be indistinguishable from no justification at all — silence here
+  would make the whole mechanism decorative.
+
+## What does not exist
+
+The gap is the connection, and it is the whole implementation:
+
+- No mechanism binds a Sounio call site to a Lean theorem name.
+- `formal/` builds separately; no gate makes a Sounio compile depend on a Lean
+  obligation closing.
+- No obligation of this family has been written. The disjoint-ancestor
+  theorem is described here and does not exist.
+- The empirical half — owner, date, citation, review — has no carrier in the
+  value either; see `SOUNIO-PROVENANCE`, which also does not exist in
+  `Knowledge`.
+
+## Claims Forbidden
+
+- Do not describe any justification mechanism as implemented. None is.
+- Do not cite `formal/`'s 182 files as evidence that this concept is underway.
+  They prove unrelated invariants and predate the decision.
+- Do not present the disjoint-ancestor obligation as proved, drafted, or
+  scheduled.
+- Do not read "the floor is a proof obligation" as a claim that Sounio verifies
+  scientific validity. It verifies a program property; validity is the paper's.
+
+## Related
+
+- `SOUNIO-NO-IMPLICIT-DEGRADATION` — requires the justification this defines
+- `SOUNIO-PROVENANCE` — receives the empirical half, and supplies the ancestor
+  sets the obligation is stated over
+- `SOUNIO-EPISTEMIC-ERASURE` — `attest(because:)` inherits this floor

--- a/docs/internal/concepts/no-implicit-degradation.md
+++ b/docs/internal/concepts/no-implicit-degradation.md
@@ -1,0 +1,87 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.concepts.no-implicit-degradation
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: claude-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.concepts.no-implicit-degradation
+-->
+
+# No Implicit Degradation
+
+Concept-ID: `SOUNIO-NO-IMPLICIT-DEGRADATION`
+
+Status: **Hypothesis** — stated by the founder in session on 2026-08-19. It is
+the generating principle behind several concepts that already exist, but
+nothing in the compiler enforces it as a principle.
+
+## Founder Intent
+
+> No epistemic degradation is implicit. Every step down the knowledge ladder
+> must be written by a person, with a reason.
+
+Not a coercion, not a default, not an automatic combination rule. Where
+knowledge becomes less than it was, a named act stands at that point and
+carries a justification.
+
+## Why this is the generator
+
+The founder's specification names types and effects as first principles, and
+the effect vocabulary was repeatedly felt to be incomplete without the missing
+entries being nameable. This document records why.
+
+Every epistemic effect in the language today — `Observe`, `Learn`, `Witness`,
+`Prob`, `Audit` — names an **acquisition**. Enumerating effects by what a
+computation *does* has no generator and does not close.
+
+Enumerating **the ways knowledge degrades** does. Each degradation requires
+one named act. That list is finite, inspectable, and generates the missing
+vocabulary directly.
+
+## The degradation table
+
+Decided in session 2026-08-19. "Act" is the named operation that must stand at
+the point of loss; absence of an act is the gap this table exists to expose.
+
+| Degradation | Act | State |
+|---|---|---|
+| Uncertainty discarded by projection (`.value`) | mark propagates; see `SOUNIO-EPISTEMIC-ERASURE` | decided, unimplemented |
+| Uncertainty restored without measuring | `attest(v, uncertainty:, because:)` | decided, unimplemented |
+| Origins of different classes combined | `misturar(a, b, because:)` | decided, unimplemented |
+| Exact result narrowed to floating point | — | `SOUNIO-EXACTNESS` states the invariant; no act named |
+| Precision narrowed (`f256` → `f64`) | — | **no act** |
+| Independence assumed where a common ancestor exists | — | **no act**; see `SOUNIO-PROVENANCE` |
+| Evaluation outside the validated domain | — | **no act** |
+| A computed value presented as measured | — | **no act**; the class distinction exists in `ProvEntity`, unenforced |
+| A witness or proof discarded | — | **no act** |
+
+The four rows marked **no act** are effects the founder designed and could not
+name. They were not forgotten: the vocabulary pointed entirely at acquisition,
+so there was nowhere for a loss to be written.
+
+## Required Invariants
+
+- A degradation without a named act is a gap in the language, not a
+  convenience. Adding the operation silently is the defect this concept names.
+- An act carries a justification. An act that only records *that* the loss
+  happened, without *why*, has recorded the wrong half.
+- The act is the only door. If the degraded state is also reachable by
+  constructing a value by hand, the act is decorative and the guarantee is
+  void. This is the same class as an unenforced ledger.
+- Saturation is failure. A mark that every value acquires after two operations
+  no longer discriminates at the point where discrimination was the purpose.
+
+## Claims Forbidden
+
+- Do not describe this principle as enforced. No compiler surface reads it.
+- Do not present the three decided rows as implemented; they are recorded
+  designs, and their own documents say so.
+- Do not treat the degradation table as complete. It is the list as of
+  2026-08-19; the generator is the principle, not the table.
+
+## Related
+
+- `SOUNIO-EPISTEMIC-ERASURE` — the first row, worked out in full
+- `SOUNIO-PROVENANCE` — supplies the sixth and eighth rows
+- `SOUNIO-EXACTNESS` — the fourth row, stated as an invariant before the
+  principle behind it was named

--- a/docs/internal/concepts/provenance.md
+++ b/docs/internal/concepts/provenance.md
@@ -1,0 +1,108 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.concepts.provenance
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: claude-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.concepts.provenance
+-->
+
+# Provenance
+
+Concept-ID: `SOUNIO-PROVENANCE`
+
+Status: **Hypothesis** — a substantial implementation exists and is
+disconnected; the design recorded here was decided in session on 2026-08-19
+and is not implemented.
+
+## Founder Intent
+
+Provenance is not bookkeeping. It is load-bearing for the arithmetic.
+
+```sounio
+let cl = medido(...)          // measured clearance
+let a  = derivar_a(cl)
+let b  = derivar_b(cl)
+let r  = combinar(a, b)       // var(a) + var(b)
+```
+
+Adding variances assumes independence. `a` and `b` share an ancestor, so the
+sum **underestimates** the true uncertainty — and the more a pipeline branches
+and rejoins, the more confident the result appears, in the opposite direction
+from the truth. Without provenance the compiler has no way to know they are
+related. With it, that is a query.
+
+This is what makes GUM propagation correct rather than optimistic.
+
+## Measured state (2026-08-19, `origin/main`)
+
+A provenance subsystem exists: `stdlib/epistemic/prov.sio` (11 KB),
+`ledger.sio` (17 KB), `slsa.sio` (14 KB), `merkle.sio` (8 KB),
+`claim_ast.sio`, `audit_runtime.sio`, plus **11** `proof_carrying_*.sio`
+files. `ProvEntity` carries a W3C-PROV-shaped record: an origin class
+(measured / literature / computed / input), value, uncertainty, confidence,
+timestamp and reference hash.
+
+**The only importers are three demos** — `examples/epistemic/prov_demo.sio`,
+`ledger_demo.sio`, `slsa_demo.sio`. No stdlib module, no compiler surface and
+no dissertation surface imports any of it.
+
+**`Knowledge` has no provenance field.** It holds `value`, `variance`,
+`confidence`. `stdlib/epistemic/README.md` draws `└── provenance: Provenance`,
+but that is the document, not the struct. Provenance therefore exists as a
+**parallel record with nothing forcing it to agree with the values**.
+
+## Design
+
+**Two carriers, because they answer different questions.**
+
+- **Class travels in the type.** `Knowledge<T, Origem>` — measured, literature,
+  computed, input. Checked before a binary exists, zero runtime cost.
+- **Instance travels as an id.** A `ProvId` in the value answers the question
+  the type cannot reach: *is this measurement THAT measurement* — the
+  correlation query above.
+
+**Mixing is an act, not a rule.** There is no automatic combination rule for
+`Origem`. Combining values of different origin classes is refused, and passes
+only through an explicit `misturar(a, b, because:)` that assumes the mixture,
+exactly as `attest` assumes restored uncertainty. This is chosen over a lattice
+(`weakest element wins`) or a set-valued `Misto` specifically because nothing
+then saturates on its own: each mixture is written down.
+
+**The constructor is the only door.** If a `Knowledge` can be built by hand
+with a `ProvId` filled in, the id is an unsourced assertion and every
+correlation query becomes decorative — returning correct answers about a graph
+that no longer corresponds to the values. This is a precondition, not a
+refinement: without it neither carrier is worth implementing.
+
+**Ancestor bitset over graph query (proposal, not founder-decided).** Carrying
+a fixed-width root-ancestor bitset in the value reduces "do these share an
+origin?" to one `AND`. A model exceeding the width must **refuse detectably**;
+a silently truncated ancestor set reports independence that does not hold,
+which is the same failure class as a capacity literal that drops past its cap.
+
+## Required Invariants
+
+- Provenance that cannot be trusted is worse than none: it converts an unknown
+  into a false assurance. A ledger nothing forces to agree with the values is
+  in this state today.
+- Variances may not be summed as independent without an ancestor check, once
+  the check exists.
+- Origin class is not confidence. A literature value may be more reliable than
+  a bad measurement; the class records where it came from, not how good it is.
+
+## Claims Forbidden
+
+- Do not describe the existing subsystem as integrated. It is imported by three
+  demos and by nothing else.
+- Do not cite `README.md`'s `provenance: Provenance` as the shape of
+  `Knowledge`. The struct has no such field.
+- Do not present the ancestor-bitset proposal as founder-decided; it is an
+  engineering suggestion recorded for evaluation.
+- Do not claim any correlation-aware GUM propagation exists.
+
+## Related
+
+- `SOUNIO-NO-IMPLICIT-DEGRADATION` — the principle `misturar` instantiates
+- `SOUNIO-EPISTEMIC-ERASURE` — `attest` needs provenance, which is why these
+  two were designed in the same session


### PR DESCRIPTION
Recorded from the founder design session of 2026-08-19, **before implementation**.

## The finding

Every epistemic effect in the language names an **acquisition** — `Observe`, `Learn`, `Witness`, `Prob`, `Audit`. None names the inverse. The operation that destroys epistemic content is legal, unmarked and invisible, and it is spelled `.value`.

Measured on `origin/main`: `Knowledge` is a plain struct (`value`, `variance`, `confidence`), **not** linear — dropping one requires nothing — and there are **2278** `.value` occurrences across `stdlib/` and `examples/`.

This reframes the FO variance defect as a **symptom, not the disease**. Repairing the codegen so variance survives a call does not make `combinar(k.value, x, y)` safe: the projection already discarded it, and `0.000000` stays the honest answer to a question the program threw away.

## Design of record

Projection taints, and the mark propagates. The **annotation burden falls on the claim, not the plumbing** — the marked type is inferred, never written in intermediate signatures, because taint systems die on migration when every intermediate must be annotated. Declassification is `attest(v, uncertainty:, because:)` with provenance, never a coercion.

The mark is refused at exactly four sinks: reading uncertainty, leaving a public stdlib function, comparison against a test tolerance, and printing or writing out.

## Semantic declaration

- **Concept-IDs**: introduces `SOUNIO-EPISTEMIC-ERASURE`. References `SOUNIO-EXACTNESS`, `MATURITY_LADDER`.
- **Intent-Preserved**: `FOUNDER_INTENT.md` — *"a small or unresolved effect reported as zero"*. This records that erasure at its source in the core epistemic type.
- **Transformation**: none. Documentation plus the filesystem-derived registry sync. Zero lines of `self-hosted/` or `stdlib/`.
- **Claims-Introduced**: that the epistemic effect vocabulary is oriented entirely toward acquisition; that `.value` is unmarked erasure; that FO and erasure are independent defects. The two measurements (`Knowledge` not linear, 2278 sites) are reproducible by `git grep` on `origin/main`.
- **Claims-Forbidden**: this is **not** implemented, not partially implemented, and not a compiler behaviour — nothing in `self-hosted/` reads this document. The FO work does not close this concept and this concept does not close FO. The sink list is a design decision of record and is enforced nowhere. The document states all of this in its own Claims Forbidden section so a later reader cannot mistake a design for a behaviour.
- **Authoritative-Only-If**: status stays **Hypothesis** under the monotone ladder until a correct program passes and a wrong program is refused. It may not be described as Executable or Claim-ready before then.