### PR TITLE
docs(audit): correct the Mod counts — 2,793 was a stdout cap, not a census

### DIFF
--- a/docs/audit/EFFECT_MOD_HOLD_EVIDENCE_2026-08-19.md
+++ b/docs/audit/EFFECT_MOD_HOLD_EVIDENCE_2026-08-19.md
@@ -83,6 +83,24 @@ outside this repository.
   functions. That propagation has never run. The blast radius is unmeasured and
   is the next thing to measure, before any edit.
 
+## Correction, 2026-08-19 — the counts in this document were wrong
+
+`docs/audit/E035_MOD_BLAST_RADIUS_2026-08-19.md` re-measured and the authoritative
+count is **2,813 sites in 365 files**.
+
+Two of my numbers were artefacts, not measurements:
+
+- **2,806** (mine) undercounts by seven: eight sites carry two `Mod` clauses on
+  one line and one adjacency was a comment. Arithmetic: 2806 − 1 + 8 = 2813.
+- **2,793** was **never a count at all**. The closed-list gate prints twenty
+  offending sites and then `omitted=2793`; 2813 − 20 = 2793. I read a **stdout
+  cap** as a census and recorded it here as an independent instrument
+  disagreeing with mine. It was the same instrument, truncated.
+
+The "13-site disagreement recorded, not averaged" below is therefore also wrong:
+there was no second measurement to disagree with. Recording a disagreement was
+right; the disagreement was not real.
+
 ## Instrument
 
 `git grep -lE '\bwith[[:space:]]+Mod\b' -- '*.sio' ':!archive/*' ':!bootstrap/*'`,


### PR DESCRIPTION
The authoritative count is **2,813 sites in 365 files** (`E035_MOD_BLAST_RADIUS_2026-08-19.md`).

Two numbers in `EFFECT_MOD_HOLD_EVIDENCE_2026-08-19.md` were **artefacts, not measurements**:

- **2,806** (mine) undercounts by seven — eight sites carry two `Mod` clauses on one line, one adjacency was a comment. `2806 − 1 + 8 = 2813`.
- **2,793 was never a count.** The closed-list gate prints twenty offending sites then `omitted=2793`; `2813 − 20 = 2793`. **I read a stdout cap as a census** and recorded it as an independent instrument disagreeing with mine. It was the same instrument, truncated.

So the document’s own *"13-site disagreement recorded, not averaged"* is wrong too: there was no second measurement to disagree with. Recording a disagreement rather than averaging it was the right instinct — the disagreement was not real.

Same failure family as the rest of the session: an instrument returned something plausible, here a **truncation notice shaped exactly like a total**.