### PR TITLE
concept(registry): SOUNIO-PIPELINE-ORDER — two rulings, and the tension between them named

### DIFF
--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -602,6 +602,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.internal.concepts.ordered-path-provenance | repo_only | docs/internal/concepts/ordered-path-provenance.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.path-conditioned-partial-identification | repo_only | docs/internal/concepts/path-conditioned-partial-identification.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.physical-observation | repo_only | docs/internal/concepts/physical-observation.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.concepts.pipeline-order | repo_only | docs/internal/concepts/pipeline-order.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.policy-observation-associator | repo_only | docs/internal/concepts/policy-observation-associator.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.policy-state-feedback | repo_only | docs/internal/concepts/policy-state-feedback.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.precision-preservation | repo_only | docs/internal/concepts/precision-preservation.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -13326,6 +13326,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.internal.concepts.pipeline-order",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/concepts/pipeline-order.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.internal.concepts.policy-observation-associator",
       "collection": "repo",
       "repo_doc_path": "docs/internal/concepts/policy-observation-associator.md",

--- a/docs/internal/concepts/pipeline-order.md
+++ b/docs/internal/concepts/pipeline-order.md
@@ -1,0 +1,119 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.concepts.pipeline-order
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: claude-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.concepts.pipeline-order
+-->
+
+# Pipeline Order
+
+Concept-ID: `SOUNIO-PIPELINE-ORDER`
+
+Status: **Hypothesis** — two founder rulings of 2026-08-19, recorded together
+because they must coexist and the tension between them is **not resolved**.
+Neither is implemented.
+
+## The two rulings
+
+**HLIR is always on the path.** It stops being the GPU frontend and becomes the
+layer everything descends through; the backends hang below it.
+
+```
+check → HLIR → ir/ → native      (CPU)
+             ↘ gpu               (GPU)
+             ↘ enir → verify     (epistemic)
+```
+
+**Verification is the floor** (`SOUNIO-VERIFIED-LOWERING`): ENIR becomes the
+path for content that must be trusted; `ir/` and the e-graph are an optional
+accelerator, and a rewrite rule may not run until it carries translation
+validation.
+
+## Measured state, 2026-08-19 (`origin/main`)
+
+The live CPU pipeline is `parser → check → ir → native`. HLIR is **not** off the
+tree and **not** uncalled — it is the **GPU frontend**: `hlir_lower_module` is
+invoked at `self-hosted/compiler/main.sio:28198`, inside the `--backend gpu`
+path, and at `self-hosted/main.sio:502`. Default `souc` never reaches it.
+
+That explains where the hypercomplex algebra lives, and it is not an accident.
+`HlirTypeOctonion` (`hlir/ir.sio:135`) lowers to `<8 x float>` — one vector
+register for eight components, which is what a SIMD unit wants. The algebra sits
+in the GPU frontend because it was designed to descend through GPU.
+
+**Consequence: the ruling is a reordering, not new construction.** Making HLIR
+always-on does not require building it.
+
+Cost of making a bare `Octonion` annotation sayable, counted in
+`docs/audit/HLIR_DISCONNECT_COST_2026-08-19.md` (PR #1957): **two** new enum
+variants (checker `TypeKind`, layout `LayTypeKind`), three if the parser also
+gets its own form rather than reusing `TypeNamed`, plus **one** absent function
+`TypeKind → HlirTypeKind`. The parameterised spelling `Hyper<Octonion, f64>`
+needs **zero** parser and checker variants — `TyHyper` (`check/types.sio`,
+tag 22) already carries `Hyper<Algebra, T>`, and `hlir_type_from_ast` already
+returns `hlir_type_octonion()`.
+
+## The unresolved tension
+
+Putting HLIR on the path solves **rich types**. It does **not** solve
+**uncertainty**, and the two problems pass through the same place.
+
+`HlirTypeKind` has `HlirTypeKnowledge` (`hlir/ir.sio:149`) — so HLIR can *name*
+an epistemic value. But variance is not part of that value: it lives in slots
+bound by hand in `ir/lower.sio` (`alloc_variance_slot_for_local`,
+`bind_variance_for_base_reg`, `emit_variance_add`, …), which is **below and
+beside** HLIR. See `SOUNIO-VERIFIED-LOWERING` for why that representation is the
+mechanism behind the FO variance defect.
+
+So if everything descends through HLIR and epistemic content then descends
+through ENIR, **HLIR must be able to carry uncertainty in order to hand it
+over** — and today it cannot. Naming a `Knowledge` is not carrying its variance.
+
+**This is recorded as an open question, not a plan.** Three shapes exist and
+none is chosen:
+
+1. HLIR carries uncertainty in the value (the representation
+   `SOUNIO-VERIFIED-LOWERING` argues for), and ENIR receives it whole.
+2. HLIR carries only the type, and the ENIR boundary reconstructs variance from
+   provenance — which requires `SOUNIO-PROVENANCE` first.
+3. Epistemic content leaves the HLIR path earlier, at the checker, and HLIR is
+   always-on only for non-epistemic code — which weakens "always on the path"
+   to "always on the ordinary path".
+
+## Required Invariants
+
+- A type is sayable in exactly one place. If `Octonion` acquires a variant in
+  the checker while a second hypercomplex representation persists elsewhere,
+  two enums must agree forever, and forever is when they stop agreeing.
+- An unknown type name is refused, never defaulted. Today the bare name
+  `"Octonion"` falls back to `hlir_type_i64()` in `hlir_type_from_ast`. Adding a
+  parser variant without closing that fallback makes an octonion compile
+  silently as a 64-bit integer — eight components reduced to one, no
+  diagnostic. This must refuse before any variant is added.
+- A downstream lowering is not evidence of a sayable type.
+  `llvm/type_convert.sio:282` already lowers `HlirTypeOctonion`, and `llvm/`
+  has **zero** external importers. Someone wrote the end of the road before the
+  beginning; that end proves nothing about the beginning.
+- Reordering is not construction, and neither is it free. HLIR handling every
+  compile means HLIR meets inputs the GPU path never gave it.
+
+## Claims Forbidden
+
+- Do not describe HLIR as on the default path. It is the GPU frontend and
+  default `souc` does not reach it.
+- Do not present the two rulings as a resolved architecture. Their interaction
+  is the open question above, stated as three unchosen shapes.
+- Do not read `HlirTypeKnowledge` as uncertainty support. It names an epistemic
+  value; variance lives in hand-bound slots in `ir/lower.sio`.
+- Do not cite the `Hyper<Octonion, f64>` path as working. It fires only inside
+  `hlir_lower_module`, which default `souc` never calls.
+- No schedule attaches to either ruling.
+
+## Related
+
+- `SOUNIO-VERIFIED-LOWERING` — the other half of the ordering, and why
+  uncertainty must be carried rather than bound
+- `SOUNIO-EPISTEMIC-ERASURE` — what the pipeline must not silently drop
+- `SOUNIO-PROVENANCE` — required first if shape 2 is chosen


### PR DESCRIPTION
Two founder rulings of 2026-08-19, recorded **together** because they must coexist — and with the tension between them recorded **unresolved** rather than smoothed over.

## The rulings

**HLIR is always on the path.**

```
check → HLIR → ir/ → native      (CPU)
             ↘ gpu               (GPU)
             ↘ enir → verify     (epistemic)
```

**Verification is the floor** — `SOUNIO-VERIFIED-LOWERING`, merged as #1955.

## What the measurement changed

HLIR is **not** off the tree and **not** uncalled. It is the **GPU frontend**: `hlir_lower_module` runs at `compiler/main.sio:28198` inside the `--backend gpu` path, and at `self-hosted/main.sio:502`. Default `souc` never reaches it.

That explains where the hypercomplex algebra lives, and it is not an accident — `HlirTypeOctonion` lowers to `<8 x float>`: one vector register for eight components, which is what a SIMD unit wants. **So the ruling is a reordering, not new construction.**

Cost from #1957: **2** new enum variants for a bare `Octonion` (checker + layout), 3 if the parser gets its own form, plus **1** absent `TypeKind → HlirTypeKind` function. The parameterised `Hyper<Octonion, f64>` needs **zero** parser and checker variants — `TyHyper` already carries `Hyper<Algebra, T>`.

## The tension, named and left open

Putting HLIR on the path solves **rich types**. It does **not** solve **uncertainty**, and both pass through the same place.

`HlirTypeKind` has `HlirTypeKnowledge`, so HLIR can *name* an epistemic value. But variance lives in **hand-bound slots** in `ir/lower.sio`, below and beside HLIR. If everything descends through HLIR and epistemic content then descends through ENIR, HLIR must carry uncertainty to hand it over — and today it cannot. Three shapes are stated in the document; **none is chosen**.

## An invariant that must land before any variant

The bare name `"Octonion"` currently falls back to `hlir_type_i64()` in `hlir_type_from_ast`. Adding a parser variant without closing that fallback makes **an octonion compile silently as a 64-bit integer** — eight components reduced to one, no diagnostic.

## Semantic declaration

- **Concept-IDs**: introduces `SOUNIO-PIPELINE-ORDER`. References `SOUNIO-VERIFIED-LOWERING`, `SOUNIO-EPISTEMIC-ERASURE`, `SOUNIO-PROVENANCE`.
- **Intent-Preserved**: the founder's *"tem que compilar direto para GPU incluindo álgebras hipercomplexas"* — measured as already true, and recorded as such rather than as pending work.
- **Transformation**: documentation plus filesystem-derived registry sync. Zero lines of `self-hosted/` or `stdlib/`.
- **Claims-Introduced**: the call sites, the `<8 x float>` lowering, the variant counts, and the `hlir_type_i64()` fallback — all reproducible by `git grep` on `origin/main` and from `docs/audit/HLIR_DISCONNECT_COST_2026-08-19.md` (#1957).
- **Claims-Forbidden**: HLIR is **not** on the default path. The two rulings are **not** a resolved architecture — their interaction is the open question. `HlirTypeKnowledge` is **not** uncertainty support. The `Hyper<Octonion, f64>` path does **not** work today: it fires only inside `hlir_lower_module`, which default `souc` never calls. A downstream lowering is not evidence of a sayable type — `llvm/` has zero external importers. **No schedule attaches to either ruling.**
- **Authoritative-Only-If**: **Hypothesis** until a program annotated with a hypercomplex type compiles on the default CPU path and a wrong one is refused.
