### PR TITLE
docs(audit): Knowledge annotation parser coverage — the measurement, without the freight

### DIFF
--- a/docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
+++ b/docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
@@ -1,0 +1,78 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.knowledge-annotation-parser-coverage-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: claude-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.knowledge-annotation-parser-coverage-2026-08-19
+-->
+
+# `Knowledge<…>` annotation components — parser coverage against the AST enums
+
+## Provenance of this document
+
+Measured **blind** by `glm-cli2` on 2026-08-19: the lane was given the question
+and explicitly not shown a parallel measurement by `claude-1`, so that agreement
+would carry weight and disagreement would be a finding.
+
+It was originally filed as `#2005` / `#2006`, which also carried +5,075,769 lines
+of accidentally committed content — `uberon.owl`, `cl.owl`, ChEBI dumps, session
+state, and edits to `CLAUDE.md`, `AGENTS.md`, `FOUNDER_INTENT.md`, `.gitignore`,
+`.githooks/` and `ci.yml`. Those PRs were closed by founder decision. **This is
+the measurement, without the freight.** No finding is altered.
+
+## Findings
+
+| family | declared | reachable from source | unreachable |
+|---|---:|---:|---|
+| `AstValidityKind` | 3 | 3 | 0 |
+| `AstProvenanceKind` | 6 | 3 | 3 — `AstProvSource`, `AstProvLiterature`, `AstProvInput` |
+| `KnowledgeConstraintKind` | 6 | 6 | 0 |
+| `ValueKind` | 4 | 4 | 0 |
+
+**The hole is specific to provenance.** Three other families in the same parser
+are wired end to end, which rules out "the annotation parser is generally
+unfinished".
+
+- The three unreachable provenance cases have **no lexer words and no parser
+  branches, and never had any** — `git log -S` over the parser files returns
+  nothing. The gap is duplicated in `self-hosted/bootstrap/bootstrap_v0.sio`.
+- Unrecognised components are **silently skipped**: identifiers are greedily
+  eaten as epsilon bounds, and everything else reaches
+  `} else { // Unknown component — skip }`.
+- `check/epistemic.sio` `provenance_from_ast` has explicit branches for
+  `Source`, `Literature` and `Input`, each with its own runtime constant. Their
+  pipeline is therefore **dead at the front end only**: consumers exist,
+  producers do not.
+
+## Controls
+
+- **Positive** — `ValidUntil` → `AstValidityKind::ValidUntilTime`, exercised by
+  `tests/run-pass/covid_2020_kernel.sio`. Without it, a count of zero reachable
+  cases would be indistinguishable from a broken instrument.
+- **Negative** — declarations and consumer match arms excluded from the
+  reachability count, so that a case which is merely *declared* and *matched*
+  cannot be counted as reachable from source.
+
+## The lane's verdict, and why it was superseded
+
+The lane concluded **"the enum grew by anticipation, not parser lag"**, on the
+grounds that all six entered in one commit with three branches and no versioned
+`.sio` or doc ever used the missing three.
+
+`claude-1` had concluded the opposite from commit history. Neither verdict
+survived a third measurement that the disagreement provoked — a layer-by-layer
+count (`docs/audit/PROVENANCE_LAYER_STAIRCASE_2026-08-19.md`), which found that
+the three unreachable cases carry **runtime constants and consumer branches**. A
+speculative enum does not acquire those. The reading is **lag**.
+
+The lane's exclusion of consumer match arms was correct for the question it
+asked, and is exactly what hid the evidence that settled it. Two correct
+measurements of different things; the disagreement was the finding.
+
+## Note on execution
+
+Slurm jobs 10392/10394 were submitted per the standing directive, but the cluster
+was degraded (jobs failing with signal 53). The measurement is static text
+analysis over versioned files, performed as reads, so no pod compute was consumed
+and the directive's purpose was met by other means. Recorded rather than omitted.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -190,6 +190,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.kaxi-ptx-golden-drop-not-mismatch-2026-08-19 | repo_only | docs/audit/KAXI_PTX_GOLDEN_DROP_NOT_MISMATCH_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kaxi-ptx-target-sm-audit-2026-06-17 | repo_only | docs/audit/KAXI_PTX_TARGET_SM_AUDIT_2026-06-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kconf-bitcast-apply-package-2026-08-18 | repo_only | docs/audit/KCONF_BITCAST_APPLY_PACKAGE_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.knowledge-annotation-parser-coverage-2026-08-19 | repo_only | docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.knowledge-annotation-surface-madaros-only-2026-08-19 | repo_only | docs/audit/KNOWLEDGE_ANNOTATION_SURFACE_MADAROS_ONLY_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.known-failure-needs-an-engine-2026-08-19 | repo_only | docs/audit/KNOWN_FAILURE_NEEDS_AN_ENGINE_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.known-failure-xpas-gate-dispatch-2026-08-18 | repo_only | docs/audit/KNOWN_FAILURE_XPAS_GATE_DISPATCH_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -3834,6 +3834,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.knowledge-annotation-parser-coverage-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.knowledge-annotation-surface-madaros-only-2026-08-19",
       "collection": "repo",
       "repo_doc_path": "docs/audit/KNOWLEDGE_ANNOTATION_SURFACE_MADAROS_ONLY_2026-08-19.md",


### PR DESCRIPTION
Re-filed from `#2005`/`#2006`, closed by founder decision because they carried **+5,075,769 lines** of accidentally committed content. **No finding is altered.**

Measured **blind** by `glm-cli2` — given the question, deliberately not shown `claude-1`’s parallel measurement, so that agreement would carry weight and disagreement would be a finding.

| family | declared | reachable | unreachable |
|---|---:|---:|---|
| `AstValidityKind` | 3 | 3 | 0 |
| `AstProvenanceKind` | 6 | 3 | 3 — `Source`, `Literature`, `Input` |
| `KnowledgeConstraintKind` | 6 | 6 | 0 |
| `ValueKind` | 4 | 4 | 0 |

**The hole is specific to provenance.** Three other families in the same parser are wired end to end, which rules out a generally unfinished annotation parser.

`check/epistemic.sio` has explicit branches **and runtime constants** for the three unreachable cases, so their pipeline is dead **at the front end only**: consumers exist, producers do not.

## The disagreement was the finding

The lane concluded *"the enum grew by anticipation, not parser lag"*. `claude-1` had concluded the opposite from commit history. **Neither survived** the third measurement the disagreement provoked — the layer-by-layer count in `PROVENANCE_LAYER_STAIRCASE_2026-08-19.md`, which found the runtime constants and consumer branches. A speculative enum does not acquire those. The reading is **lag**.

The lane’s exclusion of consumer match arms was correct for the question it asked, and is exactly what hid the evidence that settled it. **Two correct measurements of different things.**

## Execution note

Slurm jobs 10392/10394 were submitted per directive but the cluster was degraded (signal 53). The measurement is static analysis performed as reads, so no pod compute was consumed. Recorded rather than omitted.