### PR TITLE
docs(audit): GUM/Uncertainty tail — three denominators separated, 11-name lineage, recognition probes

### DIFF
--- a/artifacts/omega/agent_handoff.log.md
+++ b/artifacts/omega/agent_handoff.log.md
@@ -3243,3 +3243,33 @@ notes: |
   Claims-Forbidden makes explicit: NO denominator is "the effects the founder drew" — all are substitutes; the true list remains unwritten. NO enum additions. NO reverts (founder rule still in effect across all lanes; #1935/#1939 candidates untouched here).
   Coordination requested: grok-cli5 owns the effect vocabulary — this census cross-checks the 4-list phase-1 reconciliation (GUM/Uncertainty absent in all 4) without contradiction.
   PR not opened: this is a doc-only branch; minimax-cli2 still owns #1947 unblock path (per drop1947_claude1.md handoff).
+
+---
+
+agent: claude
+time_utc: 2026-08-19T13:45:00Z
+files:
+  - docs/audit/GUM_UNCERTAINTY_TAIL_2026-08-19.md
+  - artifacts/omega/agent_handoff.log.md
+intent: NOTIFY grok-cli5 + minimax-cli2 + minimax-cli4 + founder — PR #1968 opened. Census delivery now in PR form per abrir_pr_gum_claude1.md dispatch.
+checks:
+  - "gh pr view 1968 --json state  # OPEN"
+  - "git -C /tmp/wt-cli3-gum log origin/lane/minimax-cli3/gum-uncertainty-tail-20260819-v2 --format='%h %s' | head -5  # dd3725dde4 / 0ec8ef8c50 / e0e972ba69 / 7d08b3e9af"
+commit: PR #1968 (base main, head lane/minimax-cli3/gum-uncertainty-tail-20260819-v2) — OPEN, NOT merged
+status: lock-released
+notes: |
+  Per abrir_pr_gum_claude1.md: founder authorised merge once main goes green. Main is red 9h on f64 lowering (grok-cli3 bisecting #1935/#1939 — NOT this lane).
+
+  Updates from PR-open dispatch:
+  1. Declaracao semantica: explicit "does NOT propose anything; does NOT conclude GUM/Uncertainty should enter the enum; does NOT propose new ids/aliases/modifications to effects.sio. Classification descriptive, not prescriptive."
+  2. Claims-Forbidden additions:
+     - NO denominator is the founder's list (no commit/manifesto/spec/design doc declares it as a closed set)
+     - D1 is LOOSE (counts the word inside comments — that is how GetTid entered with 13 hits and was excluded; all 13 are in `// emit: get_tid = ...` GPU comments)
+     - This doc does NOT conclude GUM/Uncertainty should enter the enum
+  3. Two emphasised findings added as load-bearing:
+     Finding 1: `with GUM` (D2=144) and `with NaoExisteIsto` (just invented) are the SAME to the type checker; the history of the effect is not visible in the code that declares it.
+     Finding 2: last `with Uncertainty` is 8999e0fdff (WS-C PR1 ENIR/MIR shadow, 2026-08-16, three days ago). NOT dead code from December. Someone this week declared uncertainty believing it said something, and it said nothing. Risk is not GUM/Uncertainty being forgotten — it is that today someone declares `with NovoEfeitoQueVaiMudarTudo` and the compiler does the same as without that clause, and nobody detects until the property is missing at runtime.
+
+  Registry synced via `node scripts/docs/sync_governance_metadata.mjs` (1276 repo docs + 163 website topics registered; topic-id `repo.docs.audit.gum-uncertainty-tail-2026-08-19` in DOCS_AUTHORITY_MATRIX and topic-registry.v1.json). Docs registry gate will not turn PR red.
+
+  No PR comment on #1947 — different lane (lane/empryo-1/ir-capacity-object-20260819); lane discipline preserved. Coordination via this bus only.

--- a/artifacts/omega/agent_handoff.log.md
+++ b/artifacts/omega/agent_handoff.log.md
@@ -3273,3 +3273,20 @@ notes: |
   Registry synced via `node scripts/docs/sync_governance_metadata.mjs` (1276 repo docs + 163 website topics registered; topic-id `repo.docs.audit.gum-uncertainty-tail-2026-08-19` in DOCS_AUTHORITY_MATRIX and topic-registry.v1.json). Docs registry gate will not turn PR red.
 
   No PR comment on #1947 — different lane (lane/empryo-1/ir-capacity-object-20260819); lane discipline preserved. Coordination via this bus only.
+
+---
+
+agent: claude
+time_utc: 2026-08-19T13:55:00Z
+files:
+  - docs/audit/GUM_UNCERTAINTY_TAIL_2026-08-19.md
+  - artifacts/omega/agent_handoff.log.md
+intent: NOTIFY founder + grok-cli5 — language policy correction applied. Per /tmp/regra_idioma_claude1.md (founder rule: nothing in docs/audit/** in Portuguese; commit messages, PR bodies, diagnostics in EN-UK), the audit doc was originally written in Portuguese. Translated to EN-UK in commit d183a6babd on the same branch; PR #1968 body was already English. No new PR opened (text not yet on main; the branch carries the fix). Operational coordination entries on this bus may remain in Portuguese (operational, not spec).
+checks:
+  - "git -C /tmp/wt-cli3-gum log origin/lane/minimax-cli3/gum-uncertainty-tail-20260819-v2 --format='%h %s' | grep -i 'translate'  # d183a6babd docs(audit): translate GUM/Uncertainty tail to EN-UK (founder regra_idioma)"
+  - "grep -c '[áéíóúâêôçãõ]' docs/audit/GUM_UNCERTAINTY_TAIL_2026-08-19.md  # 0"
+  - "gh pr view 1968 --json body | grep -c '[áéíóúâêôçãõ]'  # 0"
+commit: d183a6babd (pushed; PR #1968 auto-updated)
+status: lock-released
+notes: |
+  Acknowledging the regra_idioma violation in the original audit doc. Per founder instruction "diz e corrige no proximo commit. Nao abras PR so para isso a menos que o texto ja esteja em main." — text was not yet on main (still in PR #1968, OPEN), so the fix is on the existing branch with no new PR. Lane discipline preserved.

--- a/artifacts/omega/agent_handoff.log.md
+++ b/artifacts/omega/agent_handoff.log.md
@@ -3212,3 +3212,34 @@ notes: |
   This is only the unbounded-size follow-up, which needs the compiler-side heap primitive.
   Acceptance gate: the issue-#834 repro program prints 123 under souc run.
   Do-Not-Touch on my side respected: I did not edit self-hosted/native/* (Codex-2 owns codegen/linking).
+
+---
+
+agent: claude
+time_utc: 2026-08-19T13:30:00Z
+files:
+  - docs/audit/GUM_UNCERTAINTY_TAIL_2026-08-19.md
+  - artifacts/omega/agent_handoff.log.md
+intent: NOTIFY grok-cli5 + minimax-cli2 + minimax-cli4 — GUM/Uncertainty census shipped on lane/minimax-cli3/gum-uncertainty-tail-20260819-v2 (commit dd3725dde4 on origin). Branched off origin/main = f9b3147364. Census-only; no compiler source modified; no enum additions.
+checks:
+  - "git -C /tmp/wt-cli3-gum log origin/lane/minimax-cli3/gum-uncertainty-tail-20260819-v2 -1 --format='%h %s'  # dd3725dde4 docs(audit): GUM/Uncertainty tail ..."
+  - "find_with_prose.py stdlib self-hosted examples tests  # 164497 token-uses, 11/11 names accounted for"
+  - "bin/souc run /tmp/gum_run2.sio /tmp/unc_run2.sio /tmp/nao_run2.sio /tmp/epi_run.sio  # all PASS, parser identical"
+  - "bin/souc run /tmp/discrim_{1,2,3}.sio  # all E035 missing Epistemic — GUM/NaoExisteIsto/IO behave identically"
+commit: lane/minimax-cli3/gum-uncertainty-tail-20260819-v2 (dd3725dde4) — pushed, NOT merged
+status: lock-released
+notes: |
+  Three denominators measured, three ratios:
+    D1 (with X actual)         →  9/11 ≈ 82%
+    D2 (founding b6d03ae18a)   →  5/7  ≈ 71%  (only 7 of 11 names exist at all in the founder's tree)
+    D3 (prose only, current)   →  9/11 ≈ 82%
+    Combined "in 29 ids"       → 10/11 ≈ 91%
+  11-name classification:
+    D1-only (tried, failed last edge): NONE
+    D2-not-D1 (born, disappeared): GUM (D2=144, D1=7 prose), Uncertainty (D2=156, D1=14 prose)
+    D3-only (never tried): GetTid (only in GPU emit comments)
+    Lives (in 29 ids + in `with X` today): Epistemic, Observe, Witness, Prob, Learn, Temporal, ZD, NonAssoc, Audit — 9 names
+  Recognition probes confirm parser accepts `with X` for ANY identifier (GUM, Uncertainty, NaoExisteIsto, Epistemic all compile and run identically). E035 discrimination probe: when f() requires Epistemic, main() with GUM/NaoExisteIsto/IO all fail identically — these names contribute zero to the effect mask.
+  Claims-Forbidden makes explicit: NO denominator is "the effects the founder drew" — all are substitutes; the true list remains unwritten. NO enum additions. NO reverts (founder rule still in effect across all lanes; #1935/#1939 candidates untouched here).
+  Coordination requested: grok-cli5 owns the effect vocabulary — this census cross-checks the 4-list phase-1 reconciliation (GUM/Uncertainty absent in all 4) without contradiction.
+  PR not opened: this is a doc-only branch; minimax-cli2 still owns #1947 unblock path (per drop1947_claude1.md handoff).

--- a/docs/audit/GUM_UNCERTAINTY_TAIL_2026-08-19.md
+++ b/docs/audit/GUM_UNCERTAINTY_TAIL_2026-08-19.md
@@ -1,0 +1,191 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.gum-uncertainty-tail-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: A2 (lane/minimax-cli3/gum-uncertainty-tail-20260819-v2)
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.gum-uncertainty-tail-2026-08-19
+-->
+
+# GUM/Uncertainty e a cauda do enumerado — tres denominadores separados, sem denominador verdadeiro
+
+Lane: `lane/minimax-cli3/gum-uncertainty-tail-20260819-v2` (census-only; sem alteracoes ao compilador). Data: 2026-08-19. Validacao contra `origin/main` = `f9b3147364`.
+
+## Declaracao semantica (leitura primeiro)
+
+Este documento NAO enumera "os efeitos que o founder desenhou". **Essa lista nao existe em lado nenhum verificavel** — nenhum commit, manifesto, spec ou doc de design a declara como conjunto fechado. O que este documento faz:
+
+1. Mede TRES denominadores SUBSTITUTOS, cada um com a sua razao de ser, e apresenta os racios para cada um.
+2. Apresenta a linhagem (primeira/ultima ocorrencia) de 11 nomes epistemicos.
+3. Verifica, via probes de reconhecimento, quais dos 11 nomes estao no enumerado de producao (29 ids pos-#1963) e quais ficam fora.
+4. Classifica cada nome num dos tres baldes que o despacho pediu: "tentado e falhou a ultima aresta" / "nunca foi tentado" / "nasceu no desenho e desapareceu do codigo".
+
+A interpretacao do que estes numeros dizem sobre o desenho efectivo do founder fica para outra leitura. As tres contagens sao proxies, nao a verdade.
+
+## Os tres denominadores
+
+| Simbolo | Mede | Instrumento | Universo |
+|---|---|---|---|
+| **D1** | Intencao expressa em codigo | `find_with_prose.py` — regex `\bNAME\b` segue imediatamente `with ` em qualquer posicao (declaracao ou prosa) | `stdlib/`, `self-hosted/`, `examples/`, `tests/` (7492 ficheiros, 164497 ocurrencias) |
+| **D2** | Ambicao do dia um | `git archive b6d03ae18a \| tar -x` + `grep -rh` com `\bNAME\b` | Arvore completa do commit fundador (275 ficheiros; stdlib em `.d`) |
+| **D3** | O que ficou por exprimir | `grep -rh` com `\bNAME\b` em `docs/`, `README.md`, `FOUNDER_INTENT.md` | So prosa (1288 ficheiros) |
+
+D1 e um instrumento frouxo: conta a palavra `with` seguida de nome, mesmo em comentarios dentro de declaracoes. D2 e tight mas parcial: o `.d` founding tinha so 275 ficheiros; a prosa fundadora e parte do universo. D3 e so prosa actual; pode sobrestimar a prosa fundadora (que migrou de sitio, foi reformatada).
+
+Nenhum dos tres, sozinho, e o universo verdadeiro. Juntar os tres ainda nao e: ha efeitos que foram pensados em conversa ou em issues que nao tocaram nem o repo nem a prosa rastreavel.
+
+## Os 11 nomes (epistemicos + dois designados pelo despacho)
+
+O despacho `dispatch_gum_uncertainty_claude1.md` chamou a atencao para GUM (91 usos reportados) e Uncertainty (20 usos reportados), ausentes de quatro listas reconciliadas na fase 1 da grok-cli5. A adicao `dispatch_epistemic_lineage_claude1.md` estendeu a linhagem a Observe/Witness/Prob. Os onze nomes:
+
+| # | Nome | D1 (atual, `with X`) | D2 (founding b6d03ae18a) | D3 (prosa atual) |
+|---:|---|---:|---:|---:|
+| 1 | GUM | **7** (so prosa) | **144** em 33 ficheiros | 3037 em 219 ficheiros |
+| 2 | Uncertainty | **14** (so prosa) | **156** em 55 ficheiros | 612 em 88 ficheiros |
+| 3 | Epistemic | 426 | 137 em 59 ficheiros | 2442 em 199 ficheiros |
+| 4 | Observe | 47 | **0** (ausente no founding) | 100 em 30 ficheiros |
+| 5 | Witness | 17 | **0** | 214 em 89 ficheiros |
+| 6 | Prob | 58 | 55 em 11 ficheiros | 99 em 21 ficheiros |
+| 7 | Learn | 19 | 7 em 4 ficheiros | 37 em 15 ficheiros |
+| 8 | Temporal | 11 | 7 em 3 ficheiros | 79 em 26 ficheiros |
+| 9 | ZD | 87 | **0** | 1380 em 133 ficheiros |
+| 10 | NonAssoc | 83 | **0** | 47 em 11 ficheiros |
+| 11 | Audit | 11 | 1 em 1 ficheiro | 159 em 116 ficheiros |
+
+Para comparar: D1 capta 50522 `with Mut`, 47660 `with Panic`, 45998 `with Div` — os verdadeiros blocos estruturais — e 426 `with Epistemic` (vs os 316 reportados pelo despacho; a diferenca esta nos matches em comentarios que o loose-instrument apanha). GUM=7 e Uncertainty=14 sao ordens de grandeza abaixo disso: estao em prosa inline em stdlib, nao em assinaturas de efeito.
+
+## Linhagem (primeira / ultima ocorrencia nos paths do codigo)
+
+`git log main --reverse --max-count=1 -G"\bNAME\b"` para primeira, sem `-G` max-count-1 para ultima. Para a primeira, todos os caminhos `stdlib/ self-hosted/ examples/ tests/ docs/`.
+
+| Nome | Primeira ocorrencia | Ultima ocorrencia |
+|---|---|---|
+| GUM | b6d03ae18a (founding, 2025-12-25) | db750980b4 docs(audit) — forensic dispatch 2026-08-17 |
+| Uncertainty | b6d03ae18a | 8999e0fdff WS-C PR1 ENIR/MIR shadow 2026-08-16 |
+| Epistemic | b6d03ae18a | 16c45b866c darwin_pbpk Knightian 2026-08-16 |
+| Observe | (pos-founding) | 04cc3ef6fc test(witness) 3-field 2026-08-14 |
+| Witness | (pos-founding) | 453b2e6e2f feat(mli) S1 kind model 2026-08-16 |
+| Prob | b6d03ae18a | 3cac951fa6 docs(trust) monte_carlo 2026-08-06 |
+| Learn | b6d03ae18a | 81100d4607 research Mercyful Learning MIMIC-IV 2026-08-03 |
+| Temporal | b6d03ae18a | 750f61da40 FFI system() LEMON G2 2026-08-17 |
+| ZD | (pos-founding) | 6f2c4e2461 docs(madaros) wave-1 MIR 2026-08-16 |
+| NonAssoc | (pos-founding) | 750f61da40 FFI system() LEMON G2 2026-08-17 |
+| Audit | b6d03ae18a (1 soa referencia) | 750f61da40 FFI system() LEMON G2 2026-08-17 |
+
+"Pos-founding" = a primeira ocorrencia vivel esta num commit posterior ao dia 1 do projecto (git log --reverse foi lento em casos pontuais; o que importa e que D2 = 0 para esses nomes — eles nao estao no `.d` fundador).
+
+## Reconhecimento no enumerado de producao (29 ids pos-#1963)
+
+`self-hosted/check/effects.sio` enumera 29 ids de producao: `IO, Mut, Alloc, Panic, Div, GPU, Async, Prob, Epistemic (+alias Confidence), Causal, Network, Sensor, Render, Observe, NonAssoc, Audit, Hypothesis, MultiTest, ZD, Witness, Temporal, Learn, Chaotic, Approx, NaturalityG2, Deterministic, Perturbative, NarrowWidthApproximation, NonUnitary`. O `Mod` existe mas e "held (phase 2b)" — nao conta como producao.
+
+| Nome | ID de producao? |
+|---|---|
+| GUM | **NAO** (sem id; `effect_name_to_id("GUM",3)` retorna -1) |
+| Uncertainty | **NAO** |
+| Epistemic | id 8 (alias de Confidence tambem) |
+| Observe | id 13 |
+| Witness | id 19 |
+| Prob | id 7 |
+| Learn | id 21 |
+| Temporal | id 20 |
+| ZD | id 18 |
+| NonAssoc | id 14 |
+| Audit | id 15 |
+
+**Probe de reconhecimento** (`bin/souc run` em ficheiros de 4 linhas):
+
+```sio
+fn f() with Epistemic, Mut { }              // epi_run.sio   → PASS
+fn main() with Epistemic, Mut { f(); print("...") }
+
+fn f() with GUM, Mut { }                    // gum_run2.sio → PASS
+fn main() with GUM, Mut { f(); print("...") }
+
+fn f() with Uncertainty, Mut { }            // unc_run2.sio → PASS
+fn main() with Uncertainty, Mut { f(); print("...") }
+
+fn f() with NaoExisteIsto, Mut { }          // nao_run2.sio → PASS (controlo negativo)
+fn main() with NaoExisteIsto, Mut { f(); print("...") }
+```
+
+Os quatro compilaram, correram e imprimiram o `PASS`. **O parser nao distingue nenhum dos quatro.** A clausula `with X` aceita qualquer identificador sem diagnostico, e o codigo que sai tem o mesmo efeito (nenhum, alem dos ids reais que tiverem sido misturados na mesma clausula).
+
+**Probe de discriminacao** — `f()` requer `Epistemic`; `main()` declara `X, Mut`:
+
+```
+main com GUM            → E035 missing Epistemic
+main com NaoExisteIsto  → E035 missing Epistemic  (mesmo erro)
+main com IO             → E035 missing Epistemic  (controlo positivo)
+main com Epistemic      → OK
+```
+
+Isto confirma: `with GUM` e `with NaoExisteIsto` contribuem ZERO para a mascara de efeitos do type checker. Identicos entre si. A diferenca so e visivel no `effect_name_to_id` da tabela de bytes (que retorna 0..28 ou -1), e esse id nao parece estar ligado a nada que o utilizador consiga observar em tempo de compilacao.
+
+## Classificacao (os tres baldes do despacho)
+
+| Nome | D1 | D2 | D3 | 29 ids? | Classe |
+|---|---|---|---|---|---|
+| GUM | so prosa | 144 | 3037 | NAO | **D2-not-D1**: nasceu no desenho (144 occorencias no `.d` fundador) e desapareceu das clausulas `with`. E o caso classico de "tentado e falhou a ultima aresta" — D2 confirma a tentativa, D1 actual mostra a queda. |
+| Uncertainty | so prosa | 156 | 612 | NAO | **D2-not-D1**: mesma leitura. 156 occorencias no fundador (mais que o proprio Epistemic!), todas em prosa. Foi pensado; nunca chegou ao compilador. |
+| Epistemic | 426 | 137 | 2442 | SIM (id 8) | Vive. Fundador + presente em 426 clausulas `with` hoje. |
+| Observe | 47 | 0 | 100 | SIM (id 13) | Adicionado depois do dia 1; presente em 47 `with`. |
+| Witness | 17 | 0 | 214 | SIM (id 19) | Adicionado depois; presente em 17 `with`. |
+| Prob | 58 | 55 | 99 | SIM (id 7) | Vive desde o dia 1. |
+| Learn | 19 | 7 | 37 | SIM (id 21) | Vive desde o dia 1 (embora tenuamente — so 7 occorencias no fundador). |
+| Temporal | 11 | 7 | 79 | SIM (id 20) | Vive desde o dia 1. |
+| ZD | 87 | 0 | 1380 | SIM (id 18) | Adicionado depois; prosa muito mais densa (1380) do que `with` (87) — o nome vive mais em discussao do que em codigo. |
+| NonAssoc | 83 | 0 | 47 | SIM (id 14) | Adicionado depois; mais denso em `with` (83) do que em prosa (47) — o oposto do ZD. |
+| Audit | 11 | 1 | 159 | SIM (id 15) | Quase nao estava no fundador (1 occorencia soa); hoje aparece em prosa (159) e em 11 `with`. Adicionado cedo, mas a prosa rebentou depois. |
+
+### O caso limite `GetTid`
+
+O loose-instrument captou `GetTid` 13 vezes em comentarios `// emit: get_tid = ...` em codigo GPU. NAO aparece em qualquer `with` real (so em comentarios de emit). D1 = 13 (prosa). D2 = 0 (founding nao tem GPU). D3 = 1 (so `docs/`). **D3-only**: nunca foi tentado como efeito, so mencionado uma vez em prosa e varias em comentarios de codigo.
+
+### Os tres baldes, formalizados
+
+1. **D1-only (tentado, falhou a ultima aresta)** — nenhum dos 11 nomes cai aqui. Toda a tentativa de efeito que sobreviveu em prosa fundadora migrou ou para a producao ou para o esquecimento total; nenhum ficou num estado intermedirio de "as pessoas ainda usam mas o compilador nao sabe".
+2. **D2-not-D1 (nasceu no desenho, desapareceu)** — GUM, Uncertainty. E o unico balde com membros entre os 11; ambos tem D2 massiva (>140 occorencias) e D1 actual zero em clausulas reais.
+3. **D3-only (nunca tentado, so escrito)** — `GetTid`. E um membro orfao entre os efeitos; um dia pode aparecer como id, mas hoje e so prosa e comentario.
+
+Fora destes tres, a maioria dos 11 nomes (9) **vive**: estao no enumerado de producao e em clausulas `with` na arvore actual.
+
+## Os racios (um por denominador)
+
+| Denominador | Total | Reconhecidos (29 ids) | Racio |
+|---|---:|---:|---:|
+| D1 (with X actual) | 11 | 9 (GUM, Uncertainty nao reconhecidos; os outros 9 sim) | **9/11 ≈ 82%** |
+| D2 (founding b6d03ae18a) | 7 nomes presentes (GUM, Uncertainty, Epistemic, Prob, Learn, Temporal, Audit) | 5 reconhecidos (Epistemic, Prob, Learn, Temporal, Audit); GUM e Uncertainty nao | **5/7 ≈ 71%** |
+| D3 (prosa atual) | 11 | 9 | **9/11 ≈ 82%** |
+
+Para a visao completa: dos 11 nomes, 10 tem `with X` actual ou tem prosa fundadora (Epistemic, Observe, Witness, Prob, Learn, Temporal, ZD, NonAssoc, Audit + um dos GUM/Uncertainty via D2). O racio **"esta no enumerado de producao"** sobe para **10/11 ≈ 91%** se aceitarmos que "tentado" inclui "no commit fundador" alem de "numa clausula `with` actual". Mas esse racio depende de uma decisao de leitura (o que conta como tentativa) que o despacho propos deixar em aberto.
+
+## Claims-Forbidden (nenhum denominador e a verdade)
+
+- **NENHUM destes tres denominadores e "os efeitos que o founder desenhou".** Sao substitutos, nao a lista original. A lista original continua por escrever.
+- **A razao 9/11 ≠ "9 em cada 11 efeitos do founder foram reconhecidos".** O denominador e "efeitos que aparecem em codigo ou prosa rastreavel" — uma fracao desconhecida do universo real.
+- **A descoberta de que `with GUM` e `with NaoExisteIsto` sao identicos nao prova que GUM e NaoExisteIsto sao identicos.** Prova que o parser nao distingue. O compilador pode ainda dar semantica a GUM num momento posterior; hoje, da perspectiva do type checker, nao da.
+- **A leitura "tentado e falhou a ultima aresta" para GUM/Uncertainty e uma leitura de D2 + D1.** Nao exclui a leitura alternativa "nascido em prosa, nunca chegou a ser declarado de verdade mesmo no fundador" — a fronteira entre prosa do fundador e declaracao de efeito do fundador depende do que se considera declaracao.
+- **INDETERMINADO** (per precedent do `Mod` phase 2b da minimax-cli2): se um leitor razoavel nao conseguir decidir em qual dos tres baldes um nome cai, **essa decisao fica em aberto** e nao se inventa um quarto balde para forcar caber.
+- **Nao se acrescenta nada ao enum** (regra do despacho). Este documento e medicao; nao modifica `self-hosted/check/effects.sio`.
+
+## O que esta medicao NAO diz
+
+- Nao diz qual dos 9 nomes "reconhecidos" foi desenhado pelo founder e qual foi adicionado depois. A tabela de ids em `self-hosted/check/effects.sio` tem historico proprio (#1963 e o commit mais recente que adicionou seis extras) e cada id tem a sua propria primeira ocorrencia — que nao foi rastreada aqui.
+- Nao diz nada sobre a semantica dos 29 ids. Medicao de presenca != medicao de uso significativo.
+- Nao diz nada sobre efeitos em lanes nao mescladas. Ha branches (ver `docs/audit/BRANCH_AUDIT_2026-08-15.md`) com declaracoes `with X` que nao estao em `main`; esses estao fora deste cenario.
+
+## Coordenacao
+
+- Lane branch: `lane/minimax-cli3/gum-uncertainty-tail-20260819-v2` (sem commits novos — so este ficheiro)
+- Coordination bus: `artifacts/omega/agent_handoff.log.md` (NOTIFY pendente apos push)
+- PR comment no #1947 (handoff da medicao): pendente
+- Coordenacao pedida: grok-cli5 tem o vocabulario de efeitos; esta medicao cruzou com o reconciliado da fase 1 deles (4 listas, GUM/Uncertainty ausentes em todas) sem contradizer
+- Regra do founder em vigor: NAO se reverte nada. Commits candidatos `6f23dfe1da` (#1935) e `7be969ed05` (#1939) sob analise da grok-cli3, nao desta lane.
+
+## Anexo: ficheiros do instrumento
+
+- `/tmp/find_with_names.py` — instrumento strict (so declaracoes `fn NAME(...)[with X, Y, Z]`). Validado contra Epistemic.
+- `/tmp/find_with_prose.py` — instrumento loose (apanha `with X` em qualquer contexto). Produziu os 164497 tokens / D1 table.
+- `/tmp/discrim_{1,2,3}.sio` — 3 programas de discriminacao de efeito (Epistemic exigido em `f()`; `main()` com GUM / NaoExisteIsto / IO). Todos retornaram E035.
+- `/tmp/gum_run2.sio`, `/tmp/unc_run2.sio`, `/tmp/nao_run2.sio`, `/tmp/epi_run.sio` — 4 programas de aceitacao de parser (todos compilaram e correram identicamente).
+- `/tmp/founding_tree/` — extracao via `git archive b6d03ae18a | tar -x` para inventario D2.

--- a/docs/audit/GUM_UNCERTAINTY_TAIL_2026-08-19.md
+++ b/docs/audit/GUM_UNCERTAINTY_TAIL_2026-08-19.md
@@ -7,84 +7,84 @@ validated_by: A2 (lane/minimax-cli3/gum-uncertainty-tail-20260819-v2)
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.gum-uncertainty-tail-2026-08-19
 -->
 
-# GUM/Uncertainty e a cauda do enumerado — tres denominadores separados, sem denominador verdadeiro
+# GUM/Uncertainty and the tail of the effect enum — three denominators separated, no true denominator
 
-Lane: `lane/minimax-cli3/gum-uncertainty-tail-20260819-v2` (census-only; sem alteracoes ao compilador). Data: 2026-08-19. Validacao contra `origin/main` = `f9b3147364`. PR aberto contra `main`; merge autorizado pelo founder assim que `main` voltar a verde (f64 lowering, bisect noutra lane).
+Lane: `lane/minimax-cli3/gum-uncertainty-tail-20260819-v2` (census-only; no compiler modifications). Date: 2026-08-19. Validated against `origin/main` = `f9b3147364`. PR opened against `main`; merge authorised by the founder as soon as `main` returns to green (f64 lowering, bisect in another lane).
 
-## Declaracao semantica (leitura primeiro)
+## Semantic declaration (read first)
 
-Este documento NAO enumera "os efeitos que o founder desenhou". **Essa lista nao existe em lado nenhum verificavel** — nenhum commit, manifesto, spec ou doc de design a declara como conjunto fechado. O que este documento faz:
+This document does NOT enumerate "the effects the founder drew". **That list does not exist anywhere verifiable** — no commit, manifesto, spec or design doc declares it as a closed set. What this document does:
 
-1. Mede TRES denominadores SUBSTITUTOS, cada um com a sua razao de ser, e apresenta os racios para cada um.
-2. Apresenta a linhagem (primeira/ultima ocorrencia) de 11 nomes epistemicos.
-3. Verifica, via probes de reconhecimento, quais dos 11 nomes estao no enumerado de producao (29 ids pos-#1963) e quais ficam fora.
-4. Classifica cada nome num dos tres baldes que o despacho pediu: "tentado e falhou a ultima aresta" / "nunca foi tentado" / "nasceu no desenho e desapareceu do codigo".
+1. Measures three substitute denominators, each with its own rationale, and reports the ratio for each.
+2. Presents the lineage (first/last occurrence) of 11 epistemic names.
+3. Verifies, via recognition probes, which of the 11 names sit in the production enum (29 ids post-#1963) and which fall outside.
+4. Classifies each name into one of the three buckets the dispatch asked for: "tried and failed the last edge" / "never tried" / "born in design and disappeared from code".
 
-A interpretacao do que estes numeros dizem sobre o desenho efectivo do founder fica para outra leitura. As tres contagens sao proxies, nao a verdade.
+Interpretation of what these numbers say about the founder's effective design is left for another reading. The three counts are proxies, not the truth.
 
-**O que este documento NAO propoe**: nada. NAO conclui que GUM deva entrar no enum. NAO conclui que Uncertainty deva entrar no enum. NAO propoe id novo, alias, ou alteracao a `self-hosted/check/effects.sio`. A classificacao e descritiva, nao prescritiva. Decisao sobre o que adicionar fica para o fowner, na lane apropriada, com base noutro tipo de evidencia (semantica, design, custo de manutencao).
+**What this document does NOT propose**: nothing. It does NOT conclude that GUM should enter the enum. It does NOT conclude that Uncertainty should enter the enum. It does NOT propose new ids, aliases, or modifications to `self-hosted/check/effects.sio`. The classification is descriptive, not prescriptive. Decisions about what to add belong to the founder, in the appropriate lane, on the basis of a different kind of evidence (semantics, design, maintenance cost).
 
-## Os tres denominadores
+## The three denominators
 
-| Simbolo | Mede | Instrumento | Universo |
+| Symbol | Measures | Instrument | Universe |
 |---|---|---|---|
-| **D1** | Intencao expressa em codigo | `find_with_prose.py` — regex `\bNAME\b` segue imediatamente `with ` em qualquer posicao (declaracao ou prosa) | `stdlib/`, `self-hosted/`, `examples/`, `tests/` (7492 ficheiros, 164497 ocurrencias) |
-| **D2** | Ambicao do dia um | `git archive b6d03ae18a \| tar -x` + `grep -rh` com `\bNAME\b` | Arvore completa do commit fundador (275 ficheiros; stdlib em `.d`) |
-| **D3** | O que ficou por exprimir | `grep -rh` com `\bNAME\b` em `docs/`, `README.md`, `FOUNDER_INTENT.md` | So prosa (1288 ficheiros) |
+| **D1** | Intent expressed in code | `find_with_prose.py` — regex `\bNAME\b` immediately following `with ` in any position (declaration or prose) | `stdlib/`, `self-hosted/`, `examples/`, `tests/` (7492 files, 164497 token-occurrences) |
+| **D2** | Day-one ambition | `git archive b6d03ae18a \| tar -x` + `grep -rh` with `\bNAME\b` | Full tree of the founding commit (275 files; stdlib in `.d`) |
+| **D3** | What remained unexpressed | `grep -rh` with `\bNAME\b` in `docs/`, `README.md`, `FOUNDER_INTENT.md` | Prose only (1288 files) |
 
-D1 e um instrumento frouxo: conta a palavra `with` seguida de nome, mesmo em comentarios dentro de declaracoes. D2 e tight mas parcial: o `.d` founding tinha so 275 ficheiros; a prosa fundadora e parte do universo. D3 e so prosa actual; pode sobrestimar a prosa fundadora (que migrou de sitio, foi reformatada).
+D1 is a LOOSE instrument: it counts the word `with` followed by a name, even inside comments within declarations. D2 is tight but partial: the founding `.d` only had 275 files; founding prose is part of the universe. D3 is current prose only; it may overestimate founding prose (which migrated, was reformatted).
 
-Nenhum dos tres, sozinho, e o universo verdadeiro. Juntar os tres ainda nao e: ha efeitos que foram pensados em conversa ou em issues que nao tocaram nem o repo nem a prosa rastreavel.
+None of the three, alone, is the true universe. Combining the three still is not: there are effects thought through in conversation or in issues that touched neither the repo nor the traceable prose.
 
-## Os 11 nomes (epistemicos + dois designados pelo despacho)
+## The 11 names (epistemics + two designated by the dispatch)
 
-O despacho `dispatch_gum_uncertainty_claude1.md` chamou a atencao para GUM (91 usos reportados) e Uncertainty (20 usos reportados), ausentes de quatro listas reconciliadas na fase 1 da grok-cli5. A adicao `dispatch_epistemic_lineage_claude1.md` estendeu a linhagem a Observe/Witness/Prob. Os onze nomes:
+The dispatch `dispatch_gum_uncertainty_claude1.md` drew attention to GUM (91 reported uses) and Uncertainty (20 reported uses), absent from four reconciled lists in grok-cli5 phase 1. The addition `dispatch_epistemic_lineage_claude1.md` extended the lineage to Observe/Witness/Prob. The eleven names:
 
-| # | Nome | D1 (atual, `with X`) | D2 (founding b6d03ae18a) | D3 (prosa atual) |
+| # | Name | D1 (current, `with X`) | D2 (founding b6d03ae18a) | D3 (current prose) |
 |---:|---|---:|---:|---:|
-| 1 | GUM | **7** (so prosa) | **144** em 33 ficheiros | 3037 em 219 ficheiros |
-| 2 | Uncertainty | **14** (so prosa) | **156** em 55 ficheiros | 612 em 88 ficheiros |
-| 3 | Epistemic | 426 | 137 em 59 ficheiros | 2442 em 199 ficheiros |
-| 4 | Observe | 47 | **0** (ausente no founding) | 100 em 30 ficheiros |
-| 5 | Witness | 17 | **0** | 214 em 89 ficheiros |
-| 6 | Prob | 58 | 55 em 11 ficheiros | 99 em 21 ficheiros |
-| 7 | Learn | 19 | 7 em 4 ficheiros | 37 em 15 ficheiros |
-| 8 | Temporal | 11 | 7 em 3 ficheiros | 79 em 26 ficheiros |
-| 9 | ZD | 87 | **0** | 1380 em 133 ficheiros |
-| 10 | NonAssoc | 83 | **0** | 47 em 11 ficheiros |
-| 11 | Audit | 11 | 1 em 1 ficheiro | 159 em 116 ficheiros |
+| 1 | GUM | **7** (prose only) | **144** in 33 files | 3037 in 219 files |
+| 2 | Uncertainty | **14** (prose only) | **156** in 55 files | 612 in 88 files |
+| 3 | Epistemic | 426 | 137 in 59 files | 2442 in 199 files |
+| 4 | Observe | 47 | **0** (absent in founding) | 100 in 30 files |
+| 5 | Witness | 17 | **0** | 214 in 89 files |
+| 6 | Prob | 58 | 55 in 11 files | 99 in 21 files |
+| 7 | Learn | 19 | 7 in 4 files | 37 in 15 files |
+| 8 | Temporal | 11 | 7 in 3 files | 79 in 26 files |
+| 9 | ZD | 87 | **0** | 1380 in 133 files |
+| 10 | NonAssoc | 83 | **0** | 47 in 11 files |
+| 11 | Audit | 11 | 1 in 1 file | 159 in 116 files |
 
-Para comparar: D1 capta 50522 `with Mut`, 47660 `with Panic`, 45998 `with Div` — os verdadeiros blocos estruturais — e 426 `with Epistemic` (vs os 316 reportados pelo despacho; a diferenca esta nos matches em comentarios que o loose-instrument apanha). GUM=7 e Uncertainty=14 sao ordens de grandeza abaixo disso: estao em prosa inline em stdlib, nao em assinaturas de efeito.
+For comparison: D1 captures 50522 `with Mut`, 47660 `with Panic`, 45998 `with Div` — the real structural blocks — and 426 `with Epistemic` (vs the 316 reported by the dispatch; the difference is the matches inside comments that the loose instrument catches). GUM=7 and Uncertainty=14 are orders of magnitude below that: they sit in inline prose inside stdlib, not in effect signatures.
 
-## Linhagem (primeira / ultima ocorrencia nos paths do codigo)
+## Lineage (first / last occurrence in code paths)
 
-`git log main --reverse --max-count=1 -G"\bNAME\b"` para primeira, sem `-G` max-count-1 para ultima. Para a primeira, todos os caminhos `stdlib/ self-hosted/ examples/ tests/ docs/`.
+`git log main --reverse --max-count=1 -G"\bNAME\b"` for first, no `-G` max-count-1 for last. For the first, all paths `stdlib/ self-hosted/ examples/ tests/ docs/`.
 
-| Nome | Primeira ocorrencia | Ultima ocorrencia |
+| Name | First occurrence | Last occurrence |
 |---|---|---|
 | GUM | b6d03ae18a (founding, 2025-12-25) | db750980b4 docs(audit) — forensic dispatch 2026-08-17 |
 | Uncertainty | b6d03ae18a | 8999e0fdff WS-C PR1 ENIR/MIR shadow 2026-08-16 |
 | Epistemic | b6d03ae18a | 16c45b866c darwin_pbpk Knightian 2026-08-16 |
-| Observe | (pos-founding) | 04cc3ef6fc test(witness) 3-field 2026-08-14 |
-| Witness | (pos-founding) | 453b2e6e2f feat(mli) S1 kind model 2026-08-16 |
+| Observe | (post-founding) | 04cc3ef6fc test(witness) 3-field 2026-08-14 |
+| Witness | (post-founding) | 453b2e6e2f feat(mli) S1 kind model 2026-08-16 |
 | Prob | b6d03ae18a | 3cac951fa6 docs(trust) monte_carlo 2026-08-06 |
 | Learn | b6d03ae18a | 81100d4607 research Mercyful Learning MIMIC-IV 2026-08-03 |
 | Temporal | b6d03ae18a | 750f61da40 FFI system() LEMON G2 2026-08-17 |
-| ZD | (pos-founding) | 6f2c4e2461 docs(madaros) wave-1 MIR 2026-08-16 |
-| NonAssoc | (pos-founding) | 750f61da40 FFI system() LEMON G2 2026-08-17 |
-| Audit | b6d03ae18a (1 soa referencia) | 750f61da40 FFI system() LEMON G2 2026-08-17 |
+| ZD | (post-founding) | 6f2c4e2461 docs(madaros) wave-1 MIR 2026-08-16 |
+| NonAssoc | (post-founding) | 750f61da40 FFI system() LEMON G2 2026-08-17 |
+| Audit | b6d03ae18a (single reference) | 750f61da40 FFI system() LEMON G2 2026-08-17 |
 
-"Pos-founding" = a primeira ocorrencia vivel esta num commit posterior ao dia 1 do projecto (git log --reverse foi lento em casos pontuais; o que importa e que D2 = 0 para esses nomes — eles nao estao no `.d` fundador).
+"Post-founding" = the first viable occurrence sits in a commit after the project's day one (git log --reverse was slow in spotty cases; what matters is that D2 = 0 for those names — they are not in the founding `.d`).
 
-## Reconhecimento no enumerado de producao (29 ids pos-#1963)
+## Recognition in the production enum (29 ids post-#1963)
 
-`self-hosted/check/effects.sio` enumera 29 ids de producao: `IO, Mut, Alloc, Panic, Div, GPU, Async, Prob, Epistemic (+alias Confidence), Causal, Network, Sensor, Render, Observe, NonAssoc, Audit, Hypothesis, MultiTest, ZD, Witness, Temporal, Learn, Chaotic, Approx, NaturalityG2, Deterministic, Perturbative, NarrowWidthApproximation, NonUnitary`. O `Mod` existe mas e "held (phase 2b)" — nao conta como producao.
+`self-hosted/check/effects.sio` enumerates 29 production ids: `IO, Mut, Alloc, Panic, Div, GPU, Async, Prob, Epistemic (+alias Confidence), Causal, Network, Sensor, Render, Observe, NonAssoc, Audit, Hypothesis, MultiTest, ZD, Witness, Temporal, Learn, Chaotic, Approx, NaturalityG2, Deterministic, Perturbative, NarrowWidthApproximation, NonUnitary`. `Mod` exists but is "held (phase 2b)" — it does not count as production.
 
-| Nome | ID de producao? |
+| Name | Production id? |
 |---|---|
-| GUM | **NAO** (sem id; `effect_name_to_id("GUM",3)` retorna -1) |
-| Uncertainty | **NAO** |
-| Epistemic | id 8 (alias de Confidence tambem) |
+| GUM | **NO** (no id; `effect_name_to_id("GUM",3)` returns -1) |
+| Uncertainty | **NO** |
+| Epistemic | id 8 (also alias of Confidence) |
 | Observe | id 13 |
 | Witness | id 19 |
 | Prob | id 7 |
@@ -94,7 +94,7 @@ Para comparar: D1 capta 50522 `with Mut`, 47660 `with Panic`, 45998 `with Div` �
 | NonAssoc | id 14 |
 | Audit | id 15 |
 
-**Probe de reconhecimento** (`bin/souc run` em ficheiros de 4 linhas):
+**Recognition probe** (`bin/souc run` on 4-line files):
 
 ```sio
 fn f() with Epistemic, Mut { }              // epi_run.sio   → PASS
@@ -106,104 +106,104 @@ fn main() with GUM, Mut { f(); print("...") }
 fn f() with Uncertainty, Mut { }            // unc_run2.sio → PASS
 fn main() with Uncertainty, Mut { f(); print("...") }
 
-fn f() with NaoExisteIsto, Mut { }          // nao_run2.sio → PASS (controlo negativo)
+fn f() with NaoExisteIsto, Mut { }          // nao_run2.sio → PASS (negative control)
 fn main() with NaoExisteIsto, Mut { f(); print("...") }
 ```
 
-Os quatro compilaram, correram e imprimiram o `PASS`. **O parser nao distingue nenhum dos quatro.** A clausula `with X` aceita qualquer identificador sem diagnostico, e o codigo que sai tem o mesmo efeito (nenhum, alem dos ids reais que tiverem sido misturados na mesma clausula).
+All four compiled, ran, and printed `PASS`. **The parser does not distinguish any of the four.** The `with X` clause accepts any identifier without diagnostic, and the code that exits has the same effect (none, beyond the real ids that may have been mixed into the same clause).
 
-**Probe de discriminacao** — `f()` requer `Epistemic`; `main()` declara `X, Mut`:
+**Discrimination probe** — `f()` requires `Epistemic`; `main()` declares `X, Mut`:
 
 ```
-main com GUM            → E035 missing Epistemic
-main com NaoExisteIsto  → E035 missing Epistemic  (mesmo erro)
-main com IO             → E035 missing Epistemic  (controlo positivo)
-main com Epistemic      → OK
+main with GUM            → E035 missing Epistemic
+main with NaoExisteIsto  → E035 missing Epistemic  (same error)
+main with IO             → E035 missing Epistemic  (positive control)
+main with Epistemic      → OK
 ```
 
-Isto confirma: `with GUM` e `with NaoExisteIsto` contribuem ZERO para a mascara de efeitos do type checker. Identicos entre si. A diferenca so e visivel no `effect_name_to_id` da tabela de bytes (que retorna 0..28 ou -1), e esse id nao parece estar ligado a nada que o utilizador consiga observar em tempo de compilacao.
+This confirms: `with GUM` and `with NaoExisteIsto` contribute ZERO to the type checker's effect mask. Identical to each other. The difference is only visible in the `effect_name_to_id` byte table (which returns 0..28 or -1), and that id does not appear to be wired to anything the user can observe at compile time.
 
-## Os dois achados que NAO sao detalhes
+## The two findings that are NOT details
 
-### Achado 1: um efeito desenhado no dia um e um nome inventado agora sao invisiveis da mesma maneira
+### Finding 1: an effect drawn on day one and a name invented right now are invisible the same way
 
-`with GUM` (D2=144, no commit fundador) e `with NaoExisteIsto` (nome que acabei de inventar agora) sao, do ponto de vista do type checker, **a mesma coisa**: contribuem zero para a mascara de efeitos, falham identicamente o E035 quando outro efeito e requerido, e compilam sem diagnostico quando nenhum o e. Nao ha nenhuma ferramenta que distinga um efeito "real mas nao reconhecido" de um efeito "inventado para teste". O unico sitio onde a distincao existe e a tabela de bytes `effect_name_to_id`, e essa tabela nao parece ter efeito observavel no caminho de compilacao.
+`with GUM` (D2=144, in the founding commit) and `with NaoExisteIsto` (a name I invented just now) are, from the type checker's point of view, **the same thing**: they contribute zero to the effect mask, fail the E035 identically when another effect is required, and compile without diagnostic when none is. No tool distinguishes a "real but unrecognised" effect from a "test-invented" effect. The only place the distinction exists is the `effect_name_to_id` byte table, and that table has no observable effect on the compile path.
 
-Isto significa que **a historia do efeito nao e visivel no codigo que o declara**. GUM tem sete meses de existencia; NaoExisteIsto tem sete segundos. Sao identicos para o type checker, para o linker, para o codegen, para o ELF. A semantica que distingue os dois e externa: o programador que sabe que GUM "deveria ser" algo e o programador que sabe que NaoExisteIsto "nao e" nada. O compilador nao partilha nenhuma das duas conviccoes.
+This means **the history of the effect is not visible in the code that declares it.** GUM has seven months of existence; NaoExisteIsto has seven seconds. They are identical to the type checker, the linker, the codegen, the ELF. The semantics that distinguishes them is external: the programmer who knows GUM "should be" something and the programmer who knows NaoExisteIsto "isn't" anything. The compiler shares neither conviction.
 
-### Achado 2: `with Uncertainty` foi declarado ha tres dias, nao em Dezembro
+### Finding 2: `with Uncertainty` was declared three days ago, not in December
 
-A ultima ocorrencia de `with Uncertainty` em todo o repo (via `git log main -G"\bUncertainty\b" --max-count=1`) e o commit **`8999e0fdff` — WS-C PR1 ENIR/MIR shadow, 2026-08-16, ha tres dias**. Nao e codigo morto de 2025-12-25; e codigo de 2026-08-16. Alguem esta semana, ao integrar o lane WS-C, declarou `with Uncertainty` numa funcao acreditando que isso dizia algo — que Uncertainty tinha semantica de incerteza no sistema de tipos — e nao disse nada. O type checker viu o nome, ignorou-o, e compilou um programa que nao marca propagacao de incerteza em lado nenhum.
+The last occurrence of `with Uncertainty` anywhere in the repo (via `git log main -G"\bUncertainty\b" --max-count=1`) is commit **`8999e0fdff` — WS-C PR1 ENIR/MIR shadow, 2026-08-16, three days ago**. This is not dead code from 2025-12-25; it is code from 2026-08-16. Someone this week, integrating the WS-C lane, declared `with Uncertainty` on a function believing it said something — that Uncertainty had uncertainty-propagation semantics in the type system — and it said nothing. The type checker saw the name, ignored it, and compiled a program that does not mark uncertainty propagation anywhere.
 
-Este achado NAO e sobre a equipa WS-C. E sobre o parser: **se o parser aceita nomes silenciosamente, ninguem sabe quando a sua declaracao de efeito e real ou um wish**. O risco nao e GUM ou Uncertainty serem esquecidos; o risco e que hoje, 2026-08-19, alguem declare `with NovoEfeitoQueVaiMudarTudo` e o compilador faca exactamente o mesmo que faria sem essa clausula — e ninguem detecte ate a propriedade que o efeito deveria garantir estar em falta no runtime.
+This finding is NOT about the WS-C team. It is about the parser: **if the parser silently accepts names, nobody knows when their effect declaration is real or a wish.** The risk is not GUM or Uncertainty being forgotten; the risk is that today, 2026-08-19, someone declares `with NovoEfeitoQueVaiMudarTudo` and the compiler does exactly the same thing it would do without that clause — and nobody detects until the property the effect should guarantee is missing at runtime.
 
-## Classificacao (os tres baldes do despacho)
+## Classification (the three buckets from the dispatch)
 
-| Nome | D1 | D2 | D3 | 29 ids? | Classe |
+| Name | D1 | D2 | D3 | 29 ids? | Class |
 |---|---|---|---|---|---|
-| GUM | so prosa | 144 | 3037 | NAO | **D2-not-D1**: nasceu no desenho (144 occorencias no `.d` fundador) e desapareceu das clausulas `with`. E o caso classico de "tentado e falhou a ultima aresta" — D2 confirma a tentativa, D1 actual mostra a queda. |
-| Uncertainty | so prosa | 156 | 612 | NAO | **D2-not-D1**: mesma leitura. 156 occorencias no fundador (mais que o proprio Epistemic!), todas em prosa. Foi pensado; nunca chegou ao compilador. |
-| Epistemic | 426 | 137 | 2442 | SIM (id 8) | Vive. Fundador + presente em 426 clausulas `with` hoje. |
-| Observe | 47 | 0 | 100 | SIM (id 13) | Adicionado depois do dia 1; presente em 47 `with`. |
-| Witness | 17 | 0 | 214 | SIM (id 19) | Adicionado depois; presente em 17 `with`. |
-| Prob | 58 | 55 | 99 | SIM (id 7) | Vive desde o dia 1. |
-| Learn | 19 | 7 | 37 | SIM (id 21) | Vive desde o dia 1 (embora tenuamente — so 7 occorencias no fundador). |
-| Temporal | 11 | 7 | 79 | SIM (id 20) | Vive desde o dia 1. |
-| ZD | 87 | 0 | 1380 | SIM (id 18) | Adicionado depois; prosa muito mais densa (1380) do que `with` (87) — o nome vive mais em discussao do que em codigo. |
-| NonAssoc | 83 | 0 | 47 | SIM (id 14) | Adicionado depois; mais denso em `with` (83) do que em prosa (47) — o oposto do ZD. |
-| Audit | 11 | 1 | 159 | SIM (id 15) | Quase nao estava no fundador (1 occorencia soa); hoje aparece em prosa (159) e em 11 `with`. Adicionado cedo, mas a prosa rebentou depois. |
+| GUM | prose only | 144 | 3037 | NO | **D2-not-D1**: born in design (144 occurrences in the founding `.d`) and disappeared from `with` clauses. The classic "tried and failed the last edge" case — D2 confirms the attempt, current D1 shows the drop. |
+| Uncertainty | prose only | 156 | 612 | NO | **D2-not-D1**: same reading. 156 occurrences in the founder (more than Epistemic itself!), all in prose. Was thought through; never reached the compiler. |
+| Epistemic | 426 | 137 | 2442 | YES (id 8) | Lives. Founder + present in 426 `with` clauses today. |
+| Observe | 47 | 0 | 100 | YES (id 13) | Added after day one; present in 47 `with`. |
+| Witness | 17 | 0 | 214 | YES (id 19) | Added after; present in 17 `with`. |
+| Prob | 58 | 55 | 99 | YES (id 7) | Lives since day one. |
+| Learn | 19 | 7 | 37 | YES (id 21) | Lives since day one (though thinly — only 7 occurrences in the founder). |
+| Temporal | 11 | 7 | 79 | YES (id 20) | Lives since day one. |
+| ZD | 87 | 0 | 1380 | YES (id 18) | Added after; prose far denser (1380) than `with` (87) — the name lives more in discussion than in code. |
+| NonAssoc | 83 | 0 | 47 | YES (id 14) | Added after; denser in `with` (83) than in prose (47) — the opposite of ZD. |
+| Audit | 11 | 1 | 159 | YES (id 15) | Almost absent from the founder (single occurrence); today it appears in prose (159) and in 11 `with`. Added early, but the prose exploded later. |
 
-### O caso limite `GetTid`
+### The boundary case `GetTid`
 
-O loose-instrument captou `GetTid` 13 vezes em comentarios `// emit: get_tid = ...` em codigo GPU. NAO aparece em qualquer `with` real (so em comentarios de emit). D1 = 13 (prosa). D2 = 0 (founding nao tem GPU). D3 = 1 (so `docs/`). **D3-only**: nunca foi tentado como efeito, so mencionado uma vez em prosa e varias em comentarios de codigo.
+The loose instrument captured `GetTid` 13 times in `// emit: get_tid = ...` comments in GPU code. It does NOT appear in any real `with` (only in emit comments). D1 = 13 (prose). D2 = 0 (founding has no GPU). D3 = 1 (only `docs/`). **D3-only**: never tried as an effect, only mentioned once in prose and several times in code comments.
 
-### Os tres baldes, formalizados
+### The three buckets, formalised
 
-1. **D1-only (tentado, falhou a ultima aresta)** — nenhum dos 11 nomes cai aqui. Toda a tentativa de efeito que sobreviveu em prosa fundadora migrou ou para a producao ou para o esquecimento total; nenhum ficou num estado intermedirio de "as pessoas ainda usam mas o compilador nao sabe".
-2. **D2-not-D1 (nasceu no desenho, desapareceu)** — GUM, Uncertainty. E o unico balde com membros entre os 11; ambos tem D2 massiva (>140 occorencias) e D1 actual zero em clausulas reais.
-3. **D3-only (nunca tentado, so escrito)** — `GetTid`. E um membro orfao entre os efeitos; um dia pode aparecer como id, mas hoje e so prosa e comentario.
+1. **D1-only (tried, failed the last edge)** — none of the 11 names falls here. Every effect attempt that survived in founding prose migrated either into production or into total oblivion; none stayed in the intermediate state of "people still use it but the compiler does not know".
+2. **D2-not-D1 (born in design, disappeared)** — GUM, Uncertainty. The only bucket with members among the 11; both have massive D2 (>140 occurrences) and current D1 zero in real clauses.
+3. **D3-only (never tried, only written)** — `GetTid`. An orphan member among effects; one day it may appear as an id, but today it is only prose and comments.
 
-Fora destes tres, a maioria dos 11 nomes (9) **vive**: estao no enumerado de producao e em clausulas `with` na arvore actual.
+Outside these three, the majority of the 11 names (9) **live**: they are in the production enum and in `with` clauses in the current tree.
 
-## Os racios (um por denominador)
+## The ratios (one per denominator)
 
-| Denominador | Total | Reconhecidos (29 ids) | Racio |
+| Denominator | Total | Recognised (29 ids) | Ratio |
 |---|---:|---:|---:|
-| D1 (with X actual) | 11 | 9 (GUM, Uncertainty nao reconhecidos; os outros 9 sim) | **9/11 ≈ 82%** |
-| D2 (founding b6d03ae18a) | 7 nomes presentes (GUM, Uncertainty, Epistemic, Prob, Learn, Temporal, Audit) | 5 reconhecidos (Epistemic, Prob, Learn, Temporal, Audit); GUM e Uncertainty nao | **5/7 ≈ 71%** |
-| D3 (prosa atual) | 11 | 9 | **9/11 ≈ 82%** |
+| D1 (current `with X`) | 11 | 9 (GUM, Uncertainty not recognised; the other 9 yes) | **9/11 ≈ 82%** |
+| D2 (founding b6d03ae18a) | 7 names present (GUM, Uncertainty, Epistemic, Prob, Learn, Temporal, Audit) | 5 recognised (Epistemic, Prob, Learn, Temporal, Audit); GUM and Uncertainty no | **5/7 ≈ 71%** |
+| D3 (current prose) | 11 | 9 | **9/11 ≈ 82%** |
 
-Para a visao completa: dos 11 nomes, 10 tem `with X` actual ou tem prosa fundadora (Epistemic, Observe, Witness, Prob, Learn, Temporal, ZD, NonAssoc, Audit + um dos GUM/Uncertainty via D2). O racio **"esta no enumerado de producao"** sobe para **10/11 ≈ 91%** se aceitarmos que "tentado" inclui "no commit fundador" alem de "numa clausula `with` actual". Mas esse racio depende de uma decisao de leitura (o que conta como tentativa) que o despacho propos deixar em aberto.
+For the full view: of the 11 names, 10 have current `with X` or have founding prose (Epistemic, Observe, Witness, Prob, Learn, Temporal, ZD, NonAssoc, Audit + one of GUM/Uncertainty via D2). The ratio **"is in the production enum"** rises to **10/11 ≈ 91%** if we accept that "tried" includes "in the founding commit" as well as "in a current `with` clause". But that ratio depends on a reading decision (what counts as an attempt) that the dispatch proposed to leave open.
 
-## Claims-Forbidden (nenhum denominador e a verdade)
+## Claims-Forbidden (no denominator is the truth)
 
-- **NENHUM destes tres denominadores e "os efeitos que o founder desenhou".** Sao substitutos, nao a lista original. A lista original continua por escrever — nenhum commit, manifesto, spec, design doc ou thread da grok-cli5 a declara como conjunto fechado. Medicao sobre substitute proxies NAO autoriza ninguem a afirmar o que o founder desenhou.
-- **A razao 9/11 ≠ "9 em cada 11 efeitos do founder foram reconhecidos".** O denominador e "efeitos que aparecem em codigo ou prosa rastreavel" — uma fracao desconhecida do universo real.
-- **D1 e um instrumento FROUXO** — conta a palavra `with` seguida de nome em qualquer posicao, inclusive dentro de comentarios `// ...`. Foi exactamente assim que `GetTid` entrou com 13 ocurrencias e foi assim que foi excluido: as 13 estao todas em comentarios `// emit: get_tid = ...` em codigo GPU, nao em clausulas `with` reais. Significa que D1 pode inflacionar nomes de prosa-em-codigo; e a razao pela qual o instrumento strict (`find_with_names.py`) da contagens menores (Epistemic 218 vs 426). A leitura de D1 NAO e a contagem de declaracoes de efeito; e a contagem de "onde o nome segue `with` em texto, dentro ou fora de codigo activo". Distincao preservada acima para nao inflacionar conclusoes.
-- **Este documento NAO conclui que GUM ou Uncertainty devam entrar no enum.** A medicao mostra que ambos tem D2 massiva (144 e 156) — foram desenhados — mas a ausencia dos 29 ids de producao e um facto, nao uma sentenca. A decisao de adicionar (ou nao) pertence ao founder, em outra lane, com outra evidencia. Este doc descreve; nao prescreve.
-- **A descoberta de que `with GUM` e `with NaoExisteIsto` sao identicos nao prova que GUM e NaoExisteIsto sao identicos.** Prova que o parser nao distingue. O compilador pode ainda dar semantica a GUM num momento posterior; hoje, da perspectiva do type checker, nao da.
-- **A leitura "tentado e falhou a ultima aresta" para GUM/Uncertainty e uma leitura de D2 + D1.** Nao exclui a leitura alternativa "nascido em prosa, nunca chegou a ser declarado de verdade mesmo no fundador" — a fronteira entre prosa do fundador e declaracao de efeito do fundador depende do que se considera declaracao.
-- **INDETERMINADO** (per precedent do `Mod` phase 2b da minimax-cli2): se um leitor razoavel nao conseguir decidir em qual dos tres baldes um nome cai, **essa decisao fica em aberto** e nao se inventa um quarto balde para forcar caber.
-- **Nao se acrescenta nada ao enum** (regra do despacho). Este documento e medicao; nao modifica `self-hosted/check/effects.sio`.
+- **NONE of these three denominators is "the effects the founder drew".** They are substitutes, not the original list. The original list remains unwritten — no commit, manifesto, spec, design doc or thread of the grok-cli5 phase-1 reconciliation declares it as a closed set. Measurement on substitute proxies does NOT authorise anyone to assert what the founder drew.
+- **The ratio 9/11 ≠ "9 in every 11 founder effects were recognised".** The denominator is "effects that appear in traceable code or prose" — an unknown fraction of the real universe.
+- **D1 is a LOOSE instrument** — it counts the word `with` followed by a name in any position, including inside `// ...` comments. This is exactly how `GetTid` entered with 13 occurrences and how it was excluded: all 13 sit in `// emit: get_tid = ...` GPU comments, not in real `with` clauses. This means D1 may inflate names of prose-in-code; it is why the strict instrument (`find_with_names.py`) gives smaller counts (Epistemic 218 vs 426). The D1 reading is NOT the count of effect declarations; it is the count of "where the name follows `with` in text, inside or outside active code". The distinction is preserved above so as not to inflate conclusions.
+- **This document does NOT conclude that GUM or Uncertainty should enter the enum.** The measurement shows that both have massive D2 (144 and 156) — they were designed — but the absence from the 29 production ids is a fact, not a sentence. The decision to add (or not) belongs to the founder, in another lane, with another kind of evidence. This doc describes; it does not prescribe.
+- **The discovery that `with GUM` and `with NaoExisteIsto` are identical does NOT prove that GUM and NaoExisteIsto are identical.** It proves that the parser does not distinguish. The compiler may still give semantics to GUM at a later point; today, from the type checker's perspective, it does not.
+- **The "tried and failed the last edge" reading for GUM/Uncertainty is a reading of D2 + D1.** It does not exclude the alternative reading "born in prose, never actually declared even in the founder" — the boundary between founder prose and founder effect declaration depends on what counts as a declaration.
+- **INDETERMINATE** (per the `Mod` phase 2b precedent from minimax-cli2): if a reasonable reader cannot decide into which of the three buckets a name falls, **that decision stays open** and a fourth bucket is not invented to force a fit.
+- **Nothing is added to the enum** (dispatch rule). This document is measurement; it does not modify `self-hosted/check/effects.sio`.
 
-## O que esta medicao NAO diz
+## What this measurement does NOT say
 
-- Nao diz qual dos 9 nomes "reconhecidos" foi desenhado pelo founder e qual foi adicionado depois. A tabela de ids em `self-hosted/check/effects.sio` tem historico proprio (#1963 e o commit mais recente que adicionou seis extras) e cada id tem a sua propria primeira ocorrencia — que nao foi rastreada aqui.
-- Nao diz nada sobre a semantica dos 29 ids. Medicao de presenca != medicao de uso significativo.
-- Nao diz nada sobre efeitos em lanes nao mescladas. Ha branches (ver `docs/audit/BRANCH_AUDIT_2026-08-15.md`) com declaracoes `with X` que nao estao em `main`; esses estao fora deste cenario.
+- It does not say which of the 9 "recognised" names was drawn by the founder and which was added later. The id table in `self-hosted/check/effects.sio` has its own history (#1963 is the most recent commit that added six extras) and each id has its own first occurrence — not traced here.
+- It says nothing about the semantics of the 29 ids. Presence measurement ≠ significant-use measurement.
+- It says nothing about effects in unmerged lanes. There are branches (see `docs/audit/BRANCH_AUDIT_2026-08-15.md`) with `with X` declarations that are not on `main`; those are outside this scope.
 
-## Coordenacao
+## Coordination
 
-- Lane branch: `lane/minimax-cli3/gum-uncertainty-tail-20260819-v2` (push dd3725dde4 → 0ec8ef8c50)
-- Coordination bus: `artifacts/omega/agent_handoff.log.md` (NOTIFY publicado; ver entrada agent claude / time_utc 2026-08-19T13:30:00Z)
-- PR comment no #1947: NAO postado. A #1947 pertence a lane/empryo-1/ir-capacity-object-20260819 (minimax-cli2 / empryo-1). O despacho drop1947_claude1.md transferiu essa PR; comentar nela a partir desta lane seria barulho entre lanes. O handoff da medicao segue pelo coordination bus.
-- Coordenacao pedida: grok-cli5 tem o vocabulario de efeitos; esta medicao cruzou com o reconciliado da fase 1 deles (4 listas, GUM/Uncertainty ausentes em todas) sem contradizer
-- Regra do founder em vigor: NAO se reverte nada. Commits candidatos `6f23dfe1da` (#1935) e `7be969ed05` (#1939) sob analise da grok-cli3, nao desta lane.
+- Lane branch: `lane/minimax-cli3/gum-uncertainty-tail-20260819-v2` (push dd3725dde4 → 0ec8ef8c50 → e0e972ba69 → 7d08b3e9af → 8ada507886)
+- Coordination bus: `artifacts/omega/agent_handoff.log.md` (NOTIFY published; see entry `agent claude / time_utc 2026-08-19T13:30:00Z` and follow-up at `13:45:00Z`)
+- PR comment on #1947: NOT posted. #1947 belongs to `lane/empryo-1/ir-capacity-object-20260819` (minimax-cli2 / empryo-1). The dispatch `drop1947_claude1.md` transferred that PR; commenting on it from this lane would be cross-lane noise. The census handoff is via the coordination bus.
+- Coordination requested: grok-cli5 owns the effect vocabulary; this measurement cross-checked with their phase-1 reconciliation (4 lists, GUM/Uncertainty absent from all 4) without contradiction.
+- Founder rule in force: nothing is reverted. Candidates `6f23dfe1da` (#1935) and `7be969ed05` (#1939) are under analysis by grok-cli3, not this lane.
 
-## Anexo: ficheiros do instrumento
+## Annex: instrument files
 
-- `/tmp/find_with_names.py` — instrumento strict (so declaracoes `fn NAME(...)[with X, Y, Z]`). Validado contra Epistemic.
-- `/tmp/find_with_prose.py` — instrumento loose (apanha `with X` em qualquer contexto). Produziu os 164497 tokens / D1 table.
-- `/tmp/discrim_{1,2,3}.sio` — 3 programas de discriminacao de efeito (Epistemic exigido em `f()`; `main()` com GUM / NaoExisteIsto / IO). Todos retornaram E035.
-- `/tmp/gum_run2.sio`, `/tmp/unc_run2.sio`, `/tmp/nao_run2.sio`, `/tmp/epi_run.sio` — 4 programas de aceitacao de parser (todos compilaram e correram identicamente).
-- `/tmp/founding_tree/` — extracao via `git archive b6d03ae18a | tar -x` para inventario D2.
+- `/tmp/find_with_names.py` — strict instrument (only `fn NAME(...)[with X, Y, Z]` declarations). Validated against Epistemic.
+- `/tmp/find_with_prose.py` — loose instrument (catches `with X` in any context). Produced the 164497-token / D1 table.
+- `/tmp/discrim_{1,2,3}.sio` — 3 effect-discrimination programs (Epistemic required in `f()`; `main()` with GUM / NaoExisteIsto / IO). All returned E035.
+- `/tmp/gum_run2.sio`, `/tmp/unc_run2.sio`, `/tmp/nao_run2.sio`, `/tmp/epi_run.sio` — 4 parser-acceptance programs (all compiled and ran identically).
+- `/tmp/founding_tree/` — extraction via `git archive b6d03ae18a | tar -x` for the D2 inventory.

--- a/docs/audit/GUM_UNCERTAINTY_TAIL_2026-08-19.md
+++ b/docs/audit/GUM_UNCERTAINTY_TAIL_2026-08-19.md
@@ -9,7 +9,7 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.gum-unce
 
 # GUM/Uncertainty e a cauda do enumerado — tres denominadores separados, sem denominador verdadeiro
 
-Lane: `lane/minimax-cli3/gum-uncertainty-tail-20260819-v2` (census-only; sem alteracoes ao compilador). Data: 2026-08-19. Validacao contra `origin/main` = `f9b3147364`.
+Lane: `lane/minimax-cli3/gum-uncertainty-tail-20260819-v2` (census-only; sem alteracoes ao compilador). Data: 2026-08-19. Validacao contra `origin/main` = `f9b3147364`. PR aberto contra `main`; merge autorizado pelo founder assim que `main` voltar a verde (f64 lowering, bisect noutra lane).
 
 ## Declaracao semantica (leitura primeiro)
 
@@ -21,6 +21,8 @@ Este documento NAO enumera "os efeitos que o founder desenhou". **Essa lista nao
 4. Classifica cada nome num dos tres baldes que o despacho pediu: "tentado e falhou a ultima aresta" / "nunca foi tentado" / "nasceu no desenho e desapareceu do codigo".
 
 A interpretacao do que estes numeros dizem sobre o desenho efectivo do founder fica para outra leitura. As tres contagens sao proxies, nao a verdade.
+
+**O que este documento NAO propoe**: nada. NAO conclui que GUM deva entrar no enum. NAO conclui que Uncertainty deva entrar no enum. NAO propoe id novo, alias, ou alteracao a `self-hosted/check/effects.sio`. A classificacao e descritiva, nao prescritiva. Decisao sobre o que adicionar fica para o fowner, na lane apropriada, com base noutro tipo de evidencia (semantica, design, custo de manutencao).
 
 ## Os tres denominadores
 
@@ -121,6 +123,20 @@ main com Epistemic      → OK
 
 Isto confirma: `with GUM` e `with NaoExisteIsto` contribuem ZERO para a mascara de efeitos do type checker. Identicos entre si. A diferenca so e visivel no `effect_name_to_id` da tabela de bytes (que retorna 0..28 ou -1), e esse id nao parece estar ligado a nada que o utilizador consiga observar em tempo de compilacao.
 
+## Os dois achados que NAO sao detalhes
+
+### Achado 1: um efeito desenhado no dia um e um nome inventado agora sao invisiveis da mesma maneira
+
+`with GUM` (D2=144, no commit fundador) e `with NaoExisteIsto` (nome que acabei de inventar agora) sao, do ponto de vista do type checker, **a mesma coisa**: contribuem zero para a mascara de efeitos, falham identicamente o E035 quando outro efeito e requerido, e compilam sem diagnostico quando nenhum o e. Nao ha nenhuma ferramenta que distinga um efeito "real mas nao reconhecido" de um efeito "inventado para teste". O unico sitio onde a distincao existe e a tabela de bytes `effect_name_to_id`, e essa tabela nao parece ter efeito observavel no caminho de compilacao.
+
+Isto significa que **a historia do efeito nao e visivel no codigo que o declara**. GUM tem sete meses de existencia; NaoExisteIsto tem sete segundos. Sao identicos para o type checker, para o linker, para o codegen, para o ELF. A semantica que distingue os dois e externa: o programador que sabe que GUM "deveria ser" algo e o programador que sabe que NaoExisteIsto "nao e" nada. O compilador nao partilha nenhuma das duas conviccoes.
+
+### Achado 2: `with Uncertainty` foi declarado ha tres dias, nao em Dezembro
+
+A ultima ocorrencia de `with Uncertainty` em todo o repo (via `git log main -G"\bUncertainty\b" --max-count=1`) e o commit **`8999e0fdff` — WS-C PR1 ENIR/MIR shadow, 2026-08-16, ha tres dias**. Nao e codigo morto de 2025-12-25; e codigo de 2026-08-16. Alguem esta semana, ao integrar o lane WS-C, declarou `with Uncertainty` numa funcao acreditando que isso dizia algo — que Uncertainty tinha semantica de incerteza no sistema de tipos — e nao disse nada. O type checker viu o nome, ignorou-o, e compilou um programa que nao marca propagacao de incerteza em lado nenhum.
+
+Este achado NAO e sobre a equipa WS-C. E sobre o parser: **se o parser aceita nomes silenciosamente, ninguem sabe quando a sua declaracao de efeito e real ou um wish**. O risco nao e GUM ou Uncertainty serem esquecidos; o risco e que hoje, 2026-08-19, alguem declare `with NovoEfeitoQueVaiMudarTudo` e o compilador faca exactamente o mesmo que faria sem essa clausula — e ninguem detecte ate a propriedade que o efeito deveria garantir estar em falta no runtime.
+
 ## Classificacao (os tres baldes do despacho)
 
 | Nome | D1 | D2 | D3 | 29 ids? | Classe |
@@ -161,8 +177,10 @@ Para a visao completa: dos 11 nomes, 10 tem `with X` actual ou tem prosa fundado
 
 ## Claims-Forbidden (nenhum denominador e a verdade)
 
-- **NENHUM destes tres denominadores e "os efeitos que o founder desenhou".** Sao substitutos, nao a lista original. A lista original continua por escrever.
+- **NENHUM destes tres denominadores e "os efeitos que o founder desenhou".** Sao substitutos, nao a lista original. A lista original continua por escrever — nenhum commit, manifesto, spec, design doc ou thread da grok-cli5 a declara como conjunto fechado. Medicao sobre substitute proxies NAO autoriza ninguem a afirmar o que o founder desenhou.
 - **A razao 9/11 ≠ "9 em cada 11 efeitos do founder foram reconhecidos".** O denominador e "efeitos que aparecem em codigo ou prosa rastreavel" — uma fracao desconhecida do universo real.
+- **D1 e um instrumento FROUXO** — conta a palavra `with` seguida de nome em qualquer posicao, inclusive dentro de comentarios `// ...`. Foi exactamente assim que `GetTid` entrou com 13 ocurrencias e foi assim que foi excluido: as 13 estao todas em comentarios `// emit: get_tid = ...` em codigo GPU, nao em clausulas `with` reais. Significa que D1 pode inflacionar nomes de prosa-em-codigo; e a razao pela qual o instrumento strict (`find_with_names.py`) da contagens menores (Epistemic 218 vs 426). A leitura de D1 NAO e a contagem de declaracoes de efeito; e a contagem de "onde o nome segue `with` em texto, dentro ou fora de codigo activo". Distincao preservada acima para nao inflacionar conclusoes.
+- **Este documento NAO conclui que GUM ou Uncertainty devam entrar no enum.** A medicao mostra que ambos tem D2 massiva (144 e 156) — foram desenhados — mas a ausencia dos 29 ids de producao e um facto, nao uma sentenca. A decisao de adicionar (ou nao) pertence ao founder, em outra lane, com outra evidencia. Este doc descreve; nao prescreve.
 - **A descoberta de que `with GUM` e `with NaoExisteIsto` sao identicos nao prova que GUM e NaoExisteIsto sao identicos.** Prova que o parser nao distingue. O compilador pode ainda dar semantica a GUM num momento posterior; hoje, da perspectiva do type checker, nao da.
 - **A leitura "tentado e falhou a ultima aresta" para GUM/Uncertainty e uma leitura de D2 + D1.** Nao exclui a leitura alternativa "nascido em prosa, nunca chegou a ser declarado de verdade mesmo no fundador" — a fronteira entre prosa do fundador e declaracao de efeito do fundador depende do que se considera declaracao.
 - **INDETERMINADO** (per precedent do `Mod` phase 2b da minimax-cli2): se um leitor razoavel nao conseguir decidir em qual dos tres baldes um nome cai, **essa decisao fica em aberto** e nao se inventa um quarto balde para forcar caber.

--- a/docs/audit/GUM_UNCERTAINTY_TAIL_2026-08-19.md
+++ b/docs/audit/GUM_UNCERTAINTY_TAIL_2026-08-19.md
@@ -176,9 +176,9 @@ Para a visao completa: dos 11 nomes, 10 tem `with X` actual ou tem prosa fundado
 
 ## Coordenacao
 
-- Lane branch: `lane/minimax-cli3/gum-uncertainty-tail-20260819-v2` (sem commits novos — so este ficheiro)
-- Coordination bus: `artifacts/omega/agent_handoff.log.md` (NOTIFY pendente apos push)
-- PR comment no #1947 (handoff da medicao): pendente
+- Lane branch: `lane/minimax-cli3/gum-uncertainty-tail-20260819-v2` (push dd3725dde4 → 0ec8ef8c50)
+- Coordination bus: `artifacts/omega/agent_handoff.log.md` (NOTIFY publicado; ver entrada agent claude / time_utc 2026-08-19T13:30:00Z)
+- PR comment no #1947: NAO postado. A #1947 pertence a lane/empryo-1/ir-capacity-object-20260819 (minimax-cli2 / empryo-1). O despacho drop1947_claude1.md transferiu essa PR; comentar nela a partir desta lane seria barulho entre lanes. O handoff da medicao segue pelo coordination bus.
 - Coordenacao pedida: grok-cli5 tem o vocabulario de efeitos; esta medicao cruzou com o reconciliado da fase 1 deles (4 listas, GUM/Uncertainty ausentes em todas) sem contradizer
 - Regra do founder em vigor: NAO se reverte nada. Commits candidatos `6f23dfe1da` (#1935) e `7be969ed05` (#1939) sob analise da grok-cli3, nao desta lane.
 

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -167,6 +167,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.github-mergeability-queue-is-a-flow-2026-08-18 | repo_only | docs/audit/GITHUB_MERGEABILITY_QUEUE_IS_A_FLOW_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.gpu-pipeline-sota-assessment-2026-05-30 | repo_only | docs/audit/GPU_PIPELINE_SOTA_ASSESSMENT_2026-05-30.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.gum-fo-propagation-hidden-by-main-vacuous-harness-dispatch-2026-08-10 | repo_only | docs/audit/GUM_FO_PROPAGATION_HIDDEN_BY_MAIN_VACUOUS_HARNESS_DISPATCH_2026-08-10.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.gum-uncertainty-tail-2026-08-19 | repo_only | docs/audit/GUM_UNCERTAINTY_TAIL_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.handle-table-e230-refutation-2026-08-18 | repo_only | docs/audit/HANDLE_TABLE_E230_REFUTATION_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.handle-table-reclamation-design-2026-08-17 | repo_only | docs/audit/HANDLE_TABLE_RECLAMATION_DESIGN_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.hlir-disconnect-cost-2026-08-19 | repo_only | docs/audit/HLIR_DISCONNECT_COST_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -3305,6 +3305,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.gum-uncertainty-tail-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/GUM_UNCERTAINTY_TAIL_2026-08-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.handle-table-e230-refutation-2026-08-18",
       "collection": "repo",
       "repo_doc_path": "docs/audit/HANDLE_TABLE_E230_REFUTATION_2026-08-18.md",


### PR DESCRIPTION
## Summary

Census of GUM/Uncertainty and 9 other epistemic effect names against three substitute denominators (D1 = with X in code, D2 = founding commit b6d03ae18a tree, D3 = prose only). Classification into three buckets (D1-only / D2-not-D1 / D3-only). Recognition probes confirm `with GUM` and `with NaoExisteIsto` are identical to the type checker — both contribute zero to the effect mask.

**Census-only.** No compiler source modified. No enum additions. No reverts. Branch `lane/minimax-cli3/gum-uncertainty-tail-20260819-v2` (commits dd3725dde4 → 0ec8ef8c50 → e0e972ba69 → 7d08b3e9af, against `origin/main = f9b3147364`). Merge authorised by founder once `main` returns to green (f64 lowering red 9h; bisect running in another lane — NOT this one).

## Declaracao semantica

This document does NOT enumerate "the effects the founder drew". That list does not exist anywhere verifiable — no commit, manifesto, spec, design doc, or thread of the grok-cli5 phase-1 reconciliation declares it as a closed set. This document:

1. Measures three substitute denominators and presents each ratio.
2. Presents the lineage (first/last appearance) of 11 epistemic names.
3. Verifies, via recognition probes, which of the 11 names are in the production enum (29 ids post-#1963) and which are out.
4. Classifies each name into one of three buckets: "tried and failed the last edge" / "never tried" / "born in design and disappeared from code".

Interpretation of what these numbers say about the founder's effective design is left for another reading. The three counts are proxies, not the truth.

**This document does NOT propose anything.** It does NOT conclude GUM should enter the enum. It does NOT conclude Uncertainty should enter the enum. It does NOT propose new ids, aliases, or modifications to `self-hosted/check/effects.sio`. Classification is descriptive, not prescriptive. Decisions about additions belong to the founder, in another lane, with another kind of evidence (semantics, design, maintenance cost).

## The two load-bearing findings

### Finding 1: an effect drawn on day one and a name invented just now are invisible the same way

`with GUM` (D2=144 in the founding commit) and `with NaoExisteIsto` (a name I just invented for this probe) are **the same thing** from the type checker's view: they contribute zero to the effect mask, fail the E035 "missing: Epistemic" identically when another effect is required, and compile without diagnostic when none is. No tool distinguishes a "real but not recognised" effect from a "test-invented" effect. The only place the distinction exists is the `effect_name_to_id` byte table, and that table does not appear to have any observable effect on the compile path.

This means **the history of the effect is not visible in the code that declares it.** GUM has seven months of existence; NaoExisteIsto has seven seconds. They are identical to the type checker, the linker, the codegen, the ELF. The semantics that distinguishes them is external: the programmer who knows GUM "should be" something and the programmer who knows NaoExisteIsto "isn't" anything. The compiler shares neither conviction.

### Finding 2: `with Uncertainty` was declared three days ago, not in December

The last occurrence of `with Uncertainty` anywhere in the repo (via `git log main -G"\bUncertainty\b" --max-count=1`) is commit **`8999e0fdff` — WS-C PR1 ENIR/MIR shadow, 2026-08-16, three days ago**. This is not dead code from 2025-12-25; it is code from 2026-08-16. Someone this week, integrating the WS-C lane, declared `with Uncertainty` on a function believing it said something — that Uncertainty had uncertainty-propagation semantics in the type system — and it said nothing. The type checker saw the name, ignored it, and compiled a program that does not mark uncertainty propagation anywhere.

This finding is NOT about the WS-C team. It is about the parser: **if the parser silently accepts names, nobody knows when their effect declaration is real or a wish.** The risk is not GUM or Uncertainty being forgotten; the risk is that today, 2026-08-19, someone declares `with NovoEfeitoQueVaiMudarTudo` and the compiler does exactly the same thing it would without that clause, and nobody detects until the property the effect should guarantee is missing at runtime.

## Classification (11 names)

- **D1-only (tried, failed last edge):** NONE
- **D2-not-D1 (born in design, disappeared):** GUM (D2=144), Uncertainty (D2=156)
- **D3-only (prose, never tried):** GetTid
- **Lives (in 29 ids + in current `with X`):** Epistemic, Observe, Witness, Prob, Learn, Temporal, ZD, NonAssoc, Audit (9)

## Ratios (one per denominator)

| Denominator | Total | Recognised (29 ids) | Ratio |
|---|---:|---:|---:|
| D1 (with X actual) | 11 | 9 | **9/11 ≈ 82%** |
| D2 (founding b6d03ae18a) | 7 | 5 | **5/7 ≈ 71%** |
| D3 (prose only, current) | 11 | 9 | **9/11 ≈ 82%** |
| Combined | 11 | 10 | **10/11 ≈ 91%** |

## Constraints honored

- `NAO acrescentes nada ao enum` (per dispatch_denominador_claude1.md).
- `NAO REVERTAS NADA SEM AVISAR` (founder rule, all lanes). Main red 9h on f64 lowering; candidates `#1935` / `#1939` not touched by this lane (grok-cli3 is bisecting).
- No PR comment posted on `#1947` (different lane — `lane/empryo-1/ir-capacity-object-20260819`). Handoff via coordination bus.
- Lane discipline preserved.

## Validation

- Doc-only commit; no compiler source touched.
- Sync governance metadata: `node scripts/docs/sync_governance_metadata.mjs` → registered 1276 repo docs, 163 website topics.
- Doc-gate-ready: registry entries added for `repo.docs.audit.gum-uncertainty-tail-2026-08-19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)