### PR TITLE
spec(frame): E2E specification frame — seventeen sections, and what each is missing

### DIFF
--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -1211,6 +1211,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.sounio-vs-python | repo_only | docs/sounio_vs_python.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.spec.e2e-specification-frame | repo_only | docs/spec/E2E_SPECIFICATION_FRAME.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.spec.language-specification | repo_only | docs/spec/LANGUAGE_SPECIFICATION.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.spec.s08-epistemic-values | repo_only | docs/spec/S08_EPISTEMIC_VALUES.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.status.madaros-main-proof-17d115 | repo_only | docs/status/madaros_main_proof_17d115.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.stdlib.linalg.blas-ffi | repo_only | docs/stdlib/linalg/BLAS_FFI.md | - | A3 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.stdlib.stdlib-api-reference | repo_only | docs/stdlib/STDLIB_API_REFERENCE.md | - | A3 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -1211,6 +1211,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.sounio-vs-python | repo_only | docs/sounio_vs_python.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.spec.e2e-specification-frame | repo_only | docs/spec/E2E_SPECIFICATION_FRAME.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.spec.language-specification | repo_only | docs/spec/LANGUAGE_SPECIFICATION.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.spec.s06-effects-rows | repo_only | docs/spec/S06_EFFECTS_ROWS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.spec.s08-epistemic-values | repo_only | docs/spec/S08_EPISTEMIC_VALUES.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.status.madaros-main-proof-17d115 | repo_only | docs/status/madaros_main_proof_17d115.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.stdlib.linalg.blas-ffi | repo_only | docs/stdlib/linalg/BLAS_FFI.md | - | A3 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -1209,6 +1209,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.serious-language.real-world-defensibility | repo_only | docs/serious-language/real-world-defensibility.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.serious-language.sunil-brief | repo_only | docs/serious-language/sunil-brief.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.sounio-vs-python | repo_only | docs/sounio_vs_python.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.spec.e2e-specification-frame | repo_only | docs/spec/E2E_SPECIFICATION_FRAME.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.spec.language-specification | repo_only | docs/spec/LANGUAGE_SPECIFICATION.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.status.madaros-main-proof-17d115 | repo_only | docs/status/madaros_main_proof_17d115.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.stdlib.linalg.blas-ffi | repo_only | docs/stdlib/linalg/BLAS_FFI.md | - | A3 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -1212,6 +1212,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.spec.e2e-specification-frame | repo_only | docs/spec/E2E_SPECIFICATION_FRAME.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.spec.language-specification | repo_only | docs/spec/LANGUAGE_SPECIFICATION.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.spec.s06-effects-rows | repo_only | docs/spec/S06_EFFECTS_ROWS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.spec.s07-effect-handlers | repo_only | docs/spec/S07_EFFECT_HANDLERS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.spec.s08-epistemic-values | repo_only | docs/spec/S08_EPISTEMIC_VALUES.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.status.madaros-main-proof-17d115 | repo_only | docs/status/madaros_main_proof_17d115.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.stdlib.linalg.blas-ffi | repo_only | docs/stdlib/linalg/BLAS_FFI.md | - | A3 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -26992,6 +26992,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.spec.s07-effect-handlers",
+      "collection": "repo",
+      "repo_doc_path": "docs/spec/S07_EFFECT_HANDLERS.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.spec.s08-epistemic-values",
       "collection": "repo",
       "repo_doc_path": "docs/spec/S08_EPISTEMIC_VALUES.md",

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -26969,6 +26969,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.spec.s08-epistemic-values",
+      "collection": "repo",
+      "repo_doc_path": "docs/spec/S08_EPISTEMIC_VALUES.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.status.madaros-main-proof-17d115",
       "collection": "repo",
       "repo_doc_path": "docs/status/madaros_main_proof_17d115.md",

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -26923,6 +26923,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.spec.e2e-specification-frame",
+      "collection": "repo",
+      "repo_doc_path": "docs/spec/E2E_SPECIFICATION_FRAME.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.spec.language-specification",
       "collection": "repo",
       "repo_doc_path": "docs/spec/LANGUAGE_SPECIFICATION.md",

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -26969,6 +26969,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.spec.s06-effects-rows",
+      "collection": "repo",
+      "repo_doc_path": "docs/spec/S06_EFFECTS_ROWS.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.spec.s08-epistemic-values",
       "collection": "repo",
       "repo_doc_path": "docs/spec/S08_EPISTEMIC_VALUES.md",

--- a/docs/spec/E2E_SPECIFICATION_FRAME.md
+++ b/docs/spec/E2E_SPECIFICATION_FRAME.md
@@ -1,0 +1,139 @@
+<!-- docs:meta
+topic_id: repo.docs.spec.e2e-specification-frame
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: claude-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.spec.e2e-specification-frame
+-->
+
+# End-to-End Specification — Frame
+
+Concept-ID: `SOUNIO-E2E-SPEC-FRAME`
+
+Status: **Garden.** This is **not** the specification. It is the frame the
+specification must fill, the method for filling it, and an honest inventory of
+what is already decided, what is contested between the two engines, and what
+does not exist.
+
+## Why a specification, and why now
+
+Founder, 2026-08-19: *the seed of Madaros being lean_single is the principal
+culprit; things will only move with an end-to-end spec.*
+
+The diagnosis is supported by the tree. `CLAUDE.md` states it directly:
+
+> **Fixed-point scope:** `make build` verifies the fixed point over
+> `lean_single.sio` (the seed), **not** over `main.sio`/Madaros. Do not describe
+> Madaros itself as fixed-point-verified.
+
+So the chain is:
+
+- **`lean_single`** is the seed, is fixed-point verified, and is what CI runs
+  (measured 2026-08-19, PR #1964: the Full Test Suite uses `souc-stage2`)
+- **Madaros** is built *by* `lean_single`, is canonical for users, and has **no
+  fixed point**
+
+**What is verified is not what is used, and what is used is built by what is
+verified.** Madaros inherits lean_single's semantics wherever it does not
+override them, and diverges silently wherever it does — because there is nothing
+both must satisfy.
+
+The consequence is precise and it is the reason this document exists:
+
+> A divergence measurement can establish **where** two engines differ. It cannot
+> establish **which is correct**. Without a specification, "divergence" has no
+> referent — one can only say *they differ*, and the choice of which to follow
+> becomes preference.
+
+A specification is what makes one of two engines **wrong** rather than merely
+different.
+
+## What this frame is not
+
+The fourteen concepts registered on 2026-08-19 are specification fragments, and
+every one of them is about a **failure mode**: what may not be lost, what may
+not be confused, what must refuse. Not one says what the language *does*.
+
+The difference is between a code of conduct and a grammar. The corpus has the
+first. This frame is the outline of the second.
+
+## Required sections, with measured status
+
+Each section is `undefined` until it has a normative statement **and** a
+conformance test that both engines are run against. Status vocabulary is the
+registry's; the ladder is monotone (`MATURITY_LADDER`).
+
+| § | Section | What exists today | Status |
+|---|---|---|---|
+| 1 | Lexical structure | `self-hosted/lexer/` (8 files); token kinds have **two numberings** and comparing raw code to an enum cast silently never matches | contested |
+| 2 | Grammar | `self-hosted/parser/` (9 files), `TypeExprKind` 54 variants; no grammar document | undefined |
+| 3 | Type system — kinds | **eight** type-kind enums, 238 variants, 57 multi-enum stems, **0 homonyms** (#1949) | measured, unspecified |
+| 4 | Type system — rules | bidirectional inference in `check/`; no written rules | undefined |
+| 5 | Effects — vocabulary | 29 ids after #1963; `EffectKind` enum now in production | measured |
+| 6 | Effects — rows and subtyping | `EffVar` row polymorphism exists in `effects/types.sio`, **not** in production | contested |
+| 7 | Effects — handlers | fast path (#1926) exists; **the CPS path has no execution semantics** (`EFFECTS_JUNCTION_ROUTING_2026-08-19`) | undefined |
+| 8 | Epistemic values | `Knowledge<T>` = `{value, variance, confidence}`; **not linear**, no provenance field; `.value` is an unmarked projection | measured, contested |
+| 9 | Uncertainty propagation | machine-level emitters in `ir/lower.sio`; `emit_variance_independent_product` assumes independence with nothing checking it | contested |
+| 10 | Units and dimensions | `stdlib/units/` 9 files incl. QUDT; whether `mg` is an alias, a nominal type or a primitive is **under measurement** | undefined |
+| 11 | Ontological validation | ChEBI, GO, HPO, LOINC bundles + reasoner; TBox present, **ABox absent** | measured, incomplete |
+| 12 | Numeric tower | `i8..i128`, `u8..u128`, `f32/f64`; `f128`/`f256` **Reserved** (`E218`); `i256`/`i512`/`u256`/`u512` **absent from every enum** | measured |
+| 13 | Memory and linearity | `linear struct`, `&`/`&!`; `OwnTypeKind` has 4 variants | undefined |
+| 14 | Lowering pipeline | live: `parser → check → ir → native`; HLIR is the **GPU frontend**; ENIR is a parallel verified pipeline with 0 production importers | contested |
+| 15 | Backends | x86-64 ELF, arm64, GPU/PTX, wasm | undefined |
+| 16 | Diagnostics | error codes `E001`–`E230+`; no catalogue with normative meaning | undefined |
+| 17 | Conformance suite | the corpus runs on **lean_single**, not the canonical compiler (#1964) | contested |
+
+`contested` means the two engines are known or suspected to disagree there, and
+**the specification's job is to say which is right** — not to describe both.
+
+## Method
+
+1. **Derive, do not invent.** Every normative statement starts as a measurement
+   of what the compiler does, with the receipt cited. A statement no receipt
+   supports is marked `undefined`, never guessed.
+2. **Where the engines disagree, the founder rules.** The measurement names the
+   divergence; the ruling picks the normative behaviour; the losing engine
+   acquires a defect with an owner. This is the only step a measurement cannot
+   perform.
+3. **A section is `Executable` when a conformance test exists and both engines
+   are run against it** — a correct programme that must pass and an incorrect
+   one that must be refused, with the negative control showing the refusal fires
+   for the stated reason (`SOUNIO-NO-VERSUS-UNKNOWN`).
+4. **Nothing is `Claim-ready` on one engine.** A section passing only on
+   lean_single is exactly the defect that produced this document.
+5. **The frame's own status is enforced.** `scripts/ci/concept_status_gate.sh`
+   (`ci.yml:68`) refuses a status claim that reality has passed; this document
+   is subject to it like any other.
+
+## Required Invariants
+
+- The specification is the referent for "correct". An engine is not a
+  specification; two engines are not a specification; a passing test on one
+  engine is not evidence about the language.
+- Every normative statement carries its receipt. `SOUNIO-EFFORT-LOCATION`: a
+  number without its measurement conditions is not evidence.
+- `undefined` is a legitimate and mandatory status. A section nobody has ruled
+  on must say so — filling it with plausible prose is the failure this whole
+  corpus exists to prevent.
+- Fixed-point scope is a specification concern. A specification that the
+  canonical compiler is not verified against describes a language nobody runs.
+
+## Claims Forbidden
+
+- Do not cite this as the specification. It is the frame; every section is
+  `undefined` or worse until filled by the method above.
+- Do not read the status column as coverage. It records what a receipt exists
+  for, not what is correct.
+- Do not treat the seventeen sections as complete. They are what one session's
+  measurements surfaced.
+- Do not read "contested" as "both are acceptable". It means a ruling is owed.
+
+## Related
+
+- `SOUNIO-GATING-ENGINE` — which engine's verdict counts while the spec is being
+  written
+- `SOUNIO-NO-VERSUS-UNKNOWN` — why `undefined` must be sayable
+- `MATURITY_LADDER` — the ladder each section climbs
+- `SOUNIO-EFFORT-LOCATION` — why each section needs a conformance test, not a
+  paragraph

--- a/docs/spec/S06_EFFECTS_ROWS.md
+++ b/docs/spec/S06_EFFECTS_ROWS.md
@@ -12,9 +12,26 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.spec.s06-effec
 Spec-Section: `SOUNIO-SPEC-06`
 Frame: `docs/spec/E2E_SPECIFICATION_FRAME.md`
 
-Status: **undefined.** No normative statement has been ruled. This section
-records the measured state and the rulings it makes owed. Nothing below is a
-specification of what Sounio *should* do.
+Status: **Hypothesis.** One normative statement is ruled (6.0). No conformance
+test exists for it. Everything else in this section is measured state and owed
+rulings, not specification.
+
+## 6.0 Normative
+
+> **A function type carries the effects of the function.**
+
+Founder ruling, 2026-08-19. A function type is not merely its parameter and
+result types; the effects the function may perform are part of it.
+
+Measured state at the time of the ruling: **559 function types occur in live
+`.sio` source and not one of them declares an effect.** The ruling is therefore a
+change of kind, not a description. What it buys is that the question *"what does
+this function argument do?"* becomes **askable**; today it is not formulable at
+all, because the type has nowhere to say it.
+
+Two things follow immediately and are recorded in 6.6 rather than assumed here:
+what a function type with no effect clause means, and whether a function may
+abstract over the effects of its argument.
 
 ## 6.1 What runs
 
@@ -95,6 +112,23 @@ Instrument: `^use effects::`, validated in the same command against
 `^use parser::` (155) and `^use ir::` (117).
 
 ## 6.6 Rulings owed
+
+- **What does a bare function type mean under 6.0?** If `fn(f64) -> f64` denotes
+  a *pure* function, then 559 existing types become purity claims overnight, and
+  the claim is already false at live call sites: of the functions actually passed
+  to higher-order functions, `sin`, `cos`, `exp` and `sqrt` are pure while
+  `my_sin`, `tc_sin` and `tc_cos` declare `with Mut, Panic, Div` — and `my_sin`
+  is passed six times. If instead a bare type denotes *any* effects, the ruling
+  buys nothing, because the type still cannot be relied upon. A third option is
+  that a bare type is **refused**, making the clause mandatory.
+
+- **May a function abstract over its argument's effects?** 6.0 makes the question
+  live; it does not answer it. Measured pressure: `my_sin` is mathematically a
+  pure `f64 -> f64` and carries three effects **because of how it is
+  implemented** — a loop (`Mut`) and division (`Div`). Sounio's effect set does
+  not separate observable effect from implementation mechanism, so effectful
+  numeric functions are the norm rather than the exception. Under 6.0 without
+  abstraction, one `deriv` cannot serve both `sin` and `my_sin`.
 
 - **Is the effect annotation a set or a row?** A flat set with subset is what
   runs. A row discipline with an open tail is what `effects_row.sio` implements

--- a/docs/spec/S06_EFFECTS_ROWS.md
+++ b/docs/spec/S06_EFFECTS_ROWS.md
@@ -1,0 +1,116 @@
+<!-- docs:meta
+topic_id: repo.docs.spec.s06-effects-rows
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: claude-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.spec.s06-effects-rows
+-->
+
+# §6 — Effects: rows and subtyping
+
+Spec-Section: `SOUNIO-SPEC-06`
+Frame: `docs/spec/E2E_SPECIFICATION_FRAME.md`
+
+Status: **undefined.** No normative statement has been ruled. This section
+records the measured state and the rulings it makes owed. Nothing below is a
+specification of what Sounio *should* do.
+
+## 6.1 What runs
+
+Measured on `origin/main`, 2026-08-19.
+
+The effect system that executes is a **flat set of integer identifiers**. The
+live operations in `self-hosted/check/effects.sio` are:
+
+| function | external call sites |
+|---|---:|
+| `has_effect_id` | 29 |
+| `effect_name_to_id` | 6 |
+| `effects_subset` | 2 |
+| `find_missing_effects` | 2 |
+| `print_effect_name` | 2 |
+
+Membership and subset. There is no composition operation in the live path:
+`extract_effects` and `merge_effects` are the file's only two functions with no
+caller anywhere, internal or external.
+
+`Confidence` is not a distinct effect. `effect_name_to_id` returns id 8 for it,
+with the comment *"Confidence is an alias of Epistemic (id 8). Not a new
+variant."*
+
+## 6.2 The set is capped at eight, and the ninth is dropped in silence
+
+`self-hosted/check/check.sio:285` declares
+
+    current_effects: [i64; 8],
+
+and the guard that admits an effect reads
+
+    if eff_id >= 0 && c.current_effect_count < 8 {
+
+Two silent losses follow from that one line. A function that already carries
+eight effects **discards the ninth without a diagnostic**. And an effect name
+that does not resolve yields `eff_id = -1`, which fails the same guard and is
+**also discarded without a diagnostic** — so `with SomeEffectThatDoesNotExist`
+contributes nothing and says nothing.
+
+Sounio names more than eight effects. The cap is therefore reachable by ordinary
+code, not a theoretical bound.
+
+## 6.3 Row polymorphism exists in the production tree and has no entry point
+
+`self-hosted/check/effects_row.sio` is 84 lines in the **live** checker
+directory — not in the orphan tree. Its header states the design:
+
+> The row tail is encoded as the `inner` field of `TyEffectRow`; an empty tail
+> is represented by `TyUnit`, and `TyEffectVar` represents an open row.
+
+It defines four functions. Three of them — `effect_row_label_eq`,
+`effect_row_contains`, `effect_row_subset` — call **one another** and have
+**zero callers outside the file**. The chain is closed and has no entrance. The
+fourth, `check_handler_coverage`, is the file's stated purpose and has no caller
+at all, not even internally.
+
+So row polymorphism is not "designed but unimplemented". It is **implemented and
+unreachable**.
+
+## 6.4 The gate that guards it tests that the file exists
+
+`scripts/archive/sprint17a_row_poly_gate.sh`, case 8:
+
+    if [ -f self-hosted/check/effects_row.sio ]; then
+      record "effects_row_sio_exists" "pass" "found"
+
+The check is file existence. It would pass on an empty file. This is recorded
+here rather than in an audit because it bears on the section directly: the
+strongest evidence that row polymorphism was *believed* to be in place is a gate
+that never tested it.
+
+## 6.5 The orphan tree
+
+`self-hosted/effects/` — `checker.sio` (2,056 lines), `handlers.sio` (2,991),
+`types.sio` (375), `mod.sio` (15) — totals **5,437 lines with zero importers**.
+Instrument: `^use effects::`, validated in the same command against
+`^use parser::` (155) and `^use ir::` (117).
+
+## 6.6 Rulings owed
+
+- **Is the effect annotation a set or a row?** A flat set with subset is what
+  runs. A row discipline with an open tail is what `effects_row.sio` implements
+  and nothing calls. These are different type systems, not two maturities of
+  one.
+- **Is eight a designed bound or an implementation limit?** If designed, the
+  specification says so and the ninth effect must be **refused with a named
+  diagnostic** rather than dropped. If not designed, the cap is a silent
+  truncation in the subsystem the language is named for.
+- **Must an unresolvable effect name be refused?** Today `with X` for unknown
+  `X` type-checks and contributes nothing. Under `SOUNIO-EFFECT-DECLARATION`
+  this is already answerable, and the answer is not the current behaviour.
+
+## Claims forbidden
+
+- Do not describe Sounio as having row-polymorphic effects. The code exists; no
+  caller reaches it.
+- Do not quote an effect count as a capability without naming the eight-slot
+  cap.

--- a/docs/spec/S06_EFFECTS_ROWS.md
+++ b/docs/spec/S06_EFFECTS_ROWS.md
@@ -23,15 +23,38 @@ rulings, not specification.
 Founder ruling, 2026-08-19. A function type is not merely its parameter and
 result types; the effects the function may perform are part of it.
 
-Measured state at the time of the ruling: **559 function types occur in live
-`.sio` source and not one of them declares an effect.** The ruling is therefore a
-change of kind, not a description. What it buys is that the question *"what does
-this function argument do?"* becomes **askable**; today it is not formulable at
-all, because the type has nowhere to say it.
+Measured state at the time of the ruling, corrected: in live `.sio` source
+**381 function types occur in parameter position; 165 carry an effect clause and
+216 do not** (`docs/audit/FN_TYPE_EFFECT_CLAUSE_CENSUS_2026-08-19.md`).
+
+The surface syntax already supports the ruling. `self-hosted/parser/types.sio:717`
+documents the grammar as `fn(T, U) -> V with E1, E2`, and it is used, e.g.
+
+    fn filter8(arr: [i64; 8], pred: fn(i64) -> bool with Div, Panic) -> ...
+
+So 6.0 is closer to **codifying existing practice** than to introducing a
+capability. What it makes normative is that the clause is not optional: the
+question *"what does this function argument do?"* must be answerable at every
+function type, not at 165 of 381.
+
+> **Correction, 2026-08-19.** An earlier revision of this section stated *"559
+> function types occur in live `.sio` source and not one of them declares an
+> effect"*. Both halves were wrong. 559 was a raw line count including
+> `archive/`, `bootstrap/`, comments and string literals; and the "not one" came
+> from a pattern whose return-type character class excluded the shapes that
+> actually occur. The ruling stands; the state it was ruled against was
+> misreported, by me, and the misreport made the ruling look more expensive than
+> it is.
 
 Two things follow immediately and are recorded in 6.6 rather than assumed here:
 what a function type with no effect clause means, and whether a function may
-abstract over the effects of its argument.
+abstract over the effects of its argument. The second is untouched by the
+correction above: **no effect variable occurs in live source.** The one apparent
+instance, `fn(T, U) -> V with E`, is the parser comment quoted above.
+
+`scripts/ci/fn_type_effect_ratchet_gate.sh` freezes the bare count at 216. It
+does not implement 6.0; it stops the gap from widening while 6.0 is
+unimplemented.
 
 ## 6.1 What runs
 

--- a/docs/spec/S07_EFFECT_HANDLERS.md
+++ b/docs/spec/S07_EFFECT_HANDLERS.md
@@ -1,0 +1,82 @@
+<!-- docs:meta
+topic_id: repo.docs.spec.s07-effect-handlers
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: claude-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.spec.s07-effect-handlers
+-->
+
+# §7 — Effect handlers
+
+Spec-Section: `SOUNIO-SPEC-07`
+Frame: `docs/spec/E2E_SPECIFICATION_FRAME.md`
+
+Status: **undefined.** No normative statement has been ruled.
+
+## 7.1 `handle` reaches the type checker and stops there
+
+Measured on `origin/main`, 2026-08-19.
+
+The front end is complete:
+
+| stage | evidence |
+|---|---|
+| token | `TokenKind::Handle`, `TokenKind::Handler` (`parser/parser.sio:775,809`) |
+| parse | `parse_handle_expr` (`parser/exprs.sio:564`), produces `ExprKind::ExprHandle` |
+| check | `check_handle_expr` (`check/check.sio:24749`) |
+
+The back end is absent. `ExprHandle` occurs **zero times** across
+`self-hosted/ir/`, `self-hosted/native/` and `self-hosted/enir/`. Positive
+control from the same command, same directories: `ExprCall` 23, `ExprBinary` 17,
+`ExprIf` 4.
+
+A handler expression is therefore parsed, type-checked, and does not appear in
+any intermediate representation.
+
+This is stronger than the frame's earlier reading. The frame recorded that *the
+CPS path* has no execution semantics. Measured, **no path does**.
+
+## 7.2 The checker's own two silent losses
+
+`check_handle_expr` resolves the handled effect name and admits it with
+
+    if eff_id >= 0 && c.current_effect_count < 8 {
+
+so `handle` inherits both silences of §6.2 at the point where an effect is
+supposedly *discharged*: an unrecognised effect name is ignored without a
+diagnostic, and a function already carrying eight effects has the handled effect
+dropped.
+
+## 7.3 What is not yet measured
+
+Whether a program containing `handle` **refuses**, **compiles and silently does
+nothing**, **crashes**, or **works** is not established by static reading. The
+lowering dispatches on `ExprKind` through `if` chains rather than a match with
+an explicit default, so the fall-through behaviour must be observed rather than
+inferred.
+
+A runtime witness is owed, under **both engines**, with a control program that
+differs only by the absence of `handle`. Until it lands this section states the
+front-end/back-end split above and nothing about execution.
+
+## 7.4 Rulings owed
+
+- **Does `handle` exist?** Three answers are coherent and they are very
+  different. *Reserved*: the surface is refused with a named diagnostic until
+  implemented — honest, and cheap. *Implemented*: handlers acquire lowering and
+  execution semantics. *Withdrawn*: the surface is removed. What is not coherent
+  is the present state, in which a program that appears to use algebraic effects
+  type-checks.
+- **If implemented, which discipline?** One-shot or multi-shot continuations;
+  deep or shallow handlers; whether a handler may itself perform effects. None
+  of these is decidable from the code, because no execution exists to read them
+  off.
+
+## Claims forbidden
+
+- Do not describe Sounio as having algebraic effect handlers. The surface exists
+  and reaches no backend.
+- Do not cite `examples/effects.sio` or `examples/effects/*.sio` as evidence
+  that handlers run. That a file uses the syntax says only that the syntax
+  parses.

--- a/docs/spec/S08_EPISTEMIC_VALUES.md
+++ b/docs/spec/S08_EPISTEMIC_VALUES.md
@@ -62,6 +62,47 @@ observation:
   the third is the one carrying confidence. Whatever 8.5 decides about where
   provenance lives, the repository currently answers it two ways at once.
 
+### 8.2.1 The three are not three representations. They are two layers and a copy.
+
+Reading the compiler type's members closes the question the table appears to
+open. Every member of `KnowledgeTypeInfo` is `Option<...>`, and none is a
+number:
+
+| Member | What it is |
+|---|---|
+| `epsilon: Option<EpsilonBound>` | a **predicate**: `EpsilonBound { op: CompareOp, value: f64 }`, `op` ∈ {`<`, `≤`, `=`, `≥`, `>`} |
+| `validity: Option<ValidityCondition>` | a predicate with an optional expression |
+| `provenance: Option<AstProvenanceKind>` | a six-way enum: `Derived`, `Source`, `Computed`, `Literature`, `Measured`, `Input` |
+| `proof_constraints` | a list of constraints |
+
+So the compiler's `Knowledge<T>` is a **type-level claim** — predicates and
+provenance, discharged at compile time. The stdlib's `Epistemic` is a
+**value-level representation** — the numbers that flow at run time. They are not
+competing encodings of the same thing; they sit at different levels, and the
+relation between them is that `epsilon` is a **predicate the runtime variance
+must satisfy**. Bridging the two needs a coverage convention, which is what GUM
+already standardises and what `gum_k95` already computes.
+
+Two things follow, and they point in opposite directions.
+
+**In the compiler's favour.** Every member being `Option<...>` is
+`SOUNIO-NO-VERSUS-UNKNOWN` done correctly: *no epsilon was declared* is `None`,
+structurally distinct from every declared bound. The checker reinforces it with
+a sentinel outside the domain — `epistemic_epsilon: 0.0 - 1.0` (that is, `-1.0`)
+at six sites in `self-hosted/check/check.sio`. A negative epsilon is a value no
+correct bound can take, which is exactly the sentinel the concept sanctions. The
+compiler already solves for `epsilon` the problem the stdlib leaves open for
+`confidence`.
+
+**Against the examples.** Shape 3's `label: i64` is documented in-file as
+`0=measured, 1=asserted, 2=constant` — **three** tags. `AstProvenanceKind` has
+**six**, and two of the three names (`asserted`, `constant`) do not appear in it
+at all. Shape 3 is therefore not a simplification of the compiler's provenance;
+it is an **independent, smaller, differently-named provenance vocabulary**, and
+it is the vocabulary the dissertation surface uses. A value labelled `constant`
+in `darwin_epistemic_pbpk.sio` has no image in the provenance the compiler can
+reason about.
+
 Other measured facts about shape 2, which is the shape the stdlib exposes:
 
 - **Not linear.** Dropping one requires nothing.
@@ -124,11 +165,16 @@ A rule can be argued away one at a time. A definition has to be replaced whole.
 
 ## 8.5 Undefined — rulings owed
 
-- **Which of the three shapes is the epistemic value.** Measured in 8.2: the
-  compiler type, the stdlib struct and the example struct differ in members and
-  in the meaning of their third field. A specification cannot rule on the
-  invariants of a type that is declared three incompatible ways. This ruling is
-  **prior to every other ruling in 8.5** and is owed first.
+- **The layering, now that 8.2.1 has narrowed it.** The question is not "which
+  of three shapes wins" — the compiler type and the stdlib struct sit at
+  different levels and do not compete. What is owed is narrower and answerable:
+  (a) that `epsilon` is normatively a **predicate over** the runtime variance
+  rather than an alternative to it; (b) which coverage convention discharges the
+  predicate (GUM `k` is the candidate, and `gum_k95` already computes it); and
+  (c) that shape 3's three-tag `label` vocabulary is **withdrawn** in favour of
+  `AstProvenanceKind`, since two of its three tags name provenances the compiler
+  cannot represent. (c) touches the dissertation surface and is not a
+  documentation change.
 
 - **Where "no confidence claim made" lives.** Ruled 2026-08-19: `1000` is
   **certainty** and `0` is **no confidence**, so the scale `0..1000` is fully

--- a/docs/spec/S08_EPISTEMIC_VALUES.md
+++ b/docs/spec/S08_EPISTEMIC_VALUES.md
@@ -31,21 +31,60 @@ stipulated beside it.
 
 ## 8.2 What is measured today
 
-`origin/main`, 2026-08-19:
+`origin/main`, 2026-08-19. **There is no single epistemic value.** The name
+denotes three structurally different objects, and they disagree about what an
+epistemic value even carries.
 
-    struct Knowledge<T> { value: T, variance: f64, confidence: i64 }
+| # | Definition site | Members | Provenance | Confidence |
+|---|---|---|---|---|
+| 1 | Compiler, `self-hosted/parser/ast.sio:492` (`KnowledgeTypeInfo`) | `inner_type`, `epsilon`, `validity`, `provenance`, `proof_constraints` | **member** | **absent** |
+| 2 | `stdlib/epistemic/knowledge.sio:63` (`Epistemic`) | `val: f64`, `variance: f64`, `confidence: i64` | absent | 0–1000 |
+| 3 | `examples/` ×4 (`Epistemic`) | `value: f64`, `variance: f64`, `label: i64` | **as a tag** | absent |
+
+Shape 3 is not a stray: it is what `examples/science/darwin_epistemic_pbpk.sio`
+uses — the dissertation surface. The four occurrences are independent
+re-declarations of the same name in separate files, not one imported type.
+
+Three consequences follow directly, and each is a defect rather than an
+observation:
+
+- **The same name, the same field position, opposite meanings.** In shape 3
+  `label: 0` annotates `measured` — the *strongest* provenance. In shape 2
+  `confidence: 0` denotes *no confidence* — the weakest possible claim. A value
+  moving between the two shapes by position, or a reader carrying a habit from
+  one file to another, inverts the epistemic claim without any diagnostic.
+- **`Knowledge<T>` as the compiler knows it has neither `variance` nor
+  `confidence`.** It carries `epsilon`, `validity`, `provenance` and
+  `proof_constraints`. The 0–1000 scale — including the endpoint ruled on in
+  8.3.5 — exists only in library and example code, and the compiler's own
+  epistemic type has no field for it to occupy.
+- **Provenance is a member in two of the three and absent from the third**, and
+  the third is the one carrying confidence. Whatever 8.5 decides about where
+  provenance lives, the repository currently answers it two ways at once.
+
+Other measured facts about shape 2, which is the shape the stdlib exposes:
 
 - **Not linear.** Dropping one requires nothing.
-- **No provenance field.** `stdlib/epistemic/README.md` draws
-  `└── provenance: Provenance`; the struct has no such member.
 - `confidence` is an integer **0–1000**, clamped at construction
   (`ep_clamp_conf`, `stdlib/epistemic/knowledge.sio:52`).
-- The scale already carries undocumented meaning: `ep_exact` constructs
-  `variance: 0.0, confidence: 1000`; `ep_measured` constructs `confidence: 900`.
-- `.value` occurs **2,278 times** across `stdlib/` and `examples/`.
+- The scale carries meaning nothing records: `ep_certain` (**not** `ep_exact`,
+  which does not exist) constructs `variance: 0.0, confidence: 1000`;
+  `ep_measured` constructs `confidence: 900`. Neither 1000 nor 900 is derived
+  anywhere — 900 is a chosen constant with no stated basis.
+- `.value` occurs **2,278 times** across `stdlib/` and `examples/` — but against
+  shape 3 and the compiler type, since shape 2 spells the member `val`.
 
-So the implementation is a record today, and the ruling is a change of kind, not
-a description of the present. That gap is the section's work.
+So the implementation is not merely "a record where the ruling wants a type".
+It is **three records that do not agree**, none of which is the ruled type. That
+gap is the section's work.
+
+> **Correction, 2026-08-19.** An earlier revision of this section stated the
+> measured type as `struct Knowledge<T> { value: T, variance: f64, confidence:
+> i64 }` and named its constructor `ep_exact`. Neither exists. The struct was a
+> merge of shapes 2 and 3 that is declared nowhere, and the constructor is
+> `ep_certain`. The error is recorded rather than silently overwritten because
+> this section's own subject is what happens when a claim is separated from what
+> justifies it.
 
 ## 8.3 Invariants entailed by the ruling
 
@@ -84,6 +123,12 @@ separately contestable and separately forgettable. After it they are
 A rule can be argued away one at a time. A definition has to be replaced whole.
 
 ## 8.5 Undefined — rulings owed
+
+- **Which of the three shapes is the epistemic value.** Measured in 8.2: the
+  compiler type, the stdlib struct and the example struct differ in members and
+  in the meaning of their third field. A specification cannot rule on the
+  invariants of a type that is declared three incompatible ways. This ruling is
+  **prior to every other ruling in 8.5** and is owed first.
 
 - **Where "no confidence claim made" lives.** Ruled 2026-08-19: `1000` is
   **certainty** and `0` is **no confidence**, so the scale `0..1000` is fully

--- a/docs/spec/S08_EPISTEMIC_VALUES.md
+++ b/docs/spec/S08_EPISTEMIC_VALUES.md
@@ -1,0 +1,122 @@
+<!-- docs:meta
+topic_id: repo.docs.spec.s08-epistemic-values
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: claude-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.spec.s08-epistemic-values
+-->
+
+# §8 — Epistemic Values
+
+Spec-Section: `SOUNIO-SPEC-08`
+Frame: `docs/spec/E2E_SPECIFICATION_FRAME.md`
+
+Status: **Hypothesis.** The normative statement below is a founder ruling of
+2026-08-19. No conformance test exists yet; the section reaches `Executable`
+only when one runs on **both** engines with a negative control
+(`SOUNIO-GATING-ENGINE`, `SOUNIO-NO-VERSUS-UNKNOWN`).
+
+## 8.1 Normative
+
+> **`Knowledge<T>` is a type with invariants, not a record with three fields.**
+
+Founder ruling. The distinction is the whole section: a record exposes fields,
+and a type exposes **operations that preserve its invariants**. What is written
+`k.value` is therefore an *operation on an epistemic value*, not a field access
+that happens to be spelled with a dot.
+
+Everything else in this section follows from that sentence rather than being
+stipulated beside it.
+
+## 8.2 What is measured today
+
+`origin/main`, 2026-08-19:
+
+    struct Knowledge<T> { value: T, variance: f64, confidence: i64 }
+
+- **Not linear.** Dropping one requires nothing.
+- **No provenance field.** `stdlib/epistemic/README.md` draws
+  `└── provenance: Provenance`; the struct has no such member.
+- `confidence` is an integer **0–1000**, clamped at construction
+  (`ep_clamp_conf`, `stdlib/epistemic/knowledge.sio:52`).
+- The scale already carries undocumented meaning: `ep_exact` constructs
+  `variance: 0.0, confidence: 1000`; `ep_measured` constructs `confidence: 900`.
+- `.value` occurs **2,278 times** across `stdlib/` and `examples/`.
+
+So the implementation is a record today, and the ruling is a change of kind, not
+a description of the present. That gap is the section's work.
+
+## 8.3 Invariants entailed by the ruling
+
+These follow from 8.1. Each is normative; none is implemented.
+
+1. **An epistemic value is inseparable from its uncertainty.** `value` and
+   `variance` are not independently meaningful members. Obtaining one without
+   the other is an operation, and the operation is not silent.
+2. **Projection is an operation with a rule.** `k.value` yields a value that
+   carries the mark of having been separated (`SOUNIO-EPISTEMIC-ERASURE`).
+   The mark is inferred and propagates; the programmer never writes it.
+3. **Re-attachment requires an act.** Uncertainty is restored only by
+   `attest(v, uncertainty:, because:)`, whose floor is a discharged proof
+   obligation (`SOUNIO-JUSTIFICATION`). There is no coercion.
+4. **Decisions read the invariant, not the number.** `Admissible<T>` requires
+   support that has not been degraded without justification
+   (`SOUNIO-ADMISSIBILITY`). Deciding is the fifth sink.
+5. **`confidence` is bounded and its endpoints mean something.** `0` and `1000`
+   are not merely clamps. What they denote is **undefined** — see 8.5.
+
+## 8.4 What the ruling buys
+
+Before it, four registered concepts were four independent decisions, each
+separately contestable and separately forgettable. After it they are
+**consequences of one definition**:
+
+| concept | becomes |
+|---|---|
+| `SOUNIO-EPISTEMIC-ERASURE` | the rule of the projection operation |
+| `SOUNIO-JUSTIFICATION` | the sole re-entry, with its floor |
+| `SOUNIO-PROVENANCE` | a member the invariant requires, not an addition |
+| `SOUNIO-ADMISSIBILITY` | a reader of the invariant at the point of action |
+
+A rule can be argued away one at a time. A definition has to be replaced whole.
+
+## 8.5 Undefined — rulings owed
+
+- **The meaning of `confidence = 1000`.** `ep_exact` uses it for an exact value
+  with zero variance. Whether it denotes *certainty*, *maximum representable
+  confidence*, or *no confidence claim made* is unstated, and the three differ
+  where it matters (`SOUNIO-NO-VERSUS-UNKNOWN`).
+- **Whether `variance = 0.0` is legitimate.** An exact value has no variance; a
+  degraded value reports none. The two currently print identically. Whether the
+  type admits a genuine zero, or reserves it, is owed.
+- **Where provenance lives.** `SOUNIO-PROVENANCE` rules class-in-the-type and
+  instance-as-id; neither exists in the struct.
+- **Linearity.** Whether `Knowledge<T>` is affine (dropping is an act) is not
+  settled; the erasure ruling addressed projection, not discard.
+- **`T`'s obligations.** What a type must satisfy to be carried — whether any
+  `T` may be, or only those with defined arithmetic — is unstated.
+
+## 8.6 Conformance
+
+The section is `Executable` when, on **both** engines:
+
+- a programme that constructs, propagates and reads uncertainty through a call
+  produces the specified variance, and
+- a programme that projects and then reads uncertainty is **refused** with a
+  named diagnostic, and
+- the negative control shows the refusal firing for the stated reason and not
+  from name-ignorance.
+
+It is **not** `Claim-ready` on one engine. The current state is the reason: the
+FO matrix gives `ADD3 = 0.000000` on Madaros and passing tests on lean_single
+for the same source (#1964).
+
+## Claims Forbidden
+
+- Do not read 8.1 as a description of the implementation. The struct is a
+  record today; the ruling is what it must become.
+- Do not treat 8.3 as implemented. None of the five invariants is enforced.
+- Do not fill 8.5 by inference. Those are rulings owed, and a plausible answer
+  written there is the failure this corpus exists to prevent.
+- Do not cite the `confidence` endpoints as meaning anything until 8.5 is ruled.

--- a/docs/spec/S08_EPISTEMIC_VALUES.md
+++ b/docs/spec/S08_EPISTEMIC_VALUES.md
@@ -103,6 +103,41 @@ it is the vocabulary the dissertation surface uses. A value labelled `constant`
 in `darwin_epistemic_pbpk.sio` has no image in the provenance the compiler can
 reason about.
 
+### 8.2.2 The cost of withdrawing the `label` vocabulary
+
+Measured on `origin/main`, 2026-08-19, because the withdrawal proposed in 8.5(c)
+touches the dissertation surface and its cost must precede its ruling.
+
+**Footprint.** Four files, thirteen constructions, **two reads**. The four files
+each carry an identical copy-pasted three-constructor preamble (`label: 0`,
+`label: 1`, `label: 2`); twelve of the thirteen constructions are inside those
+helpers. The only reads are `examples/epistemic_quantum_vqe.sio:247-248`, two
+equality comparisons. **`darwin_epistemic_pbpk.sio` — the dissertation surface —
+never reads `.label` at all.** There, the tag is write-only metadata.
+
+**The tag conflates two axes, and one of them is already recorded elsewhere.**
+Every one of the four `label: 2` sites is character-for-character the same
+literal:
+
+    Epistemic { value: value, variance: 0.0, label: 2 }
+
+`2 = constant` is not a provenance. It is a claim about the variance, and the
+claim is already made in the adjacent field of the same literal. Only `0 =
+measured` and `1 = asserted` carry provenance.
+
+**Therefore the withdrawal is not lossy — it removes a redundancy.**
+
+| tag | carries | image under withdrawal |
+|---|---|---|
+| `0` measured | provenance | `AstProvMeasured` — exact |
+| `1` asserted | provenance | `AstProvInput` or `AstProvSource` — **owed**, the only real decision |
+| `2` constant | *variance*, not provenance | already expressed by `variance: 0.0`; no provenance image needed |
+
+The residue is one mapping decision — where an *asserted* value sits among
+`Input` and `Source` — plus two equality comparisons in a file that is not the
+dissertation. `label: 2` needs no image at all, because it never carried
+provenance to lose.
+
 Other measured facts about shape 2, which is the shape the stdlib exposes:
 
 - **Not linear.** Dropping one requires nothing.
@@ -143,6 +178,20 @@ These follow from 8.1. Each is normative; none is implemented.
 4. **Decisions read the invariant, not the number.** `Admissible<T>` requires
    support that has not been degraded without justification
    (`SOUNIO-ADMISSIBILITY`). Deciding is the fifth sink.
+6. **`epsilon` is a predicate over the runtime variance, not an alternative to
+   it.** Founder ruling, 2026-08-19. The compiler's `Knowledge<T>` states a
+   bound; the value-level representation computes a variance; the bound is
+   something the variance is **checked against**. The two levels therefore do
+   not compete for the same role, and no unification of the two declarations is
+   required by this section.
+
+7. **The predicate is discharged by the GUM coverage convention.** Founder
+   ruling, 2026-08-19. `k` is the bridge from a computed variance to the
+   expanded uncertainty the bound compares against, and `gum_k95` already
+   computes it. Which `k` a given `EpsilonBound` implies is a matter for the
+   conformance test, not a further ruling; what is settled is that the bridge is
+   GUM's and not an invention of this specification.
+
 5. **`confidence = 1000` denotes certainty.** Founder ruling, 2026-08-19. It is
    not "maximum representable" and not "no claim made". `ep_exact` constructing
    an exact value with `variance: 0.0, confidence: 1000` is therefore correct
@@ -165,16 +214,8 @@ A rule can be argued away one at a time. A definition has to be replaced whole.
 
 ## 8.5 Undefined — rulings owed
 
-- **The layering, now that 8.2.1 has narrowed it.** The question is not "which
-  of three shapes wins" — the compiler type and the stdlib struct sit at
-  different levels and do not compete. What is owed is narrower and answerable:
-  (a) that `epsilon` is normatively a **predicate over** the runtime variance
-  rather than an alternative to it; (b) which coverage convention discharges the
-  predicate (GUM `k` is the candidate, and `gum_k95` already computes it); and
-  (c) that shape 3's three-tag `label` vocabulary is **withdrawn** in favour of
-  `AstProvenanceKind`, since two of its three tags name provenances the compiler
-  cannot represent. (c) touches the dissertation surface and is not a
-  documentation change.
+- **(c) Withdrawal of the `label` vocabulary — cost measured, ruling owed.**
+  See 8.2.2. (a) and (b) are ruled in 8.3.6 and 8.3.7.
 
 - **Where "no confidence claim made" lives.** Ruled 2026-08-19: `1000` is
   **certainty** and `0` is **no confidence**, so the scale `0..1000` is fully

--- a/docs/spec/S08_EPISTEMIC_VALUES.md
+++ b/docs/spec/S08_EPISTEMIC_VALUES.md
@@ -138,6 +138,32 @@ The residue is one mapping decision — where an *asserted* value sits among
 dissertation. `label: 2` needs no image at all, because it never carried
 provenance to lose.
 
+### 8.2.3 Three of the six provenance kinds cannot be written
+
+`AstProvenanceKind` declares six kinds. `self-hosted/parser/types.sio:1107-1117`
+matches exactly three token kinds — `TokenKind::Derived`, `TokenKind::Computed`,
+`TokenKind::Measured` — and constructs the corresponding three. `AstProvSource`,
+`AstProvLiterature` and `AstProvInput` occur **once each** in the whole of
+`self-hosted/parser/`: their own declaration. They are declared and unwritable.
+
+This is not `Reserved` in the sense of `MATURITY_LADDER`. A reserved name is
+refused with a named diagnostic. These three are not refused — there is simply
+no syntax that reaches them, and nothing says so.
+
+**The parse loop's fallthrough makes it silent.** The same block ends:
+
+    } else {
+        // Unknown component — skip
+        p = p.advance()
+    }
+
+An unrecognised component inside a `Knowledge<...>` annotation is **discarded
+without a diagnostic**. Writing a provenance the compiler declares but cannot
+parse yields a value with *no* provenance and no error — which is
+`SOUNIO-NO-VERSUS-UNKNOWN` at the point where provenance is claimed. Silent,
+reachable, and ungated: the `SOUNIO-S-G-R` criterion is met in full and a gate is
+required regardless of any ruling in this section.
+
 Other measured facts about shape 2, which is the shape the stdlib exposes:
 
 - **Not linear.** Dropping one requires nothing.
@@ -214,8 +240,12 @@ A rule can be argued away one at a time. A definition has to be replaced whole.
 
 ## 8.5 Undefined — rulings owed
 
-- **(c) Withdrawal of the `label` vocabulary — cost measured, ruling owed.**
-  See 8.2.2. (a) and (b) are ruled in 8.3.6 and 8.3.7.
+- **(c) Withdrawal of the `label` vocabulary — ruled, and BLOCKED on a language
+  change.** Founder ruling, 2026-08-19: withdraw the vocabulary; `asserted`
+  becomes `Input`. The ruling is right and cannot be executed as written:
+  `AstProvInput` has **no surface syntax** (8.2.3). Executing it requires giving
+  `input` a keyword, which is a language change and a separate decision.
+  Blocked-On: provenance keyword coverage.
 
 - **Where "no confidence claim made" lives.** Ruled 2026-08-19: `1000` is
   **certainty** and `0` is **no confidence**, so the scale `0..1000` is fully

--- a/docs/spec/S08_EPISTEMIC_VALUES.md
+++ b/docs/spec/S08_EPISTEMIC_VALUES.md
@@ -63,8 +63,10 @@ These follow from 8.1. Each is normative; none is implemented.
 4. **Decisions read the invariant, not the number.** `Admissible<T>` requires
    support that has not been degraded without justification
    (`SOUNIO-ADMISSIBILITY`). Deciding is the fifth sink.
-5. **`confidence` is bounded and its endpoints mean something.** `0` and `1000`
-   are not merely clamps. What they denote is **undefined** — see 8.5.
+5. **`confidence = 1000` denotes certainty.** Founder ruling, 2026-08-19. It is
+   not "maximum representable" and not "no claim made". `ep_exact` constructing
+   an exact value with `variance: 0.0, confidence: 1000` is therefore correct
+   rather than incidental. `0` is the opposite endpoint: no confidence.
 
 ## 8.4 What the ruling buys
 
@@ -83,10 +85,14 @@ A rule can be argued away one at a time. A definition has to be replaced whole.
 
 ## 8.5 Undefined — rulings owed
 
-- **The meaning of `confidence = 1000`.** `ep_exact` uses it for an exact value
-  with zero variance. Whether it denotes *certainty*, *maximum representable
-  confidence*, or *no confidence claim made* is unstated, and the three differ
-  where it matters (`SOUNIO-NO-VERSUS-UNKNOWN`).
+- **Where "no confidence claim made" lives.** Ruled 2026-08-19: `1000` is
+  **certainty** and `0` is **no confidence**, so the scale `0..1000` is fully
+  occupied by meanings. A value constructed without anyone having assessed
+  confidence must still carry a number — and every number in range is an
+  assertion nobody made. `SOUNIO-NO-VERSUS-UNKNOWN` names the exit: *the defect
+  is the collision, not the sentinel; a sentinel no correct value can occupy is
+  fine.* The sentinel must therefore live **outside** `0..1000`, or the type
+  must make an unassessed value unconstructible. Which of the two is **owed**.
 - **Whether `variance = 0.0` is legitimate.** An exact value has no variance; a
   degraded value reports none. The two currently print identically. Whether the
   type admits a genuine zero, or reserves it, is owed.


### PR DESCRIPTION
Founder, 2026-08-19: *the seed of Madaros being lean_single is the principal culprit; things will only move with an end-to-end spec.*

**This is not the specification.** It is the frame the specification must fill, the method for filling it, and an honest inventory of what is decided, contested, or missing.

## The diagnosis, supported by `CLAUDE.md` itself

> **Fixed-point scope:** `make build` verifies the fixed point over `lean_single.sio` (the seed), **not** over `main.sio`/Madaros.

So: `lean_single` is the seed, is fixed-point verified, and is what CI runs (#1964). Madaros is built *by* it, is canonical for users, and has **no fixed point**.

**What is verified is not what is used, and what is used is built by what is verified.**

## Why this document exists

> A divergence measurement establishes **where** two engines differ. It cannot establish **which is correct**. Without a specification, "divergence" has no referent — one can only say *they differ*, and the choice becomes preference.

**A specification is what makes one of two engines wrong rather than merely different.**

## Seventeen sections, with measured status

6 `undefined` · 5 `contested` · 6 measured but unspecified. Highlights:

| § | | status |
|---|---|---|
| 3 | eight type-kind enums, 238 variants, 0 homonyms | measured, unspecified |
| 7 | handlers — **the CPS path has no execution semantics** | undefined |
| 8 | `Knowledge<T>` not linear, no provenance field, `.value` unmarked | measured, contested |
| 9 | `emit_variance_independent_product` assumes independence, nothing checks it | contested |
| 11 | ChEBI/GO/HPO/LOINC + reasoner; TBox present, **ABox absent** | measured, incomplete |
| 17 | the conformance suite runs **lean_single**, not the canonical compiler | contested |

**`contested` means a ruling is owed** — the spec's job is to say which engine is right, not to describe both.

## Method

Derive from measurement with receipts, never invent. Where engines disagree, **the founder rules** and the losing engine acquires a defect with an owner — the only step a measurement cannot perform. A section is `Executable` only when a conformance test runs on **both** engines with a negative control. **Nothing is `Claim-ready` on one engine**, which is exactly the defect that produced this document.

## Semantic declaration

- **Concept-IDs**: introduces `SOUNIO-E2E-SPEC-FRAME`. References `SOUNIO-GATING-ENGINE`, `SOUNIO-NO-VERSUS-UNKNOWN`, `MATURITY_LADDER`, `SOUNIO-EFFORT-LOCATION`.
- **Intent-Preserved**: `CLAUDE.md`'s fixed-point scope note, quoted rather than paraphrased.
- **Transformation**: documentation plus filesystem-derived registry sync. Zero lines of `self-hosted/`, `stdlib/`, `scripts/ci/` or `.github/`.
- **Claims-Introduced**: the status column, each row traceable to a receipt landed or open today.
- **Claims-Forbidden**: this is **not** the specification — every section is `undefined` or worse until filled by the method. The status column is **not** coverage: it records what a receipt exists for, not what is correct. Seventeen is **not** complete. And `contested` does **not** mean both are acceptable — it means a ruling is owed.
- **Authoritative-Only-If**: **Garden**, and it stays there until at least one section carries a normative statement plus a conformance test both engines are run against.
