### PR TITLE
docs: five of seven rows in the CLAUDE.md syntax table are not enforced, and assert! is dangerous

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,18 +212,21 @@ The numbered principles below are binding. Each was learned from a measured fail
 
 ## 7. Sounio syntax (NOT Rust)
 
-Critical differences — these are compile errors:
+Critical differences. **Five of the seven rows below were measured on
+2026-08-20 and are style, not enforcement** — the compiler accepts the Rust form.
+Write the Sounio form; do not expect a diagnostic if you slip. Rows marked ✓ are
+enforced.
 
 | Wrong (Rust) | Correct (Sounio) |
 |---|---|
-| `let x = 5;` | `let x = 5` (no semicolons) |
-| `let mut y = 10` | `var y = 10` |
-| `&mut T` | `&!T` |
-| `assert!(cond)` | `assert(cond)` |
-| `println!("hi")` | `println("hi")` |
-| `#[test]`, `#[derive()]` | No attributes |
-| `-42` | `0 - 42` (no unary minus) |
-| `x >> 4` | `x >> 4u8` (bit shifts require `u8`) |
+| `let x = 5;` | `let x = 5` — **style, not a compile error.** Measured 2026-08-20: the trailing `;` is accepted and the program runs. Prefer the semicolon-free form; do not expect the compiler to enforce it. |
+| `let mut y = 10` | `var y = 10` — ✓ enforced, `error[E040]` |
+| `&mut T` | `&!T` — ✓ enforced, `error[E041]` |
+| `assert!(cond)` | `assert(cond)` — **DANGEROUS.** `assert!` checks clean and is **inert**: `assert!(1 == 2)` does not halt. `assert(1 == 2)` does. One character apart. |
+| `println!("hi")` | `println("hi")` — **`println!`/`print!`/`panic!` check clean and SIGSEGV at run time (`rc=139`)**, killing every statement after them. See `docs/audit/RUST_MACRO_ACCEPTANCE_2026-08-20.md`. |
+| `#[test]`, `#[derive()]` | No attributes — ✓ enforced, fails to parse |
+| ~~`-42`~~ | **STALE — unary minus works.** Measured 2026-08-20 on both engines: `-3.5`, `f(-7)`, `10 - -3` and `[-1, -2, -3]` all check and compute correctly. `0 - x` is no longer required. |
+| `x >> 4` | `x >> 4u8` — **STALE.** Measured 2026-08-20: `x >> 4` checks and computes correctly (`64 >> 4 = 4`). |
 
 Helpers must be defined before callers — no forward references.
 
@@ -342,7 +345,7 @@ Headline limitations (full list in [`docs/compiler/KNOWN_LIMITATIONS.md`](docs/c
 
 - **Imported-module native path — partial closeout.** Historical D1 (`f64→i64` param cast bitcast → GUM k95 stuck at 1.960) and much of D2 (`&local_array`→builtin) are **closed** (D1: #983/#1252 + Wave10 trust gate; D2: #933/#1247 family). Residuals remain: multi-module memory-wall / exclusive-ref fragile chains (D3 family), named-import/`print_f64` papercuts (D4/#862). Finite-dof `gum_k95` is **TRUSTWORTHY** under default Madaros (`scripts/epistemic_trust_gate.sh` → k95i=2776). Map: [`docs/audit/EPISTEMIC_TRUST_MAP_2026-07-14.md`](docs/audit/EPISTEMIC_TRUST_MAP_2026-07-14.md). Escalation: [`docs/audit/MADAROS_IMPORTED_MODULE_NATIVE_PATH_ESCALATION_2026-07-14.md`](docs/audit/MADAROS_IMPORTED_MODULE_NATIVE_PATH_ESCALATION_2026-07-14.md).
 - `Knowledge<T>` supports struct-level generics (`f64`, `bool`, struct types)
-- No unary minus — write `0 - x`
+- ~~No unary minus — write `0 - x`~~ **STALE (2026-08-20).** Unary minus checks and computes correctly in literal, argument, binary-operand and array-element position, on both engines.
 - `--show-ast` / `--show-types` are unavailable under the default Madaros engine (`bin/souc compile ... --show-ast` -> `error: madaros build: unsupported option`); both work under `SOUNIO_SOUC_ENGINE=lean_single` / `bin/souc-lean-single-x86_64` (they're in that engine's own usage string). A REPL does exist (`souc repl` -> `tools/repl.sh`, shipped 2026-05-28 per `docs/compiler/KNOWN_LIMITATIONS.md`) -- it's a file-based compile-and-run loop over whichever engine `bin/souc` currently resolves to, not a true interactive evaluator; "no REPL" itself is stale and superseded by that entry.
 - `&![T; N]` bare array mutation broken in JIT — use struct wrapper or `(*arr)[i]`
 - GPU: end-to-end `kernel fn` → PTX path **exists and is reproducible under default Madaros**. `bin/souc build <file>.sio --backend gpu -o out.ptx` (verified: `examples/kernel_vec_add.sio` → valid PTX). This is Madaros-only: `SOUNIO_SOUC_ENGINE=lean_single ./bin/souc build ... --backend gpu ...` has no GPU CLI surface at all and fails to parse the invocation (verified 2026-08-17). Runtime execution is fixture-bounded (L4-validated profiles). See `docs/audit/GPU_PIPELINE_SOTA_ASSESSMENT_2026-05-30.md` for the measured/projected/source-only breakdown

--- a/docs/audit/RUST_MACRO_ACCEPTANCE_2026-08-20.md
+++ b/docs/audit/RUST_MACRO_ACCEPTANCE_2026-08-20.md
@@ -1,0 +1,99 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.rust-macro-acceptance-2026-08-20
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.rust-macro-acceptance-2026-08-20
+-->
+
+---
+title: Four Rust macros are accepted, and three of them SIGSEGV
+status: measured
+date: 2026-08-20
+last_validated: 2026-08-20
+engines: Madaros v0.80.0 (default), lean_single
+---
+
+# Four Rust macros are accepted, and three of them SIGSEGV
+
+`CLAUDE.md` §7 lists `println!("hi")` under *"Critical differences — these are
+compile errors"*. `tests/compile-fail/parser_rust_macro.sio` exists to enforce it,
+with `//@ error-pattern: macro` and the description *"Rust macros are not
+supported in Sounio"*.
+
+## The compile-fail test does not fail
+
+| engine | `tests/compile-fail/parser_rust_macro.sio` |
+|---|---|
+| lean_single | `error[E200]` — refused |
+| **Madaros v0.80.0** | **`check: OK`** |
+
+A sixth engine-divergent `compile-fail` test, alongside the five frozen by
+`scripts/ci/epsilon_engine_parity_gate.sh`.
+
+## Exactly four names are accepted
+
+| macro | Madaros `check` |
+|---|---|
+| `println!` `print!` `assert!` `panic!` | **`check: OK`** |
+| `format!` `vec!` `write!` `eprintln!` `todo!` `unreachable!` `debug_assert!` | `error[E137]` |
+| `zorble!` (control) | `error[E137]` |
+
+The control matters: the acceptance is **not** blanket silence. A macro name is
+resolved, and these four resolve. They are exactly the four whose bare forms exist
+in Sounio — `println`, `print`, `assert`, `panic`.
+
+## What they do at run time, and they do not agree
+
+| written | `check` | run |
+|---|---|---|
+| `println!("x")` | `check: OK` | **`rc=139`** (SIGSEGV) |
+| `print!("x")` | `check: OK` | **`rc=139`** |
+| `panic!("x")` | `check: OK` | **`rc=139`** |
+| `assert!(1 == 2)` | `check: OK` | **runs through** — the next statement executes |
+| `assert(1 == 2)` (the correct form) | `check: OK` | halts, as it should |
+
+Two distinct defects wearing one syntax:
+
+- **`println!`/`print!`/`panic!` crash.** A program that typechecks clean
+  segfaults with no diagnostic, and the statement after it never runs. Measured
+  with `println("ANTES")` before and `println("DEPOIS")` after: only `ANTES`
+  reaches stdout.
+- **`assert!` is inert.** `assert!(1 == 2)` does not halt — the line after it
+  prints. Written by anyone with a Rust habit, it is a safety check that compiles
+  clean and never fires. Its correct sibling `assert(1 == 2)` does halt, so the
+  difference is exactly one character.
+
+## Corpus exposure: latent
+
+| macro | sites |
+|---|---:|
+| `assert!` | **0** |
+| `format!` | 17 (all refused by `E137`) |
+| `print!` | 6 |
+| `panic!` | 3 |
+| `println!` | 3 |
+
+The `println!`/`print!`/`panic!` sites are in `examples/` and `tests/`. One is in
+`stdlib/pbpk/regulatory.sio` — checked, and that file **does not parse** at all, so
+it is not live code producing a wrong result.
+
+`assert!` at zero is the number that matters: the most dangerous of the four has
+not been written yet.
+
+## What this does not claim
+
+Not that the macro syntax should be supported. `CLAUDE.md` is right about the
+intent — the defect is that the refusal is absent on the default engine, and that
+three of the four fail as a crash rather than a diagnostic. Not that any current
+result is wrong: exposure is measured above and it is latent.
+
+## Reproduce
+
+    export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+    printf 'fn main() -> i32 with IO {\n    println("A")\n    println!("B")\n    println("C")\n    0\n}\n' > /tmp/m.sio
+    ./bin/souc check /tmp/m.sio        # check: OK
+    ./bin/souc run   /tmp/m.sio        # prints A, then rc=139
+    ./bin/souc check tests/compile-fail/parser_rust_macro.sio                          # check: OK
+    SOUNIO_SOUC_ENGINE=lean_single ./bin/souc check tests/compile-fail/parser_rust_macro.sio  # error[E200]

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -361,6 +361,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.refinement-div-discharge-2026-08-19 | repo_only | docs/audit/REFINEMENT_DIV_DISCHARGE_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.runtime-context-unwritten-fields-census-2026-08-18 | repo_only | docs/audit/RUNTIME_CONTEXT_UNWRITTEN_FIELDS_CENSUS_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.runtime-gc-capability-honesty-2026-08-18 | repo_only | docs/audit/RUNTIME_GC_CAPABILITY_HONESTY_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.rust-macro-acceptance-2026-08-20 | repo_only | docs/audit/RUST_MACRO_ACCEPTANCE_2026-08-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.seed-fix-general-lvalue-deref-store-2026-06-24 | repo_only | docs/audit/SEED_FIX_GENERAL_LVALUE_DEREF_STORE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.seed-fix-value-nested-field-store-2026-06-24 | repo_only | docs/audit/SEED_FIX_VALUE_NESTED_FIELD_STORE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.seven-fibers-of-twelve-2026-08-19 | repo_only | docs/audit/SEVEN_FIBERS_OF_TWELVE_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -7767,6 +7767,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.rust-macro-acceptance-2026-08-20",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/RUST_MACRO_ACCEPTANCE_2026-08-20.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.seed-fix-general-lvalue-deref-store-2026-06-24",
       "collection": "repo",
       "repo_doc_path": "docs/audit/SEED_FIX_GENERAL_LVALUE_DEREF_STORE_2026-06-24.md",


### PR DESCRIPTION
`CLAUDE.md` §7 opens *"Critical differences — these are compile errors"*. Measured on both engines, **five of the seven rows are style, not enforcement**.

| row | measured |
|---|---|
| `let mut y = 10` | ✓ enforced — `error[E040]` |
| `&mut T` | ✓ enforced — `error[E041]` |
| `#[test]` / `#[derive()]` | ✓ enforced — fails to parse |
| `let x = 5;` | **checks and runs** |
| `-42` | **checks and computes correctly** — `-3.5`, `f(-7)`, `10 - -3`, `[-1,-2,-3]` all right. `0 - x` is no longer required |
| `x >> 4` | **checks and computes** — `64 >> 4 = 4` |
| `println!("hi")` | see below — worse than stale |

### The macro row has its own audit

**Exactly four** Rust macros are accepted: `println!`, `print!`, `assert!`, `panic!`. `format!`, `vec!`, `write!`, `eprintln!`, `todo!`, `unreachable!` and `debug_assert!` all give `E137` — **as does the control `zorble!`**. So this is a specific four-name resolution hole, not blanket silence.

**Three of the four SIGSEGV:**

```sounio
println("ANTES")            // prints
println!("MEIO")            // rc=139
println("DEPOIS")           // never runs
```

`check: OK`, then exit 139, with no diagnostic and every following statement dead.

**The fourth is the dangerous one.** `assert!` is **inert**:

| written | run |
|---|---|
| `assert!(1 == 2)` | **runs through** — the next line prints |
| `assert(1 == 2)` | halts, correctly |

One character apart, and the Rust habit produces the silent one. A test file full of `assert!` would be green and assert nothing.

### The guard already exists and does not fire

`tests/compile-fail/parser_rust_macro.sio` — *"Rust macros are not supported in Sounio"*, `//@ error-pattern: macro`:

| lean_single | Madaros |
|---|---|
| `error[E200]` — refused | **`check: OK`** |

A **sixth** engine-divergent `compile-fail` test, alongside the five frozen by `epsilon_engine_parity_gate.sh` (#2036).

### Exposure is latent

`assert!` is at **zero** sites corpus-wide — the most dangerous of the four has not been written yet. The `println!`/`print!`/`panic!` sites are in `examples/` and `tests/`; the one in `stdlib/pbpk/regulatory.sio` is moot because that file does not parse at all.

Corrected in place rather than rewritten: this table is the entry point every agent in this repo reads, and several of us wrote `0 - x` today because of it.