### PR TITLE
spec(§8.2.5): the constructor fills by position — and the dissertation is right by typing order

### DIFF
--- a/docs/spec/S08_EPISTEMIC_VALUES.md
+++ b/docs/spec/S08_EPISTEMIC_VALUES.md
@@ -218,13 +218,28 @@ So the numbers flow through plain `f64` arrays (`m`, `v`, `c`) and the
   assignments zeros `sens[0]` and fails TEST 5; the unmodified file passes 9/9
   under lean_single. The numbers pass through it.
 
-Three further facts fall out of the same measurement, and each is a defect:
+Five further facts fall out of the same measurement, and each is a defect:
 
 - **The field written is not the field read.** The literal writes `epsilon:`;
-  under Madaros `.epsilon` reads **0.0** while `.confidence` reads 0.65. One of
-  the two names is silently inert.
-- **The engines disagree on a wrong-field literal.** Madaros refuses with
-  `E012`; **lean_single warns and emits an ELF anyway**.
+  under Madaros `.epsilon` reads **0.0** while `.confidence` reads 0.65.
+- **The cause is positional filling, not a swapped alias.** Madaros fills the
+  builtin `Knowledge` literal **by position**, ignoring the written names.
+  lean_single resolves **by name** and aliases `epsilon` to `confidence`. Both
+  therefore land `c[i]` in the confidence slot *under the field order this file
+  happens to use* — Madaros by arithmetic, lean_single by meaning.
+- **Madaros does not validate constructor field names at all.** Negative control
+  (`docs/audit/repro/epsilon/neg_epsilom.sio`): a literal writing the invented
+  name `epsilom: 0.42` is accepted by Madaros with `check: OK`, rc=0, and **no
+  diagnostic**; lean_single emits `warning: unknown field in Knowledge literal`
+  and drops the write. An earlier draft of this section stated the opposite —
+  that *Madaros refuses with `E012`* — and that is **false for the builtin**,
+  re-measured on both engines. It is corrected here rather than quietly dropped,
+  because the error credited the silent engine with the rigour of the noisy one.
+- **The correctness is order-dependent and nothing records the dependence.**
+  Under Madaros, moving `epsilon:` ahead of `variance:` — a reordering no
+  diagnostic objects to — puts `c[i]` in the variance slot and zeroes
+  `.confidence`. The dissertation's GUM numbers are right because of the
+  sequence the literal was typed in, not because the names were honoured.
 - **The gate that covers this file is unreachable.**
   `scripts/ci/dissertation_pbpk_suite_gate.sh` lists it, and no workflow reaches
   that gate.

--- a/docs/spec/S08_EPISTEMIC_VALUES.md
+++ b/docs/spec/S08_EPISTEMIC_VALUES.md
@@ -218,7 +218,7 @@ So the numbers flow through plain `f64` arrays (`m`, `v`, `c`) and the
   assignments zeros `sens[0]` and fails TEST 5; the unmodified file passes 9/9
   under lean_single. The numbers pass through it.
 
-Five further facts fall out of the same measurement, and each is a defect:
+Six further facts fall out of the same measurement, and each is a defect:
 
 - **The field written is not the field read.** The literal writes `epsilon:`;
   under Madaros `.epsilon` reads **0.0** while `.confidence` reads 0.65.
@@ -232,9 +232,17 @@ Five further facts fall out of the same measurement, and each is a defect:
   name `epsilom: 0.42` is accepted by Madaros with `check: OK`, rc=0, and **no
   diagnostic**; lean_single emits `warning: unknown field in Knowledge literal`
   and drops the write. An earlier draft of this section stated the opposite —
-  that *Madaros refuses with `E012`* — and that is **false for the builtin**,
-  re-measured on both engines. It is corrected here rather than quietly dropped,
-  because the error credited the silent engine with the rigour of the noisy one.
+  that *Madaros refuses with `E012`* — and that is **false for the builtin**.
+  `E012` is real, and it fires: on a **declared** struct, `P { a: 1.0, zz: 9.0 }`
+  gives `error[E012] ... this type has no field named`, rc=1, and lean_single
+  gives two errors. The claim was a true measurement quoted from the wrong path.
+  It is corrected here rather than quietly dropped, because it credited the
+  silent engine with the rigour of the noisy one.
+- **The builtin is exempt from the checker the language already has.** Field-name
+  validation exists, works, and is enforced on every declared struct. The one
+  type that carries the dissertation's numbers is the one that does not get it.
+  This is `SOUNIO-TYPE-INTERROGATION` failure type 3 in a new form: not a missing
+  check, but a **privileged type routed around an existing one**.
 - **The correctness is order-dependent and nothing records the dependence.**
   Under Madaros, moving `epsilon:` ahead of `variance:` — a reordering no
   diagnostic objects to — puts `c[i]` in the variance slot and zeroes


### PR DESCRIPTION
The inert-field forensic (#2028) came back with the worst of the four verdicts I
offered it: **the constructor does not validate names**.

| engine | `epsilon:` | invented `epsilom:` |
|---|---|---|
| Madaros v0.80.0 | filled **by position**, name ignored | `check: OK`, rc=0, **no diagnostic** |
| lean_single | resolved by name, aliased to `confidence` | `warning: unknown field`, write dropped |

Both engines land the authored value in the confidence slot — but only under the
field order this file happens to use. Madaros gets there by arithmetic,
lean_single by meaning. Moving `epsilon:` ahead of `variance:`, which nothing
objects to, zeroes `.confidence` under Madaros.

So the dissertation's GUM numbers are correct, and they are correct because of
the sequence the literal was typed in.

### A correction to my own text

§8.2.5 previously said Madaros refuses a wrong-field literal with `E012`.
Re-measured on both engines, that is **false for the builtin**. The claim is
corrected in place rather than deleted: it credited the silent engine with the
rigour of the noisy one, which is exactly the failure this section exists to
record.

Verified by hand on `docs/audit/repro/epsilon/neg_epsilom.sio` (from #2028), not
quoted from the lane's report.

Refs #2028