### PR TITLE
docs(audit): refinement cannot discharge Div — `/` does not generate it

### DIFF
--- a/docs/audit/REFINEMENT_DIV_DISCHARGE_2026-08-19.md
+++ b/docs/audit/REFINEMENT_DIV_DISCHARGE_2026-08-19.md
@@ -1,0 +1,108 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.refinement-div-discharge-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: cursor-3
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.refinement-div-discharge-2026-08-19
+-->
+
+# Can refinement discharge a divisor≠0 obligation?
+
+**Date:** 2026-08-19  
+**SHA:** `92fade0be1a6700b583da235f64d2b344aa82f2f` (`origin/main`)  
+**Compute:** Slurm `srun` via `scripts/dev/slurm_srun_minimal.sh` (`--partition=cpu-ops`, host `cpuops-t560-proxmox`). Both engines: default Madaros (`bin/madaros-linux-x86_64`, v0.80.0) and `bin/souc-lean-single-x86_64`.  
+**Instrument:** `scripts/dev/refinement_div_discharge_probe.sh`  
+**Witnesses:** `docs/audit/repro/refinement_div_discharge/`  
+**This is a measurement.** `self-hosted/` was not edited. No split of `Div` is proposed.
+
+**Sentence the founder asked for:** **DECLARA APENAS** — refinement checks handwritten predicates (and can prove some of them). It does not derive a divisor≠0 obligation from `/`, and it cannot discharge `Div` because `/` does not generate `Div`. `Div` has nowhere to go without new checker work.
+
+## 1. What refinement checks today
+
+`self-hosted/check/refinement.sio` is a **static predicate engine** (comment: "no Z3"). Callers in `check.sio` use it at **declared-type boundaries**, not at operators.
+
+| site | what it does |
+|---|---|
+| `checker_lower_refinement_type_mut` | lowers `{ x: T \| pred }` into a `RefinementTable` slot |
+| `checker_check_refinement_literal_inplace` | literal assigned to a refined type: `refine_static_check_int_literal` / float |
+| `checker_check_call_arg_refinement_boundary_inplace` | call argument vs parameter predicate |
+| `if_cond_extract_pred` + `refine_cond_env` | pushes an `if` comparison into a guard stack for the then-branch |
+
+There is **no** call from `checker_check_binary_with_operand_types_inplace` into refinement. `OpDiv` only constant-folds an integer-zero denominator and reports **E056**. Indexing (`checker_check_index_inplace`) does not read a refinement on the index and does not mention `Panic`.
+
+So: **declared** predicates, not **derived** operator obligations. Division, indexing, and unsigned subtraction are not refinement sources.
+
+## 2. Solver or syntactic equality?
+
+Not mere textual equality. `pred_implies` (`refinement.sio`) implements interval / comparison implication: `x > 5` implies `x > 0`; `x != 0` does not imply `x > 0`. Compound `and`/`or` are handled by a conservative structural walk. There is **no** SMT solver.
+
+Path narrowing exists, but only for `if` (not `while`) and only when the condition is `ident <op> integer-literal` (or a boolean combination of those). `if d != 0.0` is **not** a guard: `if_cond_extract_pred` requires `ExprIntLit` on the RHS.
+
+Unproven call arguments fall through to a runtime-checked path (comment: W040). On this SHA, `check` accepted those cells with **no W040 token** on stderr.
+
+## 3. Decisive witnesses (both engines)
+
+Machine table: [`REFINEMENT_DIV_DISCHARGE_2026-08-19.tsv`](REFINEMENT_DIV_DISCHARGE_2026-08-19.tsv).
+
+### Div is propagated, not generated
+
+| cell | question | Madaros | lean_single |
+|---|---|---|---|
+| A1 `a / d` on `f64`, no `with Div` | does `/` introduce Div? | **accept** | **accept** |
+| A2 `a / d` on `i32`, no `with Div` | same | **accept** | **accept** |
+| A3 caller of a callee that **declares** `with Div` | generic E035? | **E035** missing Div | **E035** |
+| B1 `if d != 0.0 { a / d }`, no Div | dispatch float guard | **accept** | **accept** |
+| B2 `if d != 0 { a / d }`, no Div | extractable int guard | **accept** | **accept** |
+| C1 `denom: { d: i32 \| d != 0 }`, `num / denom`, no Div | refined NonZero | **accept** | **accept** |
+| E1 `1 / 0` | constant zero | **E056** | reject (no E056 token) |
+
+The negative control **also accepts**. Guarded and refined division accept **for the same reason** A1/A2 accept: nothing at the `/` leaf asserts Div. That is the Mut-before-#1488 shape (`tests/compile-fail/effect_mut_generated_at_excl_ref_store.sio`): effects are true only where a human wrote them, then E035 copies them up the call graph.
+
+Mut **does** have a leaf now (`checker_check_assign_stmt_inplace`, `store_effects[0] = 1`). Div and Panic do not.
+
+### Refinement itself is live (so the Div measurement is not "the checker is dead")
+
+| cell | question | Madaros | lean_single |
+|---|---|---|---|
+| D1i `takes_pos(0)` inline `{ v: i32 \| v > 0 }` | rejects bad literal? | **E042** | **E042** |
+| D2i `{ n > 5 }` passed to `{ n > 0 }` | implication? | **accept** | **accept** |
+| D3i `{ n >= 0 }` passed to `{ n > 5 }` | converse? | **E042** | **E042** |
+| D4 `if y != 0 { takes_nz(y) }` | path narrowing at a **call**? | **accept** | **accept** |
+| D5 unguarded `takes_nz(y)` | unproven arg | **accept** (no W040 seen) | **accept** |
+
+Named aliases (`type Pos = { v: i32 \| v > 0 }`) **diverge**: Madaros reports **E008** (`expected i32, found Pos`) on D1/D2/D3. lean_single treats the alias as a refined i32 (D2 accept, D1/D3 E042). The implication engine works on **inline** refinements on both engines. The `type NonZero = …` surface the Div-retirement story wants is **not** live on default Madaros.
+
+### Panic is the same leaf gap
+
+| cell | question | Madaros | lean_single |
+|---|---|---|---|
+| F1 `arr[i]` no `with Panic` | does index introduce Panic? | **accept** | **accept** |
+| F2 refined `i: { k \| k >= 0 && k < 4 }`, no Panic | discharge? | **accept** | **accept** |
+| F3 caller of a callee that **declares** Panic | E035? | **E035** missing Panic | **E035** |
+
+A refined index does not waive Panic, because Panic was never required.
+
+## 4. How much work if `Div` is to leave
+
+Not a new solver. `pred_implies` already proves `d != 0` and `d > 0`. The missing pieces are **wiring**:
+
+1. **Generate** Div at `OpDiv` / `OpRem` (copy the #1488 Mut store-site pattern into `checker_check_binary_with_operand_types_inplace`). Without this, "discharge" is undefined: there is no obligation.
+2. **Discharge** that generated fact when the denominator's refinement or `refine_cond_env` proves `≠ 0` (or `> 0` or `< 0`). That is one `refine_static_check_var` / `pred_implies` consult at the binary, which does not exist today.
+3. **Float guards:** extend `if_cond_extract_pred` past `ExprIntLit`, or the dispatch's `if d != 0.0` remains invisible.
+4. **Named aliases on Madaros:** E008 on `type Pos = { … }` must be closed if the language surface is a named `NonZero`.
+5. **Same pair for Panic** at `ExprIndex` (generate + prove `0 <= i < N`). Index does not consult refinement today.
+6. Only **after** 1–2 would retiring `Div` from tens of thousands of signatures be a migration rather than a lie.
+
+Step 1 alone without step 2 would *increase* `with Div` noise: every `/` would start requiring the effect that today is optional at the leaf.
+
+## Verdict
+
+| option | |
+|---|---|
+| DESCARREGA | no — `/` never becomes an obligation, so nothing is proved away |
+| **DECLARA APENAS** | **yes** — handwritten predicates, with real implication and `if`-narrowing at call boundaries |
+| NEM VERIFICA | no — D1i/D2i/D3i show the engine is not string equality |
+| INDETERMINADO | no |
+
+`Div` cannot be replaced by refinement on this SHA. The mechanism that would replace it has not been connected to `/`.

--- a/docs/audit/REFINEMENT_DIV_DISCHARGE_2026-08-19.tsv
+++ b/docs/audit/REFINEMENT_DIV_DISCHARGE_2026-08-19.tsv
@@ -1,0 +1,39 @@
+cell	engine	exit	codes	note
+A1_raw_f64_div_no_div	madaros	0		`/` without Div accepted
+A1_raw_f64_div_no_div	lean_single	0		`/` without Div accepted
+A2_raw_i32_div_no_div	madaros	0		`/` without Div accepted
+A2_raw_i32_div_no_div	lean_single	0		`/` without Div accepted
+A3_caller_of_declared_div	madaros	1	E035	missing Div required by uses_div
+A3_caller_of_declared_div	lean_single	1	E035	not declared in function signature
+B1_guarded_f64_div_no_div	madaros	0		float guard; `/` still no Div
+B1_guarded_f64_div_no_div	lean_single	0		float guard; `/` still no Div
+B2_guarded_i32_div_no_div	madaros	0		int guard extractable; still no Div
+B2_guarded_i32_div_no_div	lean_single	0		int guard extractable; still no Div
+C1_nonzero_param_div_no_div	madaros	0		refined denom; still no Div
+C1_nonzero_param_div_no_div	lean_single	0		refined denom; still no Div
+D1_literal_violates_pos	madaros	1	E008	named alias Pos not treated as i32
+D1_literal_violates_pos	lean_single	1	E042	refinement type violation
+D1i_inline_literal_violates	madaros	1	E042	inline predicate rejects 0
+D1i_inline_literal_violates	lean_single	1	E042	inline predicate rejects 0
+D2_gt5_implies_gt0	madaros	1	E008	named alias Positive not i32
+D2_gt5_implies_gt0	lean_single	0		named alias implication holds
+D2i_inline_gt5_implies_gt0	madaros	0		n>5 implies n>0
+D2i_inline_gt5_implies_gt0	lean_single	0		n>5 implies n>0
+D3_gt0_does_not_imply_gt5	madaros	1	E008	named alias Positive not i32
+D3_gt0_does_not_imply_gt5	lean_single	1	E042	n>=0 does not imply n>0
+D3i_inline_gt0_not_gt5	madaros	1	E042	n>=0 does not imply n>5
+D3i_inline_gt0_not_gt5	lean_single	1	E042	n>=0 does not imply n>5
+D4_guard_narrows_to_nonzero	madaros	0		if y!=0 { takes_nz(y) }
+D4_guard_narrows_to_nonzero	lean_single	0		if y!=0 { takes_nz(y) }
+D5_unguarded_var_to_nonzero	madaros	0		unproven arg accepted; W040 not on stderr
+D5_unguarded_var_to_nonzero	lean_single	0		unproven arg accepted; W040 not on stderr
+D5b_w040_probe	madaros	0		same; no W040 on check
+D5b_w040_probe	lean_single	0		same; no W040 on check
+E1_const_zero_int	madaros	1	E056	compile-time / 0; not refinement
+E1_const_zero_int	lean_single	1		rejected; no E056 token in lean_single text
+F1_index_no_panic	madaros	0		index without Panic accepted
+F1_index_no_panic	lean_single	0		index without Panic accepted
+F2_refined_index_no_panic	madaros	0		refined index; still no Panic
+F2_refined_index_no_panic	lean_single	0		refined index; still no Panic
+F3_caller_of_declared_panic	madaros	1	E035	missing Panic required by ix
+F3_caller_of_declared_panic	lean_single	1	E035	not declared in function signature

--- a/docs/audit/repro/refinement_div_discharge/A1_raw_f64_div_no_div.sio
+++ b/docs/audit/repro/refinement_div_discharge/A1_raw_f64_div_no_div.sio
@@ -1,0 +1,10 @@
+// Leaf generation: f64 / without `with Div`.
+// If this type-checks, `/` does not introduce Div.
+
+fn raw(a: f64, d: f64) -> f64 {
+    a / d
+}
+
+fn main() -> f64 {
+    raw(1.0, 2.0)
+}

--- a/docs/audit/repro/refinement_div_discharge/A2_raw_i32_div_no_div.sio
+++ b/docs/audit/repro/refinement_div_discharge/A2_raw_i32_div_no_div.sio
@@ -1,0 +1,9 @@
+// Leaf generation: i32 / without `with Div`.
+
+fn raw(a: i32, d: i32) -> i32 {
+    a / d
+}
+
+fn main() -> i32 {
+    raw(10, 2)
+}

--- a/docs/audit/repro/refinement_div_discharge/A3_caller_of_declared_div.sio
+++ b/docs/audit/repro/refinement_div_discharge/A3_caller_of_declared_div.sio
@@ -1,0 +1,14 @@
+// Propagation: callee declares Div; caller does not.
+// Expect E035 if generic effect subset checking is live.
+
+fn uses_div(a: f64, d: f64) -> f64 with Div {
+    a / d
+}
+
+fn caller(a: f64, d: f64) -> f64 {
+    uses_div(a, d)
+}
+
+fn main() -> f64 {
+    caller(1.0, 2.0)
+}

--- a/docs/audit/repro/refinement_div_discharge/B1_guarded_f64_div_no_div.sio
+++ b/docs/audit/repro/refinement_div_discharge/B1_guarded_f64_div_no_div.sio
@@ -1,0 +1,15 @@
+// Dispatch shape: explicit float guard, no `with Div`.
+// if_cond_extract_pred only accepts an integer-literal RHS, so `d != 0.0`
+// is not a refinement guard.
+
+fn guarded(a: f64, d: f64) -> f64 {
+    if d != 0.0 {
+        a / d
+    } else {
+        0.0
+    }
+}
+
+fn main() -> f64 {
+    guarded(1.0, 2.0)
+}

--- a/docs/audit/repro/refinement_div_discharge/B2_guarded_i32_div_no_div.sio
+++ b/docs/audit/repro/refinement_div_discharge/B2_guarded_i32_div_no_div.sio
@@ -1,0 +1,14 @@
+// Integer guard the checker can extract (`d != 0`), still no `with Div`.
+// Distinguishes "guard seen by refinement" from "Div discharged".
+
+fn guarded(a: i32, d: i32) -> i32 {
+    if d != 0 {
+        a / d
+    } else {
+        0
+    }
+}
+
+fn main() -> i32 {
+    guarded(10, 2)
+}

--- a/docs/audit/repro/refinement_div_discharge/C1_nonzero_param_div_no_div.sio
+++ b/docs/audit/repro/refinement_div_discharge/C1_nonzero_param_div_no_div.sio
@@ -1,0 +1,10 @@
+// Refined NonZero parameter, division, no `with Div`.
+// Matches tests/run-pass/refinement_non_zero.sio minus Panic.
+
+fn divide(num: i32, denom: { d: i32 | d != 0 }) -> i32 {
+    num / denom
+}
+
+fn main() -> i32 {
+    divide(100, 5)
+}

--- a/docs/audit/repro/refinement_div_discharge/D1_literal_violates_pos.sio
+++ b/docs/audit/repro/refinement_div_discharge/D1_literal_violates_pos.sio
@@ -1,0 +1,12 @@
+// Positive control: refinement rejects a literal that fails the predicate.
+// Expect E042.
+
+type Pos = { v: i32 | v > 0 }
+
+fn takes_pos(x: Pos) -> i32 {
+    x
+}
+
+fn main() -> i32 {
+    takes_pos(0)
+}

--- a/docs/audit/repro/refinement_div_discharge/D1i_inline_literal_violates.sio
+++ b/docs/audit/repro/refinement_div_discharge/D1i_inline_literal_violates.sio
@@ -1,0 +1,9 @@
+// Same as D1 without a named alias.
+
+fn takes_pos(x: { v: i32 | v > 0 }) -> i32 {
+    x
+}
+
+fn main() -> i32 {
+    takes_pos(0)
+}

--- a/docs/audit/repro/refinement_div_discharge/D2_gt5_implies_gt0.sio
+++ b/docs/audit/repro/refinement_div_discharge/D2_gt5_implies_gt0.sio
@@ -1,0 +1,14 @@
+// Implication, not textual equality: n > 5 satisfies n > 0.
+// Mirrors tests/frontend/refinement_interval_entailment.sio.
+
+type BigPositive = { n: i32 | n > 5 }
+type Positive = { n: i32 | n > 0 }
+
+fn needs_positive(x: Positive) -> i32 {
+    x
+}
+
+fn main() -> i32 {
+    let big: BigPositive = 10
+    needs_positive(big)
+}

--- a/docs/audit/repro/refinement_div_discharge/D2i_inline_gt5_implies_gt0.sio
+++ b/docs/audit/repro/refinement_div_discharge/D2i_inline_gt5_implies_gt0.sio
@@ -1,0 +1,10 @@
+// Implication without named aliases.
+
+fn needs_positive(x: { n: i32 | n > 0 }) -> i32 {
+    x
+}
+
+fn main() -> i32 {
+    let big: { n: i32 | n > 5 } = 10
+    needs_positive(big)
+}

--- a/docs/audit/repro/refinement_div_discharge/D3_gt0_does_not_imply_gt5.sio
+++ b/docs/audit/repro/refinement_div_discharge/D3_gt0_does_not_imply_gt5.sio
@@ -1,0 +1,14 @@
+// Converse of D2: n >= 0 does not satisfy n > 0.
+// Mirrors tests/compile-fail/refinement_subtype_strict.sio. Expect E042.
+
+type NonNeg = { n: i32 | n >= 0 }
+type Positive = { n: i32 | n > 0 }
+
+fn needs_positive(x: Positive) -> i32 {
+    x
+}
+
+fn main() -> i32 {
+    let zero: NonNeg = 0
+    needs_positive(zero)
+}

--- a/docs/audit/repro/refinement_div_discharge/D3i_inline_gt0_not_gt5.sio
+++ b/docs/audit/repro/refinement_div_discharge/D3i_inline_gt0_not_gt5.sio
@@ -1,0 +1,10 @@
+// Converse implication without named aliases. Expect reject.
+
+fn needs_big(x: { n: i32 | n > 5 }) -> i32 {
+    x
+}
+
+fn main() -> i32 {
+    let zero: { n: i32 | n >= 0 } = 0
+    needs_big(zero)
+}

--- a/docs/audit/repro/refinement_div_discharge/D4_guard_narrows_to_nonzero.sio
+++ b/docs/audit/repro/refinement_div_discharge/D4_guard_narrows_to_nonzero.sio
@@ -1,0 +1,15 @@
+// Path narrowing at a call boundary: inside `if y != 0`, y satisfies NonZero.
+// This is what refine_cond_env + pred_implies can do. No `/`.
+
+fn takes_nz(d: { x: i32 | x != 0 }) -> i32 {
+    d
+}
+
+fn main() -> i32 {
+    let y: i32 = 3
+    if y != 0 {
+        takes_nz(y)
+    } else {
+        0
+    }
+}

--- a/docs/audit/repro/refinement_div_discharge/D5_unguarded_var_to_nonzero.sio
+++ b/docs/audit/repro/refinement_div_discharge/D5_unguarded_var_to_nonzero.sio
@@ -1,0 +1,11 @@
+// Unproven argument at a refinement boundary: expect W040, still compiles
+// (epistemic fallback in checker_check_call_arg_refinement_boundary_inplace).
+
+fn takes_nz(d: { x: i32 | x != 0 }) -> i32 {
+    d
+}
+
+fn main() -> i32 {
+    let y: i32 = 3
+    takes_nz(y)
+}

--- a/docs/audit/repro/refinement_div_discharge/D5b_w040_probe.sio
+++ b/docs/audit/repro/refinement_div_discharge/D5b_w040_probe.sio
@@ -1,0 +1,11 @@
+// Same as D5; probe prints refine summary if the engine emits it.
+
+fn takes_nz(d: { x: i32 | x != 0 }) -> i32 {
+    d
+}
+
+fn main() -> i32 with IO {
+    let y: i32 = 3
+    let r = takes_nz(y)
+    r
+}

--- a/docs/audit/repro/refinement_div_discharge/E1_const_zero_int.sio
+++ b/docs/audit/repro/refinement_div_discharge/E1_const_zero_int.sio
@@ -1,0 +1,6 @@
+// Constant-folded integer zero denominator. Expect E056.
+// Independent of refinement; lives in check_binary, not refinement.sio.
+
+fn main() -> i32 {
+    1 / 0
+}

--- a/docs/audit/repro/refinement_div_discharge/F1_index_no_panic.sio
+++ b/docs/audit/repro/refinement_div_discharge/F1_index_no_panic.sio
@@ -1,0 +1,10 @@
+// Leaf generation: array index without `with Panic`.
+
+fn ix(arr: [i64; 4], i: i64) -> i64 {
+    arr[i]
+}
+
+fn main() -> i64 {
+    let a: [i64; 4] = [0; 4]
+    ix(a, 0)
+}

--- a/docs/audit/repro/refinement_div_discharge/F2_refined_index_no_panic.sio
+++ b/docs/audit/repro/refinement_div_discharge/F2_refined_index_no_panic.sio
@@ -1,0 +1,11 @@
+// Refined index bound, still no `with Panic`.
+// If F1 accepts, this accepting does not mean Panic was discharged.
+
+fn ix(arr: [i64; 4], i: { k: i64 | k >= 0 && k < 4 }) -> i64 {
+    arr[i]
+}
+
+fn main() -> i64 {
+    let a: [i64; 4] = [0; 4]
+    ix(a, 0)
+}

--- a/docs/audit/repro/refinement_div_discharge/F3_caller_of_declared_panic.sio
+++ b/docs/audit/repro/refinement_div_discharge/F3_caller_of_declared_panic.sio
@@ -1,0 +1,14 @@
+// Propagation: callee declares Panic; caller does not. Expect E035.
+
+fn ix(arr: [i64; 4], i: i64) -> i64 with Panic {
+    arr[i]
+}
+
+fn caller(arr: [i64; 4], i: i64) -> i64 {
+    ix(arr, i)
+}
+
+fn main() -> i64 {
+    let a: [i64; 4] = [0; 4]
+    caller(a, 0)
+}

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -333,6 +333,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.readme | repo_only | docs/audit/README.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.rebracket-assoc-gates-audit-2026-08-19 | repo_only | docs/audit/REBRACKET_ASSOC_GATES_AUDIT_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.rebracket-assoc-gates-census-2026-08-19 | repo_only | docs/audit/REBRACKET_ASSOC_GATES_CENSUS_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.refinement-div-discharge-2026-08-19 | repo_only | docs/audit/REFINEMENT_DIV_DISCHARGE_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.runtime-context-unwritten-fields-census-2026-08-18 | repo_only | docs/audit/RUNTIME_CONTEXT_UNWRITTEN_FIELDS_CENSUS_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.runtime-gc-capability-honesty-2026-08-18 | repo_only | docs/audit/RUNTIME_GC_CAPABILITY_HONESTY_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.seed-fix-general-lvalue-deref-store-2026-06-24 | repo_only | docs/audit/SEED_FIX_GENERAL_LVALUE_DEREF_STORE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -7123,6 +7123,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.refinement-div-discharge-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/REFINEMENT_DIV_DISCHARGE_2026-08-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.runtime-context-unwritten-fields-census-2026-08-18",
       "collection": "repo",
       "repo_doc_path": "docs/audit/RUNTIME_CONTEXT_UNWRITTEN_FIELDS_CENSUS_2026-08-18.md",

--- a/scripts/dev/refinement_div_discharge_probe.sh
+++ b/scripts/dev/refinement_div_discharge_probe.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Type-check refinement/Div/Panic witnesses on both engines.
+# Intended to run on a Slurm node (no /workspace). Set ROOT to the extracted bundle.
+set -u
+ROOT="${1:-.}"
+WIT="$ROOT/docs/audit/repro/refinement_div_discharge"
+MAD="$ROOT/bin/madaros"
+LS="$ROOT/bin/souc-lean-single-x86_64"
+OUT="${2:-/tmp/refinement_div_discharge.tsv}"
+
+ulimit -s 524288 2>/dev/null || true
+
+codes_from() {
+  local log="$1"
+  local codes=""
+  if grep -q 'error\[E035' "$log"; then codes="${codes}|E035"; fi
+  if grep -q 'error\[E042' "$log"; then codes="${codes}|E042"; fi
+  if grep -q 'error\[E056' "$log"; then codes="${codes}|E056"; fi
+  if grep -q 'error\[E001' "$log"; then codes="${codes}|E001"; fi
+  if grep -q 'warning\[W040' "$log" || grep -q 'W040' "$log"; then codes="${codes}|W040"; fi
+  if grep -q 'error\[E008' "$log"; then codes="${codes}|E008"; fi
+  if grep -qi 'division requires' "$log"; then codes="${codes}|E031msg"; fi
+  if grep -qi 'not declared in function signature' "$log"; then codes="${codes}|E035msg"; fi
+  if grep -qi 'refinement type violation' "$log"; then codes="${codes}|E042msg"; fi
+  if [[ -z "$codes" ]]; then
+    if grep -qi 'error\[' "$log"; then
+      codes="|OTHER:$(grep -o 'error\[E[0-9]*' "$log" | head -1)"
+    fi
+  fi
+  printf '%s' "${codes#|}"
+}
+
+echo -e "cell\tengine\texit\tcodes\tfirst_line" > "$OUT"
+
+for src in "$WIT"/*.sio; do
+  cell="$(basename "$src" .sio)"
+  mad_log="/tmp/${cell}.madaros.log"
+  ls_log="/tmp/${cell}.lean_single.log"
+  "$MAD" check "$src" >"$mad_log" 2>&1
+  mad_rc=$?
+  mad_codes="$(codes_from "$mad_log")"
+  mad_first="$(tr '\n' ' ' <"$mad_log" | sed 's/Madaros v0.80.0[^c]*compiler[^c]*//' | head -c 280)"
+  echo -e "${cell}\tmadaros\t${mad_rc}\t${mad_codes}\t${mad_first}" >> "$OUT"
+
+  ls_tmp="/tmp/${cell}.lean.elf"
+  "$LS" "$src" "$ls_tmp" >"$ls_log" 2>&1
+  ls_rc=$?
+  rm -f "$ls_tmp"
+  ls_codes="$(codes_from "$ls_log")"
+  ls_first="$(tr '\n' ' ' <"$ls_log" | head -c 200)"
+  echo -e "${cell}\tlean_single\t${ls_rc}\t${ls_codes}\t${ls_first}" >> "$OUT"
+done
+
+echo "__TSV_BEGIN__"
+cat "$OUT"
+echo "__TSV_END__"
+echo "host=$(hostname) date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >&2


### PR DESCRIPTION
## Summary

- **DECLARA APENAS.** Refinement checks handwritten predicates. `pred_implies` is real (`n > 5` satisfies `n > 0`); `if y != 0 { takes_nz(y) }` narrows at a **call** boundary. It does not derive a divisor≠0 fact from `/`.
- **Negative control also accepts.** `fn raw(a, d) { a / d }` type-checks on Madaros and lean_single with no `with Div`. Guarded and `NonZero` forms accept for the same reason: `/` does not generate Div. E035 only fires when a **callee already declares** Div (or Panic).
- Same leaf gap for Panic: `arr[i]` without `with Panic` is accepted; a refined index does not waive an effect that was never required.
- Named `type Pos = { v: i32 | v > 0 }` is E008 on default Madaros (`found Pos`, not i32). Inline refinements work on both engines.
- `self-hosted/` untouched. Div cannot retire onto refinement until `/` generates an obligation and the existing predicate engine is asked to discharge it (Mut-at-store / #1488 shape).

Receipt: `docs/audit/REFINEMENT_DIV_DISCHARGE_2026-08-19.md`. Cells: `docs/audit/repro/refinement_div_discharge/`.

## Test plan

- [x] Dual-engine `check` on Slurm `cpu-ops` (`cpuops-t560-proxmox`): Madaros v0.80.0 and lean_single
- [x] A1/A2 accept without Div; A3 E035; D1i/D3i E042; D2i accept; E1 E056 on Madaros; F1 accept; F3 E035
- [ ] Re-run `scripts/dev/refinement_div_discharge_probe.sh` after any checker change that claims to generate Div at `/`