### PR TITLE
concept(registry): narrowing is always an act — close the disjunction

### DIFF
--- a/docs/internal/concepts/no-implicit-degradation.md
+++ b/docs/internal/concepts/no-implicit-degradation.md
@@ -49,7 +49,7 @@ the point of loss; absence of an act is the gap this table exists to expose.
 | Uncertainty restored without measuring | `attest(v, uncertainty:, because:)` | decided, unimplemented |
 | Origins of different classes combined | `misturar(a, b, because:)` | decided, unimplemented |
 | Exact result narrowed to floating point | — | `SOUNIO-EXACTNESS` states the invariant; no act named |
-| Precision narrowed (`f256` → `f64`) | — | **no act** |
+| Precision narrowed (`f256` → `f64`) | `narrow(v, to:, because:)`, always, over epistemic and exact values | decided 2026-08-19; see `SOUNIO-PRECISION-PRESERVATION` |
 | Independence assumed where a common ancestor exists | — | **no act**; see `SOUNIO-PROVENANCE` |
 | Evaluation outside the validated domain | — | **no act** |
 | A computed value presented as measured | — | **no act**; the class distinction exists in `ProvEntity`, unenforced |

--- a/docs/internal/concepts/precision-preservation.md
+++ b/docs/internal/concepts/precision-preservation.md
@@ -2,8 +2,8 @@
 topic_id: repo.docs.internal.concepts.precision-preservation
 authority: repo_only
 audience: users
-last_validated: 2026-03-07
-validated_by: A2
+last_validated: 2026-08-19
+validated_by: claude-1
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.concepts.precision-preservation
 -->
 
@@ -27,14 +27,63 @@ double-double, and quad-double paths are scientific surfaces.
 
 ## Required Invariants
 
-- Narrowing is explicit or proven lossless for the stated contract.
+- **Narrowing is always an act.** Founder ruling, 2026-08-19: there is no
+  exception and no heuristic. The earlier form of this invariant — *explicit
+  **or** proven lossless* — was a disjunction, and the second branch is what a
+  compiler reaches for when the first is inconvenient. Both halves now hold at
+  once: the narrowing is written, and its justification carries the floor set
+  by `SOUNIO-JUSTIFICATION` — a discharged proof obligation, not prose.
+- **The domain is epistemic and exact values.** A loop counter, an index, or a
+  scalar being narrowed for display carries no knowledge, so no degradation
+  occurs and no act is required. The rule binds values that carry uncertainty
+  (`Knowledge<T>`) and values that carry decidability (exact surfaces). The
+  domain follows from `SOUNIO-NO-IMPLICIT-DEGRADATION` rather than being
+  stipulated beside it.
 - Equality after narrowing does not imply equal correction histories.
 - Tests include adversarial cancellation and residual witnesses.
 - Backend failure is never silent fallback to `f64`.
 - Higher precision alone does not establish physical significance.
+- Uncertainty is what makes narrowing survivable; exactness is what makes it
+  fatal. A measurement can afford to lose digits — if the rounding sits below
+  the declared uncertainty, nothing was lost that was not already unknown. A
+  decided fact has no error bar in which a wrap can hide, which is why
+  `SOUNIO-EXACTNESS` states width as a correctness precondition rather than a
+  tuning choice. One rule covers both because on an exact value the absorbing
+  uncertainty is zero.
 
 ## Current Frontier
 
 `dd64` has a native passing control. The qd128/EISA graph lowers without the
 former segmentation fault but native emission still fails closed on classified
 paths. This is a compiler frontier, not permission to demote precision.
+
+## Measured ladder (2026-08-19, `origin/main`)
+
+Width kinds present in the checker:
+
+| family | usable | Reserved (name taken, every use refused) | absent entirely |
+|---|---|---|---|
+| signed | `i8 i32 i64 i128` | — | **`i256` `i512`** |
+| unsigned | `u8 u32 u64 u128` | — | **`u256` `u512`** |
+| float | `f32 f64` | `f128` `f256` (`E218`) | — |
+
+The asymmetry is not accidental: integers reach further than floats because
+exactness needs wide **integers**, not wide floats. The Cayley-Dickson tower
+squares component magnitudes as it doubles, and `i512` was named by the founder
+as the **seed** of that tower.
+
+`i256`, `i512`, `u256` and `u512` are named in the founder's specification and
+exist in no enum — not even as `Reserved`. `Reserved` would be the honest
+state for them: the name taken, every use refused with a named diagnostic,
+which records the intent inside the compiler rather than only in a document.
+That is a proposal, not a founder ruling.
+
+## Claims Forbidden
+
+- Do not describe the narrowing act or its proof obligation as implemented.
+  Neither exists; this records a ruling of 2026-08-19.
+- Do not read the absence of `i256`/`i512`/`u256`/`u512` as a decision against
+  them. They were specified and never built.
+- Do not cite `f128`/`f256` as available. They are `Reserved`: every use is
+  refused with `E218`, and a refuse-fixture pair records that
+  (`tests/typekind/index.tsv`).


### PR DESCRIPTION
Founder ruling, 2026-08-19. **Amends `SOUNIO-PRECISION-PRESERVATION`** rather than adding a fifth document.

## What changed

The invariant read *"narrowing is explicit **or** proven lossless for the stated contract"*. That disjunction's second branch is what a compiler reaches for when the first is inconvenient. Both halves now hold at once: the narrowing is written, **and** its justification carries the floor from `SOUNIO-JUSTIFICATION` — a discharged proof obligation, not prose.

The uniform rule is safe from decay *because of* that earlier ruling. An act written as a string becomes reflex boilerplate within a month; a theorem cannot be faked. The two decisions interlock.

**Domain: epistemic and exact values.** A loop counter, an index, or a scalar narrowed for display carries no knowledge — no degradation, no act. Without this scope every `f64 → f32` in plotting code would need a theorem, which no principle here asks for. The scope follows from `SOUNIO-NO-IMPLICIT-DEGRADATION` rather than being stipulated beside it.

**New invariant:** uncertainty is what makes narrowing survivable; exactness is what makes it fatal. One rule covers both, because on an exact value the absorbing uncertainty is zero.

## Measured ladder recorded

| family | usable | Reserved (`E218`) | absent entirely |
|---|---|---|---|
| signed | `i8 i32 i64 i128` | — | **`i256` `i512`** |
| unsigned | `u8 u32 u64 u128` | — | **`u256` `u512`** |
| float | `f32 f64` | `f128` `f256` | — |

`i256`/`i512`/`u256`/`u512` are named in the founder's specification and exist in no enum — not even as `Reserved`. The asymmetry is not accidental: exactness needs wide **integers**, not wide floats.

The document was last validated 2026-03-07 and carried the stale disjunction the whole time.

## Semantic declaration

- **Concept-IDs**: amends `SOUNIO-PRECISION-PRESERVATION`; updates one row of `SOUNIO-NO-IMPLICIT-DEGRADATION`'s degradation table. References `SOUNIO-JUSTIFICATION`, `SOUNIO-EXACTNESS`.
- **Intent-Preserved**: *"Small, residual, or cancellation-sensitive effects must not disappear because an implementation silently narrows the representation."* The amendment strengthens this; it removes no existing invariant.
- **Transformation**: documentation plus filesystem-derived registry sync. Zero lines of `self-hosted/` or `stdlib/`.
- **Claims-Introduced**: the ladder table (reproducible by `git grep -ohE '\bTy(F|I|U)[0-9]+\b' -- self-hosted/` and `tests/typekind/index.tsv`).
- **Claims-Forbidden**: the narrowing act and its proof obligation are **not implemented** — neither exists. The absence of `i256`/`i512`/`u256`/`u512` is not a decision against them. `f128`/`f256` are not available: every use is refused with `E218`. The document states all three in its own Claims Forbidden section.
- **Authoritative-Only-If**: status remains **Hypothesis** for the narrowing act until a correct program passes and a wrong program is refused.