### PR TITLE
concept(ladder): Reserved splits in two — a promise and a marker do not owe the same

### DIFF
--- a/docs/internal/concepts/MATURITY_LADDER.md
+++ b/docs/internal/concepts/MATURITY_LADDER.md
@@ -47,6 +47,57 @@ waiting, not omission. It sits beside the ladder rather than on it: a
 `Reserved` kind has not failed to reach `Executable`, it has been held short
 of it on purpose.
 
+## Reserved splits in two
+
+Founder ruling, 2026-08-19. `Reserved` as first stated confuses two things
+that do not owe the same, and reading them alike is what lets a promise sit
+unpaid indefinitely without anyone deciding that it should.
+
+    reserved-owed   the name is taken AND SOMEONE OWES. Carries three
+                    mandatory fields:
+                      Reserved-Owner       who signs
+                      Reserved-Since       ISO date
+                      Reserved-Blocked-On  the TECHNICAL CONDITION missing,
+                                           never a deadline
+
+    reserved-taken  the name is taken so that nothing else may claim it.
+                    OWES NOTHING; staying this way forever is correct.
+                    Requires only a non-empty Reserved-Reason.
+
+**A promise that never lands misleads; a marker that stays is honest.** Before
+the split they read identically, so a promised `f128` and a blocked keyword
+were indistinguishable.
+
+`Reserved-Blocked-On` is a **condition, not a date**. `TyF128` is blocked on
+`f128` emission in the x86-64 backend — without it the type exists and does not
+descend. A reader then knows whether this is an afternoon or a year, and nobody
+has to guess.
+
+**The date is visible and does not expire.** Same rule the founder set for
+`Evidence-Does-Not-Count`: nothing expires, nothing goes red with age, and the
+gate **prints the active reservations with owner and age in days even when it
+passes**, oldest first. Age derives from `Reserved-Since`, never from the git
+log — otherwise editing the file for an unrelated reason erases the memory of
+when the reservation was made, and visibility dies by maintenance.
+
+**Both halves still owe a refusal.** A reserved name whose use is not refused
+is not reserved; it is merely unimplemented, which is a different state. The
+negative evidence requirement applies to `reserved-owed` and `reserved-taken`
+alike.
+
+**Malformed is redder than absent.** A `reserved-owed` missing Owner, Since or
+Blocked-On fails, and the diagnostic names which of the three is missing. If
+declaring badly were cheaper than declaring well, everyone would declare badly.
+
+### What is not yet reserved, and should be
+
+`i256`, `i512`, `u256` and `u512` are named in the founder's specification and
+exist in **no enum at all** — not even reserved. Writing `i512` today produces a
+generic unknown-type error, indistinguishable from a typo. Reserving them would
+record the intent **inside the compiler** rather than only in a document, and
+give them a diagnostic of their own. `i512` was named as the seed of the
+Cayley-Dickson tower (`SOUNIO-PRECISION-PRESERVATION`).
+
 Measured instance: `TyF128` and `TyF256` under Madaros. `E218` on bind, on
 arithmetic, and on signature-only use.
 


### PR DESCRIPTION
Founder ruling, 2026-08-19. Amends `MATURITY_LADDER.md`, where the fifth state lives.

## The problem with `Reserved` as first stated

It confuses two things that do not owe the same — and reading them alike is what lets a promise sit unpaid indefinitely without anyone deciding that it should.

| | owes | forever is |
|---|---|---|
| **`reserved-owed`** | `Reserved-Owner`, `Reserved-Since`, `Reserved-Blocked-On` | a debt |
| **`reserved-taken`** | only a non-empty `Reserved-Reason` | **correct** |

**A promise that never lands misleads; a marker that stays is honest.** Before the split, a promised `f128` and a blocked keyword read identically.

## `Reserved-Blocked-On` is a condition, not a date

`TyF128` is blocked on **`f128` emission in the x86-64 backend** — without it the type exists and does not descend. A reader then knows whether this is an afternoon or a year, and nobody has to guess.

## The date is visible and does not expire

Same rule the founder set for `Evidence-Does-Not-Count`: nothing expires, nothing goes red with age — and the gate **prints the active reservations with owner and age in days even when it passes**, oldest first.

Age derives from `Reserved-Since`, **never from the git log**: otherwise editing the file for an unrelated reason erases the memory of when the reservation was made, and visibility dies by maintenance.

## Two invariants carried over

**Both halves still owe a refusal.** A reserved name whose use is not refused is not reserved — it is merely unimplemented, which is a different state.

**Malformed is redder than absent.** A `reserved-owed` missing any of the three fields fails, and the diagnostic names which one. If declaring badly were cheaper than declaring well, everyone would declare badly.

## Recorded alongside

`i256`, `i512`, `u256`, `u512` are named in the founder's specification and exist in **no enum at all** — not even reserved. Writing `i512` today gives a generic unknown-type error, indistinguishable from a typo. Reserving them would record the intent **inside the compiler** rather than only in a document.

## Semantic declaration

- **Concept-IDs**: amends `MATURITY_LADDER`. References `SOUNIO-PRECISION-PRESERVATION`.
- **Intent-Preserved**: the fifth state remains beside the ladder, not on it, and still means fail-closed by decision. The split refines what it owes; it removes nothing.
- **Transformation**: documentation plus filesystem-derived registry sync. Zero lines of `self-hosted/` or `stdlib/`.
- **Claims-Introduced**: that exactly two kinds are `Reserved` today (`TyF128`, `TyF256`, both `E218` — `tests/typekind/index.tsv`) and that no concept document declares `Status: reserved`. Both reproducible on `origin/main`.
- **Claims-Forbidden**: the split is **not enforced** — the concept-status gate is under construction and does not yet know these two states. The `Blocked-On` for `TyF128`/`TyF256` stated here is a **proposal**, not a founder ruling. Reserving `i256`/`i512`/`u256`/`u512` is a recommendation and has not been done.
- **Authoritative-Only-If**: enforcement arrives with the concept-status gate, including its Phase-D cases where a malformed `reserved-owed` and a `reserved-taken` without reason each turn it red.
