### PR TITLE
docs(audit): Knowledge constructor is accepted — not E200

### DIFF
--- a/docs/audit/E200_KNOWLEDGE_REVERIFY_2026-08-19.md
+++ b/docs/audit/E200_KNOWLEDGE_REVERIFY_2026-08-19.md
@@ -1,0 +1,109 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.e200-knowledge-reverify-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: cursor-1 (Slurm souc check/run, both engines)
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.e200-knowledge-reverify-2026-08-19
+-->
+
+# E200 reverify — `Knowledge { value, variance, epsilon, provenance }` (2026-08-19)
+
+**Verdict: ACEITE.** Both engines typecheck the dissertation constructor.
+There is no `E200`. `Knowledge` is the compiler builtin
+(`TypeKind::TyKnowledge`), not `ecosystem/shared/epistemic_types.sio`.
+The `kn` block is the GUM carrier, not decoration.
+
+SHA measured: `f4dc51777e` (`origin/main`). Slurm partition `cpu-ops`
+(host `cpuops-t560-proxmox`). Compiler staged to
+`/orangefs/training/sounio/cursor-1-e200`. The dissertation file and
+`self-hosted/` were not edited.
+
+## Controls
+
+| Role | File | Madaros (`bin/souc` default, v0.80.0) | lean_single (`SOUNIO_SOUC_ENGINE=lean_single`) |
+|---|---|---|---|
+| Positive (same folder, no Knowledge ctor) | `stdlib/darwin_pbpk/constants.sio` | **check rc=0** (`check: OK`) | check rc=1, `error: no main` (lean_single check compiles to ELF and requires `main`) |
+| Positive (same folder, has `main`) | `stdlib/darwin_pbpk/test_sort_fix.sio` | not required once constants was green | **check rc=0**, ELF emitted, **0 × E200** |
+| Negative (wrong fields) | `tests/audit/e200_knowledge_wrong_fields.sio` | **check rc=1**, `error[E012]` `this type has no field named` | **check rc=0** with `warning: unknown field in Knowledge literal` (twice). Fields are **not** a hard refuse on lean_single |
+
+The command is not broken: Madaros accepts the sibling library; lean_single
+accepts a sibling with `main`. The negative control shows Madaros *does*
+check Knowledge field names (E012, not E200). lean_single only warns.
+
+## Target: `souc check stdlib/darwin_pbpk/epistemic_pbpk28.sio`
+
+| Engine | rc | Diagnostic | Line |
+|---|---|---|---|
+| Madaros v0.80.0 | **0** | `check: OK` / `verdict=0` (3 modules) | none |
+| lean_single | **0** | compile to ELF, `knowledge_subtype: 0 violations`, **E200 count = 0** | none |
+
+Isolate programs (no PBPK imports) also check rc=0 on **both** engines:
+
+- `tests/audit/e200_knowledge_literal.sio` — the struct literal
+- `tests/audit/e200_knowledge_call.sio` — `Knowledge(0.0, ε=1.0, prov="unused")`
+
+## What `Knowledge` resolves to
+
+Builtin of the compiler. Not imported. The two versioned
+`struct Knowledge[T]` files (`ecosystem/shared/epistemic_types.sio`,
+and test-local structs) are a different type (ecosystem: `value, ε, prov,
+metadata`; ε there is confidence in [0,1], and there is no `variance`).
+
+Madaros field access for `TypeKind::TyKnowledge`
+(`self-hosted/check/check.sio`): `.value` → inner `T` (needs
+`with Epistemic`, E170), `.variance` → f64, `.confidence` → f64,
+`.epsilon` → f64 at the type level. IR layout is three slots
+(`ir_register_knowledge_layout`): value, variance, confidence.
+`prov` / `provenance` has no IR slot.
+
+Live `souc run` of `tests/audit/e200_knowledge_fields_print.sio`:
+
+| Field | Madaros | lean_single |
+|---|---|---|
+| `.value` | 12.400000 | 12.400000 |
+| `.variance` | 22.202944 | 22.202944 |
+| `.epsilon` | **0.000000** | 0.650000 |
+| `.confidence` | 0.650000 | 0.650000 |
+
+That matches the in-tree comment: under Madaros `.epsilon` typechecks
+and reads 0.0; `.confidence` holds the construction-site ε. The GUM
+path in this file reads `.confidence`, not `.epsilon`.
+
+## Numeric path — carrier, not decoration
+
+`m` / `v` / `c` are locals of `ep28_rapamycin_priors`. Only `kn` is
+stored on `EpPrior28`. `ep28_run` reads `priors.kn[i].value`,
+`.variance`, and `.confidence`.
+
+Node-local copy with the seven `kn[i] = Knowledge { … }` lines
+stripped (array fill left as `Knowledge(0.0, ε=1.0, prov="unused")`,
+variance 0). Dissertation file untouched.
+
+| Run | Engine | TEST 5 `sens[0]` | zeroed components | summary |
+|---|---|---|---|---|
+| Original | Madaros | 0.697376 | 0 | TEST 5 PASS; TEST 6 FAIL (`AUC confidence: 4604219396932172800` — `print_f64` bit-pattern, already named in the file) |
+| Original | lean_single | 0.697376 | 0 | **ALL 9 TESTS PASSED**, `AUC confidence: 0.671038`, rc=0 |
+| Stripped `kn[i]=` | Madaros | **0.000000** | **7** | 5 pass / 4 fail (`Jacobian column lost`) |
+
+Removing the `kn` writes changes the GUM numbers. The block is the
+carrier. The parallel `f64` arrays are a construction-site projection
+into that builtin, not a second kernel.
+
+## Gate / workflow
+
+`scripts/ci/dissertation_pbpk_suite_gate.sh` **does** list
+`epistemic_pbpk28` and runs `souc run` on it (PASS-marker required).
+It is called from `scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh`,
+which is called from `scripts/ci/native_v2_frontend_convergence_gate.sh`.
+
+**No `.github/workflows/*.yml` mentions any of those three scripts.**
+The gate is not reachable from CI workflows on this SHA.
+
+## What this does not claim
+
+- It does not claim Madaros TEST 6 is green (the printed confidence
+  is the known `print_f64` fabrication; lean_single prints 0.671).
+- It does not claim `provenance` is stored at runtime (no IR slot).
+- It does not claim lean_single refuses unknown Knowledge fields
+  (it warns and still emits an ELF).

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -111,6 +111,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.dossier-import-closure-2026-08-17 | repo_only | docs/audit/DOSSIER_IMPORT_CLOSURE_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.e011-stale-prebuilt-phantom-2026-08-18 | repo_only | docs/audit/E011_STALE_PREBUILT_PHANTOM_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.e043-rust-macro-design-dispatch-2026-07-12 | repo_only | docs/audit/E043_RUST_MACRO_DESIGN_DISPATCH_2026-07-12.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.e200-knowledge-reverify-2026-08-19 | repo_only | docs/audit/E200_KNOWLEDGE_REVERIFY_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.effect-archaeology-51-2026-08-19 | repo_only | docs/audit/EFFECT_ARCHAEOLOGY_51_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.effect-enum-2a-2026-08-19 | repo_only | docs/audit/EFFECT_ENUM_2A_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.effect-enum-2b-2026-08-19 | repo_only | docs/audit/EFFECT_ENUM_2B_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2017,6 +2017,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.e200-knowledge-reverify-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/E200_KNOWLEDGE_REVERIFY_2026-08-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.effect-archaeology-51-2026-08-19",
       "collection": "repo",
       "repo_doc_path": "docs/audit/EFFECT_ARCHAEOLOGY_51_2026-08-19.md",

--- a/tests/audit/e200_knowledge_call.sio
+++ b/tests/audit/e200_knowledge_call.sio
@@ -1,0 +1,6 @@
+// Isolate: the dissertation Knowledge call-form used as the array fill.
+fn main() -> i32 with IO, Mut, Panic {
+    let k = Knowledge(0.0, ε=1.0, prov="unused")
+    println("e200_knowledge_call")
+    0
+}

--- a/tests/audit/e200_knowledge_fields_print.sio
+++ b/tests/audit/e200_knowledge_fields_print.sio
@@ -1,0 +1,16 @@
+fn main() -> i32 with IO, Mut, Panic, Epistemic {
+    let k = Knowledge { value: 12.4, variance: 22.202944, epsilon: 0.65, provenance: "Jiao2009_popPK_CV38|CHEBI:9168" }
+    print("value=")
+    print_f64(k.value)
+    println("")
+    print("variance=")
+    print_f64(k.variance)
+    println("")
+    print("epsilon=")
+    print_f64(k.epsilon)
+    println("")
+    print("confidence=")
+    print_f64(k.confidence)
+    println("")
+    0
+}

--- a/tests/audit/e200_knowledge_literal.sio
+++ b/tests/audit/e200_knowledge_literal.sio
@@ -1,0 +1,6 @@
+// Isolate: the dissertation Knowledge struct-literal, no PBPK imports.
+fn main() -> i32 with IO, Mut, Panic {
+    let k = Knowledge { value: 12.4, variance: 22.202944, epsilon: 0.65, provenance: "Jiao2009_popPK_CV38|CHEBI:9168" }
+    println("e200_knowledge_literal")
+    0
+}

--- a/tests/audit/e200_knowledge_wrong_fields.sio
+++ b/tests/audit/e200_knowledge_wrong_fields.sio
@@ -1,0 +1,6 @@
+// Negative control: Knowledge with fields the builtin must not have.
+fn main() -> i32 with IO, Mut, Panic {
+    let k = Knowledge { not_a_field: 1.0, also_wrong: 2.0 }
+    println("e200_knowledge_wrong_fields_should_not_print")
+    0
+}


### PR DESCRIPTION
## Summary

- Re-measured the claim that `Knowledge { value, variance, epsilon, provenance }` is refused with `E200`. It is **not**. Both Madaros and lean_single `check` the dissertation file at rc=0 with **zero E200**.
- `Knowledge` is the compiler builtin (`TypeKind::TyKnowledge`), not the ecosystem struct. Isolate literals and the call form also check clean.
- The `kn` block is the GUM **carrier**: a node-local strip of the seven assignments zeros `sens[0]` and fails TEST 5. Original lean_single run is 9/9 PASS.

**Verdict: ACEITE.**

## Test plan

- [x] Slurm Madaros `check` `stdlib/darwin_pbpk/constants.sio` rc=0 (positive)
- [x] Slurm lean_single `check` `stdlib/darwin_pbpk/test_sort_fix.sio` rc=0 (positive, same folder, has `main`)
- [x] Slurm Madaros `check` wrong-field literal → E012 (negative); lean_single warns and still emits an ELF
- [x] Slurm both engines `check` `epistemic_pbpk28.sio` rc=0, E200 count 0
- [x] Slurm `run` field-print isolate: value/variance stored; Madaros `.epsilon` reads 0.0, `.confidence` reads 0.65
- [x] Slurm Madaros `run` original: TEST 5 PASS (`sens[0]=0.697376`); stripped `kn[i]=` → seven zeroed components
- [x] Slurm lean_single `run` original: ALL 9 TESTS PASSED
- [x] `dissertation_pbpk_suite_gate.sh` lists the file; no `.github/workflows` reaches that gate