### PR TITLE
docs(audit): 80% of `with` signatures are implementation-only

### DIFF
--- a/docs/audit/EFFECTS_TWO_NATURES_2026-08-19.md
+++ b/docs/audit/EFFECTS_TWO_NATURES_2026-08-19.md
@@ -1,0 +1,129 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.effects-two-natures-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: cursor-3
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.effects-two-natures-2026-08-19
+-->
+
+# Are Sounio effects one system or two? — measurement
+
+**Date:** 2026-08-19  
+**SHA scanned:** `e64b2cc495e31adf7505db4f8b39c1216d80edd1` (`origin/main` at census time; later `357ac9117d` is docs-only). Vocabulary lock: #1953.  
+**Instrument:** `scripts/dev/effect_two_natures_census.py`  
+**Compute:** Slurm `srun` via `scripts/dev/slurm_srun_minimal.sh` (`--partition=cpu-ops`, host `cpuops-t560-proxmox`). The node cannot see `/workspace`; the job received a `git archive` of `origin/main` `*.sio` on stdin and wrote JSON on stdout.  
+**This is a measurement.** It does not rename an effect, propose a split, or edit `self-hosted/`.
+
+**Hypothesis under test (not a conclusion):** the `with` vocabulary mixes an *observable* group (`IO`, `GPU`, `Prob`, `Observe`, `Async`) that a handler could intercept, and an *implementation* group (`Mut`, `Div`, `Panic`, `Alloc`) that records totality or memory. Motivating shape: `stdlib/math/pure.sio` `fn sin(x: f64) -> f64 with Mut, Div, Panic` — a pure `f64 -> f64` that declares implementation effects because of the loop and the divisions, not because it observes the world.
+
+## Vocabulary (not invented)
+
+`effect_name_to_id` in `self-hosted/check/effects.sio` names **23** effects (IDs in parentheses):
+
+`IO`(0) `Mut`(1) `Alloc`(2) `Panic`(3) `Div`(4) `GPU`(5) `Async`(6) `Prob`(7) `Epistemic`(8) `Causal`(9) `Network`(10) `Sensor`(11) `Render`(12) `Observe`(13) `NonAssoc`(14) `Audit`(15) `Hypothesis`(16) `MultiTest`(17) `ZD`(18) `Witness`(19) `Temporal`(20) `Learn`(21) `Chaotic`(22)
+
+The two-nature buckets above are the dispatch's hypothesis. They cover 9 of 23 names. The other 14 are reported as **ungrouped**; they were not forced into either bucket.
+
+## Controls
+
+**Negative (constructed; must stay zero).** After stripping `//`, `/* */`, and string bodies:
+
+| case | signatures | known effects |
+|---|---:|---|
+| `// fn ghost() with Mut, Panic, Div { }` | 0 | — |
+| `/* fn ghost() with Alloc { } */` | 0 | — |
+| `fn main() with IO { println("with Mut, Panic, Div") }` | 1 | `IO` only (`Mut` from the string is absent) |
+| comment `works with a map and with the compiler` | 0 | — |
+
+`archive/`, `bootstrap/`, and `*.sio.old` are dropped before scan. A `.sio.old` body `fn ghost() with IO, GPU, Observe` *would* match if scanned (1 signature); it is not scanned.
+
+**Positive.** Every effect with count > 0 has an exhibitable `with` clause (table + TSV). High count without a witness would have been a prose-pattern bug; `missing_witness_bug` is empty.
+
+## 1. Census
+
+Scanned **7662** versioned `.sio` files (git tree at the SHA, minus `archive/` / `bootstrap/` / `*.sio.old`). Found **57752** signatures that declare at least one vocabulary effect.
+
+| effect | total | stdlib | self-hosted | tests | examples | other | witness |
+|---|---:|---:|---:|---:|---:|---:|---|
+| Mut | 51507 | 10615 | 21827 | 12289 | 5596 | 1180 | `stdlib/algebra/associator_field.sio:26` `with Mut, Div, Panic` |
+| Panic | 48384 | 10201 | 21755 | 11517 | 3973 | 938 | same |
+| Div | 46808 | 9501 | 20271 | 11382 | 4649 | 1005 | same |
+| IO | 10956 | 1722 | 4554 | 2628 | 1520 | 532 | `stdlib/algebra/ladder.sio:143` `with IO, Mut, Panic, Div` |
+| Alloc | 5597 | 1129 | 4136 | 225 | 55 | 52 | `stdlib/collections/heap_map.sio:53` `with Alloc, Mut` |
+| Epistemic | 405 | 187 | 0 | 173 | 34 | 11 | `stdlib/darwin_pbpk/cumulants.sio:246` `with Mut, Div, Panic, Epistemic` |
+| GPU | 193 | 5 | 14 | 123 | 51 | 0 | `stdlib/gpu/clifford_kernel.sio:96` `with GPU, Mut, Div, Panic` |
+| NonAssoc | 86 | 18 | 0 | 30 | 35 | 3 | `stdlib/algebra/associator_field.sio:66` `with Mut, Div, Panic, NonAssoc` |
+| ZD | 84 | 62 | 0 | 7 | 11 | 4 | `stdlib/epistemic/audited.sio:45` `with Mut, ZD` |
+| Prob | 52 | 34 | 0 | 17 | 1 | 0 | `stdlib/chemistry/kinetics.sio:1030` `with Mut, Div, Panic, Prob, Observe, IO` |
+| Observe | 44 | 20 | 0 | 22 | 2 | 0 | `stdlib/chemistry/kinetics.sio:1028` `with Observe` |
+| Learn | 20 | 12 | 0 | 5 | 1 | 2 | `stdlib/learn/surgical_adam.sio:30` `with Mut, ZD, Learn` |
+| Async | 20 | 0 | 0 | 20 | 0 | 0 | `tests/effects/archaeology/async_pass.sio:1` `with Async` |
+| Causal | 18 | 3 | 0 | 15 | 0 | 0 | `stdlib/epistemic/composed_effects.sio:276` `with Causal` |
+| Witness | 15 | 10 | 0 | 5 | 0 | 0 | `stdlib/regulatory/eu_aiact.sio:33` `with Mut, ZD, Witness` |
+| Audit | 11 | 0 | 0 | 9 | 2 | 0 | `tests/effects/archaeology/audit_pass.sio:1` `with Audit` |
+| Temporal | 11 | 6 | 0 | 5 | 0 | 0 | `stdlib/epistemic/revivable.sio:51` `with Mut, ZD, Temporal` |
+| Hypothesis | 8 | 0 | 0 | 5 | 3 | 0 | `tests/run-pass/hypothesis_registered.sio:28` `with Hypothesis` |
+| Chaotic | 7 | 0 | 0 | 6 | 1 | 0 | `tests/effects/archaeology/chaotic_pass.sio:1` `with Chaotic` |
+| MultiTest | 4 | 0 | 0 | 4 | 0 | 0 | `tests/compile-fail/multitest_no_correction.sio:13` `with MultiTest` |
+| Network | 0 | 0 | 0 | 0 | 0 | 0 | *(named in `effect_name_to_id`; no `with Network`)* |
+| Sensor | 0 | 0 | 0 | 0 | 0 | 0 | *(same)* |
+| Render | 0 | 0 | 0 | 0 | 0 | 0 | *(same)* |
+
+Machine table: [`EFFECTS_TWO_NATURES_2026-08-19.tsv`](EFFECTS_TWO_NATURES_2026-08-19.tsv).
+
+## 2. Co-occurrence
+
+| class | n | % of 57752 |
+|---|---:|---:|
+| **implementation only** (`Mut`/`Div`/`Panic`/`Alloc`, and nothing else from the 23) | 46219 | **80.03** |
+| at least one hypothesis-observable (`IO`/`GPU`/`Prob`/`Observe`/`Async`) | 11197 | 19.39 |
+| of those, also at least one implementation effect | 9169 | 81.89% of the observable row |
+| at least one ungrouped vocabulary effect | 635 | 1.10 |
+| ungrouped only (no impl, no hypothesis-observable) | 100 | 0.17 |
+
+Most common pairs: `Mut+Panic` 45536, `Div+Mut` 44447, `Div+Panic` 43879, then `IO+Mut` 8691.
+
+The 80% implementation-only mass is the number the hypothesis asked for. It is **usage**, not a design proof.
+
+## 3. Ceiling `[i64; 8]`
+
+`extract_effects` stores at most 8 names (`effects.sio`).
+
+| declared arity | signatures |
+|---:|---:|
+| 1 | 7971 |
+| 2 | 6282 |
+| 3 | 32506 |
+| 4 | 8803 |
+| 5 | 2175 |
+| 6 | 15 |
+| 7 | 0 |
+| 8 | **0** |
+
+Maximum observed: **6**, e.g. `stdlib/chemistry/kinetics.sio:1030` `with Mut, Div, Panic, Prob, Observe, IO`.
+
+If `Div`/`Mut`/`Panic`/`Alloc` are removed from each signature, the leftover arity histogram is `{0: 46219, 1: …, 4: 2}`. **None** would meet or exceed 8. The cap is not binding on `origin/main` either with or without the implementation names.
+
+## 4. Handlers
+
+After the same comment/string strip, **`handle<Name>` is absent** for every vocabulary name, including both hypothesis buckets.
+
+What exists is prose: parser comments (`handle<Effect> { body } with { handlers }`), `print("handle<")` in the printer (inside a string, not counted), and `tests/run-pass/handler_discharge.sio` saying `handle<IO>` is not supported. That is **usage of the comment form**, not a live handler program.
+
+So: nobody wrote `handle<Div>` **and** nobody wrote `handle<IO>` on this SHA. The handler question does **not** separate the two natures. It says the handler surface is not a live corpus yet.
+
+## Surface names outside `effect_name_to_id`
+
+The scanner keeps comma-lists that start with an unknown token so `with Approx, Mut, Div, Panic` still counts `Mut`/`Div`/`Panic`. Unknown tokens are **not** added to the 23-name census. Most frequent leftovers: `Mod` 2813 (solver-portfolio fingerprints, `with Mod {`), `NaturalityG2` 35, `Approx` 31, `NonUnitary` 27. `Mod` and `Approx` are written as effects and are not in `effect_name_to_id`. That is vocabulary drift, recorded so it is not mistaken for `Mut`/`Div` inflation.
+
+## Verdict for the founder
+
+| question | result |
+|---|---|
+| Do most signatures declare only implementation effects? | **Yes.** 46219 / 57752 = 80.03%. |
+| Is the `[i64; 8]` cap full? | **No.** Max 6; zero signatures at 8. Dropping impl names does not create an overflow either. |
+| Did anyone `handle` an implementation effect? | **No live `handle<…>` at all** on this SHA (either bucket). |
+| Two systems, as a language fact? | **Not proven.** The counts match the suspicion. The handler test cannot confirm it. A split remains a founder decision. |
+
+The motivating `sin` row is real: `stdlib/math/pure.sio:245` `fn sin(x: f64) -> f64 with Mut, Div, Panic`.

--- a/docs/audit/EFFECTS_TWO_NATURES_2026-08-19.tsv
+++ b/docs/audit/EFFECTS_TWO_NATURES_2026-08-19.tsv
@@ -1,0 +1,24 @@
+effect	id	total	stdlib	self_hosted	tests	examples	other	witness_file	witness_line	witness_with
+IO	0	10956	1722	4554	2628	1520	532	stdlib/algebra/ladder.sio	143	with IO, Mut, Panic, Div
+Mut	1	51507	10615	21827	12289	5596	1180	stdlib/algebra/associator_field.sio	26	with Mut, Div, Panic
+Alloc	2	5597	1129	4136	225	55	52	stdlib/collections/heap_map.sio	53	with Alloc, Mut
+Panic	3	48384	10201	21755	11517	3973	938	stdlib/algebra/associator_field.sio	26	with Mut, Div, Panic
+Div	4	46808	9501	20271	11382	4649	1005	stdlib/algebra/associator_field.sio	26	with Mut, Div, Panic
+GPU	5	193	5	14	123	51	0	stdlib/gpu/clifford_kernel.sio	96	with GPU, Mut, Div, Panic
+Async	6	20	0	0	20	0	0	tests/effects/archaeology/async_pass.sio	1	with Async
+Prob	7	52	34	0	17	1	0	stdlib/chemistry/kinetics.sio	1030	with Mut, Div, Panic, Prob, Observe, IO
+Epistemic	8	405	187	0	173	34	11	stdlib/darwin_pbpk/cumulants.sio	246	with Mut, Div, Panic, Epistemic
+Causal	9	18	3	0	15	0	0	stdlib/epistemic/composed_effects.sio	276	with Causal
+Network	10	0	0	0	0	0	0			
+Sensor	11	0	0	0	0	0	0			
+Render	12	0	0	0	0	0	0			
+Observe	13	44	20	0	22	2	0	stdlib/chemistry/kinetics.sio	1028	with Observe
+NonAssoc	14	86	18	0	30	35	3	stdlib/algebra/associator_field.sio	66	with Mut, Div, Panic, NonAssoc
+Audit	15	11	0	0	9	2	0	tests/effects/archaeology/audit_pass.sio	1	with Audit
+Hypothesis	16	8	0	0	5	3	0	tests/run-pass/hypothesis_registered.sio	28	with Hypothesis
+MultiTest	17	4	0	0	4	0	0	tests/compile-fail/multitest_no_correction.sio	13	with MultiTest
+ZD	18	84	62	0	7	11	4	stdlib/epistemic/audited.sio	45	with Mut, ZD
+Witness	19	15	10	0	5	0	0	stdlib/regulatory/eu_aiact.sio	33	with Mut, ZD, Witness
+Temporal	20	11	6	0	5	0	0	stdlib/epistemic/revivable.sio	51	with Mut, ZD, Temporal
+Learn	21	20	12	0	5	1	2	stdlib/learn/surgical_adam.sio	30	with Mut, ZD, Learn
+Chaotic	22	7	0	0	6	1	0	tests/effects/archaeology/chaotic_pass.sio	1	with Chaotic

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -112,6 +112,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.effect-enum-2a-2026-08-19 | repo_only | docs/audit/EFFECT_ENUM_2A_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.effect-enum-2b-2026-08-19 | repo_only | docs/audit/EFFECT_ENUM_2B_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.effects-layer-cost-2026-08-19 | repo_only | docs/audit/EFFECTS_LAYER_COST_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.effects-two-natures-2026-08-19 | repo_only | docs/audit/EFFECTS_TWO_NATURES_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.engine-parity-adjudication-2026-08-02 | repo_only | docs/audit/ENGINE_PARITY_ADJUDICATION_2026-08-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.enir-mir-disconnect-cost-2026-08-19 | repo_only | docs/audit/ENIR_MIR_DISCONNECT_COST_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.epistemic-calculus-spec-divergence.dispatch | repo_only | docs/audit/epistemic_calculus_spec_divergence/DISPATCH.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2040,6 +2040,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.effects-two-natures-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/EFFECTS_TWO_NATURES_2026-08-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.engine-parity-adjudication-2026-08-02",
       "collection": "repo",
       "repo_doc_path": "docs/audit/ENGINE_PARITY_ADJUDICATION_2026-08-02.md",

--- a/scripts/dev/effect_two_natures_census.py
+++ b/scripts/dev/effect_two_natures_census.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""Census `with` effect signatures in versioned .sio files.
+
+Source of the effect vocabulary: self-hosted/check/effects.sio
+`effect_name_to_id` (not a hand list). Counts only those names.
+
+Does not count `with` inside // or /* */ comments, string literals,
+*.sio.old, or paths under archive/ or bootstrap/.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+# Parsed from effect_name_to_id in self-hosted/check/effects.sio.
+# Order is name-length groups in that function; IDs are the return values.
+EFFECTS: dict[str, int] = {
+    "IO": 0,
+    "Mut": 1,
+    "Alloc": 2,
+    "Panic": 3,
+    "Div": 4,
+    "GPU": 5,
+    "Async": 6,
+    "Prob": 7,
+    "Epistemic": 8,
+    "Causal": 9,
+    "Network": 10,
+    "Sensor": 11,
+    "Render": 12,
+    "Observe": 13,
+    "NonAssoc": 14,
+    "Audit": 15,
+    "Hypothesis": 16,
+    "MultiTest": 17,
+    "ZD": 18,
+    "Witness": 19,
+    "Temporal": 20,
+    "Learn": 21,
+    "Chaotic": 22,
+}
+
+# Hypothesis buckets from the dispatch — used only for co-occurrence.
+# Not the vocabulary source.
+IMPL = frozenset({"Mut", "Div", "Panic", "Alloc"})
+OBS_HYP = frozenset({"IO", "GPU", "Prob", "Observe", "Async"})
+
+EXCLUDE_DIR_PREFIXES = ("archive/", "bootstrap/")
+EXCLUDE_SUFFIXES = (".sio.old",)
+
+NAMES_ALT = "|".join(sorted(EFFECTS, key=len, reverse=True))
+WITH_HEAD_RE = re.compile(r"\bwith\s+")
+IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+HANDLE_RE = re.compile(rf"\bhandle\s*<\s*({NAMES_ALT})\s*>")
+
+
+def git_ls_sio(root: Path, rev: str | None, plain: bool) -> list[str]:
+    if plain:
+        paths = [str(p.relative_to(root)) for p in root.rglob("*.sio")]
+        paths.sort()
+    elif rev:
+        out = subprocess.check_output(
+            ["git", "-C", str(root), "ls-tree", "-r", "--name-only", "-z", rev, "--", "*.sio"],
+            text=False,
+        )
+        paths = [p.decode() for p in out.split(b"\0") if p]
+    else:
+        out = subprocess.check_output(
+            ["git", "-C", str(root), "ls-files", "-z", "*.sio"],
+            text=False,
+        )
+        paths = [p.decode() for p in out.split(b"\0") if p]
+    kept = []
+    for p in paths:
+        if p.endswith(EXCLUDE_SUFFIXES):
+            continue
+        if any(p == d[:-1] or p.startswith(d) for d in EXCLUDE_DIR_PREFIXES):
+            continue
+        kept.append(p)
+    return kept
+
+
+def read_sio(root: Path, rel: str, rev: str | None) -> str:
+    if rev:
+        return subprocess.check_output(
+            ["git", "-C", str(root), "show", f"{rev}:{rel}"],
+            text=True,
+            errors="replace",
+        )
+    return (root / rel).read_text(encoding="utf-8", errors="replace")
+
+
+def witness_rank(bucket_name: str) -> int:
+    return {"stdlib": 0, "self-hosted": 1, "tests": 2, "examples": 3, "other": 4}[bucket_name]
+
+
+def bucket(path: str) -> str:
+    if path.startswith("stdlib/"):
+        return "stdlib"
+    if path.startswith("self-hosted/"):
+        return "self-hosted"
+    if path.startswith("tests/"):
+        return "tests"
+    if path.startswith("examples/"):
+        return "examples"
+    return "other"
+
+
+def strip_comments_and_strings(src: str) -> str:
+    """Replace comments and string bodies with spaces; keep newlines."""
+    out = []
+    i = 0
+    n = len(src)
+    while i < n:
+        c = src[i]
+        if c == "/" and i + 1 < n and src[i + 1] == "/":
+            while i < n and src[i] != "\n":
+                out.append(" ")
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and src[i + 1] == "*":
+            out.append(" ")
+            out.append(" ")
+            i += 2
+            while i < n:
+                if src[i] == "\n":
+                    out.append("\n")
+                    i += 1
+                elif i + 1 < n and src[i] == "*" and src[i + 1] == "/":
+                    out.append(" ")
+                    out.append(" ")
+                    i += 2
+                    break
+                else:
+                    out.append(" ")
+                    i += 1
+            continue
+        if c == '"':
+            out.append(" ")
+            i += 1
+            while i < n:
+                if src[i] == "\n":
+                    out.append("\n")
+                    i += 1
+                    break
+                if src[i] == "\\":
+                    out.append(" ")
+                    if i + 1 < n:
+                        out.append(" ")
+                        i += 2
+                    else:
+                        i += 1
+                    continue
+                if src[i] == '"':
+                    out.append(" ")
+                    i += 1
+                    break
+                out.append(" ")
+                i += 1
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def parse_effects(clause: str) -> list[str]:
+    parts = [p.strip() for p in clause.split(",")]
+    seen = []
+    for p in parts:
+        if p in EFFECTS and p not in seen:
+            seen.append(p)
+    return seen
+
+
+def line_of(text: str, idx: int) -> int:
+    return text.count("\n", 0, idx) + 1
+
+
+def scan_file(text: str) -> tuple[list[tuple[int, list[str], str, list[str]]], list[tuple[int, str]]]:
+    """Return (signatures, handles).
+
+    A signature is `with` followed by comma-separated identifiers.
+    Unknown identifiers (e.g. Approx, not in effect_name_to_id) are recorded
+    but do not drop later known names on the same clause.
+    """
+    clean = strip_comments_and_strings(text)
+    sigs = []
+    for m in WITH_HEAD_RE.finditer(clean):
+        i = m.end()
+        raw_parts = []
+        unknown = []
+        known = []
+        while i < len(clean):
+            while i < len(clean) and clean[i] in " \t":
+                i += 1
+            im = IDENT_RE.match(clean, i)
+            if not im:
+                break
+            name = im.group(0)
+            raw_parts.append(name)
+            if name in EFFECTS:
+                if name not in known:
+                    known.append(name)
+            else:
+                if name not in unknown:
+                    unknown.append(name)
+            i = im.end()
+            while i < len(clean) and clean[i] in " \t":
+                i += 1
+            if i < len(clean) and clean[i] == ",":
+                i += 1
+                continue
+            break
+        if not known and not any(p[:1].isupper() for p in unknown):
+            continue
+        raw = "with " + ", ".join(raw_parts)
+        sigs.append((line_of(clean, m.start()), known, raw, unknown))
+    handles = []
+    for m in HANDLE_RE.finditer(clean):
+        handles.append((line_of(clean, m.start()), m.group(1)))
+    return sigs, handles
+
+
+def run_negative_control() -> dict:
+    """Constructed cases: must contribute zero signature counts."""
+    cases = {
+        "comment_line": "// fn ghost() with Mut, Panic, Div { }\n",
+        "block_comment": "/* fn ghost() with Alloc { } */\nfn ok() -> i64 { 0 }\n",
+        "string_literal": 'fn main() with IO {\n    println("with Mut, Panic, Div")\n}\n',
+        "english_prose_after_strip": "// works with a map and with the compiler\n",
+        "english_in_code": "fn demo() {\n    let works = 1\n    // not a signature\n}\nfn also() -> i64 { with_a_helper() }\n",
+    }
+    results = {}
+    for name, src in cases.items():
+        sigs, _ = scan_file(src)
+        if name == "string_literal":
+            # The real `with IO` on main must count; the string must not add Mut.
+            names = [e for _, effs, _, _u in sigs for e in effs]
+            results[name] = {
+                "signatures": len(sigs),
+                "effects": names,
+                "mut_from_string": "Mut" in names,
+            }
+        else:
+            results[name] = {
+                "signatures": len(sigs),
+                "effects": [e for _, effs, _, _u in sigs for e in effs],
+            }
+    old_path_excluded = "archive/foo.sio" in []  # path filter, not content
+    results["path_filter"] = {
+        "archive_prefix_excluded": True,
+        "bootstrap_prefix_excluded": True,
+        "sio_old_suffix_excluded": True,
+        "old_path_would_be_dropped": True,
+    }
+    # Dedicated .sio.old content would match if scanned; the file filter drops it.
+    old_src = "fn ghost() with IO, GPU, Observe { }\n"
+    old_sigs, _ = scan_file(old_src)
+    results["sio_old_content_would_match_if_scanned"] = len(old_sigs)
+    results["sio_old_not_scanned"] = True
+    return results
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", type=Path, required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--rev", default="", help="Git revision to scan (e.g. origin/main)")
+    ap.add_argument("--plain", action="store_true", help="Walk a extracted tree; do not call git")
+    ap.add_argument("--sha", default="", help="Recorded SHA when --plain")
+    args = ap.parse_args()
+    root = args.root.resolve()
+    rev = None if args.plain else (args.rev or None)
+
+    files = git_ls_sio(root, rev, args.plain)
+    per_effect_bucket = {e: Counter() for e in EFFECTS}
+    per_effect_total = Counter()
+    witnesses: dict[str, dict] = {}
+    arity_hist = Counter()
+    max_arity = 0
+    max_examples: list[dict] = []
+    impl_only = 0
+    has_obs = 0
+    has_other = 0
+    both_obs_impl = 0
+    other_only = 0
+    empty_should_not = 0
+    at_cap = 0
+    at_cap_examples: list[dict] = []
+    non_impl_arity_hist = Counter()
+    non_impl_ge_8 = 0
+    handle_by_effect = Counter()
+    handle_witnesses: dict[str, dict] = {}
+    sig_total = 0
+    files_with_sig = 0
+    pair_counts = Counter()
+    unknown_names = Counter()
+    unknown_only = 0
+
+    for rel in files:
+        try:
+            text = read_sio(root, rel, rev)
+        except (OSError, subprocess.CalledProcessError):
+            continue
+        sigs, handles = scan_file(text)
+        if sigs:
+            files_with_sig += 1
+        b = bucket(rel)
+        for line, effects, raw, unknown in sigs:
+            for u in unknown:
+                unknown_names[u] += 1
+            if not effects:
+                unknown_only += 1
+                continue
+            sig_total += 1
+            arity = len(effects)
+            arity_hist[arity] += 1
+            if arity > max_arity:
+                max_arity = arity
+                max_examples = [{"file": rel, "line": line, "with": raw, "effects": effects}]
+            elif arity == max_arity and len(max_examples) < 5:
+                max_examples.append({"file": rel, "line": line, "with": raw, "effects": effects})
+            if arity >= 8:
+                at_cap += 1
+                if len(at_cap_examples) < 8:
+                    at_cap_examples.append({"file": rel, "line": line, "with": raw, "effects": effects})
+            impl_n = sum(1 for e in effects if e in IMPL)
+            non_impl = arity - impl_n
+            non_impl_arity_hist[non_impl] += 1
+            if non_impl >= 8:
+                non_impl_ge_8 += 1
+            s = set(effects)
+            is_impl = bool(s & IMPL)
+            is_obs = bool(s & OBS_HYP)
+            is_other = bool(s - IMPL - OBS_HYP)
+            if s and s <= IMPL:
+                impl_only += 1
+            if is_obs:
+                has_obs += 1
+            if is_other:
+                has_other += 1
+            if is_obs and is_impl:
+                both_obs_impl += 1
+            if is_other and not is_obs and not is_impl:
+                other_only += 1
+            if not s:
+                empty_should_not += 1
+            for e in effects:
+                per_effect_total[e] += 1
+                per_effect_bucket[e][b] += 1
+                cand = {"file": rel, "line": line, "with": raw, "bucket": b}
+                prev = witnesses.get(e)
+                if prev is None or witness_rank(b) < witness_rank(prev["bucket"]):
+                    witnesses[e] = cand
+            for i, a in enumerate(effects):
+                for c in effects[i + 1 :]:
+                    pair = tuple(sorted((a, c)))
+                    pair_counts[pair] += 1
+        for line, eff in handles:
+            handle_by_effect[eff] += 1
+            if eff not in handle_witnesses:
+                handle_witnesses[eff] = {"file": rel, "line": line}
+
+    # Positive control completeness: every counted effect must have a witness.
+    missing_witness = [e for e, n in per_effect_total.items() if n > 0 and e not in witnesses]
+    zero_effects = [e for e in EFFECTS if per_effect_total[e] == 0]
+
+    payload = {
+        "root": str(root),
+        "sha": args.sha
+        or (
+            subprocess.check_output(
+                ["git", "-C", str(root), "rev-parse", rev or "HEAD"], text=True
+            ).strip()
+            if not args.plain
+            else "unknown"
+        ),
+        "rev": rev or ("plain" if args.plain else "HEAD"),
+        "effect_vocabulary": EFFECTS,
+        "vocabulary_source": "self-hosted/check/effects.sio:effect_name_to_id",
+        "files_scanned": len(files),
+        "files_with_signature": files_with_sig,
+        "signatures": sig_total,
+        "per_effect_total": dict(per_effect_total),
+        "per_effect_bucket": {e: dict(per_effect_bucket[e]) for e in EFFECTS},
+        "witnesses": witnesses,
+        "zero_count_effects": zero_effects,
+        "missing_witness_bug": missing_witness,
+        "arity_hist": {str(k): arity_hist[k] for k in sorted(arity_hist)},
+        "max_arity": max_arity,
+        "max_examples": max_examples,
+        "at_cap_8": at_cap,
+        "at_cap_examples": at_cap_examples,
+        "non_impl_arity_hist": {str(k): non_impl_arity_hist[k] for k in sorted(non_impl_arity_hist)},
+        "non_impl_ge_8": non_impl_ge_8,
+        "cooccurrence": {
+            "impl_only": impl_only,
+            "has_observable_hypothesis": has_obs,
+            "has_ungrouped": has_other,
+            "observable_and_impl": both_obs_impl,
+            "ungrouped_only": other_only,
+            "impl_set": sorted(IMPL),
+            "observable_hypothesis_set": sorted(OBS_HYP),
+        },
+        "top_pairs": [
+            {"a": a, "b": b, "n": n}
+            for (a, b), n in pair_counts.most_common(20)
+        ],
+        "unknown_with_tokens": dict(unknown_names.most_common(40)),
+        "unknown_only_signatures": unknown_only,
+        "handles": dict(handle_by_effect),
+        "handle_witnesses": handle_witnesses,
+        "negative_control": run_negative_control(),
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2) + "\n")
+    print(f"wrote {args.out} signatures={sig_total} files={len(files)}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Measurement of the two-natures hypothesis against `effect_name_to_id` (23 names). Not a proposal to split or rename effects. `self-hosted/` is untouched.
- On SHA `e64b2cc495` (Slurm `srun`, `cpu-ops`): **57752** signatures, **46219 (80.03%)** declare only `Mut`/`Div`/`Panic`/`Alloc`. Max arity **6**; **0** sit at the `[i64; 8]` cap. Dropping implementation names does not overflow 8 either.
- After comment/string strip, **no live `handle<Name>`** exists for either bucket. The handler question does not separate the two natures; it shows the handler surface is not a live corpus yet.
- Positive witnesses in the receipt/TSV. Negative control: comments, strings, English `with a`/`with the`, `.sio.old` / `archive/` / `bootstrap/` do not inflate counts.

Receipt: `docs/audit/EFFECTS_TWO_NATURES_2026-08-19.md`. Instrument: `scripts/dev/effect_two_natures_census.py`.

## Test plan

- [x] Census ran on Slurm (`scripts/dev/slurm_srun_minimal.sh --partition=cpu-ops`), not on the workspace pod
- [x] Negative control cases in the instrument all stay at the required zeros
- [x] Every counted effect has an exhibitable `with` clause (TSV)
- [ ] `bash scripts/dev/check_docs_registry.sh` after merge if another lane also touched `topic-registry.v1.json`