### PR TITLE
Accuse silent drop of unknown Knowledge annotation components

### DIFF
--- a/.github/workflows/knowledge-annotation-silent-drop.yml
+++ b/.github/workflows/knowledge-annotation-silent-drop.yml
@@ -1,0 +1,35 @@
+name: Knowledge annotation silent drop
+
+# Accusation gate. Expected red while an unknown Knowledge annotation
+# component is accepted with no diagnostic. continue-on-error keeps the
+# signal visible without making every unrelated PR unmergeable.
+on:
+  pull_request:
+  push:
+    paths:
+      - 'self-hosted/parser/types.sio'
+      - 'self-hosted/parser/ast.sio'
+      - 'tests/audit/knowledge_annotation_*.sio'
+      - 'scripts/ci/knowledge_annotation_silent_drop_gate.sh'
+      - '.github/workflows/knowledge-annotation-silent-drop.yml'
+  workflow_dispatch:
+
+jobs:
+  accuse:
+    name: Accuse silent provenance drop
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run accusation gate
+        continue-on-error: true
+        env:
+          KNOWLEDGE_SILENT_DROP_SLURM: "0"
+        run: bash scripts/ci/knowledge_annotation_silent_drop_gate.sh
+      - name: Upload receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: knowledge-annotation-silent-drop
+          path: artifacts/audit/knowledge_annotation_silent_drop/
+          if-no-files-found: warn

--- a/scripts/ci/knowledge_annotation_silent_drop_gate.sh
+++ b/scripts/ci/knowledge_annotation_silent_drop_gate.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Accusation gate: an unrecognised Knowledge<…> annotation component is
+# swallowed with no diagnostic (parser else-arm "Unknown component — skip").
+#
+# This is NOT a regression gate. It FAILS while the silence exists. When a
+# named diagnostic starts refusing the unknown-component witness, this gate
+# turns green. Do not add keywords here; that is a language change.
+#
+# Artifact: status + metrics {total, passed, failed, not_run}
+# Receipt: tests/audit/KNOWLEDGE_ANNOTATION_SILENT_DROP_2026-08-19.md
+# (docs/audit/ blocked this turn — topic-registry claimed by another lane)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+# shellcheck disable=SC1091
+source "$ROOT/scripts/lib/resolve_souc.sh"
+sounio_require_souc
+
+UNKNOWN="$ROOT/tests/audit/knowledge_annotation_unknown_component.sio"
+MEASURED="$ROOT/tests/audit/knowledge_annotation_measured.sio"
+UNKNOWN_COERCE="$ROOT/tests/audit/knowledge_annotation_unknown_coerce.sio"
+MEASURED_COERCE="$ROOT/tests/audit/knowledge_annotation_measured_coerce.sio"
+OUT_DIR="${KNOWLEDGE_SILENT_DROP_OUT:-$ROOT/artifacts/audit/knowledge_annotation_silent_drop}"
+mkdir -p "$OUT_DIR"
+
+use_slurm=0
+if command -v srun >/dev/null 2>&1 && [[ "${KNOWLEDGE_SILENT_DROP_SLURM:-1}" != "0" ]]; then
+  use_slurm=1
+fi
+
+run_check() {
+  local src="$1"
+  local log="$2"
+  "$SOUC_BIN" check "$src" >"$log" 2>&1
+}
+
+run_all_slurm() {
+  tar -czf - -C "$ROOT" bin/madaros-linux-x86_64 bin/souc bin/madaros \
+      tests/audit/knowledge_annotation_unknown_component.sio \
+      tests/audit/knowledge_annotation_measured.sio \
+      tests/audit/knowledge_annotation_unknown_coerce.sio \
+      tests/audit/knowledge_annotation_measured_coerce.sio \
+    | srun -p "${KNOWLEDGE_SILENT_DROP_PARTITION:-cpu-ops}" -N1 -n1 -c2 \
+        --mem=8G --time=00:08:00 --chdir=/tmp --job-name=know-silent-drop \
+        bash -c '
+          set -euo pipefail
+          export TMPDIR=/tmp
+          WORKDIR=$(mktemp -d /tmp/know-silent.XXXXXX)
+          cd "$WORKDIR"
+          tar xzf -
+          export MADAROS_STACK_KB=524288
+          ulimit -s 1048576 || true
+          mkdir -p /tmp/know-silent-out
+          for f in tests/audit/knowledge_annotation_*.sio; do
+            set +e
+            ./bin/souc check "$f" >"/tmp/know-silent-out/$(basename "$f").log" 2>&1
+            echo $? >"/tmp/know-silent-out/$(basename "$f").rc"
+            set -e
+          done
+          tar -C /tmp/know-silent-out -czf - .
+        ' >"$OUT_DIR/slurm_bundle.tar.gz"
+  tar -C "$OUT_DIR" -xzf "$OUT_DIR/slurm_bundle.tar.gz"
+}
+
+total=4
+passed=0
+failed=0
+not_run=0
+silence="unknown"
+unknown_rc=99
+measured_rc=99
+unknown_coerce_rc=99
+measured_coerce_rc=99
+
+if [[ "$use_slurm" -eq 1 && ! -x "$ROOT/bin/madaros-linux-x86_64" ]]; then
+  not_run=4
+  python3 - "$OUT_DIR/status.json" "$total" "$passed" "$failed" "$not_run" <<'PY'
+import json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+total, passed, failed, not_run = map(int, sys.argv[2:])
+path.write_text(json.dumps({
+    "schema": "sounio.knowledge_annotation_silent_drop.v1",
+    "status": "not_run",
+    "reason": "madaros_elf_missing",
+    "metrics": {"total": total, "passed": passed, "failed": failed, "not_run": not_run},
+}, indent=2) + "\n")
+PY
+  echo "status=not_run"
+  echo "metrics {total=$total, passed=$passed, failed=$failed, not_run=$not_run}"
+  exit 0
+fi
+
+if [[ "$use_slurm" -eq 1 ]]; then
+  run_all_slurm
+  cp "$OUT_DIR/knowledge_annotation_unknown_component.sio.log" "$OUT_DIR/unknown.log"
+  cp "$OUT_DIR/knowledge_annotation_measured.sio.log" "$OUT_DIR/measured.log"
+  cp "$OUT_DIR/knowledge_annotation_unknown_coerce.sio.log" "$OUT_DIR/unknown_coerce.log"
+  cp "$OUT_DIR/knowledge_annotation_measured_coerce.sio.log" "$OUT_DIR/measured_coerce.log"
+  unknown_rc=$(cat "$OUT_DIR/knowledge_annotation_unknown_component.sio.rc")
+  measured_rc=$(cat "$OUT_DIR/knowledge_annotation_measured.sio.rc")
+  unknown_coerce_rc=$(cat "$OUT_DIR/knowledge_annotation_unknown_coerce.sio.rc")
+  measured_coerce_rc=$(cat "$OUT_DIR/knowledge_annotation_measured_coerce.sio.rc")
+else
+  set +e
+  run_check "$UNKNOWN" "$OUT_DIR/unknown.log"
+  unknown_rc=$?
+  run_check "$MEASURED" "$OUT_DIR/measured.log"
+  measured_rc=$?
+  run_check "$UNKNOWN_COERCE" "$OUT_DIR/unknown_coerce.log"
+  unknown_coerce_rc=$?
+  run_check "$MEASURED_COERCE" "$OUT_DIR/measured_coerce.log"
+  measured_coerce_rc=$?
+  set -e
+fi
+
+if [[ "$measured_rc" -ne 0 ]]; then
+  echo "NEGATIVE CONTROL FAILED: Knowledge[f64, Measured] did not typecheck." >&2
+  echo "The defect is not the silent else-arm described in the dispatch. Stopping." >&2
+  cat "$OUT_DIR/measured.log" >&2
+  failed=1
+  python3 - "$OUT_DIR/status.json" "$total" "$passed" "$failed" "$not_run" "$measured_rc" <<'PY'
+import json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+total, passed, failed, not_run, measured_rc = map(int, sys.argv[2:])
+path.write_text(json.dumps({
+    "schema": "sounio.knowledge_annotation_silent_drop.v1",
+    "status": "fail",
+    "reason": "negative_control_measured_did_not_compile",
+    "measured_rc": measured_rc,
+    "metrics": {"total": total, "passed": passed, "failed": failed, "not_run": not_run},
+}, indent=2) + "\n")
+PY
+  echo "status=fail"
+  echo "metrics {total=$total, passed=$passed, failed=$failed, not_run=$not_run}"
+  exit 2
+fi
+measured_ok=1
+passed=$((passed + 1))
+
+if [[ "$unknown_rc" -eq 0 ]]; then
+  silence="present"
+  failed=$((failed + 1))
+else
+  silence="absent"
+  passed=$((passed + 1))
+fi
+
+if [[ "$unknown_coerce_rc" -eq 0 ]]; then
+  passed=$((passed + 1))
+else
+  failed=$((failed + 1))
+fi
+if [[ "$measured_coerce_rc" -eq 0 ]]; then
+  passed=$((passed + 1))
+else
+  failed=$((failed + 1))
+fi
+
+if [[ "$silence" == "present" ]]; then
+  status="fail"
+else
+  status="pass"
+fi
+
+python3 - "$OUT_DIR/status.json" "$status" "$silence" "$total" "$passed" "$failed" "$not_run" \
+  "$unknown_rc" "$measured_rc" "$unknown_coerce_rc" "$measured_coerce_rc" "$use_slurm" <<'PY'
+import json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+status, silence = sys.argv[2], sys.argv[3]
+total, passed, failed, not_run = map(int, sys.argv[4:8])
+unknown_rc, measured_rc, unknown_coerce_rc, measured_coerce_rc, use_slurm = map(int, sys.argv[8:13])
+path.write_text(json.dumps({
+    "schema": "sounio.knowledge_annotation_silent_drop.v1",
+    "status": status,
+    "silence": silence,
+    "harness": "slurm" if use_slurm else "local",
+    "unknown_rc": unknown_rc,
+    "measured_rc": measured_rc,
+    "unknown_coerce_rc": unknown_coerce_rc,
+    "measured_coerce_rc": measured_coerce_rc,
+    "metrics": {"total": total, "passed": passed, "failed": failed, "not_run": not_run},
+    "note": (
+        "Accusation: unknown component typechecks with no diagnostic. "
+        "TypeEntry also drops recognised Measured provenance (both coerce to bare Knowledge)."
+        if silence == "present" else
+        "Unknown component is now refused. Silence closed."
+    ),
+}, indent=2) + "\n")
+PY
+
+echo "status=$status"
+echo "silence=$silence"
+echo "harness=$([[ "$use_slurm" -eq 1 ]] && echo slurm || echo local)"
+echo "unknown_rc=$unknown_rc measured_rc=$measured_rc unknown_coerce_rc=$unknown_coerce_rc measured_coerce_rc=$measured_coerce_rc"
+echo "metrics {total=$total, passed=$passed, failed=$failed, not_run=$not_run}"
+
+if [[ "$silence" == "present" ]]; then
+  echo >&2
+  echo "ACCUSATION: unknown Knowledge annotation component is silently dropped." >&2
+  echo "  $UNKNOWN typechecked (rc=0). Parser else-arm advances with no diagnostic." >&2
+  echo "  This gate fails while that silence exists. It is not a regression gate." >&2
+  exit 1
+fi
+exit 0

--- a/tests/audit/KNOWLEDGE_ANNOTATION_SILENT_DROP_2026-08-19.md
+++ b/tests/audit/KNOWLEDGE_ANNOTATION_SILENT_DROP_2026-08-19.md
@@ -1,0 +1,131 @@
+# Knowledge annotation silent drop — 2026-08-19
+
+An unrecognised component in a `Knowledge<…>` / `Knowledge[…]` annotation
+is accepted with no diagnostic. The parser advances and leaves provenance
+empty. This is NO-VERSUS-UNKNOWN at the site where provenance is alleged.
+
+This receipt does not change the language. It makes the silence audible.
+
+Compiler: Madaros v0.80.0. SHA: `9fdaa5772b`. Measurements ran on Slurm
+partition `cpu-ops` (host `cpuops-t560-proxmox`), not on the workspace pod.
+
+## Controls
+
+| Program | Role | Slurm `souc check` |
+|---|---|---|
+| `tests/audit/knowledge_annotation_unknown_component.sio` — `Knowledge[f64, fn]` | Positive: unrecognised **keyword** hits the else-arm (must not be `Ident`; those become epsilon binders) | **rc=0**, no diagnostic |
+| `tests/audit/knowledge_annotation_measured.sio` — `Knowledge[f64, Measured]` | Negative: recognised provenance token | **rc=0** |
+
+If the unknown witness had failed to compile, the defect would not have been
+the else-arm described in the dispatch, and this work would have stopped. It
+compiled. The silence is the one described.
+
+Angle-form `Knowledge<f64, fn>` also typechecks (rc=0). So do `true` and `IO`.
+
+`Literature` and `Source` are **not** lexer tokens. Written as components they
+take the `Ident` → epsilon-binder arm, not the else-arm. A different hole:
+they are not skipped, they are misread as ε.
+
+## Provenance is empty at TypeEntry even when the AST filled it
+
+`check_knowledge_type` (`self-hosted/check/epistemic.sio`) builds
+`ty_knowledge(inner, eps)` only. The comment in that function states that
+`TypeEntry` does not persist validity/provenance. Live check:
+
+| Program | Result |
+|---|---|
+| `Knowledge[f64, fn] -> Knowledge[f64]` | rc=0 |
+| `Knowledge[f64, Measured] -> Knowledge[f64]` | rc=0 |
+| `Knowledge[f64, Measured] -> Knowledge[f64, Derived]` | rc=0 |
+
+The negative control therefore shows only that `Measured` is a **named parser
+arm**, not that the type carries a non-empty provenance tag. `provenance_from_ast(None)`
+returns `PROVENANCE_KIND_DERIVED` (default), then that meta is discarded.
+Type-level observation cannot tell “unknown was dropped” from “provenance is
+never stored”. The accusation is the **missing diagnostic**, which the
+unknown witness still demonstrates.
+
+## Parser versus AST
+
+### Provenance — `AstProvenanceKind`
+
+| AST variant | Parser arm in `parse_knowledge` / `parse_epistemic_wrapper` |
+|---|---|
+| `AstProvDerived` | `TokenKind::Derived` |
+| `AstProvComputed` | `TokenKind::Computed` |
+| `AstProvMeasured` | `TokenKind::Measured` |
+| `AstProvSource` | **none** (not a token) |
+| `AstProvLiterature` | **none** (not a token) |
+| `AstProvInput` | **none** (not a token) |
+
+Parser recognises **3**. AST declares **6**. The three unwriteable names
+appear once each in `self-hosted/parser/` — the enum declaration.
+
+### Validity — `AstValidityKind`
+
+| AST variant | Parser arm |
+|---|---|
+| `ValidDuration` | `TokenKind::Valid` |
+| `ValidUntilTime` | `TokenKind::ValidUntil` |
+| `ValidWhileCond` | `TokenKind::ValidWhile` |
+
+**3 / 3.** Validity does not have the same unwriteable-variant hole.
+An unknown *token* in that position still falls through to the provenance
+else-arm or the Ident-as-epsilon arm.
+
+## Silent `else` arms
+
+Exact comment `Unknown component — skip`:
+
+| File | Role |
+|---|---|
+| `self-hosted/parser/types.sio` (~1117) | `parse_knowledge` component loop |
+| `self-hosted/bootstrap/bootstrap_v0.sio` (~3934) | bootstrap copy of the same loop |
+
+A second skip **without** that comment lives in
+`parse_epistemic_wrapper_type` (`self-hosted/parser/types.sio` ~1387–1391):
+`else { p = p.advance() }` after Derived/Computed/Measured. Same trap for
+`Intervention` / `Counterfactual` bracket wrappers.
+
+No other `Unknown component` comments exist under `self-hosted/`.
+
+## Versioned `Knowledge` annotations with components
+
+Non-comment lines matching `Knowledge[…]` / `Knowledge<…>` that name a
+provenance or validity word, outside `self-hosted/`, `bootstrap/`, `archive/`:
+
+| Word | Files / lines |
+|---|---|
+| `Derived` + `ValidUntil` | 10 lines, 3 test files (`tests/run-pass/covid_2020_kernel.sio`, `tests/compile-fail/covid_2020_temporal_*.sio`) |
+| `Measured`, `Computed`, `Source`, `Literature`, `Input` | **0** |
+| Keyword else-arm (`fn`, `true`, `IO`, …) | **0** |
+
+No versioned user program currently writes a component that falls into the
+else-arm. The hole is live in the parser and unoccupied in the tree. Epsilon
+components (`epsilon`, `ε`) are common and take the Ident arm by design.
+
+## Gate
+
+```text
+bash scripts/ci/knowledge_annotation_silent_drop_gate.sh
+```
+
+Uses Slurm `srun -p cpu-ops` when `srun` is present
+(`KNOWLEDGE_SILENT_DROP_SLURM=0` forces local). Artifact:
+
+`artifacts/audit/knowledge_annotation_silent_drop/status.json`
+
+```text
+status=fail
+metrics {total=4, passed=3, failed=1, not_run=0}
+```
+
+while the unknown witness typechecks. `failed=1` is the accusation. The
+gate exits 1 until a named diagnostic refuses that witness. Wiring:
+`.github/workflows/knowledge-annotation-silent-drop.yml`
+(`continue-on-error: true` so the accusation stays visible without
+blocking unrelated merges).
+
+Do not close this by adding `Source` / `Literature` / `Input` keywords.
+That is a founder language decision. Close it by refusing the unknown
+component with a named diagnostic.

--- a/tests/audit/knowledge_annotation_measured.sio
+++ b/tests/audit/knowledge_annotation_measured.sio
@@ -1,0 +1,10 @@
+//@ description: recognised Knowledge provenance component Measured
+// Negative control: the parser has a named arm for TokenKind::Measured.
+
+fn keep(x: Knowledge[f64, Measured]) -> i64 {
+    0
+}
+
+fn main() -> i64 {
+    0
+}

--- a/tests/audit/knowledge_annotation_measured_coerce.sio
+++ b/tests/audit/knowledge_annotation_measured_coerce.sio
@@ -1,0 +1,9 @@
+//@ description: Measured also coerces to bare Knowledge — TypeEntry drops provenance
+
+fn coerce(x: Knowledge[f64, Measured]) -> Knowledge[f64] {
+    x
+}
+
+fn main() -> i64 {
+    0
+}

--- a/tests/audit/knowledge_annotation_unknown_coerce.sio
+++ b/tests/audit/knowledge_annotation_unknown_coerce.sio
@@ -1,0 +1,9 @@
+//@ description: unknown component coerces to bare Knowledge — provenance empty at TypeEntry
+
+fn coerce(x: Knowledge[f64, fn]) -> Knowledge[f64] {
+    x
+}
+
+fn main() -> i64 {
+    0
+}

--- a/tests/audit/knowledge_annotation_unknown_component.sio
+++ b/tests/audit/knowledge_annotation_unknown_component.sio
@@ -1,0 +1,11 @@
+//@ description: unknown Knowledge annotation component (reserved word `fn`)
+// Hits the parser else-arm: "Unknown component — skip". Must not be Ident
+// (Ident is parsed as an epsilon binder). No diagnostic is emitted today.
+
+fn keep(x: Knowledge[f64, fn]) -> i64 {
+    0
+}
+
+fn main() -> i64 {
+    0
+}


### PR DESCRIPTION
## Summary
- An unrecognised component in a `Knowledge[…]` annotation is accepted with no diagnostic (parser else-arm `Unknown component — skip`). This PR does not change that semantics and does not add keywords.
- Adds an accusation gate (`scripts/ci/knowledge_annotation_silent_drop_gate.sh`) with two controls: `Knowledge[f64, fn]` must typecheck while the silence exists; `Knowledge[f64, Measured]` must typecheck (recognised arm). The gate exits 1 until a named diagnostic refuses the unknown witness.
- Wired as `.github/workflows/knowledge-annotation-silent-drop.yml` with `continue-on-error: true` so the accusation stays visible without blocking unrelated merges.

## Measured (Slurm `cpu-ops`, Madaros v0.80.0, `9fdaa5772b`)
- Unknown keyword component (`fn`, also `true` / `IO` / angle-form) → `souc check` rc=0, no diagnostic.
- `Measured` → rc=0. `Literature` / `Source` are not tokens; they take the Ident→epsilon arm, not the else-arm.
- Both unknown and `Measured` coerce to bare `Knowledge[f64]`. `TypeEntry` does not persist provenance; the accusation is the missing diagnostic, not a type-tag difference.
- AST declares 6 provenance kinds; the parser writes 3. Validity is 3/3 (no matching hole).
- No versioned user program currently writes an else-arm component. 10 test lines use `ValidUntil` + `Derived`.

Receipt: `tests/audit/KNOWLEDGE_ANNOTATION_SILENT_DROP_2026-08-19.md` (parked out of `docs/audit/` this turn — `topic-registry.v1.json` is leased).

## Test plan
- [x] `bash scripts/ci/knowledge_annotation_silent_drop_gate.sh` on Slurm `cpu-ops` → `status=fail`, `metrics {total=4, passed=3, failed=1, not_run=0}`, exit 1
- [ ] Workflow `Knowledge annotation silent drop` runs on this PR (`KNOWLEDGE_SILENT_DROP_SLURM=0`)
- [ ] Do not treat a green required check as closure — the accusation stays red until the unknown witness is refused