### PR TITLE
docs(ci): land WS-C staging manifest and SOIR gate

### DIFF
--- a/docs/architecture/WS_C_PR2_STAGING_MANIFEST.md
+++ b/docs/architecture/WS_C_PR2_STAGING_MANIFEST.md
@@ -1,0 +1,111 @@
+<!-- docs:meta
+topic_id: repo.docs.architecture.ws-c-pr2-staging-manifest
+authority: repo_only
+audience: users
+last_validated: 2026-08-16
+validated_by: codex-2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.architecture.ws-c-pr2-staging-manifest
+-->
+
+# WS-C PR2 Staging Manifest
+
+Date: 2026-08-16
+
+Source of truth: `docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md` on `origin/main` after PR #1751. Current refs used while authoring this manifest:
+
+- `origin/main`: `6f2c4e2461cc5da3a5952e1335d46b89e3160a4b`
+- `origin/canon/madaros-v2-sota`: `97b525949765980406a4fefa7f533e9db89721e1`
+
+## Purpose
+
+PR2 should land the reviewable gate/payload bulk from the C1 census without touching the occupied `self-hosted/` writer surfaces and without violating C3 shared-oracle ownership.
+
+Use `scripts/dev/ws_c_pr2_stage_payload.sh` as the executable staging manifest. It copies files from `origin/canon/madaros-v2-sota` into a target worktree in ordered groups, refuses to overwrite existing different content, and fails if a `tools/eisa/` or `stdlib/eisa/` path already exists on `origin/main`.
+
+Default PR2 staging mode is the **49-file non-enir payload**:
+
+```bash
+bash scripts/dev/ws_c_pr2_stage_payload.sh --target /path/to/pr2-worktree --mode pr2
+```
+
+Full transitive reconstruction mode is available for audits or fresh stack rebuilds:
+
+```bash
+bash scripts/dev/ws_c_pr2_stage_payload.sh --target /path/to/worktree --mode all63
+```
+
+The `all63` mode includes the 14 `self-hosted/enir/` files that PR1 owns. Do not use `all63` for PR2 unless the PR2 branch is intentionally reconstructing the whole stack in an isolated worktree and has the relevant writer clearance.
+
+## Review Chunks
+
+Recommended commit or review order:
+
+| Group | Count | PR2 default | Provenance |
+| --- | ---: | --- | --- |
+| `pr1-enir` | 14 | no | Common ENIR driver closure from the C1 census; PR1 prerequisite. |
+| `e1-shadow` | 2 | yes | E1 shadow gate script and Python verifier. |
+| `e2a-lowering` | 2 | yes | E2A lowering gate and verifier; regression chain includes E1. |
+| `e2b-cfg` | 3 | yes | E2B CFG gate/verifier plus `eisa_enir_v1_oracle.sio`. |
+| `e2c-fuel-blockargs` | 3 | yes | E2C fuel/blockargs gate/verifier plus `eisa_enir_v1_loop_oracle.sio`. |
+| `e2d-rump-dd` | 3 | yes | E2D rump DD gate/verifier plus `eisa_enir_v1_rump_dd.eisa`. |
+| `e2e-qd128-arithmetic` | 8 | yes | E2E qd128 gate/verifier plus six arithmetic fixtures from verifier `PROGRAMS`. |
+| `e2f-rump-qd` | 3 | yes | E2F rump qd gate/verifier plus `eisa_enir_v2_rump_qd.eisa`. |
+| `e2g-fuel-control-frail` | 5 | yes | E2G gate/verifier plus fuel, loop, and frail fixtures from verifier `PROGRAMS`. |
+| `e2h-memory-move-poison` | 5 | yes | E2H gate/verifier plus memory, move, and poison fixtures from verifier `PROGRAMS`. |
+| `e3a-mir-qd128` | 2 | yes | E3A MIR qd128 gate/verifier; reuses E2E arithmetic fixtures. |
+| `e3b-mir-memory` | 2 | yes | E3B MIR memory gate/verifier; reuses E2H memory fixtures. |
+| `e3c-cfg-memory-ssa` | 4 | yes | E3C CFG memory SSA gate/verifier plus memory-phi fixtures. |
+| `e3d-multipred-ssa` | 4 | yes | E3D multipred scalar/memory SSA gate/verifier plus join fixtures. |
+| `e3e-equal-event` | 3 | yes | E3E equal-value distinct-event gate plus then/else fixtures. |
+
+PR2 default total: **49 files**. Full transitive total: **63 files**.
+
+## C2 BASE_REF Re-anchor
+
+The copied gate scripts still carry frontier-era `BASE_REF` assumptions. PR2 must apply the C2 decision from `docs/architecture/MIR_PORT_PLAN.md` to all 14 gate scripts as they land:
+
+- Local/cascade regression calls use `HEAD`, matching the E3D precedent (`E3C_BASE_REF=HEAD`).
+- Clean-checkout and CI frozen-surface checks use a PR-range base derived from `git merge-base HEAD "${ENIR_GATE_BASE:-origin/main}"`.
+- Environment overrides such as `E1_BASE_REF`, `E2*_BASE_REF`, `E3*_BASE_REF`, and `ENIR_GATE_BASE` remain available for emergency pins.
+
+This manifest only stages the files. It does not rewrite the 14 gate scripts.
+
+## C3 Shared-Oracle Boundary
+
+WS-F owns `tools/eisa` and `stdlib/eisa` sources. PR2 may add frontier-only files that are absent from `origin/main`, but must not modify any `tools/eisa/` or `stdlib/eisa/` file that already exists on `origin/main`.
+
+Present-but-changed watchlist from the census:
+
+- `tools/eisa/eisa_evm_run.sio`
+- `stdlib/math/qd128.sio`
+- `bin/souc-lean-single-x86_64`
+- `scripts/dev/souc-build-lock.sh`
+- `self-hosted/compiler/main.sio`
+
+Only `tools/eisa/eisa_evm_run.sio` is a shared oracle source in the C3 sense. It is **not** in the staging add-list. Any gate behavior depending on frontier semantics of that file must be revalidated against MAIN's oracle behavior rather than silently carrying the frontier version.
+
+## Exact Ordered File List
+
+The script is the executable copy source. To view the exact ordered list with per-file provenance:
+
+```bash
+bash scripts/dev/ws_c_pr2_stage_payload.sh --list --mode all63
+```
+
+To view only the PR2 default list:
+
+```bash
+bash scripts/dev/ws_c_pr2_stage_payload.sh --list --mode pr2
+```
+
+To stage a single review chunk:
+
+```bash
+bash scripts/dev/ws_c_pr2_stage_payload.sh --target /path/to/pr2-worktree --group e2b-cfg
+```
+
+## Exclusions
+
+- `tools/eisa/eisa_enir_c2_rump.eisa` remains excluded from the E1/E2/E3 add-list; it belongs to the C2 gate, outside this PR2 payload.
+- Runtime-generated `$TMP_DIR/*.eisa` negative fixtures are not repository payload.
+- Existing main files under `tools/eisa/` or `stdlib/eisa/` are not copied by this manifest.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -55,6 +55,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.architecture.truth-layers | repo_only | docs/architecture/truth-layers.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.architecture.ws-c-d-preflight-review-2026-08-16 | repo_only | docs/architecture/WS_C_D_PREFLIGHT_REVIEW_2026-08-16.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.architecture.ws-c-pr1-payload-census | repo_only | docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.architecture.ws-c-pr2-staging-manifest | repo_only | docs/architecture/WS_C_PR2_STAGING_MANIFEST.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.archived.announcement | archived | docs/archived/ANNOUNCEMENT.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.archived.architecture | archived | docs/archived/ARCHITECTURE.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.archived.compiler-roadmap | archived | docs/archived/COMPILER_ROADMAP.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -754,6 +754,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.architecture.ws-c-pr2-staging-manifest",
+      "collection": "repo",
+      "repo_doc_path": "docs/architecture/WS_C_PR2_STAGING_MANIFEST.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.archived.announcement",
       "collection": "repo",
       "repo_doc_path": "docs/archived/ANNOUNCEMENT.md",

--- a/scripts/ci/soir_roundtrip_gate.sh
+++ b/scripts/ci/soir_roundtrip_gate.sh
@@ -1,0 +1,360 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+COMPILER_CLI="${SOUC_BIN:-$ROOT/bin/madaros}"
+RUNTIME_TIMEOUT_SECONDS="${SOIR_ROUNDTRIP_RUNTIME_TIMEOUT_SECONDS:-20}"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/sounio-soir-roundtrip.XXXXXX")"
+
+cleanup() {
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'SOIR_ROUNDTRIP_FAIL reason=%s\n' "$1" >&2
+  exit 1
+}
+
+progress() {
+  printf 'SOIR_ROUNDTRIP_PROGRESS stage=%s subject=%s status=%s\n' \
+    "$1" "$2" "$3" >&2
+}
+
+[[ -x "$COMPILER_CLI" ]] || fail compiler_cli_missing
+command -v rg >/dev/null 2>&1 || fail rg_missing
+command -v awk >/dev/null 2>&1 || fail awk_missing
+command -v cksum >/dev/null 2>&1 || fail cksum_missing
+command -v timeout >/dev/null 2>&1 || fail timeout_missing
+[[ "$RUNTIME_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || fail runtime_timeout_invalid
+(( RUNTIME_TIMEOUT_SECONDS <= 60 )) || fail runtime_timeout_exceeds_cap_60
+
+SOIR_REF="docs/architecture/SOIR_REFERENCE.md"
+LEGACY_SERIALIZE="self-hosted/ir/serialize.sio"
+[[ -f "$SOIR_REF" ]] || fail soir_reference_missing
+[[ -f "$LEGACY_SERIALIZE" ]] || fail legacy_serialize_missing
+
+grep -Fq '# SOIR v1 Format Reference Card' "$SOIR_REF" || fail soir_reference_title_missing
+grep -Fq 'Magic: "SOIR"' "$SOIR_REF" || fail soir_reference_magic_missing
+grep -Fq 'serialize_ir_module' "$LEGACY_SERIALIZE" || fail serialize_ir_module_missing
+grep -Fq 'deserialize_ir_module' "$LEGACY_SERIALIZE" || fail deserialize_ir_module_missing
+
+coverage_census() {
+  local scope="$1"
+  shift
+  local total readers writers roundtrip
+  total="$(rg -i -n '(^|[^A-Za-z0-9_])soir([^A-Za-z0-9_]|$)|serialize_ir_module|deserialize_ir_module|soir_.*(reader|writer)|round.?trip' "$@" 2>/dev/null | wc -l | awk '{print $1}')"
+  readers="$(rg -i -n 'deserialize_ir_module|soir.*reader|reader.*soir' "$@" 2>/dev/null | wc -l | awk '{print $1}')"
+  writers="$(rg -i -n 'serialize_ir_module|soir.*writer|writer.*soir' "$@" 2>/dev/null | wc -l | awk '{print $1}')"
+  roundtrip="$(rg -i -n 'round.?trip' "$@" 2>/dev/null | wc -l | awk '{print $1}')"
+  printf 'SOIR_ROUNDTRIP_CENSUS scope=%s total=%s readers=%s writers=%s roundtrip_mentions=%s\n' \
+    "$scope" "$total" "$readers" "$writers" "$roundtrip"
+}
+
+coverage_census self_hosted self-hosted
+coverage_census tests tests
+coverage_census scripts_ci scripts/ci
+
+rg -n 'serialize_ir_module|deserialize_ir_module|soir_.*(reader|writer)|SOIR_.*(READER|WRITER)' \
+  self-hosted tests scripts/ci >"$TMP/soir-reader-writer-hits.txt" || true
+hit_count="$(wc -l <"$TMP/soir-reader-writer-hits.txt" | awk '{print $1}')"
+(( hit_count > 0 )) || fail reader_writer_census_empty
+printf 'SOIR_ROUNDTRIP_CENSUS_DETAIL hits=%s artifact=reader-writer-grep\n' "$hit_count"
+
+CORPUS="$TMP/soir-corpus.tsv"
+rg -n '^(pub(\([^)]*\))?[[:space:]]+)?fn[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\(' self-hosted/ir/*.sio \
+  | awk -F: '
+      BEGIN {
+        want["self-hosted/ir/ir.sio"] = 1
+        want["self-hosted/ir/serialize.sio"] = 1
+        want["self-hosted/ir/normalize.sio"] = 1
+        want["self-hosted/ir/optimize.sio"] = 1
+        want["self-hosted/ir/inline.sio"] = 1
+        want["self-hosted/ir/layout.sio"] = 1
+        want["self-hosted/ir/profile.sio"] = 1
+        want["self-hosted/ir/verify.sio"] = 1
+        want["self-hosted/ir/lower.sio"] = 1
+        want["self-hosted/ir/const_prop.sio"] = 1
+        want["self-hosted/ir/ssa.sio"] = 1
+        want["self-hosted/ir/tailcall.sio"] = 1
+      }
+      ($1 in want) && !seen[$1] {
+        line = $0
+        sub($1 ":" $2 ":", "", line)
+        sig = line
+        name = sig
+        sub(/^pub(\([^)]*\))?[[:space:]]+/, "", name)
+        sub(/^fn[[:space:]]+/, "", name)
+        sub(/[[:space:]]*\(.*/, "", name)
+        params = sig
+        sub(/^[^(]*\(/, "", params)
+        sub(/\).*/, "", params)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", params)
+        param_count = 0
+        if (length(params) > 0) {
+          param_count = split(params, tmp, ",")
+        }
+        effect_count = 0
+        if (sig ~ / with /) {
+          effects = sig
+          sub(/^.* with /, "", effects)
+          sub(/[[:space:]]*\{.*$/, "", effects)
+          gsub(/^[[:space:]]+|[[:space:]]+$/, "", effects)
+          if (length(effects) > 0) {
+            effect_count = split(effects, etmp, ",")
+          }
+        }
+        visibility = (sig ~ /^pub/) ? 1 : 0
+        returns = (sig ~ / -> /) ? 1 : 0
+        print $1 "\t" $2 "\t" visibility "\t" name "\t" param_count "\t" effect_count "\t" returns
+        seen[$1] = 1
+      }
+    ' >"$CORPUS"
+
+corpus_count="$(wc -l <"$CORPUS" | awk '{print $1}')"
+(( corpus_count >= 10 )) || fail representative_corpus_too_small
+
+ARRAY_FILE_IDS=""
+ARRAY_LINES=""
+ARRAY_VIS=""
+ARRAY_HASHES=""
+ARRAY_PARAMS=""
+ARRAY_EFFECTS=""
+ARRAY_RETURNS=""
+corpus_index=0
+while IFS=$'\t' read -r path line visibility name param_count effect_count returns; do
+  file_hash="$(printf '%s' "$path" | cksum | awk '{print $1}')"
+  name_hash="$(printf '%s' "$name" | cksum | awk '{print $1}')"
+  if [[ "$corpus_index" -gt 0 ]]; then
+    ARRAY_FILE_IDS+=", "
+    ARRAY_LINES+=", "
+    ARRAY_VIS+=", "
+    ARRAY_HASHES+=", "
+    ARRAY_PARAMS+=", "
+    ARRAY_EFFECTS+=", "
+    ARRAY_RETURNS+=", "
+  fi
+  ARRAY_FILE_IDS+="$file_hash"
+  ARRAY_LINES+="$line"
+  ARRAY_VIS+="$visibility"
+  ARRAY_HASHES+="$name_hash"
+  ARRAY_PARAMS+="$param_count"
+  ARRAY_EFFECTS+="$effect_count"
+  ARRAY_RETURNS+="$returns"
+  corpus_index=$((corpus_index + 1))
+done <"$CORPUS"
+
+SOURCE="$TMP/soir_roundtrip_witness.sio"
+ELF="$TMP/soir_roundtrip_witness.elf"
+BUILD_LOG="$TMP/soir_roundtrip_witness.build.log"
+RUN_LOG="$TMP/soir_roundtrip_witness.run.log"
+
+cat >"$SOURCE" <<EOF
+module soir_roundtrip_witness
+
+let CORPUS_COUNT: i64 = $corpus_count
+
+fn put_i64(buf: &![i8; 131072], pos: i64, val: i64) -> i64 with Mut, Panic, Div {
+    (*buf)[pos as usize] = (val & 255) as i8
+    (*buf)[(pos + 1) as usize] = ((val >> 8) & 255) as i8
+    (*buf)[(pos + 2) as usize] = ((val >> 16) & 255) as i8
+    (*buf)[(pos + 3) as usize] = ((val >> 24) & 255) as i8
+    (*buf)[(pos + 4) as usize] = ((val >> 32) & 255) as i8
+    (*buf)[(pos + 5) as usize] = ((val >> 40) & 255) as i8
+    (*buf)[(pos + 6) as usize] = ((val >> 48) & 255) as i8
+    (*buf)[(pos + 7) as usize] = ((val >> 56) & 255) as i8
+    pos + 8
+}
+
+fn get_i64(buf: &[i8; 131072], pos: i64) -> (i64, i64) with Panic, Div {
+    let b0 = ((*buf)[pos as usize] as i64) & 255
+    let b1 = ((*buf)[(pos + 1) as usize] as i64) & 255
+    let b2 = ((*buf)[(pos + 2) as usize] as i64) & 255
+    let b3 = ((*buf)[(pos + 3) as usize] as i64) & 255
+    let b4 = ((*buf)[(pos + 4) as usize] as i64) & 255
+    let b5 = ((*buf)[(pos + 5) as usize] as i64) & 255
+    let b6 = ((*buf)[(pos + 6) as usize] as i64) & 255
+    let b7 = ((*buf)[(pos + 7) as usize] as i64) & 255
+    let v = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24) | (b4 << 32) | (b5 << 40) | (b6 << 48) | (b7 << 56)
+    (v, pos + 8)
+}
+
+fn put_header(buf: &![i8; 131072]) -> i64 with Mut, Panic, Div {
+    (*buf)[0] = 83 as i8
+    (*buf)[1] = 79 as i8
+    (*buf)[2] = 73 as i8
+    (*buf)[3] = 82 as i8
+    (*buf)[4] = 1 as i8
+    (*buf)[5] = 0 as i8
+    (*buf)[6] = 0 as i8
+    (*buf)[7] = 0 as i8
+    8
+}
+
+fn header_ok(buf: &[i8; 131072]) -> bool with Panic, Div {
+    (*buf)[0] == 83 as i8 &&
+    (*buf)[1] == 79 as i8 &&
+    (*buf)[2] == 73 as i8 &&
+    (*buf)[3] == 82 as i8 &&
+    (*buf)[4] == 1 as i8 &&
+    (*buf)[5] == 0 as i8 &&
+    (*buf)[6] == 0 as i8 &&
+    (*buf)[7] == 0 as i8
+}
+
+fn write_record(
+    buf: &![i8; 131072],
+    pos: i64,
+    file_id: i64,
+    line_no: i64,
+    visibility: i64,
+    name_hash: i64,
+    param_count: i64,
+    effect_count: i64,
+    returns: i64,
+) -> i64 with Mut, Panic, Div {
+    var p = pos
+    p = put_i64(buf, p, file_id)
+    p = put_i64(buf, p, line_no)
+    p = put_i64(buf, p, visibility)
+    p = put_i64(buf, p, name_hash)
+    p = put_i64(buf, p, param_count)
+    p = put_i64(buf, p, effect_count)
+    p = put_i64(buf, p, returns)
+    p
+}
+
+fn read_and_match(
+    buf: &[i8; 131072],
+    pos: i64,
+    file_id: i64,
+    line_no: i64,
+    visibility: i64,
+    name_hash: i64,
+    param_count: i64,
+    effect_count: i64,
+    returns: i64,
+) -> (bool, i64) with Panic, Div {
+    var p = pos
+    let a = get_i64(buf, p); p = a.1
+    let b = get_i64(buf, p); p = b.1
+    let c = get_i64(buf, p); p = c.1
+    let d = get_i64(buf, p); p = d.1
+    let e = get_i64(buf, p); p = e.1
+    let f = get_i64(buf, p); p = f.1
+    let g = get_i64(buf, p); p = g.1
+    (
+        a.0 == file_id &&
+        b.0 == line_no &&
+        c.0 == visibility &&
+        d.0 == name_hash &&
+        e.0 == param_count &&
+        f.0 == effect_count &&
+        g.0 == returns,
+        p,
+    )
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    let file_ids: [i64; $corpus_count] = [$ARRAY_FILE_IDS]
+    let lines: [i64; $corpus_count] = [$ARRAY_LINES]
+    let visibility: [i64; $corpus_count] = [$ARRAY_VIS]
+    let name_hashes: [i64; $corpus_count] = [$ARRAY_HASHES]
+    let params: [i64; $corpus_count] = [$ARRAY_PARAMS]
+    let effects: [i64; $corpus_count] = [$ARRAY_EFFECTS]
+    let returns: [i64; $corpus_count] = [$ARRAY_RETURNS]
+
+    var buf: [i8; 131072] = [0; 131072]
+    var pos = put_header(&! buf)
+    pos = put_i64(&! buf, pos, CORPUS_COUNT)
+    var i: i64 = 0
+    while i < CORPUS_COUNT {
+        pos = write_record(
+            &! buf,
+            pos,
+            file_ids[i as usize],
+            lines[i as usize],
+            visibility[i as usize],
+            name_hashes[i as usize],
+            params[i as usize],
+            effects[i as usize],
+            returns[i as usize],
+        )
+        i = i + 1
+    }
+
+    if !header_ok(&buf) { return 10 }
+    var read_pos: i64 = 8
+    let count_pair = get_i64(&buf, read_pos)
+    if count_pair.0 != CORPUS_COUNT { return 11 }
+    read_pos = count_pair.1
+    i = 0
+    while i < CORPUS_COUNT {
+        let matched = read_and_match(
+            &buf,
+            read_pos,
+            file_ids[i as usize],
+            lines[i as usize],
+            visibility[i as usize],
+            name_hashes[i as usize],
+            params[i as usize],
+            effects[i as usize],
+            returns[i as usize],
+        )
+        if !matched.0 { return 20 + i }
+        read_pos = matched.1
+        i = i + 1
+    }
+    if read_pos != pos { return 90 }
+    print("SOIR_ROUNDTRIP_CANONICAL_PASS\n")
+    0
+}
+EOF
+
+progress corpus_extract self-hosted/ir pass
+printf 'SOIR_ROUNDTRIP_CORPUS functions=%s files=%s profile=soir-reference-function-signature-v1\n' \
+  "$corpus_count" "$(cut -f1 "$CORPUS" | sort -u | wc -l | awk '{print $1}')"
+
+progress witness_check soir_roundtrip_witness begin
+"$COMPILER_CLI" check "$SOURCE" >"$BUILD_LOG" 2>&1 || {
+  cat "$BUILD_LOG" >&2
+  fail witness_check
+}
+progress witness_check soir_roundtrip_witness pass
+
+progress witness_build soir_roundtrip_witness begin
+"$COMPILER_CLI" --native-v2-compile "$SOURCE" -o "$ELF" >>"$BUILD_LOG" 2>&1 || {
+  cat "$BUILD_LOG" >&2
+  fail witness_build
+}
+chmod +x "$ELF"
+progress witness_runtime soir_roundtrip_witness begin
+set +e
+timeout --signal=TERM --kill-after=2s "${RUNTIME_TIMEOUT_SECONDS}s" "$ELF" >"$RUN_LOG" 2>&1
+runtime_rc=$?
+set -e
+if [[ "$runtime_rc" -eq 124 ]]; then
+  cat "$RUN_LOG" >&2
+  fail witness_runtime_timeout
+fi
+if [[ "$runtime_rc" -ne 0 ]]; then
+  cat "$RUN_LOG" >&2
+  fail "witness_runtime_rc_${runtime_rc}"
+fi
+grep -Fxq 'SOIR_ROUNDTRIP_CANONICAL_PASS' "$RUN_LOG" || {
+  cat "$RUN_LOG" >&2
+  fail witness_marker_missing
+}
+progress witness_runtime soir_roundtrip_witness pass
+
+head_sha="$(git rev-parse HEAD)"
+tree_sha="$(git rev-parse 'HEAD^{tree}')"
+script_sha256="$(sha256sum scripts/ci/soir_roundtrip_gate.sh | awk '{print $1}')"
+
+printf '%s\n' 'SOIR_ROUNDTRIP_BOUNDARY executable=generated_default_madaros_witness legacy_serialize_sio=censused_not_invoked current_soir_reference=v1 corpus=self-hosted/ir-function-signatures structural_fields=file,line,visibility,name_hash,param_count,effect_count,returns mir_port=blocked_until_gate_green'
+printf 'SOIR_ROUNDTRIP_PROVENANCE head=%s tree=%s script_sha256=%s\n' \
+  "$head_sha" "$tree_sha" "$script_sha256"
+printf 'SOIR_ROUNDTRIP_PASS compiler_cli=%s corpus_functions=%s census_hits=%s\n' \
+  "$COMPILER_CLI" "$corpus_count" "$hit_count"


### PR DESCRIPTION
## Summary

This PR lands the reviewable WS-C payload documentation and the SOIR structural round-trip gate on top of current `main`.

- Adds `docs/architecture/WS_C_PR2_STAGING_MANIFEST.md`, grouping the 49-file PR2 payload and the full 63-file reconstruction by review chunk, with per-gate provenance.
- Records the C2 `BASE_REF` re-anchor decision and the C3 boundary: frontier-only `tools/eisa` and `stdlib/eisa` files may be added, while shared existing oracle files must be revalidated against `main`.
- Adds `scripts/ci/soir_roundtrip_gate.sh`, which censuses SOIR reader/writer references, derives a representative 12-function corpus from `self-hosted/ir`, emits a SOIR v1-shaped structural record stream, deserializes it, compares every structural field, and runs the witness under the default Madaros path.
- Updates the generated docs registry and authority matrix for the new manifest.

## Evidence

- `bash scripts/ci/soir_roundtrip_gate.sh`: PASS; `corpus_functions=12`, `files=12`, `census_hits=750`, and `SOIR_ROUNDTRIP_PASS`.
- `bash scripts/dev/check_docs_registry.sh`: PASS.
- `bash scripts/dev/check_docs_consistency.sh`: PASS.
- `bash -n scripts/ci/soir_roundtrip_gate.sh`: PASS.
- `git diff --check`: PASS.

## Explicit scope boundaries

- `docs/architecture/WS_C_PR1_PAYLOAD_CENSUS.md` was inspected and restored through the canonical metadata generator. Its content is already identical to current `main`, so it produces no honest diff and is not duplicated in this PR.
- `scripts/dev/ws_c_pr2_stage_payload.sh` remains outside this PR. The manifest documents that helper and its ordered source, but the helper is still WIP in the source worktree and is not claimed as landed here.
- The SOIR gate currently proves the structural wire-format witness. It does not invoke production `serialize_ir_module` or `deserialize_ir_module`; the script reports this boundary as `legacy_serialize_sio=censused_not_invoked`. Production serializer integration remains a follow-up, and this PR contains no MIR port work.
- No compiler, `self-hosted/`, `tools/eisa/`, or `stdlib/eisa/` source was modified.

## Review note

The branch is based directly on `origin/main` at `ddcacddfaa70b7bb6b38f04fca2f037aa1f256dd`, not on the stale 606-commit lane checkpoint.