### PR TITLE
spec(keywords): two listed keywords are not reserved, and mut is reserved against itself

### DIFF
--- a/docs/spec/LANGUAGE_SPECIFICATION.md
+++ b/docs/spec/LANGUAGE_SPECIFICATION.md
@@ -114,6 +114,24 @@ mut       unsafe
 with      handle    on        resume    perform
 ```
 
+> **Measured 2026-08-19 — two of these tables are wrong, and one entry is
+> reserved against itself.** Each word was tested as an identifier
+> (`let <word> = 1`); a reserved word cannot be one. Both engines agree.
+>
+> | word | listed as | measured |
+> |---|---|---|
+> | `own` | type keyword | **not reserved** — compiles as an identifier |
+> | `handle` | effect keyword | **not reserved** — compiles as an identifier; it is *contextual*, recognised in the `handle<IO> { … }` position §7.3 measures |
+> | `mut` | type keyword | reserved, but refused **by design**: `error[E040]: Sounio uses \`var\` for mutable bindings, not \`let mut\`` |
+>
+> `mut` is reserved to teach against, not to use, so listing it beside `linear`
+> and `where` reads as an endorsement of a form the compiler exists to refuse.
+> The remaining ten refuse as parse failures and are reserved as documented.
+> `perform` is reserved on Madaros but resolves as an ordinary identifier under
+> `lean_single`, which reports `error[E200]: undefined identifier` — see
+> §7.3.4 in `S07_EFFECT_HANDLERS.md`.
+
+
 **Literal keywords:**
 ```
 true      false


### PR DESCRIPTION
Every word in the type and effect keyword tables was tested as an identifier — `let <word> = 1`, which a reserved word cannot be. **Both engines agree.**

| word | listed as | measured |
|---|---|---|
| `own` | type keyword | **not reserved** — compiles as an identifier |
| `handle` | effect keyword | **not reserved** — compiles as an identifier |
| `mut` | type keyword | reserved, but refused **by design** |

**`handle` is contextual**, not absent: it is recognised in the `handle<IO> { … }` position §7.3 measures, which is exactly why it reads as a keyword without being one. `let handle = 1` compiles on both engines.

**`mut` is reserved against itself:**

```
error[E040]: Sounio uses `var` for mutable bindings, not `let mut`
```

It is reserved *to teach against*, not to use. Listing it beside `linear` and `where` reads as an endorsement of the form the compiler exists to refuse — and this document is where a newcomer looks first.

The remaining ten refuse as parse failures and are reserved as documented, with one engine split: **`perform` is reserved on Madaros only.** lean_single resolves it as an ordinary identifier and reports `error[E200]: undefined identifier` — see §7.3.4 in `S07_EFFECT_HANDLERS.md` (#2032).

The measurement is written into the document beside the tables rather than replacing them, so the claim and its correction stay together.