### PR TITLE
test(gum): remove stale //@ known-failure on gum_fo_import_boundary.sio

### DIFF
--- a/tests/run-pass/gum_fo_import_boundary.sio
+++ b/tests/run-pass/gum_fo_import_boundary.sio
@@ -1,6 +1,5 @@
 //@ run-pass
 //@ requires: madaros
-//@ known-failure: Madaros loses first-order variance across an imported helper, including 1–2 f64 args. Observed 2026-08-18: souc compile rc=0, \x7fELF, run rc=1; variance_of(fo_add2(a,b))=0 while same-file peel of a+b is 5.0. Not print rounding. Not a regression — import FO never landed on main (d9fe77669a). Remove when imported FO lands. XPASS under #1910 is the detector.
 //@ expect-stdout: GUM_FO_IMPORT_BOUNDARY_OK
 //@ description: XPASS detector for the surgical import-FO port. 2-arg only, so arity ≥3 cannot hide a successful import fix.
 


### PR DESCRIPTION
## Semantic declaration

This PR removes one line: the `//@ known-failure` header on
`tests/run-pass/gum_fo_import_boundary.sio`. No other change to that
file. No other file is touched.

The label is stale. The test it tagged has been passing on the
Madaros Current-Source f64 Lowering job (run 32250567841 / job
96060811487) with `Fail: 0`. The job's XPASS detector (#1910) flagged
the test as `XPAS gum_fo_import_boundary.sio (known failure now
passes)` and raised `XPAS_FATAL: 1 known-failure tag(s) passed on
this engine`. That is the gate doing exactly what it was designed to
do — surfacing a stale tag, not a regression.

## Evidence the tag is stale

The test fails closed on the bug it was tagged for. The assertion
(lines 22–28 of the source as it stands on `origin/main`) is:

```sio
let peel = variance_of(a + b)              // same-file
let imp  = variance_of(fo_add2(a, b))      // imported helper
if peel > 4.9 && peel < 5.1 && imp > 4.9 && imp < 5.1 {
    println("GUM_FO_IMPORT_BOUNDARY_OK");  0
} else {
    println("GUM_FO_IMPORT_BOUNDARY_ZERO");  1
}
```

Both halves are required, both must land in `(4.9, 5.1)`. The
known-failure header records the prior failure as
`variance_of(fo_add2(a,b)) = 0` while the same-file peel is `5.0`. If
the FO loss were live, `imp = 0`, the condition fails, and the test
exits `1` with `GUM_FO_IMPORT_BOUNDARY_ZERO`. There is no way the
test passes for a reason other than FO surviving the import.

The `//@ description` header on the same file confirms the
construction intent: *"2-arg only, so arity ≥3 cannot hide a
successful import fix."* The test was built for this exact
discrimination.

## Why the FO loss is no longer live

Commit `7be969ed05` (#1939 — *"fix(madaros): imported 1-2 arg helpers
keep first-order variance"*) ports the FO transfer pre-register and
the frontend multi-module loop so an imported 1- or 2-argument pure
helper does not drop its variance. The test's own commit-message
proof on current-source `artifacts/self-hosted/madaros`:

> `gum_fo_import_boundary PEEL=5 IMP=5 rc=0; harness XPAS_FATAL=1`

`IMP=5` confirms `imp ≈ 5.0`, which is what the assertion requires.

The fix is bounded: it does not lift the >2-param skip. The 3+ arg
case is a separate known-failure (`gum_fo_arity3_boundary`,
`ADD3=0`) and remains tagged. This PR removes only the 1–2 arg tag.

## Negative control — required before merge

A test that exits the known-failure list must still be capable of
failing. Otherwise the test is dead and we have lost a detector.

**Procedure** (build lane, on a throwaway branch off this PR's
branch):

1. Tighten the assertion window in
   `tests/run-pass/gum_fo_import_boundary.sio` so the test cannot
   pass for the current value of `imp`. Recommended form: change
   `(4.9, 5.1)` to `(4.99, 5.01)` in BOTH the `peel` and the `imp`
   arms. This forces exit `1` with `GUM_FO_IMPORT_BOUNDARY_ZERO`
   for any non-tight variance, while leaving the file otherwise
   unchanged.
2. Build Madaros from this exact source via Slurm and run the test
   with `bin/madaros run`. Confirm: stdout contains
   `GUM_FO_IMPORT_BOUNDARY_ZERO`, exit code `1`.
3. Revert the window change before reporting.

**Without this control, do not merge.** A label disappearing is not
the same as a detector surviving.

## Out of scope

- The other 20 XPAS surfaced by the same job are out of scope for
  this PR. The discrimination classification (real-fix /
  dead-witness / indeterminate) is in flight elsewhere; this PR is
  the single tag removal that the evidence supports and that is
  blocking the four held PRs.
- `gum_fo_arity3_boundary` stays as `//@ known-failure`. The fix
  in #1939 is bounded to arity ≤2; the ≥3 case is not closed.
- No source code under `self-hosted/` is touched. No `bin/` binary
  is refreshed. No `ci.yml` is edited.

## FLEET_CONSTRAINTS check

- [x] Work off `origin/main`, on my own branch, my own PR. Worktree
      at `/workspace/.wt/minimax-cli1/`, branch
      `lane/minimax-cli1/xpaf-remove-gum-fo-import-boundary-20260819`.
- [x] No `git add -A`, no `checkout`, no `stash`, no `clean` in
      `/workspace/sounio/`.
- [x] Atomic commit, one logical change. Single commit
      `7708cd4dd0`, single file, one deletion.
- [x] No `Co-Authored-By` trailer. No AI attribution in commit
      message or PR body.
- [x] EN-UK orthography in new prose.
- [x] No full self-compile / `make build` / `lake build` / test
      suite on this pod.
- [x] No Slurm launch.
- [x] I do not merge. PR is DRAFT and explicitly gated on the
      negative control.
- [x] No revert. This PR adds nothing and removes only a stale
      label that has been obsolete since #1939 landed.
- [x] Founder's standing rule (`DO NOT REVERT ANYTHING WITHOUT NOTICE`)
      respected: this PR is the inverse — removing an obsolete
      tag, not reverting any code.

## Halt condition

I stop here. The PR is DRAFT. Merge is gated on the build lane
running the negative control and reporting `Fail: 1` with
`GUM_FO_IMPORT_BOUNDARY_ZERO`. Until that report lands, the PR
stays open and unmerged.

