### PR TITLE
docs(audit): the exactness boundary — formal at compile time, not numerical at run time

### DIFF
--- a/docs/audit/ZD_EXACTNESS_FLOATING_POINT_BOUNDARY_2026-08-19.md
+++ b/docs/audit/ZD_EXACTNESS_FLOATING_POINT_BOUNDARY_2026-08-19.md
@@ -1,0 +1,91 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.zd-exactness-floating-point-boundary-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: claude-1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.zd-exactness-floating-point-boundary-2026-08-19
+-->
+
+# The exactness boundary: formal at compile time, not numerical at run time
+
+## Why this exists
+
+An independent second opinion (Qwen 3.8 Max via `empryo`, run **blind** — the
+parallel receipt `UNLEARNING_QUADRANT_2026-08-19.md` was neither shown nor
+consulted) was asked one thing above all others: **is there a published reason
+this may not work?**
+
+There is, and it is direct. It does not refute the claim. It **bounds** it, and
+the bound must be stated in the claim rather than discovered by a reviewer.
+
+## The published objection
+
+Jack Kowalski, *"Zero Divisors in Sedenion Algebra under Floating-Point
+Arithmetic"* (entropment.com; **essay/preprint, not peer-reviewed**).
+
+- Over exact ℝ, zero divisors of a Cayley–Dickson algebra are **stable algebraic
+  points**: `a·b = 0` holds exactly, because the exact equalities hold across
+  coupled components.
+- Under IEEE-754, each sedenion → octonion → quaternion multiplication step
+  introduces **independent rounding per operation**. The exact equalities
+  degenerate into inequalities `|component| < ε`.
+- Consequently zero divisors stop being fixed points and become numerical
+  **orbits** that drift toward zero or are repelled from it depending on
+  rounding history. Repeated multiplications **do not converge to exact zero**
+  even where the real-algebra product is zero. The author frames the non-zero
+  residue as an invariant of the projection history, not a defect.
+
+Its non-peer-reviewed status does not weaken it much: the mechanism is
+elementary and follows from IEEE-754 alone.
+
+## What it does to the Sounio claim
+
+`formal/lean4/SounioSurgicalInterventions.lean` proves exact annihilation by
+`native_decide` over a **finite, exact model** — integers/rationals, or
+axiomatic reals. That is sound *as a statement about the model*.
+
+It does not transfer to `f64` execution. There, *"exactly zero in the
+zero-divisor core"* becomes `≈ ε`.
+
+> **The boundary of the claim is: formal exactness verified at compile time;
+> numerical exactness not guaranteed at run time.**
+
+**Sounio's own measurement reached the same place first.**
+`ZD_ANNIHILATE_BUILTIN_DISPATCH_2026-08-19.md` (#2017) already recorded, as an
+obligation fragment that escapes the checker: *"runtime `[f64;16]` weights equal
+a stated kernel combination after float ops — floating-point; at best residual
+bounds, not exact Lean equality."* The internal forensic and the external
+literature agree, arrived at independently.
+
+## What must therefore change in how the claim is stated
+
+- **Not**: "the contribution is algebraically zero".
+- **But**: "the contribution is algebraically zero *in the verified model*, and
+  the compiled program is verified to perform the annihilating operation; the
+  residual under IEEE-754 is bounded, not zero."
+
+Under `SOUNIO-TYPE-INTERROGATION`'s naming clause this is not a retreat — it is
+the clause working. The type names the proposition it interrogates, and the
+proposition is the one that is decidable.
+
+## A second bound, from the same source
+
+The receipt also records a **retrain-equivalence impossibility for local
+unlearning** (preprint, Oct 2025): retrain equivalence is unattainable for local
+methods. This bounds the *no-retraining* qualifier and should be read together
+with the exact-unlearning-for-restricted-models finding in
+`UNLEARNING_QUADRANT_2026-08-19.md`.
+
+## Convergence between the two independent measurements
+
+Both were run blind of each other and agree that the three-qualifier conjunction
+is unoccupied. The second opinion adds the two bounds above, which the first did
+not surface because it was not asked to prioritise disconfirming evidence.
+
+## Claims forbidden
+
+- Stating exact annihilation as a **runtime** property of compiled Sounio.
+- Reading "FREE" as "proven nonexistent". The consulted agent's own caveat: the
+  sweep was arXiv plus indexed web, conference proceedings were not exhaustively
+  covered, and the backend was rate-limited during part of the run.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -384,6 +384,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.ws-c2-lean-single-seed-only-surface-map-2026-08-19 | repo_only | docs/audit/WS_C2_LEAN_SINGLE_SEED_ONLY_SURFACE_MAP_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.ws-f-close-acceptance-2026-08-16 | repo_only | docs/audit/WS_F_CLOSE_ACCEPTANCE_2026-08-16.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.zd-annihilate-builtin-dispatch-2026-08-19 | repo_only | docs/audit/ZD_ANNIHILATE_BUILTIN_DISPATCH_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.zd-exactness-floating-point-boundary-2026-08-19 | repo_only | docs/audit/ZD_EXACTNESS_FLOATING_POINT_BOUNDARY_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.brand.sounio-brand-pack-v4-complete.00-readme.font-licenses | repo_only | docs/brand/Sounio_Brand_Pack_v4_COMPLETE/00_README/FONT_LICENSES.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.brand.sounio-brand-pack-v4-complete.00-readme.readme | repo_only | docs/brand/Sounio_Brand_Pack_v4_COMPLETE/00_README/README.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.competitive-position-2026 | repo_only | docs/COMPETITIVE_POSITION_2026.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8296,6 +8296,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.zd-exactness-floating-point-boundary-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/ZD_EXACTNESS_FLOATING_POINT_BOUNDARY_2026-08-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.brand.sounio-brand-pack-v4-complete.00-readme.font-licenses",
       "collection": "repo",
       "repo_doc_path": "docs/brand/Sounio_Brand_Pack_v4_COMPLETE/00_README/FONT_LICENSES.md",


### PR DESCRIPTION
An independent second opinion (Qwen 3.8 Max via `empryo`, run **blind** of the parallel receipt) was asked above all else: **is there a published reason this may not work?**

**There is, and it is direct.**

## The objection

Kowalski, *"Zero Divisors in Sedenion Algebra under Floating-Point Arithmetic"* (entropment.com; **essay/preprint, not peer-reviewed**).

- Over exact ℝ, zero divisors are **stable algebraic points** — `a·b = 0` exactly.
- Under IEEE-754, each sedenion → octonion → quaternion step introduces **independent rounding**; exact equalities degenerate into `|component| < ε`.
- Zero divisors stop being fixed points and become numerical **orbits** that drift toward or away from zero by rounding history. Repeated multiplications **do not converge to exact zero**.

Its non-peer-reviewed status does not weaken it much — the mechanism follows from IEEE-754 alone.

## It bounds the claim; it does not refute it

`SounioSurgicalInterventions.lean` proves exact annihilation by `native_decide` over a finite **exact** model. Sound as a statement about the model. It does not transfer to `f64`.

> **Formal exactness verified at compile time; numerical exactness not guaranteed at run time.**

**Sounio got there first, internally.** `#2017` already recorded that runtime `[f64;16]` weights equalling a kernel combination after float ops escapes the checker — *"at best residual bounds, not exact Lean equality"*. Internal forensic and external literature agree, arrived at independently.

## How the claim must now be stated

- **Not** *"the contribution is algebraically zero"*.
- **But** *"algebraically zero **in the verified model**, with the compiled program verified to perform the annihilating operation; the IEEE-754 residual is **bounded**, not zero."*

Under `SOUNIO-TYPE-INTERROGATION`’s naming clause this is not a retreat — **it is the clause working.**

## Second bound, same source

Retrain-equivalence impossibility for **local** unlearning (preprint, Oct 2025), which bounds the *no-retraining* qualifier.

## Claims forbidden

- Stating exact annihilation as a **runtime** property of compiled Sounio.
- Reading `FREE` as *proven nonexistent* — the sweep was arXiv plus indexed web, proceedings not exhaustive, backend rate-limited part of the run.