### PR TITLE
concept(registry): SOUNIO-GATING-ENGINE — Madaros gates, with a declared divergence debt

### DIFF
--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -603,6 +603,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.internal.concepts.erasure | repo_only | docs/internal/concepts/erasure.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.exactness | repo_only | docs/internal/concepts/exactness.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.explicit-discharge | repo_only | docs/internal/concepts/explicit-discharge.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.concepts.gating-engine | repo_only | docs/internal/concepts/gating-engine.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.hypercomplex-zero-divisor-evidence | repo_only | docs/internal/concepts/hypercomplex-zero-divisor-evidence.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.justification | repo_only | docs/internal/concepts/justification.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.maturity-ladder | repo_only | docs/internal/concepts/MATURITY_LADDER.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -13349,6 +13349,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.internal.concepts.gating-engine",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/concepts/gating-engine.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.internal.concepts.hypercomplex-zero-divisor-evidence",
       "collection": "repo",
       "repo_doc_path": "docs/internal/concepts/hypercomplex-zero-divisor-evidence.md",

--- a/docs/internal/concepts/gating-engine.md
+++ b/docs/internal/concepts/gating-engine.md
@@ -1,0 +1,115 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.concepts.gating-engine
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: claude-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.concepts.gating-engine
+-->
+
+# Gating Engine
+
+Concept-ID: `SOUNIO-GATING-ENGINE`
+
+Status: **Hypothesis** — founder ruling of 2026-08-19. **It may not be
+implemented before the divergence count exists** (in flight); the reason is in
+*Sequencing* below.
+
+## Founder Intent
+
+> **Madaros gates the repository. Red is the truth.**
+
+The canonical compiler decides whether the tree is green. A pass on any other
+engine is information, never a gate.
+
+## What forced the ruling
+
+Measured 2026-08-19 (PR #1964): the CI **Full Test Suite runs `souc-stage2`,
+which is `lean_single`** — the bootstrap seed. `CLAUDE.md` states Madaros is
+canonical and that `bin/souc` routes to it. Both could not be true at once.
+
+The consequence was not theoretical. Twenty-one known-failure tags "passed" and
+were read as the first-order-variance blocker having fallen. They were all
+lean_single results. On a Madaros built from source (Slurm job 10338, r770,
+226s, ELF 100553240 B, from `cdea9d7eef`):
+
+    ADD3 = 0.000000     ADD4 = 0.000000     IMP_ADD3 = 0
+    IMP_ADD2 = 5        <- the only branch #1939 closed
+
+The arity branch of the defect is fully open on the canonical compiler, and the
+suite could not say so, because the suite was not asking it.
+
+`bin/souc` compounds this: it resolves to Madaros **if the modular ELF exists**
+and otherwise falls back to lean_single with a stderr notice. The engine a job
+exercises therefore depends on an artefact existing in the runner. The wrapper
+already carries `_reject_science_without_madaros` — someone guarded the science
+surfaces — and the test suite goes around that guard.
+
+## The form the ruling takes
+
+Gating on Madaros outright would stop the merge queue by an unknown amount: the
+PBPK suite alone is known to go from 52/53 on lean_single to **19 failures of 53**
+on Madaros. The ruling is therefore implemented in the shape the founder already
+chose for `Reserved`:
+
+**Madaros gates, with a declared divergence list.**
+
+- The gate runs Madaros. Its verdict is the repository's verdict.
+- Every test that fails on Madaros and passes on lean_single is entered in a
+  list with an **owner** and a **reason** — the same three-field discipline as
+  `reserved-owed`, minus nothing.
+- The list is **printed at every run**, oldest first, whether or not the gate
+  passes. It is the debt, and it is counted.
+- The list may only shrink. **No new entry without a signature**: a test that
+  starts diverging must be entered deliberately, never absorbed.
+- A malformed entry — missing owner or reason — is **redder than an absent
+  one**, for the reason stated throughout this corpus: if declaring badly were
+  cheaper than declaring well, everyone would declare badly.
+
+This is not a softening of the ruling. Under it, green means *the canonical
+compiler passes*, and what does not pass is **named, counted and owned** —
+where today it is invisible behind the wrong engine.
+
+## Sequencing — this may not land yet
+
+The divergence count does not exist. A measurement is in flight: the same corpus
+run twice, once on lean_single and once on a from-source Madaros, reporting the
+difference set in both directions and classifying the Madaros failures (real
+defect / unimplemented feature / harness difference / test assuming lean
+behaviour).
+
+**188 divergences and 1,800 are different decisions.** Landing the gate before
+the number is known would be the exact error this corpus was written to prevent:
+acting on a magnitude nobody measured.
+
+## Required Invariants
+
+- A green must name the engine that produced it. An unqualified pass is a claim
+  about `(test, engine, binary vintage)` reported as a claim about the test.
+- The divergence list is a debt, not an exemption. An entry means *known and
+  owned*, never *acceptable*.
+- The inverse set is also recorded: tests failing on lean_single and passing on
+  Madaros are known-failure tags held for the wrong reason, and they are
+  findings too.
+- The fallback must be loud where it matters. A job that intends Madaros and
+  silently receives the seed reports nothing about the canonical compiler; the
+  stderr notice is not sufficient if nothing reads it.
+
+## Claims Forbidden
+
+- Do not describe this as implemented. CI runs lean_single today.
+- Do not read "red is the truth" as licence to disable tests. The divergence
+  list requires an owner and a reason per entry; silencing is the failure mode
+  it exists to prevent.
+- Do not treat a Madaros failure as automatically a compiler defect. The
+  classification decides that, and it is not done.
+- Do not quote the PBPK 19/53 as the expected scale. It is one suite, measured
+  earlier, and is the only divergence figure that exists — not an estimate of
+  the whole.
+
+## Related
+
+- `SOUNIO-NO-VERSUS-UNKNOWN` — an unqualified green is ignorance wearing
+  knowledge's face
+- `MATURITY_LADDER` — `reserved-owed` supplies the owner/date/blocked-on shape
+- `SOUNIO-EFFORT-LOCATION` — why the debt is a printed list and not a note


### PR DESCRIPTION
Founder ruling, 2026-08-19:

> **Madaros gates the repository. Red is the truth.**

A pass on any other engine is information, never a gate.

## What forced it

Measured in #1964: the CI **Full Test Suite runs `souc-stage2` — `lean_single`**, the bootstrap seed — while `CLAUDE.md` states Madaros is canonical.

Not theoretical. **21 known-failure tags "passed"** and were read as the first-order-variance blocker having fallen. All were lean results. On a from-source Madaros (Slurm job 10338, ELF 100553240 B, `cdea9d7eef`):

```
ADD3 = 0.000000   ADD4 = 0.000000   IMP_ADD3 = 0
IMP_ADD2 = 5      ← the only branch #1939 closed
```

The arity branch is **fully open on the canonical compiler**, and the suite could not say so — because it was not asking it.

## The form: gate on Madaros, with a declared divergence debt

Gating outright would stop the queue by an unknown amount (PBPK alone: 52/53 on lean → **19 failures of 53** on Madaros). So the ruling takes the shape already chosen for `Reserved`:

- the gate runs **Madaros**; its verdict is the repository's verdict
- every test failing on Madaros and passing on lean is entered with an **owner** and a **reason**
- the list **prints at every run**, oldest first, pass or fail — it is the debt, and it is counted
- it may only **shrink**; no new entry without a signature
- a malformed entry is **redder than an absent one**

**This is not a softening.** Under it, green means *the canonical compiler passes*, and what does not pass is named, counted and owned — where today it is invisible behind the wrong engine.

## Sequencing — this may not land yet

The divergence count does not exist; a measurement is in flight. **188 and 1,800 are different decisions**, and landing the gate before the number is known would be the exact error this corpus was written to prevent.

## Semantic declaration

- **Concept-IDs**: introduces `SOUNIO-GATING-ENGINE`. References `SOUNIO-NO-VERSUS-UNKNOWN`, `MATURITY_LADDER`, `SOUNIO-EFFORT-LOCATION`.
- **Intent-Preserved**: `CLAUDE.md`'s statement that Madaros is the canonical compiler — this makes the gate agree with it.
- **Transformation**: documentation plus filesystem-derived registry sync. Zero lines of `self-hosted/`, `stdlib/`, `scripts/ci/` or `.github/`.
- **Claims-Introduced**: the engine finding and the FO matrix, reproducible from #1964's receipt.
- **Claims-Forbidden**: **not implemented** — CI runs lean_single today. *"Red is the truth"* is **not** licence to disable tests: each divergence entry needs an owner and a reason, and silencing is the failure mode this exists to prevent. A Madaros failure is **not** automatically a compiler defect — classification decides, and it is not done. And PBPK's 19/53 is **not** an estimate of the whole: it is one suite, and the only divergence figure that exists.
- **Authoritative-Only-If**: **Hypothesis** until the divergence count exists and the gate has been shown red-before / green-after with the list populated.
