### PR TITLE
docs(audit): provenance — the layers disagree about which cases exist

### DIFF
--- a/docs/audit/PROVENANCE_LAYER_STAIRCASE_2026-08-19.md
+++ b/docs/audit/PROVENANCE_LAYER_STAIRCASE_2026-08-19.md
@@ -1,0 +1,80 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.provenance-layer-staircase-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: claude-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.provenance-layer-staircase-2026-08-19
+-->
+
+# Provenance: the layers disagree about which cases exist
+
+## Why this exists
+
+Two independent measurements of the same object reached opposite verdicts.
+
+- One (claude-1) read the commit history and concluded **the enum is the design
+  and the parser is behind**.
+- The other (glm-cli2, dispatched blind) read usage and concluded **the enum grew
+  by anticipation** — six cases entered together with three branches, and nothing
+  ever used the missing three.
+
+Neither verdict survives a layer-by-layer count. This records what does.
+
+## Measured
+
+`origin/main`, 2026-08-19. For each of the six `AstProvenanceKind` cases, whether
+the parser can produce it and whether `check/epistemic.sio` handles it.
+
+| case | `parser/types.sio` | `check/epistemic.sio` | end to end |
+|---|---|---|---|
+| `AstProvDerived` | **produces** | no explicit branch — falls through | via the default |
+| `AstProvSource` | — | explicit branch, `PROVENANCE_KIND_SOURCE` | **no** |
+| `AstProvComputed` | **produces** | explicit branch | **yes** |
+| `AstProvLiterature` | — | explicit branch, `PROVENANCE_KIND_LITERATURE` | **no** |
+| `AstProvMeasured` | **produces** | explicit branch | **yes** |
+| `AstProvInput` | — | explicit branch, `PROVENANCE_KIND_INPUT` | **no** |
+
+Layer totals: declaration 6, checker 5 explicit + 1 default, parser 3.
+**Two of six are wired end to end.**
+
+## This settles anticipation versus lag, and it is lag
+
+`Source`, `Literature` and `Input` are not bare enum names. Each has a **runtime
+constant** (`PROVENANCE_KIND_*`) and an **explicit branch** in
+`provenance_from_ast`. A speculative enum does not acquire runtime constants and
+consumer branches; it sits in its declaration. The checker was built six-wide and
+works. The parser was built three-wide.
+
+The blind measurement's usage count is not wrong — it excluded declarations and
+consumer match arms by design, which is exactly where the evidence lives. Two
+correct measurements of different things, and the disagreement is the finding.
+
+## A third defect, previously unrecorded
+
+`provenance_from_ast` ends:
+
+    provenance_new(PROVENANCE_KIND_DERIVED)      // fall-through
+    None => provenance_new(PROVENANCE_KIND_DERIVED)
+
+**An absent provenance and an explicit `derived` produce the same value.** A
+reader downstream cannot distinguish *"the author said this is derived"* from
+*"the author said nothing"*. `SOUNIO-NO-VERSUS-UNKNOWN`, in the field whose whole
+purpose is to record where a value came from.
+
+This is independent of the keyword question. Giving `Input` a keyword does not
+fix it; separating the two states does.
+
+## What this does to the founder's ruling
+
+`asserted → Input` (2026-08-19) is not blocked by a design question. `Input`
+already has a runtime constant and a checker branch. What it lacks is a token and
+a parser branch — measured elsewhere at 2–4 lines each, with **zero** collisions
+in versioned `.sio` (`docs/audit/PROVENANCE_KEYWORD_COVERAGE_DISPATCH_2026-08-19.md`).
+
+## Claims forbidden
+
+- That the enum grew by anticipation. Three of the unreachable cases carry
+  runtime constants and consumer branches.
+- That the checker is incomplete. It handles all six; one via a deliberate
+  default that happens to collide with absence.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -310,6 +310,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.portfolio-imported-native-139-untag-2026-08-18 | repo_only | docs/audit/PORTFOLIO_IMPORTED_NATIVE_139_UNTAG_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.portfolio-split-source-ceiling-2026-08-17 | repo_only | docs/audit/PORTFOLIO_SPLIT_SOURCE_CEILING_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.primary-checkout-reconciliation-plan-2026-06-21 | repo_only | docs/audit/PRIMARY_CHECKOUT_RECONCILIATION_PLAN_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.provenance-layer-staircase-2026-08-19 | repo_only | docs/audit/PROVENANCE_LAYER_STAIRCASE_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.r2-3-compiler-tuple-return-bug.dispatch | repo_only | docs/audit/r2_3_compiler_tuple_return_bug/DISPATCH.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.r2-3-compiler-tuple-return-bug.fix.proposed-fix | repo_only | docs/audit/r2_3_compiler_tuple_return_bug/fix/PROPOSED_FIX.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.r2-3-compiler-tuple-return-bug.r2-2-synthesis | repo_only | docs/audit/r2_3_compiler_tuple_return_bug/R2_2_SYNTHESIS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -6594,6 +6594,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.provenance-layer-staircase-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/PROVENANCE_LAYER_STAIRCASE_2026-08-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.r2-3-compiler-tuple-return-bug.dispatch",
       "collection": "repo",
       "repo_doc_path": "docs/audit/r2_3_compiler_tuple_return_bug/DISPATCH.md",


### PR DESCRIPTION
Two independent measurements of the same object reached **opposite verdicts**: I read commit history and said *the enum is the design, the parser is behind*; the blind lane read usage and said *the enum grew by anticipation*. **Neither survives a layer-by-layer count.**

| case | `parser/types.sio` | `check/epistemic.sio` | end to end |
|---|---|---|---|
| `AstProvDerived` | **produces** | falls through to the default | via default |
| `AstProvSource` | — | explicit branch + `PROVENANCE_KIND_SOURCE` | **no** |
| `AstProvComputed` | **produces** | explicit branch | **yes** |
| `AstProvLiterature` | — | explicit branch + constant | **no** |
| `AstProvMeasured` | **produces** | explicit branch | **yes** |
| `AstProvInput` | — | explicit branch + constant | **no** |

Declaration 6, checker 5 explicit + 1 default, parser 3. **Two of six are wired end to end.**

## It is lag, not anticipation

`Source`, `Literature` and `Input` are **not bare enum names** — each has a runtime constant and an explicit consumer branch. A speculative enum does not acquire those. The checker was built six-wide and works; the parser was built three-wide.

The blind measurement was not wrong: it excluded declarations and consumer match arms *by design*, which is exactly where the evidence lives. **Two correct measurements of different things — and the disagreement is the finding.**

## A third defect, previously unrecorded

```sounio
provenance_new(PROVENANCE_KIND_DERIVED)      // fall-through
None => provenance_new(PROVENANCE_KIND_DERIVED)
```

**An absent provenance and an explicit `derived` produce the same value.** `SOUNIO-NO-VERSUS-UNKNOWN`, in the field whose entire purpose is to record where a value came from. Independent of the keyword question — giving `Input` a keyword does not fix it.

## Effect on the founder ruling

`asserted → Input` is **not blocked by a design question**. `Input` already has a runtime constant and a checker branch; it lacks a token and a parser branch — 2–4 lines each, **zero** collisions in versioned `.sio`.