### PR TITLE
docs(audit): independent reverify — Knowledge constructor is ACEITE, not E200

### DIFF
--- a/docs/audit/E200_KNOWLEDGE_CONSTRUCTOR_REVERIFY_2026-08-19.md
+++ b/docs/audit/E200_KNOWLEDGE_CONSTRUCTOR_REVERIFY_2026-08-19.md
@@ -1,0 +1,219 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.e200-knowledge-constructor-reverify-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: grok-cli5
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.e200-knowledge-constructor-reverify-2026-08-19
+-->
+
+# E200 Knowledge constructor reverify (independent, grok-cli5)
+
+**Decision: ACEITE** (compiler builtin `TypeKind::TyKnowledge`; both engines
+`check` the dissertation literal; `kn` is the GUM carrier).
+
+The memory claim that `souc` still refuses
+`Knowledge { value, variance, epsilon, provenance }` with **E200** is
+**false** on the binaries staged at `b76ba90257`. E200 did not appear on
+either engine. Dissertation modules are not forced onto raw `f64` by this
+constructor.
+
+Cursor-1 filed the same ACEITE on `origin/main` as
+[`E200_KNOWLEDGE_REVERIFY_2026-08-19.md`](E200_KNOWLEDGE_REVERIFY_2026-08-19.md)
+(#2024, SHA `f4dc51777e`). This lane re-measured independently on
+`b76ba90257` and agrees on acceptance, builtin resolution, carrier,
+and workflow-unreachability. It **does not** agree that Madaros
+refuses unknown Knowledge field names: #2024's negative fixture
+omits `value`, so its E012 is the missing-`value` rule, not a field
+allowlist. Split controls below.
+
+This is a measurement. `stdlib/darwin_pbpk/epistemic_pbpk28.sio` and
+`self-hosted/` were not edited.
+
+---
+
+## Instrument
+
+| Field | Value |
+|---|---|
+| SHA of sources / staged binaries | `b76ba90257` (`origin/main` at branch creation) |
+| Submitter | workspace pod; `/workspace` is **not** visible on the node |
+| Launch | `scripts/dev/e200_knowledge_reverify.sh` → `srun`, partition `cpu-ops` |
+| Node | `cpuops-t560-proxmox` |
+| `workspace_visible` | no |
+| `orangefs_visible` | yes |
+| Stamp | `2026-08-19T20:19:27Z` |
+| Madaros | `bin/souc` default → `Madaros v0.80.0` (`bin/madaros-linux-x86_64`, sha256 `437bdd8f96a2…`) |
+| lean_single | `SOUNIO_SOUC_ENGINE=lean_single` → `bin/souc-lean-single-x86_64` (`Usage: mini_native <source.sio> <output>`) |
+| Poison | `env -u SOUC_BIN -u SOUNIO_SOUC_BIN` on the node |
+| Stack | `ulimit -s 1048576`, `MADAROS_STACK_KB=524288` |
+| Table | [`E200_KNOWLEDGE_CONSTRUCTOR_REVERIFY_2026-08-19.tsv`](E200_KNOWLEDGE_CONSTRUCTOR_REVERIFY_2026-08-19.tsv) |
+| Driver | [`scripts/dev/e200_knowledge_reverify.sh`](../../scripts/dev/e200_knowledge_reverify.sh) |
+| Isolates | [`docs/audit/repro/e200/`](repro/e200/) |
+
+`souc check` under `SOUNIO_SOUC_ENGINE=lean_single` is a **compile**
+(`souc SRC TMP`); it is not typecheck-only. Madaros `check` is typecheck-only.
+Every row names its engine.
+
+---
+
+## 1. Does `souc check epistemic_pbpk28.sio` pass?
+
+| Engine | Verb | rc | Diagnostic | Line |
+|---|---|---:|---|---|
+| Madaros v0.80.0 | `check` | **0** | none (`check: OK`, 3 modules, `verdict=0`) | — |
+| lean_single | `check` (= compile) | **0** | none (ELF 133203 bytes, 63 fns) | — |
+
+E200 is absent. The constructor at lines 292–299 is live code and is accepted.
+
+---
+
+## 2. What is `Knowledge`?
+
+A **compiler builtin**, not a stdlib struct and not the ecosystem
+`struct Knowledge[T] { value, ε, prov, metadata }`.
+
+The file imports only `darwin_pbpk::core::pbpk28_params` and
+`darwin_pbpk::tsit5_pbpk28`. There is no `Knowledge` declaration in
+that import closure.
+
+Madaros resolves the ident in `self-hosted/check/check.sio`:
+
+- call form `Knowledge(v, ε=…, prov=…)` → `call_expr_is_builtin_knowledge_ctor`
+  + `checker_check_knowledge_ctor_expr_inplace` (first argument types the
+  inner `T`; epsilon is left unspecified at the type level);
+- struct literal `Knowledge { … }` → `checker_check_struct_lit_inplace`
+  special-case on name `"Knowledge"` / `check_knowledge_struct_lit`.
+  Only the field named `value` is required. Other field names are
+  typechecked as expressions and otherwise ignored.
+
+IR layout (`ir_register_knowledge_layout`) is three `f64` slots:
+`value`, `variance`, `confidence`. `provenance` has no slot.
+`.epsilon` typechecks as `f64` and reads **0.0** under Madaros
+(pre-existing lowering gap, reproduced below).
+
+Current Madaros **E200** is *not* “undefined identifier”. It is
+“Forgettable type requires ZD effect”. lean_single E200 remains
+“unknown / undefined identifier”. Neither code fired on this constructor.
+
+---
+
+## 3. Numeric path — carrier, not decorative
+
+`m`, `v`, `c` are locals inside `ep28_rapamycin_priors` /
+`ep28_semaglutide_priors`. They exist only to fill `kn`. `ep28_run`
+reads `priors.kn[i].value`, `.variance`, `.confidence`. There is no
+second GUM path that reads the raw arrays.
+
+Removing the `kn` block would not compile: `EpPrior28` requires
+`kn: [Knowledge[f64]; 8]`, and the GUM loop has no other source.
+That is source, not a mutation of the dissertation file.
+
+Isolate `numeric_carrier.sio` (same field order as the priors:
+`value`, `variance`, `epsilon`, `provenance`) then print the four
+accessors:
+
+| Engine | `.value` | `.variance` | `.confidence` | `.epsilon` |
+|---|---|---|---|---|
+| Madaros v0.80.0 `run` | 12.400000 | 22.202944 | **0.650000** | **0.000000** |
+| lean_single `run` | 12.400000 | 22.202944 | 0.650000 | 0.650000 |
+
+Authored `ε` therefore lands in the GUM confidence slot on both
+engines when the literal is written in dissertation order. Madaros
+`.epsilon` reads 0.0; lean_single aliases `.epsilon` to confidence.
+
+Reorder isolate (`value`, `epsilon`, `variance`, `provenance`):
+
+| Engine | `.value` | `.variance` | `.confidence` |
+|---|---|---|---|
+| Madaros v0.80.0 `run` | 12.400000 | 22.202944 | **0.000000** |
+| lean_single `run` | 12.400000 | 22.202944 | **0.650000** |
+
+Madaros fills unknown names by **position** (`default_idx`). `epsilon`
+is not a named alias of `confidence`; it only hits slot 2 when it is
+the third field. lean_single maps `epsilon` by name. Dissertation
+priors use the order that happens to work on both.
+
+`provenance` is written and discarded (no IR slot). That string is
+decorative. The `value` / `variance` / (positional-or-named) confidence
+payload is not.
+
+---
+
+## 4. Controls
+
+**Positive.** Same folder, `stdlib/darwin_pbpk/test_sort_fix.sio`,
+same `souc check` command:
+
+- Madaros: rc=0, `check: OK`
+- lean_single: rc=0, ELF produced
+
+The command is not broken. The target pass is a fact about the target.
+
+**Negative (wrong field, `value` present).**
+`Knowledge { value: 1.0, mystery: 99.0 }`:
+
+- Madaros `check`: **rc=0**, no diagnostic
+- lean_single `check`: **rc=0**, `warning: unknown field in Knowledge literal`
+
+The compiler is **not** refusing unknown Knowledge field names when
+`value` is present. That is the finding the dispatch asked for. It is
+not E200.
+
+**Negative (no `value`).** `Knowledge { mystery: 99.0, provenance: "none" }`:
+
+- Madaros `check`: **rc=1**, `error[E012]` (“this type has no field named”)
+- lean_single `check`: **rc=0**, warning only
+
+This is the same shape as #2024's `tests/audit/e200_knowledge_wrong_fields.sio`
+(`not_a_field` + `also_wrong`, no `value`). Madaros E012 there is the
+missing-`value` rule, not an allowlist of field names. Extra names with
+`value` present are accepted on both engines. lean_single never hard-fails
+either negative.
+
+---
+
+## 5. Gate reachability
+
+`scripts/ci/dissertation_pbpk_suite_gate.sh` **does** list
+`epistemic_pbpk28` (`stdlib/darwin_pbpk/epistemic_pbpk28.sio`) and runs
+it with `souc run`, not `check`. The gate pins
+`SOUC_BIN` to `scripts/ci/souc-seq-leansingle.sh` (lean_single compile+run).
+
+It is invoked from `scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh`.
+That umbrella is invoked from `scripts/ci/native_v2_frontend_convergence_gate.sh`.
+
+None of those three names appears in `.github/workflows/`. Re-ran
+`python3 scripts/dev/ci_gate_workflow_reachability.py` on this SHA:
+
+- `dissertation_pbpk_suite_gate.sh` is in `dissertation_leftover`
+- census class on the committed TSV: `manual-by-design`, workflow=`no`
+- umbrella and frontend-convergence: leftover, workflow=`no`
+
+The suite is operator-reachable (umbrella / Slurm / hand). It is
+**not** workflow-reachable. That is not a forgotten wire; it is the
+census class.
+
+---
+
+## What this does not close
+
+- Rebuilding Madaros from `self-hosted/` (not done; prebuilt ELF used).
+- Whether a future field-name check should refuse `epsilon` or accept it
+  as an alias of `confidence`.
+- The TEST 6 aggregator formula (already a separate receipt).
+- Running the full PBPK28 GUM job. Check + isolate `run` are enough
+  for constructor acceptance and slot occupancy.
+
+---
+
+## Files
+
+| Path | Role |
+|---|---|
+| `docs/audit/E200_KNOWLEDGE_CONSTRUCTOR_REVERIFY_2026-08-19.md` | this receipt |
+| `docs/audit/E200_KNOWLEDGE_CONSTRUCTOR_REVERIFY_2026-08-19.tsv` | one row per measured cell |
+| `scripts/dev/e200_knowledge_reverify.sh` | Slurm packer (stdin tarball) |
+| `docs/audit/repro/e200/*.sio` | isolates and controls |
+
+Not edited: `stdlib/darwin_pbpk/epistemic_pbpk28.sio`, `self-hosted/`.

--- a/docs/audit/E200_KNOWLEDGE_CONSTRUCTOR_REVERIFY_2026-08-19.tsv
+++ b/docs/audit/E200_KNOWLEDGE_CONSTRUCTOR_REVERIFY_2026-08-19.tsv
@@ -1,0 +1,21 @@
+case	engine	verb	src	rc	diag	line	note
+pos_sort_fix	madaros	check	stdlib/darwin_pbpk/test_sort_fix.sio	0	none	-	positive same-folder; check: OK
+pos_sort_fix	lean_single	check	stdlib/darwin_pbpk/test_sort_fix.sio	0	none	-	positive same-folder; compile ELF 42014
+ep28	madaros	check	stdlib/darwin_pbpk/epistemic_pbpk28.sio	0	none	-	3 modules verdict=0; no E200
+ep28	lean_single	check	stdlib/darwin_pbpk/epistemic_pbpk28.sio	0	none	-	compile ELF 133203; 63 fns; no E200
+isolate_struct_lit	madaros	check	docs/audit/repro/e200/isolate_struct_lit.sio	0	none	-	Knowledge{value,variance,epsilon,provenance}
+isolate_struct_lit	lean_single	check	docs/audit/repro/e200/isolate_struct_lit.sio	0	none	-	same literal; compile ok
+isolate_call_form	madaros	check	docs/audit/repro/e200/isolate_call_form.sio	0	none	-	Knowledge(0.0, ε=1.0, prov="unused")
+isolate_call_form	lean_single	check	docs/audit/repro/e200/isolate_call_form.sio	0	none	-	same call form; compile ok
+negative_wrong_field	madaros	check	docs/audit/repro/e200/negative_wrong_field.sio	0	none	-	FINDING: mystery field accepted
+negative_wrong_field	lean_single	check	docs/audit/repro/e200/negative_wrong_field.sio	0	none	-	warning unknown field; rc=0
+negative_no_value	madaros	check	docs/audit/repro/e200/negative_no_value.sio	1	error[E012]	-	value required
+negative_no_value	lean_single	check	docs/audit/repro/e200/negative_no_value.sio	0	none	-	warning only; value not required
+numeric_carrier	madaros	check	docs/audit/repro/e200/numeric_carrier.sio	0	none	-	
+numeric_carrier	lean_single	check	docs/audit/repro/e200/numeric_carrier.sio	0	none	-	
+numeric_carrier	madaros	run	docs/audit/repro/e200/numeric_carrier.sio	0	none	-	prints 12.400000 22.202944 0.650000 0.000000
+numeric_carrier	lean_single	run	docs/audit/repro/e200/numeric_carrier.sio	0	none	-	prints 12.400000 22.202944 0.650000 0.650000
+numeric_reorder	madaros	check	docs/audit/repro/e200/numeric_reorder.sio	0	none	-	
+numeric_reorder	lean_single	check	docs/audit/repro/e200/numeric_reorder.sio	0	none	-	
+numeric_reorder	madaros	run	docs/audit/repro/e200/numeric_reorder.sio	0	none	-	prints 12.400000 22.202944 0.000000; epsilon not named alias
+numeric_reorder	lean_single	run	docs/audit/repro/e200/numeric_reorder.sio	0	none	-	prints 12.400000 22.202944 0.650000; epsilon named alias

--- a/docs/audit/repro/e200/isolate_call_form.sio
+++ b/docs/audit/repro/e200/isolate_call_form.sio
@@ -1,0 +1,7 @@
+// Isolate: dissertation Knowledge call-form, no imports.
+// Exact shape from stdlib/darwin_pbpk/epistemic_pbpk28.sio ~292.
+fn main() -> i32 with IO {
+    let kn = Knowledge(0.0, ε=1.0, prov="unused")
+    let _keep = kn
+    0
+}

--- a/docs/audit/repro/e200/isolate_struct_lit.sio
+++ b/docs/audit/repro/e200/isolate_struct_lit.sio
@@ -1,0 +1,7 @@
+// Isolate: dissertation Knowledge struct-literal, no imports.
+// Exact field set from stdlib/darwin_pbpk/epistemic_pbpk28.sio ~293.
+fn main() -> i32 with IO {
+    let kn = Knowledge { value: 12.4, variance: 22.202944, epsilon: 0.65, provenance: "Jiao2009_popPK_CV38|CHEBI:9168" }
+    let _keep = kn
+    0
+}

--- a/docs/audit/repro/e200/negative_no_value.sio
+++ b/docs/audit/repro/e200/negative_no_value.sio
@@ -1,0 +1,7 @@
+// Negative control: Knowledge literal with no `value` field.
+// Checker source requires `value` (E012). A pass would refute that path.
+fn main() -> i32 with IO {
+    let kn = Knowledge { mystery: 99.0, provenance: "none" }
+    let _keep = kn
+    0
+}

--- a/docs/audit/repro/e200/negative_wrong_field.sio
+++ b/docs/audit/repro/e200/negative_wrong_field.sio
@@ -1,0 +1,7 @@
+// Negative control: Knowledge literal with a deliberately unknown field.
+// Must fail if the compiler checks field names. A pass is the finding.
+fn main() -> i32 with IO {
+    let kn = Knowledge { value: 1.0, mystery: 99.0 }
+    let _keep = kn
+    0
+}

--- a/docs/audit/repro/e200/numeric_carrier.sio
+++ b/docs/audit/repro/e200/numeric_carrier.sio
@@ -1,0 +1,15 @@
+// Numeric isolate: same field order as epistemic_pbpk28 priors.
+// Prints .value .variance .confidence .epsilon so the receipt can say
+// whether the authored numbers land in the GUM slots.
+fn main() -> i32 with IO, Epistemic {
+    let kn = Knowledge { value: 12.4, variance: 22.202944, epsilon: 0.65, provenance: "Jiao2009_popPK_CV38|CHEBI:9168" }
+    print_f64(kn.value)
+    println("")
+    print_f64(kn.variance)
+    println("")
+    print_f64(kn.confidence)
+    println("")
+    print_f64(kn.epsilon)
+    println("")
+    0
+}

--- a/docs/audit/repro/e200/numeric_reorder.sio
+++ b/docs/audit/repro/e200/numeric_reorder.sio
@@ -1,0 +1,13 @@
+// Numeric isolate: epsilon before variance.
+// If .confidence then prints 22.202944, the epsilon write is positional
+// (third slot = confidence), not a named alias.
+fn main() -> i32 with IO, Epistemic {
+    let kn = Knowledge { value: 12.4, epsilon: 0.65, variance: 22.202944, provenance: "Jiao2009" }
+    print_f64(kn.value)
+    println("")
+    print_f64(kn.variance)
+    println("")
+    print_f64(kn.confidence)
+    println("")
+    0
+}

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -111,6 +111,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.dossier-import-closure-2026-08-17 | repo_only | docs/audit/DOSSIER_IMPORT_CLOSURE_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.e011-stale-prebuilt-phantom-2026-08-18 | repo_only | docs/audit/E011_STALE_PREBUILT_PHANTOM_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.e043-rust-macro-design-dispatch-2026-07-12 | repo_only | docs/audit/E043_RUST_MACRO_DESIGN_DISPATCH_2026-07-12.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.e200-knowledge-constructor-reverify-2026-08-19 | repo_only | docs/audit/E200_KNOWLEDGE_CONSTRUCTOR_REVERIFY_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.e200-knowledge-reverify-2026-08-19 | repo_only | docs/audit/E200_KNOWLEDGE_REVERIFY_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.effect-archaeology-51-2026-08-19 | repo_only | docs/audit/EFFECT_ARCHAEOLOGY_51_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.effect-enum-2a-2026-08-19 | repo_only | docs/audit/EFFECT_ENUM_2A_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2017,6 +2017,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.e200-knowledge-constructor-reverify-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/E200_KNOWLEDGE_CONSTRUCTOR_REVERIFY_2026-08-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.e200-knowledge-reverify-2026-08-19",
       "collection": "repo",
       "repo_doc_path": "docs/audit/E200_KNOWLEDGE_REVERIFY_2026-08-19.md",

--- a/scripts/dev/e200_knowledge_reverify.sh
+++ b/scripts/dev/e200_knowledge_reverify.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Pack a disposable Slurm job that type-checks the dissertation Knowledge
+# constructor on both engines. /workspace is invisible on the node.
+# Does not edit stdlib/darwin_pbpk/epistemic_pbpk28.sio or self-hosted/.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+PARTITION="${SOUNIO_REMOTE_PARTITION:-cpu-ops}"
+CPUS="${SOUNIO_REMOTE_CPUS:-8}"
+TIMELIMIT="${SOUNIO_REMOTE_TIME:-00:25:00}"
+OUT="${E200_SLURM_OUT:-/tmp/e200_reverify_slurm.out}"
+export SLURM_CONF="${SLURM_CONF:-/tmp/slurm-direct.conf}"
+
+REMOTE="$ROOT/_e200_remote.sh"
+cat >"$REMOTE" <<'REMOTE'
+#!/usr/bin/env bash
+set -uo pipefail
+ulimit -s 1048576 || true
+export MADAROS_STACK_KB="${MADAROS_STACK_KB:-524288}"
+unset SOUC_BIN SOUNIO_SOUC_BIN || true
+
+ROOT="$(pwd)"
+export SOUNIO_STDLIB_PATH="$ROOT/stdlib"
+SOUC="$ROOT/bin/souc"
+chmod +x "$ROOT/bin/souc" "$ROOT/bin/madaros" \
+  "$ROOT/bin/madaros-linux-x86_64" "$ROOT/bin/souc-lean-single-x86_64" 2>/dev/null || true
+
+echo "HOST=$(hostname)"
+echo "PWD=$ROOT"
+echo "workspace_visible=$(test -d /workspace && echo yes || echo no)"
+echo "orangefs_visible=$(test -d /orangefs && echo yes || echo no)"
+echo "date_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "=== MADAROS_VERSION ==="
+env -u SOUC_BIN -u SOUNIO_SOUC_BIN -u SOUNIO_SOUC_ENGINE \
+  "$SOUC" --version 2>&1 | head -5
+echo "=== LEAN_SINGLE_HELP ==="
+env -u SOUC_BIN -u SOUNIO_SOUC_BIN SOUNIO_SOUC_ENGINE=lean_single \
+  "$SOUC" --help 2>&1 | head -8
+
+run_one() {
+  local case="$1" engine="$2" verb="$3" src="$4"
+  local log="/tmp/e200_${case}_${engine}_${verb}.log"
+  local rc=0
+  echo ""
+  echo "=== CASE case=$case engine=$engine verb=$verb src=$src ==="
+  if [[ ! -f "$src" ]]; then
+    echo "MISSING_SRC $src"
+    echo "RESULT	$case	$engine	$verb	127	MISSING	-	missing_src"
+    return
+  fi
+  set +e
+  if [[ "$engine" == "madaros" ]]; then
+    env -u SOUC_BIN -u SOUNIO_SOUC_BIN -u SOUNIO_SOUC_ENGINE \
+      SOUNIO_STDLIB_PATH="$SOUNIO_STDLIB_PATH" \
+      "$SOUC" "$verb" "$src" >"$log" 2>&1
+    rc=$?
+  else
+    env -u SOUC_BIN -u SOUNIO_SOUC_BIN \
+      SOUNIO_SOUC_ENGINE=lean_single \
+      SOUNIO_STDLIB_PATH="$SOUNIO_STDLIB_PATH" \
+      "$SOUC" "$verb" "$src" >"$log" 2>&1
+    rc=$?
+  fi
+  set -e
+  local diag="none"
+  local line="-"
+  if grep -qoE 'error\[E[0-9]+\]' "$log"; then
+    diag="$(grep -oE 'error\[E[0-9]+\]' "$log" | head -1)"
+  elif grep -qoE 'E[0-9]{3}' "$log"; then
+    diag="$(grep -oE 'E[0-9]{3}' "$log" | head -1)"
+  fi
+  if grep -qoE 'at line [0-9]+' "$log"; then
+    line="$(grep -oE 'at line [0-9]+' "$log" | head -1 | awk '{print $3}')"
+  elif grep -qoE ':[0-9]+:[0-9]+' "$log"; then
+    line="$(grep -oE ':[0-9]+:[0-9]+' "$log" | head -1 | cut -d: -f2)"
+  fi
+  echo "rc=$rc diag=$diag line=$line"
+  echo "----- log head -----"
+  head -40 "$log"
+  echo "----- log tail -----"
+  tail -20 "$log"
+  echo "RESULT	$case	$engine	$verb	$rc	$diag	$line	ok"
+}
+
+echo "RESULT_HEADER	case	engine	verb	rc	diag	line	status"
+
+# Positive: same folder, known small program with main.
+run_one pos_sort_fix madaros check stdlib/darwin_pbpk/test_sort_fix.sio
+run_one pos_sort_fix lean_single check stdlib/darwin_pbpk/test_sort_fix.sio
+
+# Target.
+run_one ep28 madaros check stdlib/darwin_pbpk/epistemic_pbpk28.sio
+run_one ep28 lean_single check stdlib/darwin_pbpk/epistemic_pbpk28.sio
+
+# Isolates + negatives (check only).
+for f in isolate_struct_lit isolate_call_form negative_wrong_field negative_no_value; do
+  run_one "$f" madaros check "docs/audit/repro/e200/${f}.sio"
+  run_one "$f" lean_single check "docs/audit/repro/e200/${f}.sio"
+done
+
+# Numeric isolates: compile+run so field values are observed.
+for f in numeric_carrier numeric_reorder; do
+  run_one "$f" madaros check "docs/audit/repro/e200/${f}.sio"
+  run_one "$f" lean_single check "docs/audit/repro/e200/${f}.sio"
+  run_one "$f" madaros run "docs/audit/repro/e200/${f}.sio"
+  run_one "$f" lean_single run "docs/audit/repro/e200/${f}.sio"
+done
+
+echo "=== DONE ==="
+REMOTE
+chmod +x "$REMOTE"
+
+echo "[e200] packing + srun partition=$PARTITION cpus=$CPUS"
+# shellcheck disable=SC2046
+tar czf - \
+  _e200_remote.sh \
+  bin/souc bin/madaros bin/madaros-linux-x86_64 bin/souc-lean-single-x86_64 \
+  stdlib \
+  docs/audit/repro/e200 \
+  | srun -p "$PARTITION" -N1 -n1 -c "$CPUS" --mem=16G --time="$TIMELIMIT" \
+      --job-name=e200-reverify --chdir=/tmp \
+      --export=NONE,PATH=/usr/bin:/bin:/usr/local/bin,TMPDIR=/tmp,TMP=/tmp,TEMP=/tmp,HOME=/tmp \
+      /bin/bash -lc 'set -e; rm -rf /tmp/e200-in; mkdir -p /tmp/e200-in; cd /tmp/e200-in; tar xzf -; bash _e200_remote.sh' \
+      >"$OUT" 2>&1
+rc=$?
+echo "[e200] srun rc=$rc log=$OUT bytes=$(wc -c <"$OUT")"
+rm -f "$REMOTE"
+exit $rc


### PR DESCRIPTION
## Decision

**ACEITE** (compiler builtin `TypeKind::TyKnowledge`; both engines `check` the dissertation literal; `kn` is the GUM carrier).

The memory claim that `souc` still refuses `Knowledge { value, variance, epsilon, provenance }` with **E200** is false on the staged binaries. E200 did not appear. Dissertation modules are not forced onto raw `f64` by this constructor.

Independent of #2024 (cursor-1, SHA `f4dc51777e`). Agrees on acceptance, builtin, carrier, and workflow-unreachability. Does **not** agree that Madaros refuses unknown Knowledge field names: #2024's negative omitted `value`, so its E012 is the missing-`value` rule.

## Measurement (Slurm `cpuops-t560-proxmox`, `/workspace` invisible)

| Case | Madaros v0.80.0 | lean_single |
|---|---|---|
| `test_sort_fix.sio` (same-folder positive) | check rc=0 | check rc=0 |
| `epistemic_pbpk28.sio` | check rc=0, 3 modules, no E200 | check rc=0, ELF, no E200 |
| isolate struct-lit / call form | check rc=0 | check rc=0 |
| `{ value, mystery }` | **rc=0 silent** | rc=0 + warning |
| `{ mystery, provenance }` (no `value`) | rc=1 `error[E012]` | rc=0 + warning |
| numeric isolate (dissertation field order) | run `12.4 / 22.202944 / 0.65 / 0.0` | run `12.4 / 22.202944 / 0.65 / 0.65` |
| numeric reorder (`epsilon` before `variance`) | `.confidence = 0.0` (positional) | `.confidence = 0.65` (named alias) |

`m`/`v`/`c` are locals that fill `kn`. `ep28_run` reads `priors.kn[i].value/.variance/.confidence`. `provenance` has no IR slot.

## Gate

`scripts/ci/dissertation_pbpk_suite_gate.sh` lists `epistemic_pbpk28` and runs `souc run` under `souc-seq-leansingle.sh`. Called from `native_v2_cpu_compiler_umbrella_gate.sh`. None of those names is in `.github/workflows/`. Operator-reachable, not workflow-reachable.

## Not edited

`stdlib/darwin_pbpk/epistemic_pbpk28.sio`, `self-hosted/`. Not merged unless asked.

Receipt: `docs/audit/E200_KNOWLEDGE_CONSTRUCTOR_REVERIFY_2026-08-19.md`