### PR TITLE
compiler(effects): production EffectKind enum of the 23 live ids (phase 2a)

### DIFF
--- a/docs/audit/EFFECT_ENUM_2A_2026-08-19.md
+++ b/docs/audit/EFFECT_ENUM_2A_2026-08-19.md
@@ -17,10 +17,12 @@ lands, and are not started here.
 **base sha:** `cdea9d7eef` (rebased onto `origin/main` before commit).
 `self-hosted/check/effects.sio` on this tip is still the #1956 text
 (`e5715c547d`); the two intervening commits are docs/concept only.
-**Engine surface:** standalone dual-function test under the shipped Madaros
-ELF (`./bin/souc run`). The production source change is in
-`self-hosted/check/effects.sio`. The shipped ELF still contains the old
-handwritten arms until a rebuilt Madaros is used as the compiler.
+**Engine surface:** standalone dual-function test. CI Full Test Suite
+compiles it with `/tmp/souc-stage2` (native self-host, lean_single),
+not with shipped Madaros. Local `./bin/souc` defaults to Madaros and
+is the wrong compiler for that job. The production source change is in
+`self-hosted/check/effects.sio`. The shipped Madaros ELF still contains
+the old handwritten arms until a rebuilt Madaros is used as the compiler.
 **Test:** `tests/run-pass/effect_enum_equiv.sio`
 
 ---
@@ -195,6 +197,49 @@ Required by the dispatch (never on the pod; do not wrap
 - the ELF stays on the node; `souc-build-remote.sh` does not ship it back
 - this proves the new `check/effects.sio` compiles into Madaros. It is
   not a claim that the workspace `bin/souc` ELF was replaced.
+
+### CI #1960 first run (witness was the wrong measurement)
+
+PR #1960 Full Test Suite (job 96048482036, 2026-08-19T11:15–11:22Z)
+reported `FAIL effect_enum_equiv.sio (run exited 1)`. JUnit has no
+stdout. That string is the harness wrapping any non-zero `souc run`
+(`scripts/dev/run_sio_test_suite.sh` line 402). It is not an assertion
+failure.
+
+Measured, cost order:
+
+1. **Compile vs assertion.** `env -u SOUC_BIN ./bin/souc check` (Madaros)
+   is `check: OK`. The same file under
+   `SOUNIO_SOUC_ENGINE=lean_single` is `typecheck: failed`:
+   `tail type mismatch at <main>:11` and
+   `effect not declared in function signature` at lines 394/396/402.
+   Isolated probes: a bare `[0; 64]` tail of `-> [i8; 64]` is the
+   mismatch; `var buf: [i8; 64] = [0; 64]; buf` typechecks. `var`
+   assignment in `enum_effect_name_to_id` needs `with Mut` on
+   lean_single. Madaros accepts both. The test never reached
+   `check_pair` on CI.
+2. **Wrong compiler.** Full Test Suite sets
+   `SOUNIO_TEST_SOUC_BIN=/tmp/souc-stage2` (artifact of Native Self-Host).
+   The PR body measured shipped Madaros. The witness is standalone, so
+   the shipped-ELF-lacks-new-lookup claim is not this failure; the
+   engine dialect is.
+3. **Harness dialect.** `//@ run-pass` plus undeclared Mut / i8-array
+   tail. Not an import, not a missing effect on `main`.
+
+The witness was wrong. Equivalence was not disproven. Dialect-only
+fix: typed local in `empty_name`, `with Mut` on the enum lookup,
+`//@ expect-stdout` for both sentinels. Assertions and ids unchanged.
+
+### AFTER re-run (both engines, 2026-08-19T11:42Z)
+
+| engine | check | run sentinels | rc |
+|---|---|---|---|
+| Madaros `./bin/souc` | OK | `NEGATIVE_CONTROL_FIRED` + `EFFECT_ENUM_EQUIV_OK 23/23 + negative` | 0 |
+| lean_single `SOUNIO_SOUC_ENGINE=lean_single` | compiles (38 fns) | same two lines | 0 |
+| harness + `SOUNIO_TEST_SOUC_BIN=bin/souc-lean-single-x86_64` | — | `PASS effect_enum_equiv.sio` | 0 |
+
+21 unexpected passes in the same CI log (including
+`gum_fo_across_call.sio`) were not touched.
 
 ---
 

--- a/docs/audit/EFFECT_ENUM_2A_2026-08-19.md
+++ b/docs/audit/EFFECT_ENUM_2A_2026-08-19.md
@@ -1,0 +1,212 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.effect-enum-2a-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: grok-cli5
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.effect-enum-2a-2026-08-19
+-->
+
+# Effect enum 2a — production lookup of the existing 23 ids
+
+Phase 2a of the founder-approved split. This PR is **equivalence only**.
+Zero vocabulary decisions. The seven extras belong in 2b, after this
+lands, and are not started here.
+
+**Date:** 2026-08-19
+**base sha:** `cdea9d7eef` (rebased onto `origin/main` before commit).
+`self-hosted/check/effects.sio` on this tip is still the #1956 text
+(`e5715c547d`); the two intervening commits are docs/concept only.
+**Engine surface:** standalone dual-function test under the shipped Madaros
+ELF (`./bin/souc run`). The production source change is in
+`self-hosted/check/effects.sio`. The shipped ELF still contains the old
+handwritten arms until a rebuilt Madaros is used as the compiler.
+**Test:** `tests/run-pass/effect_enum_equiv.sio`
+
+---
+
+## Semantic lane declaration (mandatory)
+
+```text
+Semantic-Lane-ID: effect-enum-2a-20260819
+Owner: grok-cli5
+Concept-IDs: none
+Intent-Preserved: the 23 live `with` names keep ids 0-22; unknown stays -1;
+  EffVar remains row-polymorphism structure, not a named `with`.
+Transformation: representation only. effect_name_to_id consults an enum
+  whose declaration order is ID order. No name added, removed, or
+  renumbered. No handler, CPS, or inliner choice.
+Types-Changed: none
+Effects-Changed: none (same 23 ids, same -1)
+IR-Changed: none
+Claims-Introduced:
+  - for each of the 23 names, legacy byte-cmp and enum lookup return the
+    same i64
+  - for a name in no list (NoSuchEffectX), both return -1
+  - EffectKind::EffVar discriminant is 23 and is never returned by lookup
+Claims-Forbidden:
+  - handlers.sio is connected, or self-hosted/effects/ is on the live path
+  - any effect was removed
+  - seed FN_EFFECTS bits are production ids (Chaotic is id 22; stdlib
+    "Perturbative bit 22" is a bit)
+  - extras (Approx, NaturalityG2, Deterministic, Perturbative,
+    NarrowWidthApproximation, NonUnitary, Mod) were added
+  - Confidence is a new variant (it is an alias of Epistemic)
+  - print_effect_name now names Chaotic (id 22 still falls through to
+    Effect#22; that string was not part of the equivalence contract)
+  - the shipped bin/souc ELF contains the new lookup (it does not, until
+    a rebuilt Madaros replaces it)
+Assumptions:
+  - enum discriminants are sequential from 0 in declaration order
+  - user tests cannot call check internals; the dual-function standalone
+    file is the id proof
+  - SOUC_BIN is poison and is unset
+  - any Madaros rebuild is Slurm, never the pod; build_modular_madaros.sh
+    is not wrapped in souc-build-lock.sh
+Write-Set:
+  self-hosted/check/effects.sio
+  tests/run-pass/effect_enum_equiv.sio
+  docs/audit/EFFECT_ENUM_2A_2026-08-19.md
+  docs/audit/EFFECT_ENUM_2A_2026-08-19.tsv
+  docs/governance/topic-registry.v1.json
+  docs/governance/DOCS_AUTHORITY_MATRIX.md
+Read-Set:
+  self-hosted/check/effects.sio (pre-change, e5715c547d)
+  self-hosted/effects/types.sio (orphan 15-variant enum; not wired)
+  /tmp/dispatch_phase2_claude1.md
+  /tmp/phase1_effect_enum_union.md
+Positive-Witness: NEGATIVE_CONTROL_FIRED old=new=-1
+  and EFFECT_ENUM_EQUIV_OK 23/23 + negative, rc=0, BEFORE and AFTER
+Negative-Witness: if the negative control does not fire, the measurement
+  is null
+Acceptance-Gate: BEFORE and AFTER both print NEGATIVE_CONTROL_FIRED and
+  EFFECT_ENUM_EQUIV_OK 23/23; souc check self-hosted/compiler/main.sio
+  verdict=0 on the new source
+Integration-Target: origin/main (own PR; 2b blocked until this lands)
+Authoritative-Only-If: the dual-function test is re-run and the negative
+  control still fires
+```
+
+---
+
+## Semantic outcome
+
+```text
+Semantic-Outcome: representation of the existing 23 ids moved from 23
+  handwritten byte-cmp arms to an enum in ID order plus a discriminant
+  loop. Behaviour of effect_name_to_id is unchanged.
+Concept-Status-Before: 23 live names, ids 0-22, unknown -> -1; orphan
+  15-variant EffectKind in self-hosted/effects/types.sio disconnected
+Concept-Status-After: same 23 ids; production enum in
+  self-hosted/check/effects.sio; orphan layer still disconnected
+Distinctions-Added: ID order vs historical source-arm order is now the
+  enum declaration order (Temporal=20 Learn=21 Chaotic=22)
+Distinctions-Preserved: live name vs orphan EffectKind vs seed FN_EFFECTS
+  bits vs archaeology pairs; EffVar is structure not a `with` name
+Distinctions-Erased: none
+Evidence-Run: see BEFORE / AFTER below
+Fallback-Path: the frozen legacy_effect_name_to_id in the test file
+Legacy-Kept: print_effect_name arms unchanged (Chaotic still Effect#22);
+  collect/extract/subset/merge helpers unchanged; self-hosted/effects/**
+  untouched
+Conflicting-Lanes: grok-cli3 STALE claim on check/effects.sio
+  (effect-set-as-data); this lane holds the live claim
+Next-Semantic-Interface: phase 2b (seven extras, new ids after 22,
+  measure Mod first). Not started.
+```
+
+---
+
+## ID table (production, ID order)
+
+| id | name | source-arm order note |
+|---:|---|---|
+| 0 | IO | |
+| 1 | Mut | |
+| 2 | Alloc | |
+| 3 | Panic | |
+| 4 | Div | |
+| 5 | GPU | |
+| 6 | Async | |
+| 7 | Prob | |
+| 8 | Epistemic | |
+| 9 | Causal | |
+| 10 | Network | |
+| 11 | Sensor | |
+| 12 | Render | |
+| 13 | Observe | |
+| 14 | NonAssoc | |
+| 15 | Audit | |
+| 16 | Hypothesis | |
+| 17 | MultiTest | |
+| 18 | ZD | |
+| 19 | Witness | |
+| 20 | Temporal | source file listed Chaotic before Temporal/Learn |
+| 21 | Learn | |
+| 22 | Chaotic | production id 22; not seed bit 22 |
+| 23 | *(EffVar)* | not a `with` name; lookup never returns 23 |
+
+---
+
+## Equivalence proof
+
+The test file carries a frozen copy of production `effect_name_to_id` as
+of `e5715c547d` and a second function that loops discriminants 0..=22 of
+the new enum. User tests cannot call checker internals, so this
+standalone dual-function file is the id proof.
+
+If the negative control does not fire, the measurement is null.
+
+### BEFORE (production still handwritten arms)
+
+- when: 2026-08-19T11:00:53Z
+- command: `env -u SOUC_BIN -u SOUNIO_SOUC_BIN ./bin/souc run tests/run-pass/effect_enum_equiv.sio`
+- host: workspace pod (cheap `souc run` of a standalone file; not a Madaros rebuild)
+- output: `NEGATIVE_CONTROL_FIRED old=new=-1` then `EFFECT_ENUM_EQUIV_OK 23/23 + negative`
+- rc: 0
+- log: session `call-8d24d440-a853-474f-b7c1-f19c853dbf09-108.log`
+
+### AFTER (production source is the enum lookup)
+
+- when: 2026-08-19T11:02:22Z (first) and 2026-08-19T11:06Z (re-run this session)
+- same command, same host class
+- output: `NEGATIVE_CONTROL_FIRED old=new=-1` then `EFFECT_ENUM_EQUIV_OK 23/23 + negative`
+- rc: 0
+- log: session `call-878c4197-47b8-492f-b1ea-a22149c10f82-112.log` and this-session re-run
+
+### Production typecheck
+
+`env -u SOUC_BIN -u SOUNIO_SOUC_BIN ./bin/souc check self-hosted/compiler/main.sio`
+completed with advisory E-SRB plus truncation/stack warnings and
+`verdict=0` / `CHECK_MAIN_RC:0`. The new source typechecks. That is not
+a claim that the shipped ELF already contains the new lookup.
+
+### Slurm Madaros rebuild
+
+Required by the dispatch (never on the pod; do not wrap
+`build_modular_madaros.sh` in `souc-build-lock.sh`).
+
+- launcher: `scripts/dev/souc-build-remote.sh` (stdin tarball; no local fallback)
+- job: 10327
+- node: `gpuorangefs-r770-proxmox` (partition `all`, 32 CPUs)
+- unpacked: 69M
+- `REMOTE: build rc=0 elapsed=226s`
+- `REMOTE: elf bytes=100551595`
+- the ELF stays on the node; `souc-build-remote.sh` does not ship it back
+- this proves the new `check/effects.sio` compiles into Madaros. It is
+  not a claim that the workspace `bin/souc` ELF was replaced.
+
+---
+
+## What this PR does not do
+
+- does not add Approx, NaturalityG2, Deterministic, Perturbative,
+  NarrowWidthApproximation, NonUnitary, or Mod
+- does not treat Confidence as a new variant
+- does not wire `self-hosted/effects/` (handlers.sio stays disconnected)
+- does not change `print_effect_name` so Chaotic would print as "Chaotic"
+- does not start 2b
+- does not merge
+
+Pairs in the exact #1944 pass/refuse layout belong in 2b, after this
+lands, and only after Mod is measured (311 `with Mod` files; `-1` today).

--- a/docs/audit/EFFECT_ENUM_2A_2026-08-19.tsv
+++ b/docs/audit/EFFECT_ENUM_2A_2026-08-19.tsv
@@ -1,0 +1,36 @@
+# EFFECT_ENUM_2A_2026-08-19
+# base_sha	cdea9d7eef
+# effects_sio_still	e5715c547d_text
+# slurm_job	10327	gpuorangefs-r770-proxmox	rc=0	elapsed=226s	elf_bytes=100551595
+# test	tests/run-pass/effect_enum_equiv.sio
+# before	2026-08-19T11:00:53Z	NEGATIVE_CONTROL_FIRED	EFFECT_ENUM_EQUIV_OK 23/23	rc=0
+# after	2026-08-19T11:02:22Z	NEGATIVE_CONTROL_FIRED	EFFECT_ENUM_EQUIV_OK 23/23	rc=0
+# after_rerun	2026-08-19T11:06:00Z	NEGATIVE_CONTROL_FIRED	EFFECT_ENUM_EQUIV_OK 23/23	rc=0
+# instrument	standalone dual-function file; user tests cannot call check internals
+# negative_control	NoSuchEffectX must be -1 on both sides or the measurement is null
+name	id	legacy	enum	match	role
+IO	0	0	0	yes	live
+Mut	1	1	1	yes	live
+Alloc	2	2	2	yes	live
+Panic	3	3	3	yes	live
+Div	4	4	4	yes	live
+GPU	5	5	5	yes	live
+Async	6	6	6	yes	live
+Prob	7	7	7	yes	live
+Epistemic	8	8	8	yes	live
+Causal	9	9	9	yes	live
+Network	10	10	10	yes	live
+Sensor	11	11	11	yes	live
+Render	12	12	12	yes	live
+Observe	13	13	13	yes	live
+NonAssoc	14	14	14	yes	live
+Audit	15	15	15	yes	live
+Hypothesis	16	16	16	yes	live
+MultiTest	17	17	17	yes	live
+ZD	18	18	18	yes	live
+Witness	19	19	19	yes	live
+Temporal	20	20	20	yes	live
+Learn	21	21	21	yes	live
+Chaotic	22	22	22	yes	live
+NoSuchEffectX	-1	-1	-1	yes	NEGATIVE_CONTROL_FIRED
+EffVar	23	n/a	n/a	disc_only	row_polymorphism_not_a_with_name

--- a/docs/audit/EFFECT_ENUM_2A_2026-08-19.tsv
+++ b/docs/audit/EFFECT_ENUM_2A_2026-08-19.tsv
@@ -6,6 +6,8 @@
 # before	2026-08-19T11:00:53Z	NEGATIVE_CONTROL_FIRED	EFFECT_ENUM_EQUIV_OK 23/23	rc=0
 # after	2026-08-19T11:02:22Z	NEGATIVE_CONTROL_FIRED	EFFECT_ENUM_EQUIV_OK 23/23	rc=0
 # after_rerun	2026-08-19T11:06:00Z	NEGATIVE_CONTROL_FIRED	EFFECT_ENUM_EQUIV_OK 23/23	rc=0
+# ci_fail	#1960 job 96048482036	FAIL effect_enum_equiv.sio (run exited 1)	lean_single typecheck	not assertion
+# after_lean	2026-08-19T11:42:00Z	lean_single+Madaros	NEGATIVE_CONTROL_FIRED	EFFECT_ENUM_EQUIV_OK 23/23	rc=0
 # instrument	standalone dual-function file; user tests cannot call check internals
 # negative_control	NoSuchEffectX must be -1 on both sides or the measurement is null
 name	id	legacy	enum	match	role

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -105,6 +105,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.dossier-import-closure-2026-08-17 | repo_only | docs/audit/DOSSIER_IMPORT_CLOSURE_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.e011-stale-prebuilt-phantom-2026-08-18 | repo_only | docs/audit/E011_STALE_PREBUILT_PHANTOM_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.e043-rust-macro-design-dispatch-2026-07-12 | repo_only | docs/audit/E043_RUST_MACRO_DESIGN_DISPATCH_2026-07-12.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.effect-enum-2a-2026-08-19 | repo_only | docs/audit/EFFECT_ENUM_2A_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.effects-layer-cost-2026-08-19 | repo_only | docs/audit/EFFECTS_LAYER_COST_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.engine-parity-adjudication-2026-08-02 | repo_only | docs/audit/ENGINE_PARITY_ADJUDICATION_2026-08-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.enir-mir-disconnect-cost-2026-08-19 | repo_only | docs/audit/ENIR_MIR_DISCONNECT_COST_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1879,6 +1879,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.effect-enum-2a-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/EFFECT_ENUM_2A_2026-08-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.effects-layer-cost-2026-08-19",
       "collection": "repo",
       "repo_doc_path": "docs/audit/EFFECTS_LAYER_COST_2026-08-19.md",

--- a/self-hosted/check/effects.sio
+++ b/self-hosted/check/effects.sio
@@ -1,212 +1,149 @@
 // Effect processing for type checker
 //
 // Converts parsed EffectList from AST to effect ID arrays in FnSig.
-// Effect IDs: 0=IO, 1=Mut, 2=Alloc, 3=Panic, 4=Div, 5=GPU, 6=Async,
-// 7=Prob, 8=Epistemic, 9=Causal, 10=Network, 11=Sensor, 12=Render,
-// 13=Observe, 14=NonAssoc, 15=Audit, 16=Hypothesis, 17=MultiTest,
-// 18=ZD (zero-divisor effect for Forgettable<T>),
-// 19=Witness (emits machine-checkable Lean witness, required by Audited<T>),
-// 20=Temporal (time-bounded reversibility, required by Revivable<T>),
-// 21=Learn (gradient production; required by SurgicalOptimizer)
+// Effect IDs are EffectKind discriminants in declaration order (ID order,
+// not the historical source-arm order). Phase 2a: the 23 live names only.
+//   0=IO 1=Mut 2=Alloc 3=Panic 4=Div 5=GPU 6=Async 7=Prob
+//   8=Epistemic 9=Causal 10=Network 11=Sensor 12=Render 13=Observe
+//   14=NonAssoc 15=Audit 16=Hypothesis 17=MultiTest 18=ZD 19=Witness
+//   20=Temporal 21=Learn 22=Chaotic
+// EffVar is the row-polymorphism slot (discriminant 23). It is not a
+// user-facing `with` name and effect_name_to_id never returns 23.
 
 // ============================================================
-// Effect name to ID mapping
+// Production effect enum — ID order
+// ============================================================
+
+enum EffectKind {
+    EffIO,
+    EffMut,
+    EffAlloc,
+    EffPanic,
+    EffDiv,
+    EffGPU,
+    EffAsync,
+    EffProb,
+    EffEpistemic,
+    EffCausal,
+    EffNetwork,
+    EffSensor,
+    EffRender,
+    EffObserve,
+    EffNonAssoc,
+    EffAudit,
+    EffHypothesis,
+    EffMultiTest,
+    EffZD,
+    EffWitness,
+    EffTemporal,
+    EffLearn,
+    EffChaotic,
+    EffVar,
+}
+
+fn effect_kind_name_len(k: i64) -> i64 {
+    if k == 0 { 2 }
+    else if k == 1 { 3 }
+    else if k == 2 { 5 }
+    else if k == 3 { 5 }
+    else if k == 4 { 3 }
+    else if k == 5 { 3 }
+    else if k == 6 { 5 }
+    else if k == 7 { 4 }
+    else if k == 8 { 9 }
+    else if k == 9 { 6 }
+    else if k == 10 { 7 }
+    else if k == 11 { 6 }
+    else if k == 12 { 6 }
+    else if k == 13 { 7 }
+    else if k == 14 { 8 }
+    else if k == 15 { 5 }
+    else if k == 16 { 10 }
+    else if k == 17 { 9 }
+    else if k == 18 { 2 }
+    else if k == 19 { 7 }
+    else if k == 20 { 8 }
+    else if k == 21 { 5 }
+    else if k == 22 { 7 }
+    else { 0 }
+}
+
+fn effect_kind_name_byte(k: i64, i: i64) -> i8 {
+    if k == 0 {
+        if i == 0 { 73 as i8 } else { 79 as i8 }
+    } else if k == 1 {
+        if i == 0 { 77 as i8 } else if i == 1 { 117 as i8 } else { 116 as i8 }
+    } else if k == 2 {
+        if i == 0 { 65 as i8 } else if i == 1 { 108 as i8 } else if i == 2 { 108 as i8 } else if i == 3 { 111 as i8 } else { 99 as i8 }
+    } else if k == 3 {
+        if i == 0 { 80 as i8 } else if i == 1 { 97 as i8 } else if i == 2 { 110 as i8 } else if i == 3 { 105 as i8 } else { 99 as i8 }
+    } else if k == 4 {
+        if i == 0 { 68 as i8 } else if i == 1 { 105 as i8 } else { 118 as i8 }
+    } else if k == 5 {
+        if i == 0 { 71 as i8 } else if i == 1 { 80 as i8 } else { 85 as i8 }
+    } else if k == 6 {
+        if i == 0 { 65 as i8 } else if i == 1 { 115 as i8 } else if i == 2 { 121 as i8 } else if i == 3 { 110 as i8 } else { 99 as i8 }
+    } else if k == 7 {
+        if i == 0 { 80 as i8 } else if i == 1 { 114 as i8 } else if i == 2 { 111 as i8 } else { 98 as i8 }
+    } else if k == 8 {
+        if i == 0 { 69 as i8 } else if i == 1 { 112 as i8 } else if i == 2 { 105 as i8 } else if i == 3 { 115 as i8 } else if i == 4 { 116 as i8 } else if i == 5 { 101 as i8 } else if i == 6 { 109 as i8 } else if i == 7 { 105 as i8 } else { 99 as i8 }
+    } else if k == 9 {
+        if i == 0 { 67 as i8 } else if i == 1 { 97 as i8 } else if i == 2 { 117 as i8 } else if i == 3 { 115 as i8 } else if i == 4 { 97 as i8 } else { 108 as i8 }
+    } else if k == 10 {
+        if i == 0 { 78 as i8 } else if i == 1 { 101 as i8 } else if i == 2 { 116 as i8 } else if i == 3 { 119 as i8 } else if i == 4 { 111 as i8 } else if i == 5 { 114 as i8 } else { 107 as i8 }
+    } else if k == 11 {
+        if i == 0 { 83 as i8 } else if i == 1 { 101 as i8 } else if i == 2 { 110 as i8 } else if i == 3 { 115 as i8 } else if i == 4 { 111 as i8 } else { 114 as i8 }
+    } else if k == 12 {
+        if i == 0 { 82 as i8 } else if i == 1 { 101 as i8 } else if i == 2 { 110 as i8 } else if i == 3 { 100 as i8 } else if i == 4 { 101 as i8 } else { 114 as i8 }
+    } else if k == 13 {
+        if i == 0 { 79 as i8 } else if i == 1 { 98 as i8 } else if i == 2 { 115 as i8 } else if i == 3 { 101 as i8 } else if i == 4 { 114 as i8 } else if i == 5 { 118 as i8 } else { 101 as i8 }
+    } else if k == 14 {
+        if i == 0 { 78 as i8 } else if i == 1 { 111 as i8 } else if i == 2 { 110 as i8 } else if i == 3 { 65 as i8 } else if i == 4 { 115 as i8 } else if i == 5 { 115 as i8 } else if i == 6 { 111 as i8 } else { 99 as i8 }
+    } else if k == 15 {
+        if i == 0 { 65 as i8 } else if i == 1 { 117 as i8 } else if i == 2 { 100 as i8 } else if i == 3 { 105 as i8 } else { 116 as i8 }
+    } else if k == 16 {
+        if i == 0 { 72 as i8 } else if i == 1 { 121 as i8 } else if i == 2 { 112 as i8 } else if i == 3 { 111 as i8 } else if i == 4 { 116 as i8 } else if i == 5 { 104 as i8 } else if i == 6 { 101 as i8 } else if i == 7 { 115 as i8 } else if i == 8 { 105 as i8 } else { 115 as i8 }
+    } else if k == 17 {
+        if i == 0 { 77 as i8 } else if i == 1 { 117 as i8 } else if i == 2 { 108 as i8 } else if i == 3 { 116 as i8 } else if i == 4 { 105 as i8 } else if i == 5 { 84 as i8 } else if i == 6 { 101 as i8 } else if i == 7 { 115 as i8 } else { 116 as i8 }
+    } else if k == 18 {
+        if i == 0 { 90 as i8 } else { 68 as i8 }
+    } else if k == 19 {
+        if i == 0 { 87 as i8 } else if i == 1 { 105 as i8 } else if i == 2 { 116 as i8 } else if i == 3 { 110 as i8 } else if i == 4 { 101 as i8 } else if i == 5 { 115 as i8 } else { 115 as i8 }
+    } else if k == 20 {
+        if i == 0 { 84 as i8 } else if i == 1 { 101 as i8 } else if i == 2 { 109 as i8 } else if i == 3 { 112 as i8 } else if i == 4 { 111 as i8 } else if i == 5 { 114 as i8 } else if i == 6 { 97 as i8 } else { 108 as i8 }
+    } else if k == 21 {
+        if i == 0 { 76 as i8 } else if i == 1 { 101 as i8 } else if i == 2 { 97 as i8 } else if i == 3 { 114 as i8 } else { 110 as i8 }
+    } else if k == 22 {
+        if i == 0 { 67 as i8 } else if i == 1 { 104 as i8 } else if i == 2 { 97 as i8 } else if i == 3 { 111 as i8 } else if i == 4 { 116 as i8 } else if i == 5 { 105 as i8 } else { 99 as i8 }
+    } else {
+        0 as i8
+    }
+}
+
+// ============================================================
+// Effect name to ID mapping — enum lookup, not 23 handwritten arms
 // ============================================================
 
 pub fn effect_name_to_id(name_buf: [i8; 64], name_len: i64) -> i64 with Mut, Panic, Div {
-    // IO
-    if name_len == 2 {
-        if name_buf[0] == 73 as i8 && name_buf[1] == 79 as i8 {  // "IO"
-            return 0
+    var k: i64 = 0
+    while k <= 22 {
+        let nlen = effect_kind_name_len(k)
+        if nlen == name_len {
+            var i: i64 = 0
+            var ok = true
+            while i < nlen {
+                if name_buf[i as usize] != effect_kind_name_byte(k, i) {
+                    ok = false
+                }
+                i = i + 1
+            }
+            if ok {
+                return k
+            }
         }
+        k = k + 1
     }
-
-    // Mut
-    if name_len == 3 {
-        if name_buf[0] == 77 as i8 && name_buf[1] == 117 as i8 && name_buf[2] == 116 as i8 {  // "Mut"
-            return 1
-        }
-        // Div
-        if name_buf[0] == 68 as i8 && name_buf[1] == 105 as i8 && name_buf[2] == 118 as i8 {  // "Div"
-            return 4
-        }
-        // GPU
-        if name_buf[0] == 71 as i8 && name_buf[1] == 80 as i8 && name_buf[2] == 85 as i8 {  // "GPU"
-            return 5
-        }
-    }
-
-    // Alloc
-    if name_len == 5 {
-        if name_buf[0] == 65 as i8 && name_buf[1] == 108 as i8 && name_buf[2] == 108 as i8
-           && name_buf[3] == 111 as i8 && name_buf[4] == 99 as i8 {  // "Alloc"
-            return 2
-        }
-        // Async
-        if name_buf[0] == 65 as i8 && name_buf[1] == 115 as i8 && name_buf[2] == 121 as i8
-           && name_buf[3] == 110 as i8 && name_buf[4] == 99 as i8 {  // "Async"
-            return 6
-        }
-        // Panic
-        if name_buf[0] == 80 as i8 && name_buf[1] == 97 as i8 && name_buf[2] == 110 as i8
-           && name_buf[3] == 105 as i8 && name_buf[4] == 99 as i8 {  // "Panic"
-            return 3
-        }
-    }
-
-    // Prob
-    if name_len == 4 {
-        if name_buf[0] == 80 as i8 && name_buf[1] == 114 as i8 && name_buf[2] == 111 as i8
-           && name_buf[3] == 98 as i8 {  // "Prob"
-            return 7
-        }
-    }
-
-    // Epistemic (9 chars)
-    if name_len == 9 {
-        if name_buf[0] == 69 as i8 && name_buf[1] == 112 as i8 && name_buf[2] == 105 as i8
-           && name_buf[3] == 115 as i8 && name_buf[4] == 116 as i8 && name_buf[5] == 101 as i8
-           && name_buf[6] == 109 as i8 && name_buf[7] == 105 as i8 && name_buf[8] == 99 as i8 {
-            return 8
-        }
-    }
-
-    // Causal (6 chars)
-    if name_len == 6 {
-        if name_buf[0] == 67 as i8 && name_buf[1] == 97 as i8 && name_buf[2] == 117 as i8
-           && name_buf[3] == 115 as i8 && name_buf[4] == 97 as i8 && name_buf[5] == 108 as i8 {
-            return 9
-        }
-    }
-
-    // Network (7 chars)
-    if name_len == 7 {
-        if name_buf[0] == 78 as i8 && name_buf[1] == 101 as i8 && name_buf[2] == 116 as i8
-           && name_buf[3] == 119 as i8 && name_buf[4] == 111 as i8 && name_buf[5] == 114 as i8
-           && name_buf[6] == 107 as i8 {
-            return 10
-        }
-    }
-
-    // Sensor (6 chars)
-    if name_len == 6 {
-        if name_buf[0] == 83 as i8 && name_buf[1] == 101 as i8 && name_buf[2] == 110 as i8
-           && name_buf[3] == 115 as i8 && name_buf[4] == 111 as i8 && name_buf[5] == 114 as i8 {
-            return 11
-        }
-    }
-
-    // Render (6 chars)
-    if name_len == 6 {
-        if name_buf[0] == 82 as i8 && name_buf[1] == 101 as i8 && name_buf[2] == 110 as i8
-           && name_buf[3] == 100 as i8 && name_buf[4] == 101 as i8 && name_buf[5] == 114 as i8 {
-            return 12
-        }
-    }
-
-    // Observe (7 chars) — von Foerster's observer-inclusion effect
-    // Any function that performs observation (reads system state through
-    // an observer with measurable cost) must declare this effect.
-    if name_len == 7 {
-        if name_buf[0] == 79 as i8 && name_buf[1] == 98 as i8 && name_buf[2] == 115 as i8
-           && name_buf[3] == 101 as i8 && name_buf[4] == 114 as i8 && name_buf[5] == 118 as i8
-           && name_buf[6] == 101 as i8 {  // "Observe"
-            return 13
-        }
-    }
-
-    // NonAssoc (8 chars) — non-associative algebraic operations
-    // Any function that multiplies elements of a non-associative algebra
-    // (octonions, sedenions, or higher Cayley-Dickson) must declare this.
-    // The compiler uses this to block unsafe reassociation optimizations.
-    if name_len == 8 {
-        if name_buf[0] == 78 as i8 && name_buf[1] == 111 as i8 && name_buf[2] == 110 as i8
-           && name_buf[3] == 65 as i8 && name_buf[4] == 115 as i8 && name_buf[5] == 115 as i8
-           && name_buf[6] == 111 as i8 && name_buf[7] == 99 as i8 {  // "NonAssoc"
-            return 14
-        }
-    }
-
-    // Audit (5 chars) — runtime provenance and regulatory trace logging
-    if name_len == 5 {
-        if name_buf[0] == 65 as i8 && name_buf[1] == 117 as i8 && name_buf[2] == 100 as i8
-           && name_buf[3] == 105 as i8 && name_buf[4] == 116 as i8 {  // "Audit"
-            return 15
-        }
-    }
-
-    // Hypothesis (10 chars) — statistical tests must target registered study outcomes
-    if name_len == 10 {
-        if name_buf[0] == 72 as i8 && name_buf[1] == 121 as i8 && name_buf[2] == 112 as i8
-           && name_buf[3] == 111 as i8 && name_buf[4] == 116 as i8 && name_buf[5] == 104 as i8
-           && name_buf[6] == 101 as i8 && name_buf[7] == 115 as i8 && name_buf[8] == 105 as i8
-           && name_buf[9] == 115 as i8 {
-            return 16
-        }
-    }
-
-    // MultiTest (9 chars) — multiple statistical tests in one function
-    // require an explicit correction call before the function exits.
-    if name_len == 9 {
-        if name_buf[0] == 77 as i8 && name_buf[1] == 117 as i8 && name_buf[2] == 108 as i8
-           && name_buf[3] == 116 as i8 && name_buf[4] == 105 as i8 && name_buf[5] == 84 as i8
-           && name_buf[6] == 101 as i8 && name_buf[7] == 115 as i8 && name_buf[8] == 116 as i8 {
-            return 17
-        }
-    }
-
-    // ZD (2 chars) — zero-divisor effect for sedenion-based exact erasure
-    // Functions that use Forgettable<T> must declare this effect.
-    // Enforces that the ZD algebraic structure is available for hard reset.
-    if name_len == 2 {
-        if name_buf[0] == 90 as i8 && name_buf[1] == 68 as i8 {  // "ZD"
-            return 18
-        }
-    }
-
-    // Witness (7 chars) — required alongside ZD by Audited<T>.
-    // Signals that every surgical op emits a machine-checkable Lean term.
-    if name_len == 7 {
-        if name_buf[0] == 87 as i8 && name_buf[1] == 105 as i8 && name_buf[2] == 116 as i8
-           && name_buf[3] == 110 as i8 && name_buf[4] == 101 as i8 && name_buf[5] == 115 as i8
-           && name_buf[6] == 115 as i8 {  // "Witness"
-            return 19
-        }
-    }
-
-    // Chaotic (7 chars) — A-layer-2: the function integrates a vector field with a
-    // positive largest Lyapunov exponent (chaos-sensitivity manifest). The compiler
-    // refuses float reassociation on its integration path (e^{λt} amplification).
-    if name_len == 7 {
-        if name_buf[0] == 67 as i8 && name_buf[1] == 104 as i8 && name_buf[2] == 97 as i8
-           && name_buf[3] == 111 as i8 && name_buf[4] == 116 as i8 && name_buf[5] == 105 as i8
-           && name_buf[6] == 99 as i8 {  // "Chaotic"
-            return 22
-        }
-    }
-
-    // Temporal (8 chars) — required alongside ZD by Revivable<T>.
-    // Signals that surgical ops are reversible within a bounded window.
-    if name_len == 8 {
-        if name_buf[0] == 84 as i8 && name_buf[1] == 101 as i8 && name_buf[2] == 109 as i8
-           && name_buf[3] == 112 as i8 && name_buf[4] == 111 as i8 && name_buf[5] == 114 as i8
-           && name_buf[6] == 97 as i8 && name_buf[7] == 108 as i8 {  // "Temporal"
-            return 20
-        }
-    }
-
-    // Learn (5 chars) — declared by functions that produce gradients and
-    // will be consumed by a SurgicalOptimizer that enforces preservation
-    // of the ZD annihilator at each step.
-    if name_len == 5 {
-        if name_buf[0] == 76 as i8 && name_buf[1] == 101 as i8 && name_buf[2] == 97 as i8
-           && name_buf[3] == 114 as i8 && name_buf[4] == 110 as i8 {  // "Learn"
-            return 21
-        }
-    }
-
-    // Unknown effect
-    -1
+    0 - 1
 }
 
 // ============================================================

--- a/tests/run-pass/effect_enum_equiv.sio
+++ b/tests/run-pass/effect_enum_equiv.sio
@@ -1,5 +1,7 @@
 //@ run-pass
 //@ description: Phase 2a equivalence — legacy byte-cmp vs enum lookup, 23 ids + NoSuchEffect=-1
+//@ expect-stdout: NEGATIVE_CONTROL_FIRED
+//@ expect-stdout: EFFECT_ENUM_EQUIV_OK
 
 // Frozen copy of production effect_name_to_id as of origin/main e5715c547d
 // (bit-identical to the #1956 measurement). Do not "improve" this function.
@@ -8,7 +10,11 @@
 // fire, the measurement is null.
 
 fn empty_name() -> [i8; 64] {
-    [0; 64]
+    // lean_single (CI Full Test Suite / souc-stage2) rejects a bare
+    // `[0; 64]` tail as `-> [i8; 64]` (`tail type mismatch`). A typed
+    // local is the same bytes and typechecks on both engines.
+    var buf: [i8; 64] = [0; 64]
+    buf
 }
 
 fn name2(a: i8, b: i8) -> ([i8; 64], i64) with Mut {
@@ -382,7 +388,7 @@ fn effect_kind_name_byte(k: i64, i: i64) -> i8 {
     }
 }
 
-fn enum_effect_name_to_id(name_buf: [i8; 64], name_len: i64) -> i64 {
+fn enum_effect_name_to_id(name_buf: [i8; 64], name_len: i64) -> i64 with Mut {
     var k: i64 = 0
     while k <= 22 {
         let nlen = effect_kind_name_len(k)

--- a/tests/run-pass/effect_enum_equiv.sio
+++ b/tests/run-pass/effect_enum_equiv.sio
@@ -1,0 +1,553 @@
+//@ run-pass
+//@ description: Phase 2a equivalence — legacy byte-cmp vs enum lookup, 23 ids + NoSuchEffect=-1
+
+// Frozen copy of production effect_name_to_id as of origin/main e5715c547d
+// (bit-identical to the #1956 measurement). Do not "improve" this function.
+// The enum lookup must return the same i64 for each of the 23 names and
+// the same -1 for a name in no list. If the negative control does not
+// fire, the measurement is null.
+
+fn empty_name() -> [i8; 64] {
+    [0; 64]
+}
+
+fn name2(a: i8, b: i8) -> ([i8; 64], i64) with Mut {
+    var buf: [i8; 64] = empty_name()
+    buf[0] = a
+    buf[1] = b
+    (buf, 2)
+}
+
+fn name3(a: i8, b: i8, c: i8) -> ([i8; 64], i64) with Mut {
+    var buf: [i8; 64] = empty_name()
+    buf[0] = a
+    buf[1] = b
+    buf[2] = c
+    (buf, 3)
+}
+
+fn name4(a: i8, b: i8, c: i8, d: i8) -> ([i8; 64], i64) with Mut {
+    var buf: [i8; 64] = empty_name()
+    buf[0] = a
+    buf[1] = b
+    buf[2] = c
+    buf[3] = d
+    (buf, 4)
+}
+
+fn name5(a: i8, b: i8, c: i8, d: i8, e: i8) -> ([i8; 64], i64) with Mut {
+    var buf: [i8; 64] = empty_name()
+    buf[0] = a
+    buf[1] = b
+    buf[2] = c
+    buf[3] = d
+    buf[4] = e
+    (buf, 5)
+}
+
+fn name6(a: i8, b: i8, c: i8, d: i8, e: i8, f: i8) -> ([i8; 64], i64) with Mut {
+    var buf: [i8; 64] = empty_name()
+    buf[0] = a
+    buf[1] = b
+    buf[2] = c
+    buf[3] = d
+    buf[4] = e
+    buf[5] = f
+    (buf, 6)
+}
+
+fn name7(a: i8, b: i8, c: i8, d: i8, e: i8, f: i8, g: i8) -> ([i8; 64], i64) with Mut {
+    var buf: [i8; 64] = empty_name()
+    buf[0] = a
+    buf[1] = b
+    buf[2] = c
+    buf[3] = d
+    buf[4] = e
+    buf[5] = f
+    buf[6] = g
+    (buf, 7)
+}
+
+fn name8(a: i8, b: i8, c: i8, d: i8, e: i8, f: i8, g: i8, h: i8) -> ([i8; 64], i64) with Mut {
+    var buf: [i8; 64] = empty_name()
+    buf[0] = a
+    buf[1] = b
+    buf[2] = c
+    buf[3] = d
+    buf[4] = e
+    buf[5] = f
+    buf[6] = g
+    buf[7] = h
+    (buf, 8)
+}
+
+fn name9(a: i8, b: i8, c: i8, d: i8, e: i8, f: i8, g: i8, h: i8, i: i8) -> ([i8; 64], i64) with Mut {
+    var buf: [i8; 64] = empty_name()
+    buf[0] = a
+    buf[1] = b
+    buf[2] = c
+    buf[3] = d
+    buf[4] = e
+    buf[5] = f
+    buf[6] = g
+    buf[7] = h
+    buf[8] = i
+    (buf, 9)
+}
+
+fn name10(a: i8, b: i8, c: i8, d: i8, e: i8, f: i8, g: i8, h: i8, i: i8, j: i8) -> ([i8; 64], i64) with Mut {
+    var buf: [i8; 64] = empty_name()
+    buf[0] = a
+    buf[1] = b
+    buf[2] = c
+    buf[3] = d
+    buf[4] = e
+    buf[5] = f
+    buf[6] = g
+    buf[7] = h
+    buf[8] = i
+    buf[9] = j
+    (buf, 10)
+}
+
+fn name13(a: i8, b: i8, c: i8, d: i8, e: i8, f: i8, g: i8, h: i8, i: i8, j: i8, k: i8, l: i8, m: i8) -> ([i8; 64], i64) with Mut {
+    var buf: [i8; 64] = empty_name()
+    buf[0] = a
+    buf[1] = b
+    buf[2] = c
+    buf[3] = d
+    buf[4] = e
+    buf[5] = f
+    buf[6] = g
+    buf[7] = h
+    buf[8] = i
+    buf[9] = j
+    buf[10] = k
+    buf[11] = l
+    buf[12] = m
+    (buf, 13)
+}
+
+// ============================================================
+// LEGACY — verbatim production byte comparisons (ids 0-22)
+// ============================================================
+
+fn legacy_effect_name_to_id(name_buf: [i8; 64], name_len: i64) -> i64 {
+    if name_len == 2 {
+        if name_buf[0] == 73 as i8 && name_buf[1] == 79 as i8 {
+            return 0
+        }
+    }
+    if name_len == 3 {
+        if name_buf[0] == 77 as i8 && name_buf[1] == 117 as i8 && name_buf[2] == 116 as i8 {
+            return 1
+        }
+        if name_buf[0] == 68 as i8 && name_buf[1] == 105 as i8 && name_buf[2] == 118 as i8 {
+            return 4
+        }
+        if name_buf[0] == 71 as i8 && name_buf[1] == 80 as i8 && name_buf[2] == 85 as i8 {
+            return 5
+        }
+    }
+    if name_len == 5 {
+        if name_buf[0] == 65 as i8 && name_buf[1] == 108 as i8 && name_buf[2] == 108 as i8
+           && name_buf[3] == 111 as i8 && name_buf[4] == 99 as i8 {
+            return 2
+        }
+        if name_buf[0] == 65 as i8 && name_buf[1] == 115 as i8 && name_buf[2] == 121 as i8
+           && name_buf[3] == 110 as i8 && name_buf[4] == 99 as i8 {
+            return 6
+        }
+        if name_buf[0] == 80 as i8 && name_buf[1] == 97 as i8 && name_buf[2] == 110 as i8
+           && name_buf[3] == 105 as i8 && name_buf[4] == 99 as i8 {
+            return 3
+        }
+    }
+    if name_len == 4 {
+        if name_buf[0] == 80 as i8 && name_buf[1] == 114 as i8 && name_buf[2] == 111 as i8
+           && name_buf[3] == 98 as i8 {
+            return 7
+        }
+    }
+    if name_len == 9 {
+        if name_buf[0] == 69 as i8 && name_buf[1] == 112 as i8 && name_buf[2] == 105 as i8
+           && name_buf[3] == 115 as i8 && name_buf[4] == 116 as i8 && name_buf[5] == 101 as i8
+           && name_buf[6] == 109 as i8 && name_buf[7] == 105 as i8 && name_buf[8] == 99 as i8 {
+            return 8
+        }
+    }
+    if name_len == 6 {
+        if name_buf[0] == 67 as i8 && name_buf[1] == 97 as i8 && name_buf[2] == 117 as i8
+           && name_buf[3] == 115 as i8 && name_buf[4] == 97 as i8 && name_buf[5] == 108 as i8 {
+            return 9
+        }
+    }
+    if name_len == 7 {
+        if name_buf[0] == 78 as i8 && name_buf[1] == 101 as i8 && name_buf[2] == 116 as i8
+           && name_buf[3] == 119 as i8 && name_buf[4] == 111 as i8 && name_buf[5] == 114 as i8
+           && name_buf[6] == 107 as i8 {
+            return 10
+        }
+    }
+    if name_len == 6 {
+        if name_buf[0] == 83 as i8 && name_buf[1] == 101 as i8 && name_buf[2] == 110 as i8
+           && name_buf[3] == 115 as i8 && name_buf[4] == 111 as i8 && name_buf[5] == 114 as i8 {
+            return 11
+        }
+    }
+    if name_len == 6 {
+        if name_buf[0] == 82 as i8 && name_buf[1] == 101 as i8 && name_buf[2] == 110 as i8
+           && name_buf[3] == 100 as i8 && name_buf[4] == 101 as i8 && name_buf[5] == 114 as i8 {
+            return 12
+        }
+    }
+    if name_len == 7 {
+        if name_buf[0] == 79 as i8 && name_buf[1] == 98 as i8 && name_buf[2] == 115 as i8
+           && name_buf[3] == 101 as i8 && name_buf[4] == 114 as i8 && name_buf[5] == 118 as i8
+           && name_buf[6] == 101 as i8 {
+            return 13
+        }
+    }
+    if name_len == 8 {
+        if name_buf[0] == 78 as i8 && name_buf[1] == 111 as i8 && name_buf[2] == 110 as i8
+           && name_buf[3] == 65 as i8 && name_buf[4] == 115 as i8 && name_buf[5] == 115 as i8
+           && name_buf[6] == 111 as i8 && name_buf[7] == 99 as i8 {
+            return 14
+        }
+    }
+    if name_len == 5 {
+        if name_buf[0] == 65 as i8 && name_buf[1] == 117 as i8 && name_buf[2] == 100 as i8
+           && name_buf[3] == 105 as i8 && name_buf[4] == 116 as i8 {
+            return 15
+        }
+    }
+    if name_len == 10 {
+        if name_buf[0] == 72 as i8 && name_buf[1] == 121 as i8 && name_buf[2] == 112 as i8
+           && name_buf[3] == 111 as i8 && name_buf[4] == 116 as i8 && name_buf[5] == 104 as i8
+           && name_buf[6] == 101 as i8 && name_buf[7] == 115 as i8 && name_buf[8] == 105 as i8
+           && name_buf[9] == 115 as i8 {
+            return 16
+        }
+    }
+    if name_len == 9 {
+        if name_buf[0] == 77 as i8 && name_buf[1] == 117 as i8 && name_buf[2] == 108 as i8
+           && name_buf[3] == 116 as i8 && name_buf[4] == 105 as i8 && name_buf[5] == 84 as i8
+           && name_buf[6] == 101 as i8 && name_buf[7] == 115 as i8 && name_buf[8] == 116 as i8 {
+            return 17
+        }
+    }
+    if name_len == 2 {
+        if name_buf[0] == 90 as i8 && name_buf[1] == 68 as i8 {
+            return 18
+        }
+    }
+    if name_len == 7 {
+        if name_buf[0] == 87 as i8 && name_buf[1] == 105 as i8 && name_buf[2] == 116 as i8
+           && name_buf[3] == 110 as i8 && name_buf[4] == 101 as i8 && name_buf[5] == 115 as i8
+           && name_buf[6] == 115 as i8 {
+            return 19
+        }
+    }
+    if name_len == 7 {
+        if name_buf[0] == 67 as i8 && name_buf[1] == 104 as i8 && name_buf[2] == 97 as i8
+           && name_buf[3] == 111 as i8 && name_buf[4] == 116 as i8 && name_buf[5] == 105 as i8
+           && name_buf[6] == 99 as i8 {
+            return 22
+        }
+    }
+    if name_len == 8 {
+        if name_buf[0] == 84 as i8 && name_buf[1] == 101 as i8 && name_buf[2] == 109 as i8
+           && name_buf[3] == 112 as i8 && name_buf[4] == 111 as i8 && name_buf[5] == 114 as i8
+           && name_buf[6] == 97 as i8 && name_buf[7] == 108 as i8 {
+            return 20
+        }
+    }
+    if name_len == 5 {
+        if name_buf[0] == 76 as i8 && name_buf[1] == 101 as i8 && name_buf[2] == 97 as i8
+           && name_buf[3] == 114 as i8 && name_buf[4] == 110 as i8 {
+            return 21
+        }
+    }
+    0 - 1
+}
+
+// ============================================================
+// NEW — enum in ID order, lookup by discriminant 0..=22
+// EffVar is the 24th variant (discriminant 23) and is not a name.
+// ============================================================
+
+enum EffectKind {
+    EffIO,
+    EffMut,
+    EffAlloc,
+    EffPanic,
+    EffDiv,
+    EffGPU,
+    EffAsync,
+    EffProb,
+    EffEpistemic,
+    EffCausal,
+    EffNetwork,
+    EffSensor,
+    EffRender,
+    EffObserve,
+    EffNonAssoc,
+    EffAudit,
+    EffHypothesis,
+    EffMultiTest,
+    EffZD,
+    EffWitness,
+    EffTemporal,
+    EffLearn,
+    EffChaotic,
+    EffVar,
+}
+
+fn effect_kind_name_len(k: i64) -> i64 {
+    if k == 0 { 2 }
+    else if k == 1 { 3 }
+    else if k == 2 { 5 }
+    else if k == 3 { 5 }
+    else if k == 4 { 3 }
+    else if k == 5 { 3 }
+    else if k == 6 { 5 }
+    else if k == 7 { 4 }
+    else if k == 8 { 9 }
+    else if k == 9 { 6 }
+    else if k == 10 { 7 }
+    else if k == 11 { 6 }
+    else if k == 12 { 6 }
+    else if k == 13 { 7 }
+    else if k == 14 { 8 }
+    else if k == 15 { 5 }
+    else if k == 16 { 10 }
+    else if k == 17 { 9 }
+    else if k == 18 { 2 }
+    else if k == 19 { 7 }
+    else if k == 20 { 8 }
+    else if k == 21 { 5 }
+    else if k == 22 { 7 }
+    else { 0 }
+}
+
+fn effect_kind_name_byte(k: i64, i: i64) -> i8 {
+    if k == 0 {
+        if i == 0 { 73 as i8 } else { 79 as i8 }
+    } else if k == 1 {
+        if i == 0 { 77 as i8 } else if i == 1 { 117 as i8 } else { 116 as i8 }
+    } else if k == 2 {
+        if i == 0 { 65 as i8 } else if i == 1 { 108 as i8 } else if i == 2 { 108 as i8 } else if i == 3 { 111 as i8 } else { 99 as i8 }
+    } else if k == 3 {
+        if i == 0 { 80 as i8 } else if i == 1 { 97 as i8 } else if i == 2 { 110 as i8 } else if i == 3 { 105 as i8 } else { 99 as i8 }
+    } else if k == 4 {
+        if i == 0 { 68 as i8 } else if i == 1 { 105 as i8 } else { 118 as i8 }
+    } else if k == 5 {
+        if i == 0 { 71 as i8 } else if i == 1 { 80 as i8 } else { 85 as i8 }
+    } else if k == 6 {
+        if i == 0 { 65 as i8 } else if i == 1 { 115 as i8 } else if i == 2 { 121 as i8 } else if i == 3 { 110 as i8 } else { 99 as i8 }
+    } else if k == 7 {
+        if i == 0 { 80 as i8 } else if i == 1 { 114 as i8 } else if i == 2 { 111 as i8 } else { 98 as i8 }
+    } else if k == 8 {
+        if i == 0 { 69 as i8 } else if i == 1 { 112 as i8 } else if i == 2 { 105 as i8 } else if i == 3 { 115 as i8 } else if i == 4 { 116 as i8 } else if i == 5 { 101 as i8 } else if i == 6 { 109 as i8 } else if i == 7 { 105 as i8 } else { 99 as i8 }
+    } else if k == 9 {
+        if i == 0 { 67 as i8 } else if i == 1 { 97 as i8 } else if i == 2 { 117 as i8 } else if i == 3 { 115 as i8 } else if i == 4 { 97 as i8 } else { 108 as i8 }
+    } else if k == 10 {
+        if i == 0 { 78 as i8 } else if i == 1 { 101 as i8 } else if i == 2 { 116 as i8 } else if i == 3 { 119 as i8 } else if i == 4 { 111 as i8 } else if i == 5 { 114 as i8 } else { 107 as i8 }
+    } else if k == 11 {
+        if i == 0 { 83 as i8 } else if i == 1 { 101 as i8 } else if i == 2 { 110 as i8 } else if i == 3 { 115 as i8 } else if i == 4 { 111 as i8 } else { 114 as i8 }
+    } else if k == 12 {
+        if i == 0 { 82 as i8 } else if i == 1 { 101 as i8 } else if i == 2 { 110 as i8 } else if i == 3 { 100 as i8 } else if i == 4 { 101 as i8 } else { 114 as i8 }
+    } else if k == 13 {
+        if i == 0 { 79 as i8 } else if i == 1 { 98 as i8 } else if i == 2 { 115 as i8 } else if i == 3 { 101 as i8 } else if i == 4 { 114 as i8 } else if i == 5 { 118 as i8 } else { 101 as i8 }
+    } else if k == 14 {
+        if i == 0 { 78 as i8 } else if i == 1 { 111 as i8 } else if i == 2 { 110 as i8 } else if i == 3 { 65 as i8 } else if i == 4 { 115 as i8 } else if i == 5 { 115 as i8 } else if i == 6 { 111 as i8 } else { 99 as i8 }
+    } else if k == 15 {
+        if i == 0 { 65 as i8 } else if i == 1 { 117 as i8 } else if i == 2 { 100 as i8 } else if i == 3 { 105 as i8 } else { 116 as i8 }
+    } else if k == 16 {
+        if i == 0 { 72 as i8 } else if i == 1 { 121 as i8 } else if i == 2 { 112 as i8 } else if i == 3 { 111 as i8 } else if i == 4 { 116 as i8 } else if i == 5 { 104 as i8 } else if i == 6 { 101 as i8 } else if i == 7 { 115 as i8 } else if i == 8 { 105 as i8 } else { 115 as i8 }
+    } else if k == 17 {
+        if i == 0 { 77 as i8 } else if i == 1 { 117 as i8 } else if i == 2 { 108 as i8 } else if i == 3 { 116 as i8 } else if i == 4 { 105 as i8 } else if i == 5 { 84 as i8 } else if i == 6 { 101 as i8 } else if i == 7 { 115 as i8 } else { 116 as i8 }
+    } else if k == 18 {
+        if i == 0 { 90 as i8 } else { 68 as i8 }
+    } else if k == 19 {
+        if i == 0 { 87 as i8 } else if i == 1 { 105 as i8 } else if i == 2 { 116 as i8 } else if i == 3 { 110 as i8 } else if i == 4 { 101 as i8 } else if i == 5 { 115 as i8 } else { 115 as i8 }
+    } else if k == 20 {
+        if i == 0 { 84 as i8 } else if i == 1 { 101 as i8 } else if i == 2 { 109 as i8 } else if i == 3 { 112 as i8 } else if i == 4 { 111 as i8 } else if i == 5 { 114 as i8 } else if i == 6 { 97 as i8 } else { 108 as i8 }
+    } else if k == 21 {
+        if i == 0 { 76 as i8 } else if i == 1 { 101 as i8 } else if i == 2 { 97 as i8 } else if i == 3 { 114 as i8 } else { 110 as i8 }
+    } else if k == 22 {
+        if i == 0 { 67 as i8 } else if i == 1 { 104 as i8 } else if i == 2 { 97 as i8 } else if i == 3 { 111 as i8 } else if i == 4 { 116 as i8 } else if i == 5 { 105 as i8 } else { 99 as i8 }
+    } else {
+        0 as i8
+    }
+}
+
+fn enum_effect_name_to_id(name_buf: [i8; 64], name_len: i64) -> i64 {
+    var k: i64 = 0
+    while k <= 22 {
+        let nlen = effect_kind_name_len(k)
+        if nlen == name_len {
+            var i: i64 = 0
+            var ok = true
+            while i < nlen {
+                if name_buf[i as usize] != effect_kind_name_byte(k, i) {
+                    ok = false
+                }
+                i = i + 1
+            }
+            if ok {
+                return k
+            }
+        }
+        k = k + 1
+    }
+    0 - 1
+}
+
+fn check_pair(old_id: i64, new_id: i64, expected: i64, tag: i64) -> i64 with IO {
+    if old_id != expected {
+        print("LEGACY_MISMATCH tag=")
+        print_int(tag)
+        print(" old=")
+        print_int(old_id)
+        print(" expected=")
+        print_int(expected)
+        print("\n")
+        return 1
+    }
+    if new_id != expected {
+        print("ENUM_MISMATCH tag=")
+        print_int(tag)
+        print(" new=")
+        print_int(new_id)
+        print(" expected=")
+        print_int(expected)
+        print("\n")
+        return 1
+    }
+    if old_id != new_id {
+        print("OLD_NE_NEW tag=")
+        print_int(tag)
+        print(" old=")
+        print_int(old_id)
+        print(" new=")
+        print_int(new_id)
+        print("\n")
+        return 1
+    }
+    0
+}
+
+fn main() -> i32 with IO, Mut, Panic, Div {
+    var fails: i64 = 0
+
+    let p0 = name2(73 as i8, 79 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p0.0, p0.1), enum_effect_name_to_id(p0.0, p0.1), 0, 0)
+
+    let p1 = name3(77 as i8, 117 as i8, 116 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p1.0, p1.1), enum_effect_name_to_id(p1.0, p1.1), 1, 1)
+
+    let p2 = name5(65 as i8, 108 as i8, 108 as i8, 111 as i8, 99 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p2.0, p2.1), enum_effect_name_to_id(p2.0, p2.1), 2, 2)
+
+    let p3 = name5(80 as i8, 97 as i8, 110 as i8, 105 as i8, 99 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p3.0, p3.1), enum_effect_name_to_id(p3.0, p3.1), 3, 3)
+
+    let p4 = name3(68 as i8, 105 as i8, 118 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p4.0, p4.1), enum_effect_name_to_id(p4.0, p4.1), 4, 4)
+
+    let p5 = name3(71 as i8, 80 as i8, 85 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p5.0, p5.1), enum_effect_name_to_id(p5.0, p5.1), 5, 5)
+
+    let p6 = name5(65 as i8, 115 as i8, 121 as i8, 110 as i8, 99 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p6.0, p6.1), enum_effect_name_to_id(p6.0, p6.1), 6, 6)
+
+    let p7 = name4(80 as i8, 114 as i8, 111 as i8, 98 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p7.0, p7.1), enum_effect_name_to_id(p7.0, p7.1), 7, 7)
+
+    let p8 = name9(69 as i8, 112 as i8, 105 as i8, 115 as i8, 116 as i8, 101 as i8, 109 as i8, 105 as i8, 99 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p8.0, p8.1), enum_effect_name_to_id(p8.0, p8.1), 8, 8)
+
+    let p9 = name6(67 as i8, 97 as i8, 117 as i8, 115 as i8, 97 as i8, 108 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p9.0, p9.1), enum_effect_name_to_id(p9.0, p9.1), 9, 9)
+
+    let p10 = name7(78 as i8, 101 as i8, 116 as i8, 119 as i8, 111 as i8, 114 as i8, 107 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p10.0, p10.1), enum_effect_name_to_id(p10.0, p10.1), 10, 10)
+
+    let p11 = name6(83 as i8, 101 as i8, 110 as i8, 115 as i8, 111 as i8, 114 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p11.0, p11.1), enum_effect_name_to_id(p11.0, p11.1), 11, 11)
+
+    let p12 = name6(82 as i8, 101 as i8, 110 as i8, 100 as i8, 101 as i8, 114 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p12.0, p12.1), enum_effect_name_to_id(p12.0, p12.1), 12, 12)
+
+    let p13 = name7(79 as i8, 98 as i8, 115 as i8, 101 as i8, 114 as i8, 118 as i8, 101 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p13.0, p13.1), enum_effect_name_to_id(p13.0, p13.1), 13, 13)
+
+    let p14 = name8(78 as i8, 111 as i8, 110 as i8, 65 as i8, 115 as i8, 115 as i8, 111 as i8, 99 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p14.0, p14.1), enum_effect_name_to_id(p14.0, p14.1), 14, 14)
+
+    let p15 = name5(65 as i8, 117 as i8, 100 as i8, 105 as i8, 116 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p15.0, p15.1), enum_effect_name_to_id(p15.0, p15.1), 15, 15)
+
+    let p16 = name10(72 as i8, 121 as i8, 112 as i8, 111 as i8, 116 as i8, 104 as i8, 101 as i8, 115 as i8, 105 as i8, 115 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p16.0, p16.1), enum_effect_name_to_id(p16.0, p16.1), 16, 16)
+
+    let p17 = name9(77 as i8, 117 as i8, 108 as i8, 116 as i8, 105 as i8, 84 as i8, 101 as i8, 115 as i8, 116 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p17.0, p17.1), enum_effect_name_to_id(p17.0, p17.1), 17, 17)
+
+    let p18 = name2(90 as i8, 68 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p18.0, p18.1), enum_effect_name_to_id(p18.0, p18.1), 18, 18)
+
+    let p19 = name7(87 as i8, 105 as i8, 116 as i8, 110 as i8, 101 as i8, 115 as i8, 115 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p19.0, p19.1), enum_effect_name_to_id(p19.0, p19.1), 19, 19)
+
+    let p20 = name8(84 as i8, 101 as i8, 109 as i8, 112 as i8, 111 as i8, 114 as i8, 97 as i8, 108 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p20.0, p20.1), enum_effect_name_to_id(p20.0, p20.1), 20, 20)
+
+    let p21 = name5(76 as i8, 101 as i8, 97 as i8, 114 as i8, 110 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p21.0, p21.1), enum_effect_name_to_id(p21.0, p21.1), 21, 21)
+
+    let p22 = name7(67 as i8, 104 as i8, 97 as i8, 111 as i8, 116 as i8, 105 as i8, 99 as i8)
+    fails = fails + check_pair(legacy_effect_name_to_id(p22.0, p22.1), enum_effect_name_to_id(p22.0, p22.1), 22, 22)
+
+    // Negative control: a name in no list. Both must return -1.
+    // If this does not fire, the measurement is null.
+    let neg = name13(78 as i8, 111 as i8, 83 as i8, 117 as i8, 99 as i8, 104 as i8, 69 as i8, 102 as i8, 102 as i8, 101 as i8, 99 as i8, 116 as i8, 88 as i8)
+    let old_neg = legacy_effect_name_to_id(neg.0, neg.1)
+    let new_neg = enum_effect_name_to_id(neg.0, neg.1)
+    if old_neg != (0 - 1) {
+        print("NEGATIVE_CONTROL_DID_NOT_FIRE legacy=")
+        print_int(old_neg)
+        print("\n")
+        fails = fails + 1
+    } else if new_neg != (0 - 1) {
+        print("NEGATIVE_CONTROL_DID_NOT_FIRE enum=")
+        print_int(new_neg)
+        print("\n")
+        fails = fails + 1
+    } else if old_neg != new_neg {
+        print("NEGATIVE_CONTROL_SPLIT\n")
+        fails = fails + 1
+    } else {
+        print("NEGATIVE_CONTROL_FIRED old=new=-1\n")
+    }
+
+    // EffVar is structure, not a name: discriminant 23 must not be a lookup hit.
+    let var_disc: i64 = EffectKind::EffVar
+    if var_disc != 23 {
+        print("EFFVAR_DISC_NOT_23 disc=")
+        print_int(var_disc)
+        print("\n")
+        fails = fails + 1
+    }
+
+    if fails == 0 {
+        print("EFFECT_ENUM_EQUIV_OK 23/23 + negative\n")
+        0
+    } else {
+        print("EFFECT_ENUM_EQUIV_FAIL fails=")
+        print_int(fails)
+        print("\n")
+        1
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2a of the founder-approved split. **Equivalence only.** Zero vocabulary decisions.

- Production `enum EffectKind` of the 23 live names, ids 0–22 preserved.
- Declaration order is **ID order**, not the historical source-arm order (`Temporal=20`, `Learn=21`, `Chaotic=22`).
- `effect_name_to_id` consults the enum (discriminant loop 0..=22).
- `EffVar` survives as row-polymorphism structure (discriminant 23). It is not a `with` name and lookup never returns 23.
- No extras. No `self-hosted/effects/` wire. `handlers.sio` stays disconnected.

Phase 2b (seven extras, new ids after 22, measure Mod first) is a **separate PR after this lands**. Not started.

## Semantic lane declaration

```text
Semantic-Lane-ID: effect-enum-2a-20260819
Owner: grok-cli5
Concept-IDs: none
Intent-Preserved: the 23 live `with` names keep ids 0-22; unknown stays -1;
  EffVar remains row-polymorphism structure, not a named `with`.
Transformation: representation only. effect_name_to_id consults an enum
  whose declaration order is ID order. No name added, removed, or
  renumbered. No handler, CPS, or inliner choice.
Types-Changed: none
Effects-Changed: none (same 23 ids, same -1)
IR-Changed: none
Claims-Introduced:
  - for each of the 23 names, legacy byte-cmp and enum lookup return the
    same i64
  - for a name in no list (NoSuchEffectX), both return -1
  - EffectKind::EffVar discriminant is 23 and is never returned by lookup
Claims-Forbidden:
  - handlers.sio is connected, or self-hosted/effects/ is on the live path
  - any effect was removed
  - seed FN_EFFECTS bits are production ids (Chaotic is id 22; stdlib
    "Perturbative bit 22" is a bit)
  - extras (Approx, NaturalityG2, Deterministic, Perturbative,
    NarrowWidthApproximation, NonUnitary, Mod) were added
  - Confidence is a new variant (it is an alias of Epistemic)
  - print_effect_name now names Chaotic (id 22 still falls through to
    Effect#22; that string was not part of the equivalence contract)
  - the shipped bin/souc ELF contains the new lookup (it does not, until
    a rebuilt Madaros replaces it)
Assumptions:
  - enum discriminants are sequential from 0 in declaration order
  - user tests cannot call check internals; the dual-function standalone
    file is the id proof
  - SOUC_BIN is poison and is unset
  - any Madaros rebuild is Slurm, never the pod
Write-Set:
  self-hosted/check/effects.sio
  tests/run-pass/effect_enum_equiv.sio
  docs/audit/EFFECT_ENUM_2A_2026-08-19.md
  docs/audit/EFFECT_ENUM_2A_2026-08-19.tsv
  docs/governance/topic-registry.v1.json
  docs/governance/DOCS_AUTHORITY_MATRIX.md
Read-Set:
  self-hosted/check/effects.sio (pre-change)
  self-hosted/effects/types.sio (orphan 15-variant enum; not wired)
  /tmp/dispatch_phase2_claude1.md
Positive-Witness: NEGATIVE_CONTROL_FIRED old=new=-1
  and EFFECT_ENUM_EQUIV_OK 23/23 + negative, rc=0, BEFORE and AFTER
Negative-Witness: if the negative control does not fire, the measurement
  is null
Acceptance-Gate: BEFORE and AFTER both print NEGATIVE_CONTROL_FIRED and
  EFFECT_ENUM_EQUIV_OK 23/23; souc check main.sio verdict=0; Slurm
  Madaros rebuild rc=0
Integration-Target: origin/main (own PR; 2b blocked until this lands)
Authoritative-Only-If: the dual-function test is re-run and the negative
  control still fires
```

## Evidence

| step | result |
|---|---|
| BEFORE `souc run tests/run-pass/effect_enum_equiv.sio` | `NEGATIVE_CONTROL_FIRED` + `EFFECT_ENUM_EQUIV_OK 23/23 + negative` rc=0 |
| AFTER (same command, twice) | same, rc=0 |
| `souc check self-hosted/compiler/main.sio` | verdict=0 |
| Slurm job 10327 `gpuorangefs-r770-proxmox` | `REMOTE: build rc=0 elapsed=226s` elf 100551595 bytes |

Receipt: `docs/audit/EFFECT_ENUM_2A_2026-08-19.md` + `.tsv`.

## Test plan

- [x] Dual-function equivalence test BEFORE and AFTER, negative control fired
- [x] `souc check` of `main.sio` on the new source
- [x] Slurm Madaros rebuild (not the pod; not double-wrapped in `souc-build-lock.sh`)
- [ ] CI on this PR
- [ ] Do not merge until asked
- [ ] Do not start 2b until this lands