### PR TITLE
docs(audit): measure E035 blast radius if Mod became Mut

### DIFF
--- a/docs/audit/E035_MOD_BLAST_RADIUS_2026-08-19.md
+++ b/docs/audit/E035_MOD_BLAST_RADIUS_2026-08-19.md
@@ -1,0 +1,190 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.e035-mod-blast-radius-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: grok-cli5
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.e035-mod-blast-radius-2026-08-19
+-->
+
+# E035 blast radius if `with Mod` became `Mut`
+
+**Filed:** 2026-08-19 · **Lane:** grok-cli5 · **Verdict:** LARGE BUT CLOSED
+
+**SHA:** `bd361fd092` (`origin/main`). Engine named on every number.
+
+This is a measurement. `self-hosted/` is not edited. `Mod` is not added
+to `effect_name_to_id`. The substitution was applied only in a disposable
+tree on a Slurm node and was never committed.
+
+## Verdict
+
+**LARGE BUT CLOSED.** The caller closure terminates at depth 2. It does
+not enter the compiler. It does not add any stdlib file beyond the 59
+that already write `with Mod`. The new annotations live in tests.
+
+If the founder later decides to rewrite `Mod` as `Mut`, the edit is:
+
+- 2,813 function signatures (`Mod` → `Mut`)
+- **843 further functions / 552 files** that must gain a `Mut`
+  declaration (759 of them at wave 1, 84 at wave 2)
+
+That is a large mechanical pass, not an open-ended refactor.
+
+## 1. How many `with Mod` sites?
+
+Three instruments, same SHA, **not averaged**:
+
+| Instrument | Sites | Files | What it counts |
+|---|---:|---:|---|
+| `git grep -nE '\bwith[[:space:]]+Mod\b'` (#2009) | **2806** | 363 | Adjacent `with Mod`, including comments |
+| Parser-faithful `with`-clause tokens (#2004 gate) | **2813** | 365 | Every `Mod` in a `with` list; no comments/strings |
+| Function-owned signatures (this lane) | **2813** | 365 | The function's own clause, not a parameter fn-type |
+
+**Why they differ, site by site:**
+
+- Grep has **1** hit the extractor refuses:
+  `self-hosted/check/effects.sio:24` — the hold comment
+  (`` `with Mod` still return -1 ``).
+- The extractor has **8** hits grep misses: `Mod` is in the clause but
+  not adjacent to `with` (`-> i64 with Div, Mod` in
+  `stdlib/systems/ball_fixed.sio:873` and seven siblings).
+- Arithmetic: 2806 − 1 + 8 = **2813**.
+
+**The 2,793 from #2004 / #2009 is not a third count.** The closed-list
+gate printed twenty `Mod` sites and then `omitted=2793` (2813 − 20
+stdout cap). #2009 read that line as a census. It is a log cap.
+
+Coexistence (parser-faithful files): 3 files write both `Mod` and
+`Mut`; **362 write `Mod` and never `Mut`**. Directory buckets of the
+365 files: `tests/run-pass` 304, `stdlib/systems` 41,
+`stdlib/theorem` 13, `stdlib/safety` 5, `tests/effects` 2.
+
+## 2. Transitive caller closure (static)
+
+A file-local then unique-name call graph over versioned `.sio`
+(archive / bootstrap / `*.sio.old` excluded).
+
+| | |
+|---|---:|
+| Affected functions (`with Mod` on the fn itself) | 2813 |
+| Affected files | 365 |
+| Closure functions | 3656 |
+| Closure files | 695 |
+| Maximum chain depth | **2** |
+| Wave-1 callers that would lack `Mut` after the rewrite | 759 |
+| Wave-1 callers already covered (they also have `Mod`) | 1239 |
+| Wave-1 callers that already declare `Mut` only | **0** |
+| Closure members that need a new `Mut` | **843** |
+| Closure members that already declare `Mut` only | 0 |
+| Closure members that get `Mut` from the rewrite | 2813 |
+| Reaches `self-hosted/` | **no** |
+| Extra stdlib files in the closure | **0** (59 = the 59 that already write Mod) |
+| Test files in the closure | 636 |
+
+The 843 sit in **552 files**, all under `tests/` (551 `tests/run-pass`,
+1 `tests/effects`). They are `main` / helper functions that call a
+Mod-function and declare neither `Mod` nor `Mut`. Typical shape:
+`tests/run-pass/*_imported.sio` `fn main() -> i64 { … }`.
+
+## 3. Empirical (Slurm, both engines)
+
+Disposable tree `/tmp/e035-in` on **cpuops-t560-proxmox** (partition
+`cpu-ops`, 32 cores). Tarball stdin. 2,813 `Mod` tokens rewritten to
+`Mut` in that tree only. The git worktree refused `--apply-scratch`
+because `.git` exists.
+
+Corpus: the 695-file closure. `souc check` (Madaros v0.80.0) and
+`SOUNIO_SOUC_ENGINE=lean_single` compile. Baseline then after.
+
+| Engine | Condition | Files | E035 | Files with E035 | check/compile rc=0 |
+|---|---|---:|---:|---:|---:|
+| **Madaros** | baseline | 695 | **0** | 0 | 695 |
+| **Madaros** | after Mod→Mut | 695 | **13653** | **552** | 143 |
+| lean_single | baseline | 695 | 0 | 0 | 13 |
+| lean_single | after Mod→Mut | 695 | 0 | 0 | 221 |
+
+**Madaros delta: +13,653 E035 on 552 files.** Zero E035 in the
+baseline, so the difference is the whole after-count. File-level match
+with the static “need new Mut” set: **552 = 552**.
+
+The 143 files that still `check: OK` after the rewrite are the
+self-contained Mod files: every function in them already had `Mod`,
+so after the rewrite they all declare `Mut` and do not call anything
+that now requires more.
+
+13,653 diagnostics vs 759/843 functions: E035 is per call site, not
+per function. A handful of `*_tiny.sio` files emit >100 lines
+(e.g. `lorenz_i256_cover_child0_local_flowpipe_preflight_tiny.sio`
++111). Same files, denser reports. Not a disagreement about *where*.
+
+**lean_single emits no E035** on either side. The seed does not carry
+this diagnostic. Its rc=0 counts (13 → 221) are compile-to-ELF of a
+mixed library/test corpus and are not an effect signal. Do not read
+them as a blast radius.
+
+### Positive control
+
+`tests/effects/archaeology/mod_refuse.sio`
+
+```
+fn marked() -> i64 with Mod { 7 }
+fn drops_effect() -> i64 { marked() }
+```
+
+| | Madaros |
+|---|---|
+| before | `check: OK` · rc=0 · E035=0 |
+| after  | rc=1 · **E035=1** |
+
+```
+error[E035] in archaeology/mod_refuse::drops_effect at 0..147:
+effect not declared in function signature (missing: Mut)
+-- required by `marked`
+```
+
+That line does not exist in the baseline log. It is the change, not
+corpus noise.
+
+A second imported witness, same pattern:
+
+```
+error[E035] in run-pass/kernel_replay_evidence_router_imported::main
+(missing: Mut) -- required by `kernel_replay_evidence_router_check`
+error[E035] in run-pass/kernel_replay_evidence_router_imported::main
+(missing: Mut) -- required by `kernel_replay_evidence_router_audit_fingerprint`
+```
+
+Baseline of that file: `check: OK`.
+
+### Negative control
+
+Same 695-file Madaros check **without** the substitution: **E035 = 0**.
+The after-count is the delta.
+
+Self-contained library `stdlib/safety/kernel_replay_evidence_router.sio`:
+`check: OK` before and after, E035=0. Intra-file callers already had
+`Mod`; the rewrite does not invent a hole there.
+
+## What this does not decide
+
+- Whether every `Mod` *means* `Mut`. #2009 read two bodies; this lane
+  did not re-read 2,811 more.
+- Whether to do the rewrite. That is the founder's. This only says
+  the E035 wave is large, closed, and confined to tests.
+
+## Reproduce
+
+```bash
+# static (no compiler)
+python3 scripts/dev/e035_mod_blast_radius.py --root . --json-out /tmp/e035_mod_static.json
+
+# substitution is refused inside a git checkout
+python3 scripts/dev/e035_mod_blast_radius.py --apply-scratch .   # exits 1
+
+# empirical: disposable copy + Slurm, never the worktree
+# see /tmp/e035_mod_slurm.sh from the measurement turn
+```
+
+Instrument: `scripts/dev/e035_mod_blast_radius.py`.
+Table: `docs/audit/E035_MOD_BLAST_RADIUS_2026-08-19.tsv`.

--- a/docs/audit/E035_MOD_BLAST_RADIUS_2026-08-19.tsv
+++ b/docs/audit/E035_MOD_BLAST_RADIUS_2026-08-19.tsv
@@ -1,0 +1,34 @@
+# E035 blast radius if with Mod became Mut. SHA bd361fd092. Not averaged.
+# field	value	engine	notes
+verdict	LARGE_BUT_CLOSED	n/a	depth 2, no compiler, no extra stdlib files
+sha	bd361fd0923bbc83ab7b0e7e00432c12baefdebd	n/a	origin/main
+git_grep_sites	2806	n/a	#2009 instrument; includes 1 comment
+git_grep_files	363	n/a	
+parser_faithful_sites	2813	n/a	#2004 extractor; no comments
+parser_faithful_files	365	n/a	
+function_owned	2813	n/a	fn's own with-clause
+closed_list_2793	2813-20	n/a	stdout cap, not a census
+grep_comment_only	1	n/a	self-hosted/check/effects.sio:24
+extractor_nonadjacent	8	n/a	with Div, Mod etc.
+files_mod_and_mut	3	n/a	
+files_mod_never_mut	362	n/a	
+closure_functions	3656	static	
+closure_files	695	static	
+max_depth	2	static	
+wave1_e035_predicted_fns	759	static	callers that would lack Mut
+wave1_ok_because_mod	1239	static	
+wave1_already_mut	0	static	
+closure_need_new_mut	843	static	759 wave1 + 84 wave2
+need_mut_files	552	static	all under tests/
+reaches_compiler	false	static	
+extra_stdlib_files	0	static	59 stdlib files already had Mod
+madaros_baseline_e035	0	madaros	695 files, all check:OK
+madaros_after_e035	13653	madaros	per call site
+madaros_files_gained	552	madaros	exact file-level match
+madaros_after_rc0	143	madaros	self-contained Mod files
+lean_baseline_e035	0	lean_single	seed does not emit E035
+lean_after_e035	0	lean_single	seed does not emit E035
+positive_mod_refuse_base_e035	0	madaros	check:OK
+positive_mod_refuse_after_e035	1	madaros	drops_effect missing Mut, required by marked
+slurm_host	cpuops-t560-proxmox	n/a	partition cpu-ops
+applied_sites_scratch	2813	n/a	disposable /tmp/e035-in only

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -110,6 +110,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.dissertation-pbpk-suite-residual-split-2026-08-17 | repo_only | docs/audit/DISSERTATION_PBPK_SUITE_RESIDUAL_SPLIT_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.dossier-import-closure-2026-08-17 | repo_only | docs/audit/DOSSIER_IMPORT_CLOSURE_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.e011-stale-prebuilt-phantom-2026-08-18 | repo_only | docs/audit/E011_STALE_PREBUILT_PHANTOM_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.e035-mod-blast-radius-2026-08-19 | repo_only | docs/audit/E035_MOD_BLAST_RADIUS_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.e043-rust-macro-design-dispatch-2026-07-12 | repo_only | docs/audit/E043_RUST_MACRO_DESIGN_DISPATCH_2026-07-12.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.effect-archaeology-51-2026-08-19 | repo_only | docs/audit/EFFECT_ARCHAEOLOGY_51_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.effect-enum-2a-2026-08-19 | repo_only | docs/audit/EFFECT_ENUM_2A_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1994,6 +1994,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.e035-mod-blast-radius-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/E035_MOD_BLAST_RADIUS_2026-08-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.e043-rust-macro-design-dispatch-2026-07-12",
       "collection": "repo",
       "repo_doc_path": "docs/audit/E043_RUST_MACRO_DESIGN_DISPATCH_2026-07-12.md",

--- a/scripts/ci/e035_mod_blast_radius_measure.sh
+++ b/scripts/ci/e035_mod_blast_radius_measure.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Static re-run of the E035 / Mod blast-radius census.
+# Does not apply the substitution. Does not edit self-hosted/.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT="${E035_MOD_BLAST_OUT:-/tmp/e035_mod_static.json}"
+python3 "$ROOT/scripts/dev/e035_mod_blast_radius.py" --root "$ROOT" --json-out "$OUT"
+python3 - "$OUT" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+cg = d["call_graph"]
+print(
+    "E035_MOD_BLAST "
+    f"sha={d['sha'][:12]} "
+    f"mod_fns={cg['affected_functions']} "
+    f"closure_fns={cg['closure_functions']} "
+    f"need_mut={cg['closure_need_new_mut']} "
+    f"need_files={len(d['need_mut_files'])} "
+    f"depth={cg['max_depth']} "
+    f"compiler={cg['reaches_compiler']}"
+)
+print("status=measured")
+print(
+    "metrics "
+    f"{{total={cg['closure_functions']}, "
+    f"passed={cg['closure_get_mut_from_mod']}, "
+    f"failed={cg['closure_need_new_mut']}, "
+    f"not_run=0}}"
+)
+PY

--- a/scripts/dev/e035_mod_blast_radius.py
+++ b/scripts/dev/e035_mod_blast_radius.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+"""Static census + caller closure for `with Mod` → `with Mut` E035 radius.
+
+Measurement only. Does not write the substitution into any git tree.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+SKIP_PREFIXES = (
+    "archive/",
+    "bootstrap/",
+    "self-hosted/bootstrap/",
+)
+IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+WITH_RE = re.compile(r"\bwith\b")
+FN_RE = re.compile(r"\b(?:pub\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)")
+CALL_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+
+
+def skip_path(rel: str) -> bool:
+    if rel.endswith(".sio.old"):
+        return True
+    return any(rel == p[:-1] or rel.startswith(p) for p in SKIP_PREFIXES)
+
+
+def mask_comments_and_strings(text: str) -> str:
+    out = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == "/" and i + 1 < n and text[i + 1] == "/":
+            out.extend("  ")
+            i += 2
+            while i < n and text[i] != "\n":
+                out.append(" ")
+                i += 1
+            continue
+        if ch == "/" and i + 1 < n and text[i + 1] == "*":
+            out.extend("  ")
+            i += 2
+            while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
+                out.append("\n" if text[i] == "\n" else " ")
+                i += 1
+            if i + 1 < n:
+                out.extend("  ")
+                i += 2
+            continue
+        if ch == '"':
+            out.append(" ")
+            i += 1
+            while i < n:
+                if text[i] == "\\" and i + 1 < n:
+                    out.extend("  ")
+                    i += 2
+                    continue
+                if text[i] == '"':
+                    out.append(" ")
+                    i += 1
+                    break
+                out.append("\n" if text[i] == "\n" else " ")
+                i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def skip_ws(s: str, pos: int) -> int:
+    while pos < len(s) and s[pos] in " \t\n":
+        pos += 1
+    return pos
+
+
+def skip_payload(s: str, pos: int) -> int:
+    if pos >= len(s) or s[pos] != "(":
+        return pos
+    depth = 0
+    while pos < len(s):
+        if s[pos] == "(":
+            depth += 1
+        elif s[pos] == ")":
+            depth -= 1
+            pos += 1
+            if depth == 0:
+                return pos
+            continue
+        pos += 1
+    return pos
+
+
+def extract_with_names(text: str) -> list[tuple[int, str, int]]:
+    """Return (line, name, start_index) for each with-clause identifier."""
+    masked = mask_comments_and_strings(text)
+    hits = []
+    for m in WITH_RE.finditer(masked):
+        pos = m.end()
+        while True:
+            pos = skip_ws(masked, pos)
+            im = IDENT_RE.match(masked, pos)
+            if not im:
+                break
+            name = im.group(0)
+            after = skip_ws(masked, skip_payload(masked, im.end()))
+            if after < len(masked) and masked[after] == ",":
+                nxt = skip_ws(masked, after + 1)
+                im2 = IDENT_RE.match(masked, nxt)
+                if im2:
+                    after2 = skip_ws(masked, skip_payload(masked, im2.end()))
+                    if after2 < len(masked) and masked[after2] == ":":
+                        hits.append(
+                            (masked.count("\n", 0, im.start()) + 1, name, im.start())
+                        )
+                        break
+            hits.append((masked.count("\n", 0, im.start()) + 1, name, im.start()))
+            pos = after
+            if pos < len(masked) and masked[pos] == ",":
+                pos += 1
+                continue
+            break
+    return hits
+
+
+def match_parens(s: str, open_pos: int) -> int | None:
+    if open_pos >= len(s) or s[open_pos] != "(":
+        return None
+    depth = 0
+    i = open_pos
+    while i < len(s):
+        if s[i] == "(":
+            depth += 1
+        elif s[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return None
+
+
+def skip_type(s: str, pos: int) -> int:
+    """Skip a type after `->`. Conservative: stop at `with` / `{` / `;`."""
+    pos = skip_ws(s, pos)
+    depth_paren = 0
+    depth_brack = 0
+    depth_angle = 0
+    while pos < len(s):
+        ch = s[pos]
+        if ch == "(":
+            depth_paren += 1
+        elif ch == ")":
+            if depth_paren == 0:
+                break
+            depth_paren -= 1
+        elif ch == "[":
+            depth_brack += 1
+        elif ch == "]":
+            depth_brack -= 1
+        elif ch == "<":
+            depth_angle += 1
+        elif ch == ">":
+            depth_angle -= 1
+        elif depth_paren == 0 and depth_brack == 0 and depth_angle == 0:
+            if s.startswith("with", pos) and (pos + 4 == len(s) or not (s[pos + 4].isalnum() or s[pos + 4] == "_")):
+                break
+            if ch in "{;":
+                break
+        pos += 1
+    return pos
+
+
+def parse_functions(text: str) -> list[dict]:
+    """Function-owned with-clauses (not parameter fn-types)."""
+    masked = mask_comments_and_strings(text)
+    fns = []
+    for m in FN_RE.finditer(masked):
+        name = m.group(1)
+        pos = skip_ws(masked, m.end())
+        if pos >= len(masked) or masked[pos] != "(":
+            continue
+        close = match_parens(masked, pos)
+        if close is None:
+            continue
+        after = skip_ws(masked, close + 1)
+        if after < len(masked) - 1 and masked.startswith("->", after):
+            after = skip_type(masked, after + 2)
+            after = skip_ws(masked, after)
+        effects = []
+        w = WITH_RE.match(masked, after) if after < len(masked) else None
+        if w:
+            p = w.end()
+            while True:
+                p = skip_ws(masked, p)
+                im = IDENT_RE.match(masked, p)
+                if not im:
+                    break
+                effects.append(im.group(0))
+                p = skip_ws(masked, skip_payload(masked, im.end()))
+                if p < len(masked) and masked[p] == ",":
+                    nxt = skip_ws(masked, p + 1)
+                    im2 = IDENT_RE.match(masked, nxt)
+                    if im2:
+                        after2 = skip_ws(masked, skip_payload(masked, im2.end()))
+                        if after2 < len(masked) and masked[after2] == ":":
+                            break
+                    p += 1
+                    continue
+                break
+        line = masked.count("\n", 0, m.start()) + 1
+        # body start
+        brace = masked.find("{", after if after else close)
+        body_end = None
+        if brace >= 0:
+            depth = 0
+            i = brace
+            while i < len(masked):
+                if masked[i] == "{":
+                    depth += 1
+                elif masked[i] == "}":
+                    depth -= 1
+                    if depth == 0:
+                        body_end = i
+                        break
+                i += 1
+        fns.append(
+            {
+                "name": name,
+                "line": line,
+                "effects": effects,
+                "start": m.start(),
+                "body_start": brace if brace >= 0 else None,
+                "body_end": body_end,
+            }
+        )
+    return fns
+
+
+def versioned_sio(root: pathlib.Path) -> list[str]:
+    raw = subprocess.check_output(
+        ["git", "-C", str(root), "ls-files", "-z", "*.sio"], text=False
+    )
+    return [p.decode() for p in raw.split(b"\0") if p]
+
+
+def grep_mod_sites(root: pathlib.Path) -> tuple[int, int, list[str]]:
+    """#2009 instrument: git grep -lE plus per-file occurrence count."""
+    raw = subprocess.check_output(
+        [
+            "git",
+            "-C",
+            str(root),
+            "grep",
+            "-nE",
+            r"\bwith[[:space:]]+Mod\b",
+            "--",
+            "*.sio",
+            ":!archive/*",
+            ":!bootstrap/*",
+        ],
+        text=True,
+    )
+    files = []
+    n = 0
+    for line in raw.splitlines():
+        if not line:
+            continue
+        n += 1
+        path = line.split(":", 1)[0]
+        if path not in files:
+            files.append(path)
+    return n, len(files), files
+
+
+def dir_bucket(rel: str) -> str:
+    parts = rel.split("/")
+    if len(parts) >= 2:
+        return "/".join(parts[:2])
+    return parts[0]
+
+
+def analyse(root: pathlib.Path) -> dict:
+    rels = [r for r in versioned_sio(root) if not skip_path(r)]
+    token_mod = []  # parser-faithful every with-Mod token
+    fns_by_file: dict[str, list[dict]] = {}
+    for rel in rels:
+        path = root / rel
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for line, name, _idx in extract_with_names(text):
+            if name == "Mod":
+                token_mod.append({"path": rel, "line": line})
+        fns = parse_functions(text)
+        for fn in fns:
+            fn["path"] = rel
+        fns_by_file[rel] = fns
+
+    grep_sites, grep_files, grep_file_list = grep_mod_sites(root)
+
+    affected_fns = []
+    for rel, fns in fns_by_file.items():
+        for fn in fns:
+            if "Mod" in fn["effects"]:
+                affected_fns.append(fn)
+
+    # file coexistence
+    files_mod = set()
+    files_mut = set()
+    for rel, fns in fns_by_file.items():
+        text = (root / rel).read_text(encoding="utf-8", errors="replace")
+        names = [n for _l, n, _i in extract_with_names(text)]
+        if "Mod" in names:
+            files_mod.add(rel)
+        if "Mut" in names:
+            files_mut.add(rel)
+
+    import bisect
+
+    # call graph: file-local first, then unique name.
+    by_name: dict[str, list[dict]] = collections.defaultdict(list)
+    for rel, fns in fns_by_file.items():
+        for fn in fns:
+            by_name[fn["name"]].append(fn)
+
+    def key(fn: dict) -> str:
+        return f"{fn['path']}:{fn['name']}:{fn['line']}"
+
+    affected_keys = {key(fn) for fn in affected_fns}
+    affected_names = {fn["name"] for fn in affected_fns}
+    has_mut = {}
+    has_mod = {}
+    for rel, fns in fns_by_file.items():
+        for fn in fns:
+            has_mut[key(fn)] = "Mut" in fn["effects"]
+            has_mod[key(fn)] = "Mod" in fn["effects"]
+
+    def would_have_mut(k: str) -> bool:
+        return has_mut.get(k, False) or has_mod.get(k, False)
+
+    local_by_name: dict[str, dict[str, list[dict]]] = {}
+    body_index: dict[str, tuple[list[int], list[dict]]] = {}
+    for rel, fns in fns_by_file.items():
+        lb: dict[str, list[dict]] = collections.defaultdict(list)
+        starts = []
+        owners = []
+        for fn in fns:
+            lb[fn["name"]].append(fn)
+            if fn["body_start"] is not None and fn["body_end"] is not None:
+                starts.append(fn["body_start"])
+                owners.append(fn)
+        local_by_name[rel] = lb
+        # sort by body_start for bisect
+        order = sorted(range(len(starts)), key=lambda i: starts[i])
+        body_index[rel] = ([starts[i] for i in order], [owners[i] for i in order])
+
+    def owning_fn(rel: str, pos: int) -> dict | None:
+        starts, owners = body_index.get(rel, ([], []))
+        i = bisect.bisect_right(starts, pos) - 1
+        if i < 0:
+            return None
+        fn = owners[i]
+        if fn["body_start"] < pos < fn["body_end"]:
+            return fn
+        return None
+
+    def resolve(rel: str, name: str) -> dict | None:
+        local = local_by_name.get(rel, {}).get(name, [])
+        if local:
+            return local[0]
+        cands = by_name.get(name, [])
+        if len(cands) == 1:
+            return cands[0]
+        return None
+
+    callers_of: dict[str, set[str]] = collections.defaultdict(set)
+    unresolved_calls = 0
+    resolved_calls = 0
+    # Only resolve calls whose name is an affected function. Transitive
+    # callers are themselves found when we walk callers_of of those keys,
+    # then of *their* callers — so we must also record calls TO any
+    # function that we later put in the closure. That requires all calls.
+    # Compromise: record every call whose callee resolves, but skip
+    # keyword/builtin names that never match a defined fn (resolve=None).
+    for rel, fns in fns_by_file.items():
+        text = (root / rel).read_text(encoding="utf-8", errors="replace")
+        masked = mask_comments_and_strings(text)
+        for cm in CALL_RE.finditer(masked):
+            name = cm.group(1)
+            if name not in by_name:
+                continue
+            owner = owning_fn(rel, cm.start())
+            if owner is None:
+                continue
+            callee = resolve(rel, name)
+            if callee is None:
+                unresolved_calls += 1
+                continue
+            resolved_calls += 1
+            callers_of[key(callee)].add(key(owner))
+
+    # Transitive caller closure of affected functions
+    # Wave 0 = affected fns themselves
+    # Wave d+1 = callers of wave d that are not already in the closure
+    closure = set(affected_keys)
+    wave = list(affected_keys)
+    depth_of = {k: 0 for k in affected_keys}
+    max_depth = 0
+    while wave:
+        nxt = []
+        for k in wave:
+            for c in callers_of.get(k, ()):
+                if c not in closure:
+                    closure.add(c)
+                    depth_of[c] = depth_of[k] + 1
+                    max_depth = max(max_depth, depth_of[c])
+                    nxt.append(c)
+        wave = nxt
+
+    # Who would fail E035 at wave 1: callers of an affected fn that would
+    # NOT have Mut after the substitution.
+    wave1_fail = set()
+    wave1_ok_already_mut = set()
+    wave1_ok_because_mod = set()
+    for ak in affected_keys:
+        for c in callers_of.get(ak, ()):
+            if would_have_mut(c):
+                if has_mut.get(c) and not has_mod.get(c):
+                    wave1_ok_already_mut.add(c)
+                else:
+                    wave1_ok_because_mod.add(c)
+            else:
+                wave1_fail.add(c)
+
+    # In the FULL closure, after iteratively adding Mut to every failing
+    # caller, who still needs a new Mut annotation?
+    # = members of closure that do not already have Mut and do not have Mod
+    need_mut_annotation = {k for k in closure if not would_have_mut(k)}
+    already_mut_in_closure = {k for k in closure if has_mut.get(k) and not has_mod.get(k)}
+    get_mut_from_mod = {k for k in closure if has_mod.get(k)}
+
+    def files_of(keys):
+        return sorted({k.split(":")[0] for k in keys})
+
+    closure_files = files_of(closure)
+    need_files = files_of(need_mut_annotation)
+    affected_files = files_of(affected_keys)
+
+    # Does the closure reach the compiler or the whole stdlib?
+    reaches_compiler = any(f.startswith("self-hosted/") for f in closure_files)
+    stdlib_files = [f for f in closure_files if f.startswith("stdlib/")]
+    test_files = [f for f in closure_files if f.startswith("tests/")]
+
+    # buckets of affected files
+    buckets = collections.Counter(dir_bucket(f) for f in affected_files)
+
+    # grep-only comment sites: grep hits whose line is a comment
+    grep_comment_only = 0
+    grep_not_in_extractor = []
+    extractor_set = {(h["path"], h["line"]) for h in token_mod}
+    # rebuild grep line list
+    raw = subprocess.check_output(
+        [
+            "git",
+            "-C",
+            str(root),
+            "grep",
+            "-nE",
+            r"\bwith[[:space:]]+Mod\b",
+            "--",
+            "*.sio",
+            ":!archive/*",
+            ":!bootstrap/*",
+        ],
+        text=True,
+    )
+    grep_pairs = []
+    for line in raw.splitlines():
+        path, rest = line.split(":", 1)
+        ln_s, _src = rest.split(":", 1)
+        ln = int(ln_s)
+        grep_pairs.append((path, ln))
+        if (path, ln) not in extractor_set:
+            grep_not_in_extractor.append({"path": path, "line": ln, "text": _src.strip()[:120]})
+
+    extractor_not_in_grep = [
+        h for h in token_mod if (h["path"], h["line"]) not in {(p, l) for p, l in grep_pairs}
+    ]
+
+    return {
+        "sha": subprocess.check_output(
+            ["git", "-C", str(root), "rev-parse", "HEAD"], text=True
+        ).strip(),
+        "instruments": {
+            "git_grep_with_Mod": {
+                "sites": grep_sites,
+                "files": grep_files,
+                "note": "counts comments and strings; #2009 instrument",
+            },
+            "parser_faithful_tokens": {
+                "sites": len(token_mod),
+                "files": len({h["path"] for h in token_mod}),
+                "note": "closed-list gate extractor; excludes comments/strings",
+            },
+            "function_owned_signatures": {
+                "functions": len(affected_fns),
+                "files": len(affected_files),
+                "note": "fn's own with-clause, not parameter fn-types",
+            },
+            "disagreement": {
+                "grep_not_in_extractor": grep_not_in_extractor[:40],
+                "grep_not_in_extractor_count": len(grep_not_in_extractor),
+                "extractor_not_in_grep_count": len(extractor_not_in_grep),
+                "extractor_not_in_grep_sample": extractor_not_in_grep[:20],
+                "closed_list_stdout_cap_explain": (
+                    "PR #2004 printed omitted=2793 (= 2813-20 stdout cap). "
+                    "That is not a second count."
+                ),
+            },
+        },
+        "coexistence": {
+            "files_with_mod": len(files_mod),
+            "files_with_mod_and_mut": len(files_mod & files_mut),
+            "files_with_mod_never_mut": len(files_mod - files_mut),
+        },
+        "buckets": dict(buckets),
+        "call_graph": {
+            "resolved_calls": resolved_calls,
+            "unresolved_calls": unresolved_calls,
+            "affected_functions": len(affected_keys),
+            "affected_files": len(affected_files),
+            "closure_functions": len(closure),
+            "closure_files": len(closure_files),
+            "max_depth": max_depth,
+            "wave1_e035_predicted": len(wave1_fail),
+            "wave1_ok_already_mut": len(wave1_ok_already_mut),
+            "wave1_ok_because_also_mod": len(wave1_ok_because_mod),
+            "closure_need_new_mut": len(need_mut_annotation),
+            "closure_already_mut": len(already_mut_in_closure),
+            "closure_get_mut_from_mod": len(get_mut_from_mod),
+            "reaches_compiler": reaches_compiler,
+            "stdlib_files_in_closure": len(stdlib_files),
+            "test_files_in_closure": len(test_files),
+        },
+        "wave1_fail_sample": sorted(wave1_fail)[:40],
+        "need_mut_sample": sorted(need_mut_annotation)[:40],
+        "closure_files": closure_files,
+        "need_mut_files": need_files,
+        "affected_fn_sample": [
+            {"path": fn["path"], "line": fn["line"], "name": fn["name"], "effects": fn["effects"]}
+            for fn in affected_fns[:15]
+        ],
+    }
+
+
+def apply_mod_to_mut(root: pathlib.Path) -> int:
+    """Replace with-clause Mod tokens with Mut. Refuses a git checkout."""
+    if (root / ".git").exists():
+        raise SystemExit(
+            "refuse: will not apply Mod→Mut inside a git checkout; "
+            "pass a disposable scratch copy"
+        )
+    n = 0
+    for p in root.rglob("*.sio"):
+        rel = p.relative_to(root).as_posix()
+        if skip_path(rel):
+            continue
+        text = p.read_text(encoding="utf-8", errors="replace")
+        hits = [(idx, name) for _ln, name, idx in extract_with_names(text) if name == "Mod"]
+        if not hits:
+            continue
+        chars = list(text)
+        for idx, _name in sorted(hits, reverse=True):
+            # 'Mod' is 3 chars; masked indices align with original.
+            if text[idx : idx + 3] != "Mod":
+                raise SystemExit(f"index mismatch {rel} @{idx}")
+            chars[idx : idx + 3] = list("Mut")
+            n += 1
+        p.write_text("".join(chars), encoding="utf-8")
+    return n
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--json-out", default="")
+    ap.add_argument(
+        "--apply-scratch",
+        default="",
+        help="disposable tree only; refuses if ROOT/.git exists",
+    )
+    args = ap.parse_args()
+    if args.apply_scratch:
+        n = apply_mod_to_mut(pathlib.Path(args.apply_scratch).resolve())
+        print(f"applied_mod_to_mut sites={n} root={args.apply_scratch}")
+        return 0
+    root = pathlib.Path(args.root).resolve()
+    result = analyse(root)
+    text = json.dumps(result, indent=2)
+    if args.json_out:
+        pathlib.Path(args.json_out).write_text(text + "\n", encoding="utf-8")
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

`with Mod` is **held** (`self-hosted/check/effects.sio:23-26`).
`effect_name_to_id("Mod")` returns −1; the checker treats those
functions as declaring nothing. #2009 showed the misspelling
reading. The founder asked for the E035 blast radius **before
any edit**.

This PR does **not** rewrite `Mod` to `Mut`. `self-hosted/` is
untouched. `Mod` is not added to `effect_name_to_id`. The
substitution ran only in a disposable tree on Slurm and was
never committed.

## Verdict

**LARGE BUT CLOSED.** The caller closure terminates at depth 2.
It does not enter the compiler. It does not add any stdlib file
beyond the 59 that already write `with Mod`. The new annotations
live in tests.

If the founder later decides to rewrite, the edit is 2,813
signatures plus **843 further functions / 552 files** that must
gain a `Mut` declaration. A large mechanical pass, not an
open-ended refactor.

## How many `with Mod` sites (not averaged)

| Instrument | Sites | Files |
|---|---:|---:|
| `git grep '\bwith[[:space:]]+Mod\b'` (#2009) | 2806 | 363 |
| Parser-faithful `with`-clause tokens (#2004) | **2813** | 365 |
| Function-owned signatures (this lane) | **2813** | 365 |

Grep includes 1 comment (`effects.sio:24`) and misses 8
non-adjacent clauses (`with Div, Mod`). 2806 − 1 + 8 = 2813.
The 2,793 from #2004 is `omitted=2813−20` (stdout cap), not a
census.

Coexistence: 3 files write both `Mod` and `Mut`; **362 write
`Mod` and never `Mut`**.

## Static closure

SHA `bd361fd092` (`origin/main`).

| | |
|---|---:|
| Closure functions | 3656 |
| Closure files | 695 |
| Maximum chain depth | **2** |
| Wave-1 callers that would lack `Mut` | 759 |
| Wave-1 already covered via their own `Mod` | 1239 |
| Wave-1 already declare `Mut` only | **0** |
| Need a new `Mut` | **843** in **552** test files |
| Reaches `self-hosted/` | **no** |
| Extra stdlib files | **0** |

## Empirical (Slurm, both engines)

Host `cpuops-t560-proxmox`, partition `cpu-ops`. Disposable
`/tmp/e035-in`. 2,813 tokens rewritten there only. Corpus: the
695-file closure.

| Engine | Condition | E035 | Files with E035 | rc=0 |
|---|---|---:|---:|---:|
| **Madaros v0.80.0** | baseline | **0** | 0 | 695 |
| **Madaros v0.80.0** | after Mod→Mut | **13653** | **552** | 143 |
| lean_single | baseline | 0 | 0 | 13 |
| lean_single | after Mod→Mut | 0 | 0 | 221 |

Madaros file-level match with the static “need new Mut” set:
**552 = 552**. 13,653 diagnostics vs 843 functions is per
call-site reporting, not a disagreement about *where*.
lean_single emits **no E035** on either side; the seed does
not carry this diagnostic. Its rc=0 swing is compile-to-ELF
noise, not an effect signal.

### Positive control

`tests/effects/archaeology/mod_refuse.sio` — `marked() with Mod`
called from `drops_effect()` with no effects.

- before (Madaros): `check: OK` · rc=0 · E035=0
- after (Madaros): rc=1 · **E035=1**

```
error[E035] in archaeology/mod_refuse::drops_effect
effect not declared in function signature (missing: Mut)
-- required by `marked`
```

That line is absent from the baseline log.

### Negative control

Same 695-file Madaros check **without** the substitution:
**E035 = 0**. The after-count is the delta.

## What this does not decide

- Whether every `Mod` *means* `Mut`. #2009 read two bodies;
  this lane did not re-read 2,811 more.
- Whether to do the rewrite. That remains the founder's.

## Files

- `docs/audit/E035_MOD_BLAST_RADIUS_2026-08-19.md`
- `docs/audit/E035_MOD_BLAST_RADIUS_2026-08-19.tsv`
- `scripts/dev/e035_mod_blast_radius.py` (`--apply-scratch`
  refuses a git checkout)
- `scripts/ci/e035_mod_blast_radius_measure.sh` (static re-run;
  not a CI gate)

Do not merge unless asked.