### PR TITLE
spec(§2.3): int and uint do not work, and a parameter type is not asked to exist

### DIFF
--- a/docs/spec/LANGUAGE_SPECIFICATION.md
+++ b/docs/spec/LANGUAGE_SPECIFICATION.md
@@ -129,6 +129,21 @@ uint      u8        u16       u32       u64       u128
 f32       f64       bool      char      string
 ```
 
+> **Measured 2026-08-19 — `int` and `uint` are listed and do not work.**
+> `let x: i64 = 0` checks; `let x: int = 0` gives
+> `error[E001]: this binding expects a different type`, as does `uint`. The two
+> widths this document might have been expected to be aspirational about,
+> `i128` and `u128`, **do** check — that guess was tested and was wrong.
+>
+> **A test in parameter position proves nothing here.** `fn f(x: T) -> i32 { 0 }`
+> checks under Madaros for *every* `T`, including `naoexiste_zorble`. An
+> undeclared parameter type is refused only once the function has a caller
+> (`error[E009]`), so the declaration is never interrogated on its own — the use
+> is. lean_single emits an ELF **either way**, caller or not.
+>
+> This is `SOUNIO-TYPE-INTERROGATION` at the level of the type namespace: a name
+> in a declaration is not asked to exist until something forces the question.
+
 ### 2.4 Built-in Effect Names
 
 ```


### PR DESCRIPTION
`let x: i64 = 0` checks. `let x: int = 0` gives `error[E001]: this binding expects a different type` — and so does `uint`. Both are listed in §2.3 as built-in type names.

The two entries I expected to be aspirational, **`i128` and `u128`, do check**. The guess was tested before it was written, and it was wrong.

### Why the obvious test is void

`fn f(x: T) -> i32 { 0 }` checks under Madaros for **every** `T` — `naoexiste_zorble` included. So a parameter-position test distinguishes nothing, and any conclusion drawn from one is worthless. I had already drawn one about `char` from exactly that test before the negative control killed it.

The refusal appears only once the function has a caller:

| | no caller | with `f(42)` |
|---|---|---|
| Madaros v0.80.0 | `check: OK` | `error[E009]` |
| lean_single | ELF emitted | **ELF emitted** |

**The declaration is never interrogated on its own — the use is.** That is `SOUNIO-TYPE-INTERROGATION` at the level of the type namespace, and lean_single does not ask even then.

The measurement is written beside the table rather than replacing it, as with the keyword tables in #2033.