### PR TITLE
docs(concepts): ONTOLOGICAL-VALIDATION — founder quotation rendered into English

### DIFF
--- a/docs/internal/concepts/ontological-validation.md
+++ b/docs/internal/concepts/ontological-validation.md
@@ -19,8 +19,12 @@ a reader or a gate can find it.
 
 Stated in session, 2026-08-19:
 
-> **"praticamente tudo deve ser ontologicamente validado… isso faz parte da alma
-> do Sounio"**
+> **"Practically everything must be ontologically validated — that is part of
+> Sounio's soul."**
+>
+> <sub>Founder, in Portuguese: *"praticamente tudo deve ser ontologicamente
+> validado… isso faz parte da alma do Sounio"*. The English rendering above is
+> the normative text; the original is retained as attribution.</sub>
 
 Not a feature. A commitment about what it means for a Sounio program to be
 correct: a term is not merely well-typed, it is **answerable to a model of what


### PR DESCRIPTION
The concept document states its founding principle in a Portuguese block quotation. Founder directive: nothing in the specification or the language documentation is written in Portuguese. `CLAUDE.md` §9 separately permits preserving quoted source text.

Both hold at once only if the **English rendering is the normative line** and the original is retained as attribution. That is this change — one block quotation, no other edit.

Found by the twelve-concept cross-check, which read the corpus for contradiction and reported this as a language residue rather than a substantive conflict. The earlier language sweep missed it: it scanned authored prose and skipped block quotations.