### PR TITLE
docs(audit): unlearning quadrant — conjunction free, over-claim occupied

### DIFF
--- a/docs/audit/UNLEARNING_QUADRANT_2026-08-19.md
+++ b/docs/audit/UNLEARNING_QUADRANT_2026-08-19.md
@@ -1,0 +1,330 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.unlearning-quadrant-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: grok-cli3
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.unlearning-quadrant-2026-08-19
+-->
+
+# Unlearning quadrant — is it occupied? 2026-08-19
+
+**Question.** Does the published field already occupy the conjunction
+
+> exact unlearning **without retraining**, **by algebraic annihilation**,
+> **verified at compile time**
+
+that a Sounio paper would claim for `ExactlyPrivate<T>`?
+
+**This receipt exists to try to knock that claim down**, not to confirm it.
+A result that occupies the quadrant, or that occupies one of the three
+qualifiers, is the useful result.
+
+**Verdict on the conjunction:** **FREE** as a *published triple*.
+Nobody was found who does all three at once.
+
+**Verdict on the attractive over-claim:** **occupied in pieces.**
+"Exact without retrain" is not unique. "Privacy checked at compile
+time" is not unique. "The field of machine unlearning is entirely
+approximate and statistical" is **false**. Those three knockdowns
+are the load-bearing output of this search.
+
+No code was changed.
+
+```text
+Semantic-Lane-ID: unlearning-quadrant-20260819
+Owner: grok-cli3
+Concept-IDs: none created
+Intent-Preserved: a green claim must survive an attempt to occupy it
+Transformation: none — literature census
+Types-Changed: none
+Effects-Changed: none
+IR-Changed: none
+Claims-Introduced:
+  - Q1 PARTIAL: exact unlearning without full retrain exists for restricted models
+  - Q2 PARTIAL: compile-time privacy types exist; they verify DP/IFC, not forgetting
+  - Q3 FREE: no published use of Cayley–Dickson zero-divisors as an unlearning operator
+  - Q4 PARTIAL: published algebra already implies annihilation is unstable off the ZD variety
+  - the three-qualifier conjunction is FREE; the over-claim "the field is all approximate" is false
+Claims-Forbidden:
+  - Sounio uniquely has exact unlearning
+  - Sounio currently verifies forgetting at compile time
+  - Lean unlearning_kernel_exact is a theorem about trained models
+  - left-multiplication by a zero-divisor is a projection onto the complement
+  - IEEE f64 residual on the exact ±1 ZD pair is the kill-shot (it is 0.0)
+Assumptions: English-language peer-reviewed + arXiv through 2026-08-19
+Write-Set:
+  docs/audit/UNLEARNING_QUADRANT_2026-08-19.md
+  docs/audit/UNLEARNING_QUADRANT_2026-08-19.tsv
+Read-Set: formal/lean4/SounioSurgicalInterventions.lean;
+  self-hosted/check/check.sio lower_exactly_private_type;
+  examples/zd_machine_unlearning.sio;
+  grok-cli4 docs/audit/ZD_ANNIHILATE_BUILTIN_DISPATCH_2026-08-19.md (read-only)
+Positive-Witness: Cao & Yang IEEE S&P 2015; Fuzz ICFP 2010; Moreno 1998
+Negative-Witness: no sedenion-ZD × unlearning hit in the search set
+Acceptance-Gate: each of Q1–Q4 is OCCUPIED / FREE / PARTIAL with method;
+  peer-reviewed distinguished from preprint; engines/Lean not over-read
+Integration-Target: docs (audit)
+Authoritative-Only-If: n/a — observational
+```
+
+Companion TSV: `docs/audit/UNLEARNING_QUADRANT_2026-08-19.tsv`.
+
+## What Sounio actually has (local baseline, not the field)
+
+State this first so the literature is not compared to a stronger
+Sounio than exists.
+
+| Surface | What it is | What it is not |
+|---|---|---|
+| `unlearning_kernel_exact` in `formal/lean4/SounioSurgicalInterventions.lean` | `native_decide` that four listed primitives are right-annihilated by `primA`. No `sorry`, no Mathlib. | A theorem that a trained model forgot a subject. The file itself labels the type correspondence a **propositional scaffold** and says the full semantics of `ExactlyPrivate<T>` are out of scope. |
+| `every_primitive_has_4_annihilators` | Finite census: 84 primitives, degree 4. | A forgetting operator. |
+| E201 / `lower_exactly_private_type` | If the type constructor `ExactlyPrivate` is written, effect id 18 (`ZD`) must be declared. The inner type is then returned unchanged. | A check that annihilation occurred, that `x` lies in `ker(A)`, or that the result is indistinguishable from never-trained. |
+| `examples/zd_machine_unlearning.sio` Method 3 | Euclidean projection `W − ⟨W,u1⟩u1 − ⟨W,u2⟩u2`. The file **says** the sedenion product is not a projection and is not `W_bob`. | Left-multiplication by `e3+e10` as the unlearning map. |
+| grok-cli4 forensic `ZD_ANNIHILATE_BUILTIN_DISPATCH_2026-08-19.md` | Closed builtin `zd_annihilate` proposed, not shipped. Recognition ≠ contribution-zero. | A compile-time forgetting proof. |
+
+So even if the field were empty, the candidate sentence would still
+over-read the Lean file and the checker.
+
+## Method
+
+Searched 2026-08-19. Absence is reported only with the query in front.
+
+| # | Query family | Surfaces |
+|---|---|---|
+| S1 | `exact machine unlearning without retraining algebraic closed form` | web index |
+| S2 | `SISA Bourtoule machine unlearning` | web + arXiv `1912.03817` (confirmed live) |
+| S3 | `Cao Yang Towards Making Systems Forget` | web; IEEE S&P 2015 |
+| S4 | `Cauwenberghs Poggio incremental decremental SVM` | NIPS 2000 proceedings |
+| S5 | `Ginart Making AI Forget You k-means` | arXiv `1907.05012` (confirmed live) |
+| S6 | `Guo Certified Data Removal` | arXiv `1911.03030` (confirmed live) |
+| S7 | `Izzo Approximate Data Deletion Regression` | arXiv `2002.10077` |
+| S8 | `Closed-form Machine Unlearning Matrix Factorization CIKM 2023` | ACM `10.1145/3583780.3614811` |
+| S9 | `Fuzz Reed Pierce differential privacy type system` | ICFP 2010 |
+| S10 | `DFuzz Gaboardi POPL 2013` | POPL 2013 |
+| S11 | `Duet Near type system differential privacy` | OOPSLA 2019 / arXiv `1909.02481` |
+| S12 | `Jif Myers Liskov information flow` | POPL 1999 |
+| S13 | `"zero divisor" (privacy OR unlearning OR forgetting OR GDPR) (sedenion OR octonion OR "Cayley-Dickson")` | web index |
+| S14 | `sedenion zero divisor floating point numerical instability` | web; then primary algebra |
+| S15 | `Moreno zero divisors Cayley-Dickson Bol Soc Mat Mexicana` | arXiv `q-alg/9710013`; *Boletín* 1998 |
+| S16 | `Cawagas structure zero divisors sedenion` | *Discussiones Mathematicae* 2004 |
+| S17 | `"certified unlearning" OR "verifiable unlearning" type system OR compile-time` | web + arXiv `2210.09126` (confirmed live) |
+| S18 | `Nguyen Survey of Machine Unlearning` | arXiv `2209.02299` (confirmed live) |
+| S19 | `Higham Cholesky downdating unstable` | Higham ASNA 2002; Bojanczyk–Brent–van Dooren–de Hoog *SISC* 1987 |
+
+arXiv titles confirmed by `export.arxiv.org` on 2026-08-19 for
+`2209.02299`, `1912.03817`, `1911.03030`, `1907.05012`, `2411.18881`,
+`2210.09126`.
+
+Not treated as evidence: unsourced survey-tool paraphrases; arXiv IDs
+that did not resolve; patents except as a negative (octonion FHE has
+no zero-divisors).
+
+Coverage hole, declared: non-English venues, dissertations not on
+arXiv, and 2026 workshop papers not yet indexed. That hole is why
+Q3 is FREE and not a proof of non-existence.
+
+## Q1 — Exact unlearning without retraining
+
+**PARTIAL.**
+
+The field is **not** "entirely approximate and statistical". Exact
+removal without a full from-scratch retrain is published for
+restricted model classes. SISA is exact **and retrains fragments**;
+it occupies exactness, not the "no retrain" cell.
+
+| Work | Venue / date | Review | What is exact | Retrain? |
+|---|---|---|---|---|
+| Cauwenberghs & Poggio, incremental/decremental SVM | NIPS 2000 | peer-reviewed | decremental step yields the batch SVM without the point | no full QP restart |
+| Cao & Yang, *Towards Making Systems Forget with Machine Unlearning* | IEEE S&P 2015 | peer-reviewed | subtract the sample from SQ / summation statistics and recompute the model | no full pass over the retain set |
+| Ginart, Guan, Valiant, Zou, *Making AI Forget You* | NeurIPS 2019; arXiv `1907.05012` | peer-reviewed | deletion-efficient *k*-means, equal in distribution to never-trained | not full Lloyd from scratch; supporting structures |
+| Bourtoule et al., SISA / *Machine Unlearning* | IEEE S&P 2021; arXiv `1912.03817` | peer-reviewed | aggregated model ≡ train without the point | **yes** — the affected shard/slice |
+| Sherman–Morrison / Woodbury on ridge / OLS | classical NLA; used by Izzo et al. AISTATS 2021 (`2002.10077`) | peer-reviewed (Izzo: **approximate** for logistic; OLS downdate is exact) | rank-1 downdate of \((X^\top X)^{-1}\) | no |
+| Zhang, Lou, Xiong, Zhang, Liu, CMUMF | CIKM 2023, ACM `10.1145/3583780.3614811` | peer-reviewed | closed-form Newton / Hessian step for matrix factorisation | no full MF retrain |
+| Guo, Goldstein, Hannun, van der Maaten, *Certified Data Removal* | ICML 2020; `1911.03030` | peer-reviewed | **certified**, not exact: Newton + loss perturbation | no |
+
+**Occupied cell:** exact, no-full-retrain, for linear / SQ / SVM /
+some clustering / some MF.
+
+**Free cell:** exact, no-retrain, for a general non-convex net, by
+an operator that does not look at the retain set. Surveys
+(Nguyen et al., arXiv `2209.02299`, v6 2024) still split the field
+into exact (usually shard/retrain) and approximate (influence,
+ascent, distillation).
+
+Sounio Method 3, as written, is ordinary orthonormal projection
+onto the complement of a known subspace. That operator has been
+available since least squares. It occupies nothing new.
+
+## Q2 — Compile-time verification of a privacy property
+
+**PARTIAL.**
+
+Languages **do** verify privacy-adjacent properties statically.
+They do **not** verify "this programme forgot subject Alice".
+
+| System | Venue / date | Review | What the types actually check |
+|---|---|---|---|
+| Fuzz (Reed & Pierce) | ICFP 2010 | peer-reviewed | metric sensitivity; well-typed + Laplace ⇒ ε-DP |
+| DFuzz (Gaboardi, Haeberlen, Hsu, Narayan, Pierce) | POPL 2013 | peer-reviewed | linear dependent sensitivity; still DP, not forgetting |
+| Duet (Near, Darais, Abuah, …) | OOPSLA 2019; `1909.02481` | peer-reviewed | dual linear types for sensitivity and privacy composition, including SGD-shaped programmes |
+| Jif / JFlow (Myers; Myers & Liskov labels) | POPL 1999; SOSP 1997 | peer-reviewed | information-flow confidentiality / integrity, not unlearning |
+| Eisenhofer, Riepel, Chandrasekaran, Ghosh, Ohrimenko, Papernot | arXiv `2210.09126`; IEEE SaTML 2025 | preprint then peer-reviewed | **cryptographic** proof that an agreed unlearning procedure ran; SNARKs + hash chains. Not a type system. Runtime / protocol. |
+
+Search S17 (`certified unlearning` / `verifiable unlearning` +
+`type system` / `compile-time`) returned certified *statistical*
+removal and cryptographic *execution* proofs. It did not return a
+type system whose judgement is "the contribution of this value has
+been annihilated".
+
+Sounio E201 is closer to an effect-annotation mandate than to Fuzz.
+Fuzz proves a metric bound. E201 proves the letters `with ZD` are
+present.
+
+## Q3 — Zero-divisors used for privacy or unlearning
+
+**FREE**, for the search set in the Method table.
+
+Hits that look adjacent and are **not** the cell:
+
+| Work | Why it is not the cell |
+|---|---|
+| Saoud & Al-Marzouqi, metacognitive sedenion NN | IEEE Access 2020, peer-reviewed. Time-series forecasting. Zero-divisors are an algebraic fact of the algebra, not an unlearning operator. |
+| Reggiani, *The geometry of sedenion zero divisors* | arXiv `2411.18881`, 2024, preprint. Riemannian geometry of \(Z(\mathbb{S})\). Mentions ML as motivation, does not erase training points. |
+| Cawagas 2004; Moreno 1998 | Structure of the 84 pairs / \(\dim\ker L_a \equiv 0 \pmod 4\). Algebra, not privacy. |
+| US patent US20190007196A1 (octonion FHE) | Octonions are a **division** algebra: no zero-divisors. Wrong algebra. |
+| Visconti, *The Right to Be Zero-Knowledge Forgotten* | ARES 2024. ZK + GDPR. No Cayley–Dickson. |
+
+Why this absence is informative rather than empty-handed:
+
+1. The 84-pair sedenion ZD literature is well indexed (Moreno,
+   Cawagas, de Marrais "box-kites"). A privacy application would
+   cite those names.
+2. Unlearning surveys 2022–2024 (`2209.02299` and siblings) classify
+   exact vs approximate, shard vs influence vs certified. None of
+   the abstracts retrieved mention hypercomplex annihilation.
+3. Query S13 is the direct conjunction. It produced the rows above,
+   not a forgetting paper.
+
+Declared hole: a thesis or a 2026 workshop not on arXiv could
+exist. That would move Q3 to PARTIAL. It was not found today.
+
+## Q4 — Published reason not to do it
+
+**PARTIAL.**
+
+There is **no** paper that says "do not unlearn with sedenion
+zero-divisors", because Q3 is empty. There **are** published facts
+that kill the identity once it leaves the exact variety, and a
+local measurement that kills the "product *is* the unlearn" reading.
+
+### Published algebra — the useful kill
+
+Moreno, *The zero divisors of the Cayley-Dickson algebras over the
+real numbers*, *Boletín de la Sociedad Matemática Mexicana* (3) 4
+(1998) 13–28; arXiv `q-alg/9710013`. For \(n \ge 4\),
+\(\dim\ker L_a \equiv 0 \pmod 4\) and \(\ker L_a\) is a proper
+subspace. A generic perturbation of \(a\) has trivial kernel.
+
+Consequence, not a quotation: **exact annihilation is a property of
+a thin variety**. Move \(A\) by \(10^{-8}\) in a transverse
+direction and \(A\circ v\) is no longer zero. Measured here, IEEE
+f64 Cayley–Dickson doubling:
+
+| pair | \(\lVert A\circ v\rVert_2^2\) |
+|---|---|
+| \(A=e_3+e_{10}\), \(v=e_6-e_{15}\) | `0.0` (bit-exact; ±1 coordinates) |
+| same \(A\), \(v=(e_6-e_{15})+2^{-52}e_0\) | `9.86e-32` (linear in the leak) |
+| \(A'=A+10^{-8}e_2\), \(v=e_6-e_{15}\) | `2.00e-16` (\(\lVert\cdot\rVert_2 \approx 1.41\times 10^{-8}\)) |
+
+So "floating point destroys the identity" is **the wrong slogan**
+for the exact pair. The published reason not to *rely* on it is
+Moreno's kernel dimension: the identity does not survive a
+perturbation of the annihilator, nor a contribution that is not
+exactly in the kernel.
+
+### Published numerics — occupies the Woodbury cousin, not ZD
+
+Bojanczyk, Brent, van Dooren, de Hoog, *A note on downdating the
+Cholesky factorization*, *SIAM J. Sci. Stat. Comput.* 8 (1987).
+One of three natural downdating algorithms is unstable; the others
+are only mixed-stable. Higham, *Accuracy and Stability of Numerical
+Algorithms*, SIAM 2002, preface to the 2nd ed.: updating/downdating
+were omitted for space; later Higham (2021 note on
+pseudo-orthogonal matrices) records that hyperbolic downdating
+transforms can be arbitrarily ill-conditioned.
+
+That is a published reason not to treat **ridge / OLS exact
+unlearning** as bit-stable. It is not a paper about sedenions.
+
+### Local, not published — product is the wrong map
+
+`examples/zd_machine_unlearning.sio` already writes that
+\(A\circ W\) is not \(W_{\mathrm{bob}}\). Measured:
+
+\[
+\lVert A\circ(e_0+0.5\,e_1) - (e_0+0.5\,e_1)\rVert_2^2 = 3.75.
+\]
+
+Left-multiplication by a zero-divisor **kills the kernel and
+moves the complement**. Unlearning-as-indistinguishable-from-never-
+trained wants a **projection**. The flagship example therefore
+implements a projection and cites the ZD theorem only as a reason
+to pick the subspace. That gap is already in-tree. It is not a
+literature occupation of the quadrant.
+
+The grok-cli4 forensic already records the same limitation for a
+future `zd_annihilate` builtin: recognising the product is not a
+proof that a contribution is zero.
+
+## The conjunction
+
+| Qualifier | Status | Occupied by |
+|---|---|---|
+| exact, no full retrain | **PARTIAL / occupied for restricted models** | Cao 2015; Cauwenberghs 2000; Woodbury; Ginart 2019; CMUMF 2023 |
+| by algebraic annihilation (ZD / CD) | **FREE** | — |
+| compile-time verification of *forgetting* | **FREE** (compile-time *DP/IFC* is occupied) | Fuzz family occupies a different property |
+| all three | **FREE** | — |
+
+**What a paper may still say, if it stays inside the evidence:**
+
+- Lean proves a finite ZD census, not a trained-model forget.
+- No prior paper was found that uses sedenion annihilators as an
+  unlearning map.
+- Compile-time privacy types exist; they check sensitivity or
+  information flow, not erasure of a subject's contribution.
+- Exact no-retrain unlearning already exists for linear / SQ / SVM
+  / some clustering. Claiming novelty there is a correction waiting
+  to happen.
+
+**What a paper must not say:**
+
+- "Machine unlearning is entirely approximate." False since at
+  least Cao & Yang 2015 and Cauwenberghs & Poggio 2000.
+- "`ExactlyPrivate<T>` is compile-time verification of forgetting."
+  Today it is an effect gate.
+- "Annihilation is a projection that leaves the complement
+  untouched." False as a map; the in-tree example already recants.
+
+## What this is not
+
+- Not a patch to `self-hosted/`, `formal/`, or the example.
+- Not a claim that Q3 cannot be occupied next month.
+- Not a repeat of the grok-cli4 builtin forensic. That document is
+  cited, not rewritten.
+- Not an LLM-offload of a paper draft. This is an internal audit.
+  A dissertation or submission that uses these sentences still owes
+  the offload policy.
+
+## Commands
+
+```text
+# arXiv title check, 2026-08-19
+curl -sS 'https://export.arxiv.org/api/query?id_list=2209.02299,1912.03817,1911.03030,1907.05012,2411.18881,2210.09126'
+
+# local product-vs-projection and Moreno-style perturbation (IEEE f64)
+# Cayley–Dickson doubling; A = e3+e10
+#   ||A*(e6-e15)||^2              = 0.0
+#   ||A*(e0+0.5 e1) - (e0+0.5 e1)||^2 = 3.75
+#   ||(A+1e-8 e2)*(e6-e15)||^2    = 2.00e-16
+```

--- a/docs/audit/UNLEARNING_QUADRANT_2026-08-19.tsv
+++ b/docs/audit/UNLEARNING_QUADRANT_2026-08-19.tsv
@@ -1,0 +1,39 @@
+# UNLEARNING_QUADRANT_2026-08-19
+# sha	f79c93c772
+# intent	try to occupy the ExactlyPrivate conjunction; knockdown is the useful result
+# search_date	2026-08-19
+# verdict_vocab	OCCUPIED | FREE | PARTIAL | INDETERMINATE
+section	item	verdict	review	year	venue_or_id	what_it_does	what_it_is_not
+local	unlearning_kernel_exact	PARTIAL	in-tree	n/a	formal/lean4/SounioSurgicalInterventions.lean	native_decide 4 primitives annihilated by primA	not a trained-model forget theorem
+local	E201_lower_exactly_private	PARTIAL	in-tree	n/a	self-hosted/check/check.sio	requires effect id 18 ZD; returns inner type	does not check annihilation or ker membership
+local	zd_machine_unlearning_m3	PARTIAL	in-tree	n/a	examples/zd_machine_unlearning.sio	Euclidean projection W-<W,u1>u1-<W,u2>u2	not left-mult by e3+e10
+local	A_circ_bob_not_bob	OCCUPIED	measured	2026-08-19	IEEE f64 CD doubling	||A*(e0+0.5 e1)-(e0+0.5 e1)||^2 = 3.75	product is not a projection
+local	exact_pair_f64_zero	OCCUPIED	measured	2026-08-19	IEEE f64 CD doubling	||A*(e6-e15)||^2 = 0.0	f64 residual is not the kill-shot
+local	perturb_A_1e-8	OCCUPIED	measured	2026-08-19	IEEE f64 CD doubling	||(A+1e-8 e2)*(e6-e15)||^2 = 2.00e-16	identity dies off the variety
+Q1	Cauwenberghs_Poggio_SVM	OCCUPIED	peer-reviewed	2000	NIPS 2000	decremental SVM = batch without the point	not deep nets; not ZD
+Q1	Cao_Yang_SQ	OCCUPIED	peer-reviewed	2015	IEEE S&P 2015	subtract sample from summation form	restricted to SQ-shaped algorithms
+Q1	Ginart_kmeans	OCCUPIED	peer-reviewed	2019	NeurIPS 2019; arXiv 1907.05012	deletion-efficient k-means	clustering; supporting structures
+Q1	Bourtoule_SISA	OCCUPIED	peer-reviewed	2021	IEEE S&P 2021; arXiv 1912.03817	exact via shard/slice	retrains the affected fragment
+Q1	Woodbury_OLS	OCCUPIED	classical	n/a	Sherman-Morrison-Woodbury	exact rank-1 downdate of Gram inverse	linear / ridge; NLA stability separate
+Q1	Izzo_deletion	PARTIAL	peer-reviewed	2021	AISTATS 2021; arXiv 2002.10077	approximate deletion; uses SM for regression	logistic is approximate
+Q1	Guo_certified_removal	PARTIAL	peer-reviewed	2020	ICML 2020; arXiv 1911.03030	certified (eps) Newton + noise	not exact
+Q1	Zhang_CMUMF	OCCUPIED	peer-reviewed	2023	CIKM 2023; 10.1145/3583780.3614811	closed-form MF unlearning	matrix factorisation only
+Q1	general_deep_net_exact_no_retrain	FREE	surveys	2024	arXiv 2209.02299 v6	surveys still split exact=shard vs approximate	not a uniqueness claim for Sounio
+Q1	field_is_all_approximate	OCCUPIED	n/a	2015	correction	the slogan is false	—
+Q2	Fuzz	OCCUPIED	peer-reviewed	2010	ICFP 2010	compile-time sensitivity => DP	not unlearning
+Q2	DFuzz	OCCUPIED	peer-reviewed	2013	POPL 2013	linear dependent sensitivity	not unlearning
+Q2	Duet	OCCUPIED	peer-reviewed	2019	OOPSLA 2019; arXiv 1909.02481	dual linear types; SGD-shaped DP	not unlearning
+Q2	Jif	OCCUPIED	peer-reviewed	1999	POPL 1999	information-flow confidentiality	not unlearning
+Q2	Eisenhofer_verifiable	PARTIAL	peer-reviewed	2025	SaTML 2025; arXiv 2210.09126	SNARK that agreed procedure ran	not a type system; not compile-time
+Q2	compile_time_forgetting_types	FREE	search S17	2026-08-19	certified/verifiable + type/compile-time	no hit	absence != impossibility
+Q3	Saoud_sedenion_NN	FREE	peer-reviewed	2020	IEEE Access	forecasting with sedenion NN	not privacy / unlearning
+Q3	Reggiani_geometry	FREE	preprint	2024	arXiv 2411.18881	geometry of Z(S)	cites ML; does not erase points
+Q3	Moreno_1998	FREE	peer-reviewed	1998	Bol. Soc. Mat. Mexicana; q-alg/9710013	ker L_a structure	algebra, not privacy
+Q3	Cawagas_2004	FREE	peer-reviewed	2004	Discussiones Mathematicae 24(2)	84 pairs in 7 quasi-octonions	algebra, not privacy
+Q3	octonion_FHE_patent	FREE	patent	2019	US20190007196A1	octonion FHE	octonions have no zero-divisors
+Q3	ZD_as_unlearning_operator	FREE	search S13	2026-08-19	zero-divisor + privacy/unlearning + CD	no hit in the search set	theses/workshops undeclared
+Q4	Moreno_thin_variety	PARTIAL	peer-reviewed	1998	q-alg/9710013	generic perturbation of A has ker={0}	does not name unlearning
+Q4	Bojanczyk_downdate	PARTIAL	peer-reviewed	1987	SIAM J. Sci. Stat. Comput. 8	Cholesky downdate can be unstable	Woodbury cousin, not ZD
+Q4	Higham_ASNA_omit	PARTIAL	peer-reviewed	2002	SIAM ASNA 2ed preface	update/downdate omitted; later ill-conditioned hyperbolic	not sedenions
+Q4	paper_do_not_use_ZD_unlearn	FREE	search S14	2026-08-19	no such paper	Q3 empty so no rebuttal paper	—
+conjunction	exact_no_retrain_AND_ZD_AND_compile_forget	FREE	this census	2026-08-19	docs/audit/UNLEARNING_QUADRANT_2026-08-19.md	no published triple	pieces exist separately

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -370,6 +370,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.type-enum-denominator-2026-08-19 | repo_only | docs/audit/TYPE_ENUM_DENOMINATOR_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.typekind-archaeology-fh-2026-08-19 | repo_only | docs/audit/TYPEKIND_ARCHAEOLOGY_FH_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.units-promise-measurement-2026-08-19 | repo_only | docs/audit/UNITS_PROMISE_MEASUREMENT_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.unlearning-quadrant-2026-08-19 | repo_only | docs/audit/UNLEARNING_QUADRANT_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.vec-new-path-call-fabrication-census-2026-08-17 | repo_only | docs/audit/VEC_NEW_PATH_CALL_FABRICATION_CENSUS_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.wave14d-thinlink-921-residual-2026-07-21 | repo_only | docs/audit/WAVE14D_THINLINK_921_RESIDUAL_2026-07-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.windows-assert-a64-parity.ad-hessian-diagonal | repo_only | docs/audit/windows_assert_a64_parity/AD_HESSIAN_DIAGONAL.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -7974,6 +7974,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.unlearning-quadrant-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/UNLEARNING_QUADRANT_2026-08-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.vec-new-path-call-fabrication-census-2026-08-17",
       "collection": "repo",
       "repo_doc_path": "docs/audit/VEC_NEW_PATH_CALL_FABRICATION_CENSUS_2026-08-17.md",


### PR DESCRIPTION
## Question

Does the published field already occupy

> exact unlearning **without retraining**, **by algebraic annihilation**, **verified at compile time**

that a Sounio paper would claim for `ExactlyPrivate<T>`?

This receipt tries to **knock that claim down**.

## Verdicts

| Question | Verdict |
|---|---|
| Q1 exact unlearning without retrain | **PARTIAL** — occupied for restricted models |
| Q2 compile-time privacy types | **PARTIAL** — occupied for DP / information flow, not forgetting |
| Q3 zero-divisors used for privacy / unlearning | **FREE** (search set; method in the receipt) |
| Q4 published reason not to | **PARTIAL** — Moreno 1998: annihilation lives on a thin variety |
| Three-qualifier conjunction | **FREE** |

## Load-bearing knockdowns

1. **"The field is entirely approximate and statistical" is false.** Cao & Yang (IEEE S&P 2015) give exact unlearning by subtracting a sample from a summation form. Cauwenberghs & Poggio (NIPS 2000) give exact decremental SVM. Sherman–Morrison / Woodbury gives exact OLS / ridge downdates. SISA (IEEE S&P 2021) is exact **and retrains shards** — it occupies exactness, not the no-retrain cell.
2. **Compile-time privacy is not unique.** Fuzz (ICFP 2010), DFuzz (POPL 2013), Duet (OOPSLA 2019) check sensitivity / DP. Jif (POPL 1999) checks information flow. None of them check "this programme forgot Alice".
3. **Sounio does not currently check forgetting either.** E201 requires `with ZD`. Lean `unlearning_kernel_exact` is `native_decide` on four primitives. The Lean file itself calls the type correspondence a propositional scaffold.
4. **The flagship example's Method 3 is Euclidean projection**, not left-multiplication. The file already says \(A\circ W\) is not \(W_{\mathrm{bob}}\). Measured: \(\lVert A\circ(e_0+0.5 e_1)-(e_0+0.5 e_1)\rVert_2^2 = 3.75\).
5. **IEEE f64 residual on the exact ±1 pair is `0.0`.** The published reason not to rely on the identity is Moreno (1998): a generic perturbation of \(A\) has trivial kernel. Measured: \(\lVert(A+10^{-8}e_2)\circ(e_6-e_{15})\rVert_2^2 = 2.00\times 10^{-16}\).

## What remains free

No paper in the search set uses Cayley–Dickson zero-divisors as an unlearning operator. That sliver is not a uniqueness claim for exact unlearning, nor for compile-time privacy.

## What this is not

No `self-hosted/` or `formal/` edit. Not a builtin. Not a paper draft.

Receipt: `docs/audit/UNLEARNING_QUADRANT_2026-08-19.md` + `.tsv`.

Governance registry not written (owned by grok-cli5). Expect `check_docs_registry.sh` red until that topic is folded.