### PR TITLE
docs(concepts): close the two contradictions the corpus cross-check found

### DIFF
--- a/docs/internal/concepts/erasure.md
+++ b/docs/internal/concepts/erasure.md
@@ -69,7 +69,7 @@ must be annotated; here the boundary set is small and is itself the
 specification of what counts as a claim in Sounio.
 
 **Declassification is an act, not a coercion.** Returning knowledge to a bare
-number requires `attest(v, uncertainty: u, because: <provenance>)` — an
+number requires `attest(v, uncertainty: u, provenance: <provenance>)` — an
 assertion someone signs, never a cast. Every site where uncertainty was
 restored by hand is therefore visible.
 

--- a/docs/internal/concepts/ontological-validation.md
+++ b/docs/internal/concepts/ontological-validation.md
@@ -55,7 +55,16 @@ language with a units table.
 
 ## The gap this document exists to record
 
-**Three of the seventeen gates are named by any workflow. Fourteen never run.**
+**Three of the seventeen gates are named by any workflow. What the other
+fourteen do is not established by that number.**
+
+The count measures **direct invocation** — whether a workflow names the script —
+not **coverage**, which would require establishing that no running parent invokes
+it. `SOUNIO-EFFORT-LOCATION` measured the difference elsewhere and found 45
+scripts that no workflow names but a running parent covers. Under its invariant
+— *a number carries how it was measured, or it is not evidence* — the earlier
+wording "fourteen never run" claimed more than the instrument supported and is
+withdrawn here. The coverage of the fourteen is **unmeasured**.
 
 Among the fourteen: the reasoner, the query compiler, the typed bridge, the
 cache, the generated-ontology manifest, and `ontology_unit_metadata_gate.sh`.


### PR DESCRIPTION
The twelve-concept cross-check found two outright contradictions in the concept corpus, alongside nine tensions that are `INDETERMINATE` and belong to the founder. Only the two contradictions are touched here, because **both resolutions are derivable from the corpus itself** — neither is a new decision.

## C1 — what `because:` holds

`erasure.md:72` wrote `attest(v, uncertainty: u, because: <provenance>)`, putting provenance inside `because:`.

`justification.md` is the document that fixes what a justification is. It states that `because:` names a theorem in `formal/`, and that *"Empirical claims live in provenance, not in `because:`."*

`erasure.md` yields — the parameter is now `provenance:`.

## C2 — invocation written as coverage

`ontological-validation.md:58` read **"Fourteen never run."**

That is an *invocation* count — whether a workflow names the script — written as a *coverage* claim, which would additionally require establishing that no running parent invokes them. `SOUNIO-EFFORT-LOCATION` measured exactly this distinction elsewhere and found **45 scripts that no workflow names but a running parent covers**.

Under its invariant — *a number carries how it was measured, or it is not evidence* — the earlier wording claimed more than the instrument supported. Withdrawn: the coverage of the fourteen is recorded as **unmeasured**.

The nine `INDETERMINATE` tensions are untouched.