### PR TITLE
docs(audit): the eight ZD types cannot be called, and the one path in verifies nothing

### DIFF
--- a/docs/audit/ZD_FAMILY_CALL_PATH_2026-08-20.md
+++ b/docs/audit/ZD_FAMILY_CALL_PATH_2026-08-20.md
@@ -60,6 +60,43 @@ The cast works. Its controls are what matter:
 So the cast confirms the target type exists and verifies **nothing about the
 source**. A string enters an `ExactlyPrivate<f64>` without a diagnostic.
 
+## There is no ceremony either: E201 was never reached
+
+This document first said the guarantee amounts to *declare `with ZD`, then cast
+anything in*. That is still too generous, and the correction is recorded rather
+than folded in silently, because it runs in the direction of my own earlier
+claim.
+
+`lower_exactly_private_type` is where `E201` — *"ExactlyPrivate&lt;T&gt; requires ZD
+effect"* — is emitted. **Six positions were written without any `with ZD` at all,
+and every one checks clean:**
+
+| position | Madaros |
+|---|---|
+| `fn r(x: ExactlyPrivate<f64>) -> f64 { 0.0 }` | `check: OK` |
+| `let x: ExactlyPrivate<f64> = 1.0 as ExactlyPrivate<f64>` | `check: OK` |
+| the same, inside a function with a live caller | `check: OK` |
+| `fn make() -> ExactlyPrivate<f64> { ... }` (return position) | `check: OK` |
+| `struct Holder { p: ExactlyPrivate<f64> }` | `check: OK` |
+| `docs/audit/exactly_private_lean/witness_nozd.sio` — the witness written to demonstrate the refusal | `check: OK` |
+
+The cause is structural, and it is why a patch to the obvious function changes
+nothing. There are **two** lowering spines. Parameter types go through
+`checker_lower_type_expr_mut` (`check/check.sio:2329`), whose `match` handles
+`TypeNamed`, `TypeUnit`, `TypeNever`, `TypeInfer`, `TypeSelfUpper`,
+`TypeKnowledge`, `TypeModel`, `TypePolicy`, `TypeDecisionPolicy` and
+`TypeDeferralPolicy` — and **not one** of the eight ZD kinds. They fall to the
+`_ =>` default. `lower_exactly_private_type`, with its E201 and its inner-type
+lowering, sits on the *other* spine.
+
+**Verified by positive control, not inferred.** `zd_locus_is_wellformed` was
+forced to return `false` unconditionally and the compiler rebuilt: a locus that
+must then be refused was still accepted. The function is not reached.
+
+The claim is bounded: six positions were measured and none reached it. That is
+not a proof of unreachability, but it is every position a program can put the
+type in that I could construct.
+
 ## What the guarantee currently amounts to
 
 Write `with ZD`, then cast any value at all into the wrapper — including one of a
@@ -68,9 +105,11 @@ type the wrapper does not name. `lower_exactly_private_type`
 and returns the inner type.
 
 `docs/internal/concepts/type-interrogation.md` calls this failure type 3,
-*ceremony instead of proof*. That description is too generous. The ceremony
-**admits anything**: it is not that the compiler asks the programmer to assert
-something it never verifies — it is that the assertion itself has no content.
+*ceremony instead of proof*. Both that description and this document's first
+version of it are too generous. **There is no ceremony.** The compiler does not
+ask the programmer to assert anything: the effect requirement is unreached, the
+wrapper accepts a string through a cast, and a program may write any of the eight
+names in any position with no consequence of any kind.
 
 ## Scope of the claim
 

--- a/docs/audit/ZD_FAMILY_CALL_PATH_2026-08-20.md
+++ b/docs/audit/ZD_FAMILY_CALL_PATH_2026-08-20.md
@@ -1,0 +1,90 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.zd-family-call-path-2026-08-20
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.zd-family-call-path-2026-08-20
+-->
+
+---
+title: The eight ZD types cannot be called, and the one path in verifies nothing
+status: measured
+date: 2026-08-20
+last_validated: 2026-08-20
+engines: Madaros v0.80.0 (default), lean_single
+---
+
+# The eight ZD types cannot be called, and the one path in verifies nothing
+
+`Forgettable`, `ExactlyPrivate`, `Editable`, `CapabilityGated`, `Composable`,
+`Audited`, `Revivable`, `Interpretable` — diagnostics E200–E207, the family the
+Lean development proves the G3 theorem about. This measures what a program can
+actually do with them.
+
+## A function taking one cannot be called
+
+    fn release(x: ExactlyPrivate<f64>) -> f64 with ZD { 0.0 }
+    fn caller() -> f64 with ZD { release(1.0) }
+
+| engine | result |
+|---|---|
+| Madaros v0.80.0 | `error[E009]: argument type does not match parameter` / `expected ExactlyPrivate` / `found f64` |
+| lean_single | accepted, ELF emitted |
+
+**All eight behave identically** under Madaros — E009 on any call with a bare
+value. Producing one from a body of the inner type
+(`fn make() -> ExactlyPrivate<f64> { 1.0 }`) gives **E008**.
+
+Remove the caller and the same file checks clean. This is why no test in the tree
+calls one, and why both witnesses the ExactlyPrivate forensic shipped
+(`docs/audit/exactly_private_ta/witness_ep_one.sio`,
+`docs/audit/exactly_private_lean/witness_ceremony_with_zd.sio`) declare a
+parameter and never call it. It is not an oversight in those files. **The call
+does not typecheck.**
+
+At the time of measurement the corpus contained **zero** `run-pass` tests
+exercising any of the eight.
+
+## There is exactly one way in, and it checks the target only
+
+    fn caller() -> f64 with ZD { release(1.0 as ExactlyPrivate<f64>) }   // check: OK
+
+The cast works. Its controls are what matter:
+
+| cast | Madaros |
+|---|---|
+| `1.0 as NaoExisteZorble` | **`error[E009]`** — the target type *is* verified |
+| `"uma string" as ExactlyPrivate<f64>` | **`check: OK`** |
+
+So the cast confirms the target type exists and verifies **nothing about the
+source**. A string enters an `ExactlyPrivate<f64>` without a diagnostic.
+
+## What the guarantee currently amounts to
+
+Write `with ZD`, then cast any value at all into the wrapper — including one of a
+type the wrapper does not name. `lower_exactly_private_type`
+(`check/check.sio`) confirms the effect was declared, emits E201 if it was not,
+and returns the inner type.
+
+`docs/internal/concepts/type-interrogation.md` calls this failure type 3,
+*ceremony instead of proof*. That description is too generous. The ceremony
+**admits anything**: it is not that the compiler asks the programmer to assert
+something it never verifies — it is that the assertion itself has no content.
+
+## Scope of the claim
+
+This measures the **call path**, not the algebra. The Lean development
+(`formal/lean4/`) proves what it proves; nothing here touches that. What is
+measured is that the type the theorem names, in the language, today, can be
+inhabited by a string.
+
+## Reproduce
+
+    export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+    # E009 on the call
+    printf 'fn r(x: ExactlyPrivate<f64>) -> f64 with ZD { 0.0 }\nfn c() -> f64 with ZD { r(1.0) }\nfn main() -> i32 with IO { 0 }\n' > /tmp/a.sio
+    ./bin/souc check /tmp/a.sio
+    # accepted through the cast, from a string
+    printf 'fn r(x: ExactlyPrivate<f64>) -> f64 with ZD { 0.0 }\nfn c() -> f64 with ZD { r("s" as ExactlyPrivate<f64>) }\nfn main() -> i32 with IO { 0 }\n' > /tmp/b.sio
+    ./bin/souc check /tmp/b.sio

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -400,6 +400,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.ws-f-close-acceptance-2026-08-16 | repo_only | docs/audit/WS_F_CLOSE_ACCEPTANCE_2026-08-16.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.zd-annihilate-builtin-dispatch-2026-08-19 | repo_only | docs/audit/ZD_ANNIHILATE_BUILTIN_DISPATCH_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.zd-exactness-floating-point-boundary-2026-08-19 | repo_only | docs/audit/ZD_EXACTNESS_FLOATING_POINT_BOUNDARY_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.zd-family-call-path-2026-08-20 | repo_only | docs/audit/ZD_FAMILY_CALL_PATH_2026-08-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.brand.sounio-brand-pack-v4-complete.00-readme.font-licenses | repo_only | docs/brand/Sounio_Brand_Pack_v4_COMPLETE/00_README/FONT_LICENSES.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.brand.sounio-brand-pack-v4-complete.00-readme.readme | repo_only | docs/brand/Sounio_Brand_Pack_v4_COMPLETE/00_README/README.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.competitive-position-2026 | repo_only | docs/COMPETITIVE_POSITION_2026.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8664,6 +8664,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.zd-family-call-path-2026-08-20",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/ZD_FAMILY_CALL_PATH_2026-08-20.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.brand.sounio-brand-pack-v4-complete.00-readme.font-licenses",
       "collection": "repo",
       "repo_doc_path": "docs/brand/Sounio_Brand_Pack_v4_COMPLETE/00_README/FONT_LICENSES.md",


### PR DESCRIPTION
`Forgettable`, `ExactlyPrivate`, `Editable`, `CapabilityGated`, `Composable`, `Audited`, `Revivable`, `Interpretable` — E200–E207, the family the Lean development proves the G3 theorem about. This measures what a program can actually **do** with them.

### A function taking one cannot be called

```sounio
fn release(x: ExactlyPrivate<f64>) -> f64 with ZD { 0.0 }
fn caller() -> f64 with ZD { release(1.0) }
```

| engine | result |
|---|---|
| Madaros v0.80.0 | `error[E009]` — `expected ExactlyPrivate` / `found f64` |
| lean_single | accepted, ELF emitted |

**All eight behave identically.** Returning one from a body of the inner type gives **E008**. Remove the caller and the same file checks clean.

That is why **no `run-pass` test in the tree exercises any of the eight**, and why both witnesses the ExactlyPrivate forensic shipped declare a parameter and never call it. Those files are not careless — the call does not typecheck.

### There is exactly one way in, and it checks the target only

```sounio
fn caller() -> f64 with ZD { release(1.0 as ExactlyPrivate<f64>) }   // check: OK
```

The controls are the finding:

| cast | Madaros |
|---|---|
| `1.0 as NaoExisteZorble` | **`error[E009]`** — the target type *is* verified |
| `"uma string" as ExactlyPrivate<f64>` | **`check: OK`** |

The cast confirms the target type exists and verifies **nothing about the source**. A string enters an `ExactlyPrivate<f64>` without a diagnostic.

### What the guarantee amounts to today

Declare `with ZD`, then cast any value at all into the wrapper — including one of a type the wrapper does not name.

`type-interrogation.md` calls this failure type 3, *ceremony instead of proof*. **That is too generous.** It is not that the compiler asks the programmer to assert something it never verifies — it is that **the assertion has no content**.

### Scope

This measures the **call path**, not the algebra. The Lean development proves what it proves; nothing here touches that. What is measured is that the type the theorem names can, in the language today, be inhabited by a string.