### PR TITLE
concept(registry): SOUNIO-ADMISSIBILITY — the output half, and deciding as the fifth sink

### DIFF
--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -589,6 +589,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.implementation.test-triage-report | historical | docs/implementation/test_triage_report.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.implementation.tooling-summary | repo_only | docs/implementation/TOOLING_SUMMARY.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.implementation.ui-type-deignore-candidates | historical | docs/implementation/UI_TYPE_DEIGNORE_CANDIDATES.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.concepts.admissibility | repo_only | docs/internal/concepts/admissibility.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.dyadic-nonreduction | repo_only | docs/internal/concepts/dyadic-nonreduction.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.endogenous-observability | repo_only | docs/internal/concepts/endogenous-observability.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.epistemic-numeric-value | repo_only | docs/internal/concepts/epistemic-numeric-value.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -13027,6 +13027,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.internal.concepts.admissibility",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/concepts/admissibility.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.internal.concepts.dyadic-nonreduction",
       "collection": "repo",
       "repo_doc_path": "docs/internal/concepts/dyadic-nonreduction.md",

--- a/docs/internal/concepts/admissibility.md
+++ b/docs/internal/concepts/admissibility.md
@@ -1,0 +1,120 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.concepts.admissibility
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: claude-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.concepts.admissibility
+-->
+
+# Admissibility
+
+Concept-ID: `SOUNIO-ADMISSIBILITY`
+
+Status: **Hypothesis** — the coupling ruled by the founder on 2026-08-19 is not
+implemented. The *types* below are live and tested; what does not exist is the
+link between them and `SOUNIO-EPISTEMIC-ERASURE`.
+
+## Founder Intent
+
+Sounio's epistemic work has two halves, and only one of them had a
+specification.
+
+**Degradation** — how knowledge is lost — was specified on 2026-08-19:
+`SOUNIO-EPISTEMIC-ERASURE`, `SOUNIO-NO-IMPLICIT-DEGRADATION`,
+`SOUNIO-PROVENANCE`, `SOUNIO-JUSTIFICATION`. That is the **input** side.
+
+**Admissibility** — what one is permitted to *do* with the knowledge that
+remains — is the **output** side. It was implemented first and specified never.
+
+Founder ruling: **`Admissible<T>` requires non-degraded input.** An
+unjustified degradation anywhere in the chain makes the decision inadmissible.
+Not a warning, not a record on the side: the decision does not typecheck.
+
+## Measured state (2026-08-19, `origin/main`)
+
+Ten decision- and causality-typed kinds are live in the checker
+(`self-hosted/check/types.sio:55-65`, constructors at 1064–1530):
+
+| kind | stated role | test/example files |
+|---|---|---:|
+| `TyContest` | contest carrier | **122** |
+| `TyDeferred` | `Deferred<T>` — explicit action deferral certificate | **52** |
+| `TyRobust` | robustness carrier | 28 |
+| `TyAdmissible` | `Admissible<T>` — decision-admissibility proof carrier | 16 |
+| `TyIntervention` | `Intervention<T>` — causal `do(X=x)` | 13 |
+| `TyCounterfactual` | `Counterfactual<T>` — causal `Y(x)` | 12 |
+| `TyValidated` | `Validated<T>` — compile-time validated | 11 |
+| `TyRollbackCertificate` | rollback certificate | 4 |
+| `TyDecisionPolicy` | decision policy | 1 |
+| `TyDeferralPolicy` | deferral policy | — |
+
+**These are not `Garden`.** They are implemented and exercised.
+
+What is missing is not implementation but **a place where they are defined**.
+No concept document is dedicated to any of them; they are mentioned across
+others — `contest` in 10 documents, `intervention` in 5, `admissib` in 3. That
+is dispersion, which is the state from which documents contradict one another
+without anyone noticing.
+
+## The joint
+
+An `Admissible<T>` asserts a decision is admissible. **Admissible given what?**
+If the value behind it passed through a `.value` and lost its uncertainty, the
+admissibility was computed over a number that is no longer knowledge. Today
+nothing connects the two: `Admissible` cannot see that its input was degraded,
+and the erasure machinery does not know a decision is downstream.
+
+The ruling closes that: an unjustified degradation in the chain makes the
+decision inadmissible. `attest(v, uncertainty:, because:)` remains the way
+through, and its floor is a discharged proof (`SOUNIO-JUSTIFICATION`) — so a
+chain that legitimately strips uncertainty must say so with a theorem rather
+than by silence.
+
+**Deciding is the fifth sink.** `SOUNIO-EPISTEMIC-ERASURE` names four
+boundaries where a marked value is refused: reading uncertainty, leaving a
+public stdlib function, comparison against a test tolerance, and printing or
+writing out. All four concern **reporting** a number. This one concerns
+**acting** on it, and it is the one that reaches the world.
+
+## The row that was in the wrong table
+
+`SOUNIO-NO-IMPLICIT-DEGRADATION` lists *evaluation outside the validated
+domain* as a degradation with no act. **It belongs here instead.** A PBPK model
+run at a dose outside its calibration has lost no information — the information
+is intact. What fails is that the decision is not admissible at that point.
+Degradation is about the information; admissibility is about the domain and the
+policy. Filing it as degradation is what left it without an act for so long.
+
+## Required Invariants
+
+- Admissibility is computed over knowledge, not over numbers. A decision whose
+  support was degraded without justification does not typecheck.
+- The escape is `attest` with provenance, and its floor is a proof. There is no
+  weaker way past this boundary, because a decision is where a wrong number
+  stops being a printed digit and becomes an action.
+- Admissibility and degradation are **not** the same axis and neither subsumes
+  the other. Both must be green: the information survived, **and** the decision
+  fits the domain.
+- A concept scattered across ten documents has no definition. These kinds get
+  one place, and the ten mentions defer to it.
+
+## Claims Forbidden
+
+- Do not describe the coupling as implemented. `Admissible<T>` performs no
+  check on the epistemic history of its input today.
+- Do not read the test-file counts as evidence that the kinds are
+  `Claim-ready`. Counting files that mention a name measures reach, not the
+  two-program test.
+- Do not treat this document as a specification of what each of the ten kinds
+  *means*. It specifies the **joint**; the individual definitions do not exist
+  yet and their absence is the finding.
+- Do not move *evaluation outside the validated domain* out of the degradation
+  table until an act exists for it here. Removing it from one table without
+  landing it in the other loses it entirely.
+
+## Related
+
+- `SOUNIO-EPISTEMIC-ERASURE` — the input half; deciding becomes its fifth sink
+- `SOUNIO-JUSTIFICATION` — supplies the only way past the boundary
+- `SOUNIO-NO-IMPLICIT-DEGRADATION` — holds the misfiled row


### PR DESCRIPTION
Founder ruling, 2026-08-19: **`Admissible<T>` requires non-degraded input.** An unjustified degradation anywhere in the chain makes the decision inadmissible — not a warning, not a record on the side: it does not typecheck.

## The half that was never specified

The epistemic work has two halves. **Degradation** — how knowledge is lost — was specified today across four concepts. **Admissibility** — what one may *do* with what remains — was implemented first and specified never.

Measured on `origin/main`: ten decision- and causality-typed kinds are live in `check/types.sio:55-65` (constructors 1064–1530).

| kind | role | test/example files |
|---|---|---:|
| `TyContest` | contest carrier | **122** |
| `TyDeferred` | explicit action deferral certificate | **52** |
| `TyRobust` | robustness carrier | 28 |
| `TyAdmissible` | decision-admissibility proof carrier | 16 |
| `TyIntervention` | causal `do(X=x)` | 13 |
| `TyCounterfactual` | causal `Y(x)` | 12 |
| `TyValidated` | compile-time validated | 11 |
| `TyRollbackCertificate` / `TyDecisionPolicy` / `TyDeferralPolicy` | — | 4 / 1 / — |

**These are not `Garden`** — they are implemented and exercised. What is missing is a place where they are **defined**: no concept is dedicated to any of them, and they appear scattered across others (`contest` in 10 documents, `intervention` in 5, `admissib` in 3). Dispersion is the state from which documents contradict each other unnoticed.

## The joint

An `Admissible<T>` asserts a decision is admissible — **given what?** If the value behind it passed through a `.value`, the admissibility was computed over a number that is no longer knowledge.

**Deciding therefore becomes the fifth sink** of `SOUNIO-EPISTEMIC-ERASURE`. The other four concern *reporting* a number; this one concerns *acting* on it, and it is the one that reaches the world.

## A row that was in the wrong table

`SOUNIO-NO-IMPLICIT-DEGRADATION` files *evaluation outside the validated domain* as a degradation with **no act**. It belongs here: a PBPK model run outside its calibration has lost **no information** — the information is intact. What fails is that the decision is not admissible there. Filing it as degradation is why it went so long without an act.

## Semantic declaration

- **Concept-IDs**: introduces `SOUNIO-ADMISSIBILITY`. References `SOUNIO-EPISTEMIC-ERASURE`, `SOUNIO-JUSTIFICATION`, `SOUNIO-NO-IMPLICIT-DEGRADATION`.
- **Intent-Preserved**: `FOUNDER_INTENT.md` — a small or unresolved effect reported as zero, carried to the point where a number becomes an action.
- **Transformation**: documentation plus filesystem-derived registry sync. Zero lines of `self-hosted/` or `stdlib/`.
- **Claims-Introduced**: the ten kinds, their line numbers, and the file counts — reproducible by `git grep` on `origin/main`.
- **Claims-Forbidden**: the coupling is **not implemented** — `Admissible<T>` performs no check on the epistemic history of its input today. Test-file counts are **not** evidence of `Claim-ready`: counting files that mention a name measures reach, not the two-program test. This document does **not** define what each of the ten kinds means — it specifies the joint, and the individual definitions do not exist. And the misfiled row must **not** be removed from the degradation table until an act exists here, or it is lost entirely.
- **Authoritative-Only-If**: **Hypothesis** until a decision over degraded support is refused and one over sound support passes.
