### PR TITLE
docs(audit): written epsilon is not read epsilon — constructor does not validate names

### DIFF
--- a/docs/audit/EPSILON_WRITE_READ_MISMATCH_2026-08-19.md
+++ b/docs/audit/EPSILON_WRITE_READ_MISMATCH_2026-08-19.md
@@ -1,0 +1,177 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.epsilon-write-read-mismatch-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: grok-cli5
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.epsilon-write-read-mismatch-2026-08-19
+-->
+
+# Written `epsilon:` is not read `.epsilon`
+
+**Decision: CONSTRUTOR NÃO VALIDA.** Madaros `check` accepts any Knowledge
+field name once `value` is present, including the invented `epsilom:`,
+with no diagnostic. An invented **third** name writes the confidence
+slot by position. That is larger than a swapped alias.
+
+lean_single warns on unknown names and still emits an ELF (`rc=0`).
+It does alias `epsilon` ↔ `confidence` by name. Madaros does not.
+
+`self-hosted/` and `stdlib/darwin_pbpk/epistemic_pbpk28.sio` were not
+edited.
+
+---
+
+## Instrument
+
+| Field | Value |
+|---|---|
+| SHA | `ef69121b26` (`origin/main`, contains #2024) |
+| Node | `cpuops-t560-proxmox` (`workspace_visible=no`) |
+| Stamp | `2026-08-19T20:26:44Z` |
+| Madaros | `bin/souc` default → `Madaros v0.80.0` |
+| lean_single | `SOUNIO_SOUC_ENGINE=lean_single` |
+| Driver | [`scripts/dev/epsilon_write_read.sh`](../../scripts/dev/epsilon_write_read.sh) |
+| Isolates | [`docs/audit/repro/epsilon/`](repro/epsilon/) |
+| Table | [`EPSILON_WRITE_READ_MISMATCH_2026-08-19.tsv`](EPSILON_WRITE_READ_MISMATCH_2026-08-19.tsv) |
+
+---
+
+## Controls
+
+**Positive.** Write `value: 12.4`, read `.value`:
+
+| Engine | check rc | run |
+|---|---:|---|
+| Madaros v0.80.0 | 0 | **12.400000** |
+| lean_single | 0 | **12.400000** |
+
+The isolate reads fields. A later `.epsilon` of `0.0` is not a dead printer.
+
+**Negative.** Write `epsilom: 0.42` (invented name):
+
+| Engine | check | run `.value` / `.confidence` / `.epsilon` |
+|---|---|---|
+| Madaros v0.80.0 | **rc=0, silence** | 1.000000 / 0.000000 / 0.000000 |
+| lean_single | rc=0, `warning: unknown field` | 1.000000 / 1.000000 / 1.000000 |
+
+Madaros does not validate constructor names. lean_single warns and
+drops the unknown write (`.confidence` stays the default `1.0`, not
+`0.42`).
+
+---
+
+## 1. Where does written `epsilon:` go?
+
+**Madaros.** `checker_check_struct_lit_inplace` special-cases
+`Knowledge` and only requires a field named `value`. Other names are
+typechecked as expressions and otherwise ignored. Lowering
+(`field_idx_from_struct_literal_name`) matches `value` / `variance` /
+`confidence` against the three-slot IR layout. `epsilon` is not in
+that layout, so it is stored at **`default_idx` = position in the
+literal**. Dissertation order is `value`, `variance`, `epsilon`,
+`provenance` → `epsilon` is index 2 → IR field 2 = `confidence`.
+
+**lean_single.** Write of `epsilon` and `confidence` is one branch
+(`lean_single.sio` ~10447, ~10710). Both store the confidence slot.
+Unknown names take the `tc_error` / warning path, not a hard refuse.
+
+Call form `Knowledge(v, ε=…, prov=…)` on Madaros lowers the second
+argument into field 2 by construction (`lower_knowledge_ctor_call_ref`),
+not by the struct-literal name table.
+
+---
+
+## 2. Where does `.confidence == 0.65` come from?
+
+It is the authored `c[0]`, not a default.
+
+Sentinel isolate writes `epsilon: 0.42` in dissertation field order:
+
+| Engine | `.value` | `.variance` | `.confidence` | `.epsilon` |
+|---|---|---|---|---|
+| Madaros v0.80.0 | 1.000000 | 2.000000 | **0.420000** | **0.000000** |
+| lean_single | 1.000000 | 2.000000 | 0.420000 | 0.420000 |
+
+Default confidence on lean_single when the slot is not written is
+**1.0** (`epsilom` negative). 0.42 is therefore the write, not a
+constant. #2024's 0.65 is `c[0]`.
+
+Invented third name `epsilom: 0.42` after `value` and `variance`:
+
+| Engine | `.confidence` |
+|---|---|
+| Madaros v0.80.0 | **0.420000** (any third name fills slot 2) |
+| lean_single | **1.000000** (unknown dropped; default) |
+
+Writing the layout name `confidence: 0.42`:
+
+| Engine | `.confidence` | `.epsilon` |
+|---|---|---|
+| Madaros v0.80.0 | 0.420000 | 0.000000 |
+| lean_single | 0.420000 | 0.420000 |
+
+Madaros `.epsilon` is not an alias. It typechecks as `f64` and the
+field-get lowering has no layout entry, so the name hashes to a vacant
+index (`'e' % 64 = 37`) and reads 0.0. lean_single loads offset 16 for
+both names.
+
+---
+
+## 3. Write set versus read set (`TyKnowledge`)
+
+| Name | Madaros write | Madaros read | lean_single write | lean_single read |
+|---|---|---|---|---|
+| `value` | required | yes (E170) | yes | yes |
+| `variance` | by name | yes | yes | yes |
+| `uncertainty` | by position if used | no (E, no field) | yes (σ² via square) | yes (√variance) |
+| `confidence` | by name | yes | yes (alias of epsilon) | yes (offset 16) |
+| `epsilon` | **position only** | typechecks; runtime 0.0 | yes (alias of confidence) | yes (offset 16) |
+| `provenance` / `prov` | ignored / position | no | ignored | no |
+| any other name | **accepted, stored by position** | no (no-field error on access) | warning, dropped | no (unknown field access) |
+
+The sets differ. A constructor that accepts names the reader does not
+know loses data without a Madaros diagnostic. That is the defect.
+
+---
+
+## 4. Dissertation dependence
+
+`stdlib/darwin_pbpk/` contains **zero** `.epsilon` reads. The live
+writers are `epistemic_pbpk28.sio` (lines 293–299, 566–572) and
+`validation/pbpk28_mc_cross_validation.sio` (line 520). The GUM loop
+reads `priors.kn[i].value`, `.variance`, `.confidence`
+(`ep28_run` ~366–418).
+
+TEST 5 (`sens[0]`) survives on `value`/`variance`. TEST 6
+(`auc_blood_conf`) reads `.confidence`. Under dissertation field
+order that slot **does** hold `c[i]` on both engines (Madaros by
+position, lean_single by alias). Nothing downstream of those writers
+reads `.epsilon` and therefore nothing in this tree observes the
+Madaros 0.0.
+
+The lost name is `.epsilon` as a **reader**. The authored number is
+not lost from GUM, given the current literal order. Reordering
+`epsilon` ahead of `variance` would zero Madaros `.confidence`
+(#2027 reorder isolate). That is a silent order dependence, not a
+named alias.
+
+---
+
+## What this does not close
+
+- Repair. Forense only.
+- Whether `epsilon` should become a real fourth slot or a named alias
+  of `confidence` on Madaros.
+- Rebuilding Madaros from `self-hosted/` (prebuilt ELF used).
+
+---
+
+## Files
+
+| Path | Role |
+|---|---|
+| `docs/audit/EPSILON_WRITE_READ_MISMATCH_2026-08-19.md` | this receipt |
+| `docs/audit/EPSILON_WRITE_READ_MISMATCH_2026-08-19.tsv` | one row per cell |
+| `scripts/dev/epsilon_write_read.sh` | Slurm packer |
+| `docs/audit/repro/epsilon/*.sio` | isolates |

--- a/docs/audit/EPSILON_WRITE_READ_MISMATCH_2026-08-19.tsv
+++ b/docs/audit/EPSILON_WRITE_READ_MISMATCH_2026-08-19.tsv
@@ -1,0 +1,21 @@
+case	engine	verb	rc	diag	stdout	note
+pos_value	madaros	check	0	none		positive write value: read .value
+pos_value	lean_single	check	0	none		
+pos_value	madaros	run	0	none	12.400000	positive
+pos_value	lean_single	run	0	none	12.400000	positive
+neg_epsilom	madaros	check	0	none		FINDING: invented name silence
+neg_epsilom	lean_single	check	0	unknown_field_warning	warning: unknown field	not a hard refuse
+neg_epsilom	madaros	run	0	none	1.000000 0.000000 0.000000	epsilom as 2nd field misses confidence slot
+neg_epsilom	lean_single	run	0	none	1.000000 1.000000 1.000000	unknown dropped; default conf=1.0
+sentinel_epsilon	madaros	check	0	none		
+sentinel_epsilon	lean_single	check	0	none		
+sentinel_epsilon	madaros	run	0	none	1.000000 2.000000 0.420000 0.000000	0.42 is c written; .epsilon dead
+sentinel_epsilon	lean_single	run	0	none	1.000000 2.000000 0.420000 0.420000	named alias
+epsilom_third	madaros	check	0	none		
+epsilom_third	lean_single	check	0	unknown_field_warning		
+epsilom_third	madaros	run	0	none	1.000000 2.000000 0.420000	ANY third name fills confidence
+epsilom_third	lean_single	run	0	none	1.000000 2.000000 1.000000	unknown dropped
+write_confidence	madaros	check	0	none		
+write_confidence	lean_single	check	0	none		
+write_confidence	madaros	run	0	none	0.420000 0.000000	layout name works; .epsilon still 0
+write_confidence	lean_single	run	0	none	0.420000 0.420000	alias

--- a/docs/audit/repro/epsilon/epsilom_third.sio
+++ b/docs/audit/repro/epsilon/epsilom_third.sio
@@ -1,0 +1,12 @@
+// Invented name in the third slot. If .confidence prints 0.42, ANY third
+// name fills the confidence slot by position, not by alias.
+fn main() -> i32 with IO, Epistemic {
+    let kn = Knowledge { value: 1.0, variance: 2.0, epsilom: 0.42 }
+    print_f64(kn.value)
+    println("")
+    print_f64(kn.variance)
+    println("")
+    print_f64(kn.confidence)
+    println("")
+    0
+}

--- a/docs/audit/repro/epsilon/neg_epsilom.sio
+++ b/docs/audit/repro/epsilon/neg_epsilom.sio
@@ -1,0 +1,11 @@
+// Negative: invented field name. If check is silent, names are not validated.
+fn main() -> i32 with IO, Epistemic {
+    let kn = Knowledge { value: 1.0, epsilom: 0.42 }
+    print_f64(kn.value)
+    println("")
+    print_f64(kn.confidence)
+    println("")
+    print_f64(kn.epsilon)
+    println("")
+    0
+}

--- a/docs/audit/repro/epsilon/pos_value.sio
+++ b/docs/audit/repro/epsilon/pos_value.sio
@@ -1,0 +1,7 @@
+// Positive: a field known to work. Write value:, read .value.
+fn main() -> i32 with IO, Epistemic {
+    let kn = Knowledge { value: 12.4 }
+    print_f64(kn.value)
+    println("")
+    0
+}

--- a/docs/audit/repro/epsilon/sentinel_epsilon.sio
+++ b/docs/audit/repro/epsilon/sentinel_epsilon.sio
@@ -1,0 +1,14 @@
+// Sentinel: unique 0.42 as the third field named epsilon.
+// If .confidence prints 0.42, the write landed in the confidence slot.
+fn main() -> i32 with IO, Epistemic {
+    let kn = Knowledge { value: 1.0, variance: 2.0, epsilon: 0.42, provenance: "x" }
+    print_f64(kn.value)
+    println("")
+    print_f64(kn.variance)
+    println("")
+    print_f64(kn.confidence)
+    println("")
+    print_f64(kn.epsilon)
+    println("")
+    0
+}

--- a/docs/audit/repro/epsilon/write_confidence.sio
+++ b/docs/audit/repro/epsilon/write_confidence.sio
@@ -1,0 +1,9 @@
+// Write the layout name confidence:. Compare .confidence and .epsilon.
+fn main() -> i32 with IO, Epistemic {
+    let kn = Knowledge { value: 1.0, variance: 2.0, confidence: 0.42 }
+    print_f64(kn.confidence)
+    println("")
+    print_f64(kn.epsilon)
+    println("")
+    0
+}

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -131,6 +131,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.epistemic-self-application-audit-2026-06-03 | repo_only | docs/audit/EPISTEMIC_SELF_APPLICATION_AUDIT_2026-06-03.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.epistemic-shape-ratchet-2026-08-19 | repo_only | docs/audit/EPISTEMIC_SHAPE_RATCHET_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.epistemic-trust-map-2026-07-14 | repo_only | docs/audit/EPISTEMIC_TRUST_MAP_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.epsilon-write-read-mismatch-2026-08-19 | repo_only | docs/audit/EPSILON_WRITE_READ_MISMATCH_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.equivalence-theory-a-layer2-benettin-2026-06-23 | repo_only | docs/audit/EQUIVALENCE_THEORY_A_LAYER2_BENETTIN_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.equivalence-theory-a-layer2-gate-2026-06-23 | repo_only | docs/audit/EQUIVALENCE_THEORY_A_LAYER2_GATE_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.equivalence-theory-a-layer2-substrate-2026-06-23 | repo_only | docs/audit/EQUIVALENCE_THEORY_A_LAYER2_SUBSTRATE_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2477,6 +2477,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.epsilon-write-read-mismatch-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/EPSILON_WRITE_READ_MISMATCH_2026-08-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.equivalence-theory-a-layer2-benettin-2026-06-23",
       "collection": "repo",
       "repo_doc_path": "docs/audit/EQUIVALENCE_THEORY_A_LAYER2_BENETTIN_2026-06-23.md",

--- a/scripts/dev/epsilon_write_read.sh
+++ b/scripts/dev/epsilon_write_read.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Slurm forensic: written Knowledge field names vs read names.
+# /workspace is invisible on the node. Does not edit self-hosted/ or the dissertation file.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+PARTITION="${SOUNIO_REMOTE_PARTITION:-cpu-ops}"
+CPUS="${SOUNIO_REMOTE_CPUS:-4}"
+TIMELIMIT="${SOUNIO_REMOTE_TIME:-00:15:00}"
+OUT="${EPSILON_SLURM_OUT:-/tmp/epsilon_inerte_slurm.out}"
+export SLURM_CONF="${SLURM_CONF:-/tmp/slurm-direct.conf}"
+
+REMOTE="$ROOT/_epsilon_remote.sh"
+cat >"$REMOTE" <<'REMOTE'
+#!/usr/bin/env bash
+set -uo pipefail
+ulimit -s 1048576 || true
+export MADAROS_STACK_KB="${MADAROS_STACK_KB:-524288}"
+unset SOUC_BIN SOUNIO_SOUC_BIN || true
+ROOT="$(pwd)"
+SOUC="$ROOT/bin/souc"
+chmod +x "$ROOT/bin/souc" "$ROOT/bin/madaros" \
+  "$ROOT/bin/madaros-linux-x86_64" "$ROOT/bin/souc-lean-single-x86_64" 2>/dev/null || true
+echo "HOST=$(hostname)"
+echo "PWD=$ROOT"
+echo "workspace_visible=$(test -d /workspace && echo yes || echo no)"
+echo "date_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "=== MADAROS_VERSION ==="
+env -u SOUC_BIN -u SOUNIO_SOUC_BIN -u SOUNIO_SOUC_ENGINE "$SOUC" --version 2>&1 | head -3
+echo "RESULT_HEADER	case	engine	verb	rc	diag	note"
+
+run_one() {
+  local case="$1" engine="$2" verb="$3" src="$4"
+  local log="/tmp/eps_${case}_${engine}_${verb}.log"
+  local rc=0
+  echo ""
+  echo "=== CASE case=$case engine=$engine verb=$verb src=$src ==="
+  set +e
+  if [[ "$engine" == "madaros" ]]; then
+    env -u SOUC_BIN -u SOUNIO_SOUC_BIN -u SOUNIO_SOUC_ENGINE \
+      "$SOUC" "$verb" "$src" >"$log" 2>&1
+    rc=$?
+  else
+    env -u SOUC_BIN -u SOUNIO_SOUC_BIN SOUNIO_SOUC_ENGINE=lean_single \
+      "$SOUC" "$verb" "$src" >"$log" 2>&1
+    rc=$?
+  fi
+  set -e
+  local diag="none"
+  if grep -qoE 'error\[E[0-9]+\]' "$log"; then
+    diag="$(grep -oE 'error\[E[0-9]+\]' "$log" | head -1)"
+  elif grep -qoE 'E[0-9]{3}' "$log"; then
+    diag="$(grep -oE 'E[0-9]{3}' "$log" | head -1)"
+  elif grep -q 'unknown field' "$log"; then
+    diag="unknown_field_warning"
+  fi
+  echo "rc=$rc diag=$diag"
+  echo "----- log -----"
+  if [[ "$verb" == "run" ]]; then
+    # keep numbers; drop banner
+    grep -E '^[0-9]|warning:|error|check:|unknown field' "$log" || tail -20 "$log"
+  else
+    tail -25 "$log"
+  fi
+  echo "RESULT	$case	$engine	$verb	$rc	$diag	ok"
+}
+
+for f in pos_value neg_epsilom sentinel_epsilon epsilom_third write_confidence; do
+  src="docs/audit/repro/epsilon/${f}.sio"
+  run_one "$f" madaros check "$src"
+  run_one "$f" lean_single check "$src"
+  run_one "$f" madaros run "$src"
+  run_one "$f" lean_single run "$src"
+done
+echo "=== DONE ==="
+REMOTE
+chmod +x "$REMOTE"
+
+echo "[epsilon] packing + srun partition=$PARTITION"
+tar czf - \
+  _epsilon_remote.sh \
+  bin/souc bin/madaros bin/madaros-linux-x86_64 bin/souc-lean-single-x86_64 \
+  docs/audit/repro/epsilon \
+  | srun -p "$PARTITION" -N1 -n1 -c "$CPUS" --mem=8G --time="$TIMELIMIT" \
+      --job-name=epsilon-inerte --chdir=/tmp \
+      --export=NONE,PATH=/usr/bin:/bin:/usr/local/bin,TMPDIR=/tmp,TMP=/tmp,TEMP=/tmp,HOME=/tmp \
+      /bin/bash -lc 'set -e; rm -rf /tmp/eps-in; mkdir -p /tmp/eps-in; cd /tmp/eps-in; tar xzf -; bash _epsilon_remote.sh' \
+      >"$OUT" 2>&1
+rc=$?
+echo "[epsilon] srun rc=$rc log=$OUT bytes=$(wc -c <"$OUT")"
+rm -f "$REMOTE"
+exit $rc


### PR DESCRIPTION
## Decision

**CONSTRUTOR NÃO VALIDA.** Madaros `check` accepts any Knowledge field name once `value` is present, including invented `epsilom:`, with no diagnostic. An invented **third** name writes the confidence slot by position. That is larger than a missing alias.

lean_single warns on unknown names (`rc=0`) and aliases `epsilon` ↔ `confidence` by name. Madaros does not.

## Measurement (Slurm `cpuops-t560-proxmox`)

Positive: write `value: 12.4`, read `.value` → `12.400000` on both engines.

| Isolate | Madaros v0.80.0 | lean_single |
|---|---|---|
| `{ value, epsilom: 0.42 }` check | rc=0, silence | rc=0 + warning |
| `{ value, variance, epsilon: 0.42 }` run | `.confidence=0.42`, `.epsilon=0.0` | both `0.42` |
| `{ value, variance, epsilom: 0.42 }` run | `.confidence=0.42` (any 3rd name) | `.confidence=1.0` (dropped) |
| write `confidence: 0.42` | `.confidence=0.42`, `.epsilon=0.0` | both `0.42` |

`0.65` in #2024 is authored `c[0]`, not a default (sentinel `0.42`).

## Dissertation

`stdlib/darwin_pbpk/` has **zero** `.epsilon` readers. GUM reads `.confidence`. Under dissertation field order that slot holds `c[i]` on both engines. Nothing downstream observes the Madaros `.epsilon == 0.0`.

## Not edited

`self-hosted/`, `stdlib/darwin_pbpk/epistemic_pbpk28.sio`. Not merged unless asked.

Receipt: `docs/audit/EPSILON_WRITE_READ_MISMATCH_2026-08-19.md`