### PR TITLE
feat(ci): shipped-compiler-selfhost gate — refuse silent compiler/source drift (DRAFT)

### DIFF
--- a/scripts/ci/shipped_compiler_selfhost_gate.sh
+++ b/scripts/ci/shipped_compiler_selfhost_gate.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# shipped_compiler_selfhost_gate.sh — refuse silent compiler/source drift.
+#
+# ENGINE: Madaros (the user-facing default per bin/souc), with lean_single as a
+# secondary subject. Both compile paths are exercised; failure on either fails
+# the gate. Per FLEET_CONSTRAINTS, this is the gate that catches "the compiler
+# that is in git does not compile the tree that is in git" — the silent-defect
+# class that bit #1689 (imports cap), the DCE census at PR #1951, and the e230
+# v3 patch (committed against a binary that did not match its source).
+#
+# Subject — the shipped compiler binaries:
+#   SHIPPED_MADAROS     = bin/madaros-linux-x86_64     (the default user compiler)
+#   SHIPPED_LEAN_SINGLE = bin/souc-lean-single-x86_64  (the bootstrap seed)
+# Both are tracked in git. Either can be overridden via env vars. Each must be
+# a raw ELF, never a wrapper script (bin/souc and bin/madaros are wrappers and
+# cannot be tested directly; they route through the raw ELFs above).
+#
+# Object — the canonical source the shipped compiler must reproduce:
+#   CANONICAL_SRC = self-hosted/compiler/lean_single.sio
+# This is the same source lean_single_fixed_point_gate.sh uses as its
+# fixed-point probe (stage1 == stage2 == stage3). It is the smallest source
+# in self-hosted/ that exercises the full Madaros multi-module pipeline.
+#
+# Witness contract:
+#   G1 PASS: SHIPPED_MADAROS compiles CANONICAL_SRC into an x86-64 ELF,
+#            ELF starts with \x7fELF (the four-byte ELF magic).
+#   G2 PASS: SHIPPED_LEAN_SINGLE compiles CANONICAL_SRC into an x86-64 ELF,
+#            ELF starts with \x7fELF.
+#
+# Why "compiles to an ELF" is the criterion (not md5 equality):
+#   - The whole point of "shipped compiler compiles current source" is that a
+#     fresh clone can rebuild the compiler from source. If the shipped binary
+#     cannot compile the source, the seed chain is broken — and a fresh clone
+#     has no recourse.
+#   - The strict fixed-point (stage1 == stage2 == stage3) is owned by
+#     lean_single_fixed_point_gate.sh. This gate's job is the FIRST link in
+#     that chain: "can the shipped binary, AS IS, compile the current source?"
+#     Fail-closed at this question.
+#
+# Positive control (RED):
+#   On 2026-08-19, bin/madaros-linux-x86_64 (committed 3d1f143e7a at
+#   2026-08-17) fails G1 with E007 typecheck errors in
+#   compile_primary_a64 / compile_postfix_tail_a64 / compile_multiplicative_a64
+#   — the shipped Madaros is stale w.r.t. self-hosted/compiler/lean_single.sio
+#   on origin/main. This is the canonical "compiler does not compile tree"
+#   that the gate exists to catch. The gate's first run on origin/main MUST
+#   come up RED on G1, with the E007 errors named in the verdict.
+#
+# Wiring:
+#   Hand-run as of 2026-08-19. Candidate site in .github/workflows/ci.yml is
+#   the "Compiler lane status contract" step, immediately after
+#   scripts/ci/compiler_lane_status_gate.sh. Wire ONLY after coordinating
+#   with grok-cli4 and grok-cli5, who also have work in ci.yml.
+#   Run: SOUNIO_STDLIB_PATH=$PWD/stdlib bash scripts/ci/shipped_compiler_selfhost_gate.sh
+#
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+# ── Platform guard ───────────────────────────────────────────────────────────
+if [[ "$(uname -s 2>/dev/null || echo unknown)" != "Linux" ]]; then
+    echo "[shipped-compiler-selfhost] SKIP: Linux-only gate" >&2
+    exit 0
+fi
+case "$(uname -m 2>/dev/null || echo unknown)" in
+    x86_64|amd64) ;;
+    *)
+        echo "[shipped-compiler-selfhost] SKIP: x86-64 Linux-only gate" >&2
+        exit 0
+        ;;
+esac
+
+# ── Subjects ─────────────────────────────────────────────────────────────────
+SHIPPED_MADAROS="${SOUNIO_SHIPPED_MADAROS:-$ROOT_DIR/bin/madaros-linux-x86_64}"
+SHIPPED_LEAN_SINGLE="${SOUNIO_SHIPPED_LEAN_SINGLE:-$ROOT_DIR/bin/souc-lean-single-x86_64}"
+CANONICAL_SRC="$ROOT_DIR/self-hosted/compiler/lean_single.sio"
+
+# Self-test: subject files exist, are executable, are raw ELFs (not wrappers).
+for label_subject in "Madaros:$SHIPPED_MADAROS" "LeanSingle:$SHIPPED_LEAN_SINGLE"; do
+    label="${label_subject%%:*}"
+    subj="${label_subject#*:}"
+    if [[ ! -e "$subj" ]]; then
+        echo "[shipped-compiler-selfhost] FAIL self-test: $label subject missing: $subj" >&2
+        echo "[shipped-compiler-selfhost]      override with SOUNIO_SHIPPED_${label^^}=<raw ELF>" >&2
+        exit 2
+    fi
+    if [[ ! -x "$subj" ]]; then
+        echo "[shipped-compiler-selfhost] FAIL self-test: $label subject not executable: $subj" >&2
+        exit 2
+    fi
+    if head -c2 "$subj" 2>/dev/null | grep -q '#!'; then
+        echo "[shipped-compiler-selfhost] FAIL self-test: $label subject is a wrapper script, not a raw ELF: $subj" >&2
+        echo "[shipped-compiler-selfhost]      a wrapper routes to whatever compiler it likes;" >&2
+        echo "[shipped-compiler-selfhost]      self-testing it does not measure this binary." >&2
+        exit 2
+    fi
+done
+
+if [[ ! -s "$CANONICAL_SRC" ]]; then
+    echo "[shipped-compiler-selfhost] FAIL self-test: canonical source missing or empty: $CANONICAL_SRC" >&2
+    exit 2
+fi
+
+echo "[shipped-compiler-selfhost] madaros=$SHIPPED_MADAROS"
+echo "[shipped-compiler-selfhost] lean_single=$SHIPPED_LEAN_SINGLE"
+echo "[shipped-compiler-selfhost] canonical_src=$CANONICAL_SRC"
+
+OUT_DIR="${SOUNIO_SHIPPED_COMPILER_SELFHOST_DIR:-$(mktemp -d /tmp/sounio-shipped-compiler-selfhost.XXXXXX)}"
+mkdir -p "$OUT_DIR"
+
+# Helper: returns 0 (true) if the ELF magic is present.
+is_elf_magic() {
+    head -c4 "$1" 2>/dev/null | od -An -c | grep -q '177   E   L   F'
+}
+
+# ── G1: Madaros compiles canonical source ────────────────────────────────────
+G1_ELF="$OUT_DIR/g1_madaros.elf"
+G1_LOG="$OUT_DIR/g1_madaros.log"
+
+echo
+echo "[shipped-compiler-selfhost] running G1: Madaros compiles lean_single.sio"
+set +e
+timeout 600 "$SHIPPED_MADAROS" -o "$G1_ELF" "$CANONICAL_SRC" >"$G1_LOG" 2>&1
+G1_RC=$?
+set -e
+
+G1_PASS=0
+if [[ $G1_RC -ne 0 ]]; then
+    echo "[shipped-compiler-selfhost] G1 FAIL: Madaros exit=$G1_RC" >&2
+    echo "[shipped-compiler-selfhost]      last 30 lines of compiler log:" >&2
+    tail -n 30 "$G1_LOG" | sed 's/^/        /' >&2
+elif [[ ! -f "$G1_ELF" ]]; then
+    echo "[shipped-compiler-selfhost] G1 FAIL: Madaros exit=0 but no ELF at $G1_ELF" >&2
+    echo "[shipped-compiler-selfhost]      this is the bare '-o' swallow: the binary wrote nothing" >&2
+    echo "[shipped-compiler-selfhost]      and reported success. last 30 lines:" >&2
+    tail -n 30 "$G1_LOG" | sed 's/^/        /' >&2
+elif ! is_elf_magic "$G1_ELF"; then
+    echo "[shipped-compiler-selfhost] G1 FAIL: ELF at $G1_ELF does not start with ELF magic" >&2
+    echo "[shipped-compiler-selfhost]      first 16 bytes (od):" >&2
+    head -c16 "$G1_ELF" | od -An -tx1 | sed 's/^/        /' >&2
+else
+    G1_SIZE=$(stat -c%s "$G1_ELF")
+    echo "[shipped-compiler-selfhost] G1 PASS: madaros.elf=$G1_SIZE bytes"
+    G1_PASS=1
+fi
+
+# ── G2: lean_single compiles canonical source ────────────────────────────────
+G2_ELF="$OUT_DIR/g2_lean_single.elf"
+G2_LOG="$OUT_DIR/g2_lean_single.log"
+
+echo
+echo "[shipped-compiler-selfhost] running G2: lean_single compiles lean_single.sio"
+set +e
+# lean_single CLI is positional: <src> <out>. NO -o flag — it parses -o as a
+# source filename and emits "lex error line 1: Unexpected character".
+timeout 600 "$SHIPPED_LEAN_SINGLE" "$CANONICAL_SRC" "$G2_ELF" >"$G2_LOG" 2>&1
+G2_RC=$?
+set -e
+
+G2_PASS=0
+if [[ $G2_RC -ne 0 ]]; then
+    echo "[shipped-compiler-selfhost] G2 FAIL: lean_single exit=$G2_RC" >&2
+    echo "[shipped-compiler-selfhost]      last 30 lines of compiler log:" >&2
+    tail -n 30 "$G2_LOG" | sed 's/^/        /' >&2
+elif [[ ! -f "$G2_ELF" ]]; then
+    echo "[shipped-compiler-selfhost] G2 FAIL: lean_single exit=0 but no ELF at $G2_ELF" >&2
+elif ! is_elf_magic "$G2_ELF"; then
+    echo "[shipped-compiler-selfhost] G2 FAIL: ELF at $G2_ELF does not start with ELF magic" >&2
+else
+    G2_SIZE=$(stat -c%s "$G2_ELF")
+    echo "[shipped-compiler-selfhost] G2 PASS: lean_single.elf=$G2_SIZE bytes"
+    G2_PASS=1
+fi
+
+# ── Final verdict ────────────────────────────────────────────────────────────
+echo
+echo "[shipped-compiler-selfhost] verdict: G1=$G1_PASS G2=$G2_PASS"
+echo "[shipped-compiler-selfhost] artifacts: $OUT_DIR"
+
+if [[ $G1_PASS -eq 1 && $G2_PASS -eq 1 ]]; then
+    echo "[shipped-compiler-selfhost] PASS: both shipped compilers compile canonical source"
+    exit 0
+fi
+
+if [[ $G1_PASS -eq 0 ]]; then
+    echo "[shipped-compiler-selfhost] FAIL: G1 Madaros cannot compile current source" >&2
+    echo "[shipped-compiler-selfhost]       this is the silent-defect class: a fresh clone" >&2
+    echo "[shipped-compiler-selfhost]       receives a compiler that does not compile the tree" >&2
+    echo "[shipped-compiler-selfhost]       it carries. Refresh the binary via Slurm and re-run." >&2
+fi
+if [[ $G2_PASS -eq 0 ]]; then
+    echo "[shipped-compiler-selfhost] FAIL: G2 lean_single cannot compile current source" >&2
+    echo "[shipped-compiler-selfhost]       lean_single is the bootstrap seed; this means a fresh" >&2
+    echo "[shipped-compiler-selfhost]       clone cannot rebuild the compiler at all." >&2
+fi
+
+exit 1


### PR DESCRIPTION
## Semantic declaration

This PR adds one CI gate and one gate only. It does **not** refresh the
shipped binary. It does **not** wire itself into `ci.yml`. Its single
deliverable is a measurable, fail-closed assertion that the compiler
binaries in `bin/` can compile the source in `self-hosted/`. The gate's
first run on `origin/main` MUST come up RED; that is the positive control
showing the gate is alive.

The gate exists because the silent-defect class itself is silent:
nothing in the repo today asks whether the shipped ELF still speaks to
the current source. The PR that fixes the silent defect is the gate; the
PR that fixes the stale binary is a separate ticket for the build lane
(Slurm, not this pod).

## What the gate asserts

Two mutually independent witness checks, both fail-closed:

| ID  | Subject                                               | Object                                          | Criterion |
| --- | ----------------------------------------------------- | ----------------------------------------------- | --------- |
| G1  | `bin/madaros-linux-x86_64` (the user-facing default)  | `self-hosted/compiler/lean_single.sio`          | ELF with `\\x7fELF` magic |
| G2  | `bin/souc-lean-single-x86_64` (the bootstrap seed)    | `self-hosted/compiler/lean_single.sio`          | ELF with `\\x7fELF` magic |

Subjects are the **raw ELFs** in `bin/`, not the wrapper scripts. The
wrappers (`bin/souc`, `bin/madaros`) route through the raw ELFs and
self-testing them would not measure the binary under audit. The gate
self-tests this: any subject whose first two bytes are `#!` is rejected
with rc=2 ("this is a wrapper script, not a raw ELF").

The criterion is "compiles to an ELF", not md5 equality. The strict
fixed-point (stage1 == stage2 == stage3) is owned by
`lean_single_fixed_point_gate.sh`; this gate is the first link in that
chain — "can the shipped binary, *as is*, compile the current source?"

## Positive control — RED on origin/main

`SOUNIO_STDLIB_PATH=$PWD/stdlib bash scripts/ci/shipped_compiler_selfhost_gate.sh`

```
[shipped-compiler-selfhost] running G1: Madaros compiles lean_single.sio
[shipped-compiler-selfhost] G1 FAIL: Madaros exit=1
[shipped-compiler-selfhost]      last 30 lines of compiler log:
           = found i64
           |
           = help: ensure both branches return the same type, or use explicit conversion
           = note: the type of an if-expression is determined by its branches
        error[E007] in compiler/lean_single::compile_primary_a64 at 1669822..1670291: branches have incompatible types
           |
           = expected i64
           = found ()
           |
           = help: ensure both branches return the same type, or use explicit conversion
           = note: the type of an if-expression is determined by its branches
        error[E007] in compiler/lean_single::compile_postfix_tail_a64 at 1712359..1712652: branches have incompatible types
           |
           = expected i64
           = found ()
           |
           = help: ensure both branches return the same type, or use explicit conversion
           = note: the type of an if-expression is determined by its branches
        error[E007] in compiler/lean_single::compile_multiplicative_a64 at 1736736..1737238: branches have incompatible types
           |
           = expected i64
           = found ()
           |
           = help: ensure both branches return the same type, or use explicit conversion
           = note: the type of an if-expression is determined by its branches
        note: preflight covers module-closure parsing AND the full multi-module typecheck; see the diagnostics above for the actual cause
        Compilation failed!

[shipped-compiler-selfhost] running G2: lean_single compiles lean_single.sio
[shipped-compiler-selfhost] G2 PASS: lean_single.elf=2555805 bytes

[shipped-compiler-selfhost] verdict: G1=0 G2=1
[shipped-compiler-selfhost] artifacts: /tmp/sounio-shipped-compiler-selfhost.XligvL
[shipped-compiler-selfhost] FAIL: G1 Madaros cannot compile current source
```

`G1 = 0, G2 = 1, exit = 1`. Gate is RED. The pair RED-before /
GREEN-after is the delivery; the GREEN half is the build lane's ticket
(Slurm only, never on this pod).

### Other RED signal measured independently (cross-reference)

The same shipped `bin/madaros-linux-x86_64` (md5 `518006cc413e6e4e3debb28b82809d0b`,
mtime `2026-08-17 09:22:42Z`, last touched by commit `3d1f143e7a`
`build(madaros): refresh prebuilt bin/madaros-linux-x86_64 [skip ci]`)
prints, when compiling a larger tree:

> `IR slot census: globals 1892 + functions 7224 = 9116 (max 8191, over by 925)`
>
> `IR lowering failed during merge`

The `max 8191` ceiling is `IR_MAX_FUNCS - 1` at
`module_frontend.sio:4965`; `self-hosted/ir/ir.sio:35` reads
`IR_MAX_FUNCS = 16384`. The shipped ELF carries the pre-#1938 cap.
Third-party evidence is `docs/audit/DCE_SILENT_TRUNCATION_CENSUS_2026-08-19.md`
(#1951, already on `main`).

Both RED signals are the same root cause (shipped binary stale w.r.t.
current source). The gate catches it via G1 (E007 cascade on
`lean_single.sio`); the IR census catches it on a different program that
exceeds the old cap. A future revision of this gate could add a third
witness (G3) that exercises the IR_MAX_FUNCS boundary directly — for
this PR the G1 cascade is the load-bearing signal.

## Audit of other versioned binaries — same risk class

| Path                                       | md5       | mtime                  | Last touched              | ELF? | On the path of this gate? |
| ------------------------------------------ | --------- | ---------------------- | ------------------------- | ---- | ------------------------- |
| `bin/souc`                                 | fc3201f4  | 2026-08-19 11:07:00Z   | wrapper script            | no   | routes to madaros/lean_single, both audited |
| `bin/souc-lean-single-x86_64`              | c28659d8  | 2026-08-19 00:19:00Z   | 2026-08-19 (today)        | yes  | **G2**                    |
| `bin/souc-linux-x86_64`                    | c7d5e838  | 2026-08-15 00:00:00Z   | 2026-06-16 by 84aa8a583b  | yes  | NOT audited by this gate — see §"Gap" |
| `bin/souc-linux-x86_64.new`                | 27b13901  | (untracked neighbour)  | untracked                 | yes  | NOT audited — untracked, not in git |
| `bin/madaros`                              | 9fa473d4  | 2026-08-17 09:22:00Z   | wrapper script            | no   | routes to madaros-linux-x86_64, audited |
| `bin/madaros-linux-x86_64`                 | 518006cc  | 2026-08-17 09:22:42Z   | 2026-08-17 by 3d1f143e7a  | yes  | **G1**                    |
| `artifacts/self-hosted/souc-self-hosted-x86_64` | 6374e52f  | 2026-08-15 00:00:00Z | 2026-08-15 (build lane)  | yes  | NOT audited — not the user-facing compiler |

### Gap — `bin/souc-linux-x86_64`

This binary is the historical legacy compiler, last touched
**2026-06-16 by commit 84aa8a583b** — two months before this PR. It is
the same risk class (long-lived, last-touched date far precedes today's
`self-hosted/`) but is **not** reachable by `bin/souc` (the wrapper
defaults to Madaros, falls back to lean_single). It is reachable only
by direct invocation. This gate does not include it because:

1. It is not on the default user path, so it does not block a fresh clone.
2. Adding a third column would triple the gate's surface area without
   catching the dispatch's actual failure mode.

A separate gate (`legacy_shipped_compiler_gate.sh` or similar) is the
right place for it. Filing that as a follow-up.

### `bin/souc-lean-single-x86_64` — already PASSES

G2 passes today with md5 `c28659d8` and mtime `2026-08-19 00:19:00Z`.
This is the bootstrap seed; a fresh clone with a working seed AND a
broken Madaros is still rebuildable. The moment the seed stops passing
G2, the gate flips RED on G2 instead of G1 — and the failure class jumps
from "compiler does not compile tree" to "fresh clone cannot rebuild at
all", which is strictly worse.

## Coordination intent for `ci.yml` — proposed wiring (NOT edited in this PR)

Per dispatch, three gates of the same risk class as this one
(`effect_archaeology_gate.sh`, `typekind_archaeology_gate.sh`,
`typekind_archaeology_c.sh`) sit in `scripts/ci/` and are **not named by
any workflow** — zero wiring, zero coverage. This is the same pattern
the dispatch cites: a gate that nobody runs is a gate that rots.

`concept_status_gate.sh` (commit `226030a3e1` / PR #1959, landed on
`ci.yml:68` of `origin/main`) is the pattern to follow. The site is
the Contracts section, between `Docs registry` (line 65) and `Website
docs support` (line 70). The exact diff to add my gate, in the same
position as `concept_status_gate`:

```diff
       - name: Docs registry
         run: bash scripts/dev/check_docs_registry.sh
+      # Refuses silent compiler/source drift: shipped bin/madaros must be
+      # able to compile current self-hosted/, and bin/souc-lean-single-x86_64
+      # must remain the bootstrap seed. RED on origin/main as of 2026-08-19
+      # (shipped Madaros is pre-#1938). Fails before any compiler-touching
+      # gate can give a vacuous green.
+      - name: Shipped-compiler selfhost
+        run: bash scripts/ci/shipped_compiler_selfhost_gate.sh
       # Concept contracts must declare Status and not drift past/behind
       # bindings.tsv evidence (both directions). No skip escape.
       - name: Concept status ladder (bindings evidence)
         run: bash scripts/ci/concept_status_gate.sh
```

I do not edit `ci.yml` in this PR because:

- `grok-cli4` and `grok-cli5` are also working on `ci.yml` right now.
- The dispatch mandates `falem antes de editarem o mesmo ficheiro`.
- I could not reach either agent via `SendMessage` (no in-process
  channels open from this session).
- I asked twice; `ListAgents` returned `No reachable agents` both times.

The gate is **independent of the workflow edit**: it can be wired by
either party once they agree on adjacency. The diff above is the
proposal; the build lane or any agent with the channel to grok-cli4
can land the edit as a separate atomic commit.

`grok-cli4`, `grok-cli5` — please review this PR and either ACK the
suggested wiring or propose an alternative. I will not edit `ci.yml`
until we agree.

## What this PR does NOT do

- **Does not refresh the shipped Madaros binary.** That is the build
  lane's job (Slurm, not this pod). The dispatch is explicit:
  `Slurm para qualquer build, nunca no pod.`
- **Does not wrap `scripts/ci/build_modular_madaros.sh` in
  `scripts/dev/souc-build-lock.sh`.** The dispatch is explicit:
  `ele ja toma o lock e envolve-lo auto-bloqueia em silencio.`
- **Does not touch `ci.yml`.** See coordination section above.
- **Does not touch `self-hosted/ir/ir.sio`** or any other source file.
  The gate is the source of truth on whether such edits require a
  binary refresh; making the gate come up GREEN is downstream work.

## No-revert statement (founder rule, in effect until lifted)

Per the founder's standing rule (`NAO REVERTAS NADA SEM AVISAR`,
effective across all lanes until lifted): if any agent considers
reverting this gate or the commit that introduces it, they MUST say so
and wait. No `git revert`, no "put it back to unblock", no removal of
this gate from `ci.yml` as a stop-gap. The gate is the positive
control on a silent defect class; pulling it out re-introduces the
silence.

The rule is recorded in this PR body so the constraint is visible to
whoever merges, regardless of session.

## FLEET_CONSTRAINTS check

- [x] Work off `origin/main`, on my own branch, my own PR. Worktree at
      `/workspace/.wt/minimax-cli1/`, branch
      `lane/minimax-cli1/shipped-gate-20260819`. No writes to
      `/workspace/sounio/` — verified `git status` clean on the shared
      checkout at every step.
- [x] No `git add -A`, no `checkout`, no `stash`, no `clean` in
      `/workspace/sounio/`.
- [x] `./bin/souc` is PREBUILT noted — the gate's whole point is to
      check whether that prebuilt still compiles the tree.
- [x] No full self-compile / `make build` / `lake build` / test suite
      on this pod. Only the gate, which is bounded by `timeout 600`.
- [x] No Slurm launch. No build.
- [x] I do not merge. PR is DRAFT.
- [x] Atomic commits, one logical change each. Single commit
      `49de6ede9c`, single file `scripts/ci/shipped_compiler_selfhost_gate.sh`,
      198 insertions.
- [x] No `Co-Authored-By` trailer. No AI attribution in commit message.
- [x] EN-UK orthography in new doc (gate header).
- [x] Docs registry: no doc in this PR, so no sync needed.
- [x] Gate artifacts: status is `pass`/`fail` plus metrics
      `{G1, G2, exit}` printed in the final verdict line.
- [x] No revert of anyone else's work. This PR only adds a new gate.
- [x] Founder's no-revert rule acknowledged and quoted in the PR body.

## Halt conditions

I stop here. The gate is RED on `origin/main`; turning it GREEN is the
build lane's ticket. I will not silently tighten the criterion (e.g.
add md5 equality, add `bin/souc-linux-x86_64` audit) without an
explicit follow-up from the owner.
