### PR TITLE
docs(audit): the rich Knowledge<…> annotation surface exists only in Madaros

### DIFF
--- a/docs/audit/KNOWLEDGE_ANNOTATION_SURFACE_MADAROS_ONLY_2026-08-19.md
+++ b/docs/audit/KNOWLEDGE_ANNOTATION_SURFACE_MADAROS_ONLY_2026-08-19.md
@@ -1,0 +1,75 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.knowledge-annotation-surface-madaros-only-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: claude-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.knowledge-annotation-surface-madaros-only-2026-08-19
+-->
+
+# The rich `Knowledge<…>` annotation surface exists only in Madaros
+
+## The question that produced this
+
+Founder ruling 2026-08-19 gives `Input` a keyword. Before implementing, the risk
+to check was: **if only Madaros gains the keyword, a valid program compiles on one
+engine and not the other** — the divergence that already costs 437 of 1,527
+greens (`#1985`).
+
+## Answer
+
+**`lean_single` does not need the keyword, because it has no provenance parsing
+to extend.** Adding `Input` to Madaros creates **no new divergence**: this axis
+has been fully divergent from the start.
+
+Measured on `origin/main`, 2026-08-19, over
+`self-hosted/compiler/lean_single.sio`:
+
+| symbol | occurrences |
+|---|---:|
+| `Knowledge` | 118 |
+| `measure` | 66 |
+| `variance_of` | 5 |
+| `ExactlyPrivate` | 3 |
+| **`KnowledgeTypeInfo`** | **0** |
+| **`EpsilonBound`** | **0** |
+| **`ValidityCondition`** | **0** |
+| **`AstProvenanceKind`** | **0** |
+
+The first four are the positive control: the seed carries plenty of epistemic
+content, so a zero in the second group is a measurement and not a dead command.
+`Derived`, `Computed`, `Measured` and `Input` are likewise **0** in that file —
+the three keywords that already work are already Madaros-only.
+
+## The larger finding
+
+The seed knows `Knowledge<T>` as a **bare** constructor. It has none of the
+annotation-component machinery: no epsilon bound, no validity condition, no
+provenance kind.
+
+So every epistemic claim expressed through an annotation —
+`Knowledge<f64 measured>`, an `ε` bound, a `valid_while(…)` — is **invisible to
+the engine CI actually runs** (`#1978`: the Full Test Suite runs `souc-stage2`,
+which is lean_single).
+
+This changes how `#1985`'s 437-of-1,527 should be read. Part of what CI does not
+test is not a *difference in result between two engines*. It is a **language
+surface one engine does not have**. A test exercising an annotated `Knowledge`
+type cannot disagree between the engines; it can only fail to parse on one.
+
+## What this does and does not license
+
+- **Licenses:** implementing the `Input` keyword in Madaros alone, without
+  waiting on a seed decision. Nothing regresses, because nothing on this axis
+  currently agrees.
+- **Does not license:** describing annotated `Knowledge` types as a property of
+  *Sounio*. They are a property of *Madaros*. Under
+  `SOUNIO-GATING-ENGINE`, a claim about them must name the engine.
+- **Does not license:** reading the divergence census as fully explained. This
+  accounts for the annotation surface; it says nothing about the rest of the 437.
+
+## Instrument
+
+`git grep -c <symbol> origin/main -- self-hosted/compiler/lean_single.sio`, with
+the four-symbol positive control run in the same command. Word-boundary matching
+was not needed: the symbols are distinctive identifiers.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -187,6 +187,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.kaxi-ptx-golden-drop-not-mismatch-2026-08-19 | repo_only | docs/audit/KAXI_PTX_GOLDEN_DROP_NOT_MISMATCH_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kaxi-ptx-target-sm-audit-2026-06-17 | repo_only | docs/audit/KAXI_PTX_TARGET_SM_AUDIT_2026-06-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kconf-bitcast-apply-package-2026-08-18 | repo_only | docs/audit/KCONF_BITCAST_APPLY_PACKAGE_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.knowledge-annotation-surface-madaros-only-2026-08-19 | repo_only | docs/audit/KNOWLEDGE_ANNOTATION_SURFACE_MADAROS_ONLY_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.known-failure-needs-an-engine-2026-08-19 | repo_only | docs/audit/KNOWN_FAILURE_NEEDS_AN_ENGINE_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.known-failure-xpas-gate-dispatch-2026-08-18 | repo_only | docs/audit/KNOWN_FAILURE_XPAS_GATE_DISPATCH_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.known-failure-xpas-signal-2026-08-18 | repo_only | docs/audit/KNOWN_FAILURE_XPAS_SIGNAL_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -3765,6 +3765,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.knowledge-annotation-surface-madaros-only-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/KNOWLEDGE_ANNOTATION_SURFACE_MADAROS_ONLY_2026-08-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.known-failure-needs-an-engine-2026-08-19",
       "collection": "repo",
       "repo_doc_path": "docs/audit/KNOWN_FAILURE_NEEDS_AN_ENGINE_2026-08-19.md",


### PR DESCRIPTION
Asked before implementing the founder’s `Input`-keyword ruling: **if only Madaros gains the keyword, does a valid program compile on one engine and not the other?**

**It does not — `lean_single` has no provenance parsing to extend.**

| symbol in `lean_single.sio` | occurrences |
|---|---:|
| `Knowledge` | 118 |
| `measure` | 66 |
| `variance_of` | 5 |
| `ExactlyPrivate` | 3 |
| **`KnowledgeTypeInfo`** | **0** |
| **`EpsilonBound`** | **0** |
| **`ValidityCondition`** | **0** |
| **`AstProvenanceKind`** | **0** |

The first four are the **positive control**, run in the same command: the seed is full of epistemic content, so the zeros are a measurement and not a dead grep. `Derived`, `Computed`, `Measured`, `Input` are likewise **0** — the three keywords that already work are **already Madaros-only**.

## The larger finding

The seed knows `Knowledge<T>` as a **bare** constructor: no epsilon bound, no validity condition, no provenance kind. So **every epistemic claim expressed through an annotation is invisible to the engine CI actually runs** (`#1978`: the Full Test Suite runs `souc-stage2`).

That changes how `#1985`’s 437-of-1,527 reads. Part of what CI does not test is **not a difference in result** between two engines — it is a **language surface one engine does not have**. A test exercising an annotated `Knowledge` type cannot *disagree* between engines; it can only fail to parse on one.

## What this does and does not license

- **Licenses:** implementing `Input` in Madaros alone. Nothing regresses, because nothing on this axis currently agrees.
- **Does not license:** calling annotated `Knowledge` types a property of *Sounio*. They are a property of *Madaros*, and a claim must name the engine (`SOUNIO-GATING-ENGINE`).
- **Does not license:** reading the divergence census as explained. This accounts for the annotation surface only.