### PR TITLE
check: enforce parameterized epistemic confidence floors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -724,6 +724,11 @@ jobs:
         env:
           MADAROS_RAW_BIN: /tmp/madaros-ci.elf
         run: bash scripts/ci/madaros_source_to_elf_gate.sh
+      - name: Parameterized Epistemic confidence floor against the fresh build
+        env:
+          MADAROS_RAW_BIN: /tmp/madaros-ci.elf
+          SOUNIO_WITNESS_GLOB: tests/compiler/epistemic_payload_gate/*.sio
+        run: bash scripts/ci/madaros_epistemic_payload_gate.sh
       # Grep correspondence lives in Contracts. This arm compiles the
       # E219 fixture against the Madaros just built from this commit.
       - name: E219 live refuse against the fresh build

--- a/docs/audit/MADAROS_EPISTEMIC_PAYLOAD_GATE_2026-08-20.md
+++ b/docs/audit/MADAROS_EPISTEMIC_PAYLOAD_GATE_2026-08-20.md
@@ -1,0 +1,120 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-epistemic-payload-gate-2026-08-20
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-epistemic-payload-gate-2026-08-20
+-->
+
+# Madaros `Epistemic(N)` payload gate receipt
+
+Date: 2026-08-20
+
+## Source boundary
+
+- Consumer branch base: `0e523d0643320b7d5a55f3574e4a65339b702ebc`
+- Required payload branch: `origin/feat/effect-payload` at the same commit
+- Comparison target at measurement time: `origin/main` at
+  `67aa2aec127020122ff961480b83b36c09e91432`
+- The four witnesses under `tests/compiler/epistemic_payload_gate/` are
+  byte-identical after replacing the integer in `Epistemic(N)` with `N`.
+
+The consumer stores the parsed floor in `FnSig.epistemic_min_confidence` in
+both function-signature collection spines and both function-type lowerers. The `Knowledge` constructor keeps
+its literal confidence in the semantic type. While checking a function with a
+parameterised `Epistemic(N)` effect, Madaros emits E215 when a literal
+confidence is below the floor, and treats a non-literal confidence as unknown
+and therefore insufficient.
+
+## Before: measured engine divergence
+
+Command, using the checked-in Madaros prebuilt only as the pre-fix control:
+
+```bash
+MADAROS_RAW_BIN="$PWD/bin/madaros-linux-x86_64" \
+SOUNIO_WITNESS_GLOB='tests/compiler/epistemic_payload_gate/*.sio' \
+bash scripts/ci/madaros_epistemic_payload_gate.sh
+```
+
+| N | Madaros prebuilt | lean_single |
+|---:|---|---|
+| 400 | accept, rc 0, ELF yes | accept, rc 0, ELF yes |
+| 401 | **incorrectly accepts**, rc 0, ELF yes | reject, rc 1, E215 text, no ELF |
+| 950 | **incorrectly accepts**, rc 0, ELF yes | reject, rc 1, E215 text, no ELF |
+| 999 | **incorrectly accepts**, rc 0, ELF yes | reject, rc 1, E215 text, no ELF |
+
+## Non-vacuous positive control
+
+The in-place comparison was temporarily changed from:
+
+```sio
+if minimum > 0 && confidence_milli < minimum
+```
+
+to unconditional rejection whenever a parameterised floor was present:
+
+```sio
+if minimum > 0
+```
+
+The compiler was rebuilt from that live source on Slurm. The previously green
+Madaros N=400 cell then failed with rc 1, no ELF, and:
+
+```text
+error[E215] in epistemic_payload_gate/n400::gated_value at 0..146: EpistemicComplete violation
+```
+
+In the same run lean_single still accepted N=400. This distinguishes a live
+consumer path from a gate that merely reports green without observing it. The
+temporary comparison was then restored; it is not present in the committed
+diff.
+
+## After: current-source side-by-side oracle
+
+Exact command:
+
+```bash
+env SLURM_CONF=/tmp/slurm-direct.conf \
+  SOUNIO_WITNESS_GLOB='tests/compiler/epistemic_payload_gate/*.sio' \
+  bash scripts/dev/souc-build-remote.sh \
+    --partition gpu-orangefs \
+    --node gpuorangefs-r770-proxmox \
+    --cpus 32 \
+    --gate witness
+```
+
+Build receipt:
+
+```text
+REMOTE: host=gpuorangefs-r770-proxmox nproc=32 unpacked=196M
+REMOTE: build rc=0 elapsed=227s
+REMOTE: elf bytes=100574016
+```
+
+| Engine | N | Expected | rc | ELF | Diagnostic | Verdict |
+|---|---:|---|---:|---|---|---|
+| Madaros, rebuilt from source | 400 | accept | 0 | yes | n/a | PASS |
+| Madaros, rebuilt from source | 401 | reject | 1 | no | E215 text present | PASS |
+| Madaros, rebuilt from source | 950 | reject | 1 | no | E215 text present | PASS |
+| Madaros, rebuilt from source | 999 | reject | 1 | no | E215 text present | PASS |
+| lean_single seed | 400 | accept | 0 | yes | n/a | PASS |
+| lean_single seed | 401 | reject | 1 | no | EpistemicComplete text present | PASS |
+| lean_single seed | 950 | reject | 1 | no | EpistemicComplete text present | PASS |
+| lean_single seed | 999 | reject | 1 | no | EpistemicComplete text present | PASS |
+
+Final gate output:
+
+```text
+epistemic-payload-gate: PASS
+REMOTE: witness_gate rc=0
+```
+
+## Claim boundary
+
+This receipt proves the four-rung literal-constructor oracle. It does not claim
+that Madaros now implements lean_single's complete general
+`EXPR_CONF` algebra, cross-call `FN_EFF_CONF` certificates, or confidence
+propagation through every expression kind. Those broader propagation surfaces
+remain separate work and are not needed to distinguish or close the measured
+payload-consumer divergence above.

--- a/docs/audit/MADAROS_EPISTEMIC_PAYLOAD_GATE_2026-08-20.md
+++ b/docs/audit/MADAROS_EPISTEMIC_PAYLOAD_GATE_2026-08-20.md
@@ -17,15 +17,17 @@ Date: 2026-08-20
 - Required payload branch: `origin/feat/effect-payload` at the same commit
 - Comparison target at measurement time: `origin/main` at
   `67aa2aec127020122ff961480b83b36c09e91432`
+- Final rebase target: `origin/main` at
+  `e021ce8a3` (revalidated 2026-08-21 before this receipt-only update)
 - The four witnesses under `tests/compiler/epistemic_payload_gate/` are
   byte-identical after replacing the integer in `Epistemic(N)` with `N`.
 
 The consumer stores the parsed floor in `FnSig.epistemic_min_confidence` in
-both function-signature collection spines and both function-type lowerers. The `Knowledge` constructor keeps
-its literal confidence in the semantic type. While checking a function with a
-parameterised `Epistemic(N)` effect, Madaros emits E215 when a literal
-confidence is below the floor, and treats a non-literal confidence as unknown
-and therefore insufficient.
+both function-signature collection spines and both function-type lowerers. The
+`Knowledge` constructor keeps its literal confidence in the semantic type.
+While checking a function with a parameterised `Epistemic(N)` effect, Madaros
+emits E215 when a literal confidence is below the floor, and treats a
+non-literal confidence as unknown and therefore insufficient.
 
 ## Before: measured engine divergence
 
@@ -89,7 +91,7 @@ Build receipt:
 ```text
 REMOTE: host=gpuorangefs-r770-proxmox nproc=32 unpacked=196M
 REMOTE: build rc=0 elapsed=227s
-REMOTE: elf bytes=100574016
+REMOTE: elf bytes=100642004
 ```
 
 | Engine | N | Expected | rc | ELF | Diagnostic | Verdict |

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -241,6 +241,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-engine-parity-nongum-cluster-2026-07-28 | repo_only | docs/audit/MADAROS_ENGINE_PARITY_NONGUM_CLUSTER_2026-07-28.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-enir-driver-native-lower-139-dispatch-2026-08-16 | repo_only | docs/audit/MADAROS_ENIR_DRIVER_NATIVE_LOWER_139_DISPATCH_2026-08-16.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-enum-variant-sigsegv-2026-06-20 | repo_only | docs/audit/MADAROS_ENUM_VARIANT_SIGSEGV_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-epistemic-payload-gate-2026-08-20 | repo_only | docs/audit/MADAROS_EPISTEMIC_PAYLOAD_GATE_2026-08-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-f64-bitcast-sitofp-boundary-2026-08-17 | repo_only | docs/audit/MADAROS_F64_BITCAST_SITOFP_BOUNDARY_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-field-if-i64-2026-07-26 | repo_only | docs/audit/MADAROS_FIELD_IF_I64_2026-07-26.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-fo-call-boundary-dispatch-2026-08-18 | repo_only | docs/audit/MADAROS_FO_CALL_BOUNDARY_DISPATCH_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -5007,6 +5007,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-epistemic-payload-gate-2026-08-20",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_EPISTEMIC_PAYLOAD_GATE_2026-08-20.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-f64-bitcast-sitofp-boundary-2026-08-17",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_F64_BITCAST_SITOFP_BOUNDARY_2026-08-17.md",

--- a/scripts/ci/epistemic_measure_correspondence_gate.sh
+++ b/scripts/ci/epistemic_measure_correspondence_gate.sh
@@ -134,7 +134,9 @@ if [[ "$NOT_RUN" -eq 0 ]]; then
   check_grep "knowledge_ctor_checks_first_argument" \
     'let v_ty = checker_check_opt_expr_inplace\(c, first_arg\)' "$KNOWLEDGE_BODY"
   check_grep "knowledge_ctor_propagates_argument_type" \
-    'ty_knowledge\(v_ty,[[:space:]]*0\.0[[:space:]]*-[[:space:]]*1\.0\)' "$KNOWLEDGE_BODY"
+    'ty_knowledge\(v_ty,[[:space:]]*confidence\)' "$KNOWLEDGE_BODY"
+  check_grep "knowledge_ctor_preserves_literal_confidence" \
+    'let confidence = checker_enforce_knowledge_confidence_inplace\(c, e\.args, e\.span\)' "$KNOWLEDGE_BODY"
   check_absent "knowledge_ctor_must_not_pin_scalar_type" \
     'ty_knowledge\((ty_f64\(\)|ty_real\(\)|ty_real|TypeEntry::Real|\.treal)' "$KNOWLEDGE_BODY"
 

--- a/scripts/ci/madaros_epistemic_payload_gate.sh
+++ b/scripts/ci/madaros_epistemic_payload_gate.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+WITNESS_GLOB="${SOUNIO_WITNESS_GLOB:-tests/compiler/epistemic_payload_gate/*.sio}"
+WORK="$(mktemp -d /tmp/sounio-epistemic-payload.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+shopt -s nullglob
+witnesses=( $WITNESS_GLOB )
+shopt -u nullglob
+if [[ ${#witnesses[@]} -ne 4 ]]; then
+  echo "epistemic-payload-gate: FAIL expected 4 witnesses from $WITNESS_GLOB, got ${#witnesses[@]}" >&2
+  exit 1
+fi
+
+normalized=""
+for src in "${witnesses[@]}"; do
+  current="$(sed -E 's/Epistemic\([0-9]+\)/Epistemic(N)/' "$src")"
+  if [[ -z "$normalized" ]]; then
+    normalized="$current"
+  elif [[ "$current" != "$normalized" ]]; then
+    echo "epistemic-payload-gate: FAIL witnesses differ outside Epistemic(N): $src" >&2
+    exit 1
+  fi
+done
+
+compile_one() {
+  local engine="$1" src="$2" out="$3" log="$4"
+  if [[ "$engine" == "madaros" ]]; then
+    MADAROS_RAW_BIN="${MADAROS_RAW_BIN:?current-source Madaros ELF required}" \
+      "$ROOT_DIR/bin/souc" compile "$src" -o "$out" >"$log" 2>&1
+  else
+    SOUNIO_SOUC_ENGINE=lean_single \
+      "$ROOT_DIR/bin/souc" compile "$src" -o "$out" >"$log" 2>&1
+  fi
+}
+
+fails=0
+for engine in madaros lean_single; do
+  echo "ENGINE=$engine"
+  for src in "${witnesses[@]}"; do
+    base="$(basename "$src" .sio)"
+    n="${base#n}"
+    out="$WORK/${engine}_${base}.elf"
+    log="$WORK/${engine}_${base}.log"
+    rm -f "$out"
+    set +e
+    compile_one "$engine" "$src" "$out" "$log"
+    rc=$?
+    set -e
+    if [[ "$n" == "400" ]]; then
+      if [[ $rc -eq 0 && -s "$out" ]]; then
+        verdict="PASS"
+      else
+        verdict="FAIL"
+        fails=$((fails + 1))
+      fi
+      echo "N=$n expected=accept rc=$rc elf=$([[ -s "$out" ]] && echo yes || echo no) verdict=$verdict"
+    else
+      diag=no
+      grep -q "EpistemicComplete violation" "$log" && diag=yes
+      if [[ $rc -ne 0 && ! -e "$out" && "$diag" == yes ]]; then
+        verdict="PASS"
+      else
+        verdict="FAIL"
+        fails=$((fails + 1))
+      fi
+      echo "N=$n expected=reject rc=$rc elf=$([[ -e "$out" ]] && echo yes || echo no) diagnostic=$diag verdict=$verdict"
+    fi
+    if [[ "$verdict" == "FAIL" ]]; then
+      sed -n '1,20p' "$log" | sed 's/^/  | /'
+    fi
+  done
+done
+
+if [[ $fails -ne 0 ]]; then
+  echo "epistemic-payload-gate: FAIL ($fails)"
+  exit 1
+fi
+echo "epistemic-payload-gate: PASS"

--- a/scripts/dev/souc-build-remote.sh
+++ b/scripts/dev/souc-build-remote.sh
@@ -26,6 +26,8 @@
 #   scripts/dev/souc-build-remote.sh --gate full           # + madaros_full_gate.sh
 #   scripts/dev/souc-build-remote.sh --gate corpus         # + corpus regression gate
 #   scripts/dev/souc-build-remote.sh --gate check          # + gen1 typechecks main.sio
+#   SOUNIO_WITNESS_GLOB='tests/compiler/foo/*.sio' \
+#     scripts/dev/souc-build-remote.sh --gate witness      # + task witness gate
 #   scripts/dev/souc-build-remote.sh --gate full --gate corpus
 #   SOUNIO_REMOTE_PARTITION=cpu-ops SOUNIO_REMOTE_CPUS=32 ...
 #
@@ -141,38 +143,45 @@ for g in $GATES; do
       export SOUNIO_STDLIB_PATH="\$W/stdlib"
       ulimit -s 524288 2>/dev/null || true
       WITNESS_GLOB="${SOUNIO_WITNESS_GLOB:-tests/run-pass/r1_i*_lorenz_peak.sio}"
-      wit_rc=0
-      for src in \$W/\$WITNESS_GLOB; do
-        echo "REMOTE: witness src=\$src"
-        # Positive control: sabotaged mul MUST fail the fixture.
-        out_bad=/tmp/witness-bad-\$\$.elf
-        SOUNIO_WIDE_MUL_SABOTAGE=1 "\$W/madaros.elf" build "\$src" "\$out_bad"
-        if [ \$? -eq 0 ]; then
-          chmod +x "\$out_bad"
-          "\$out_bad"
-          bad_rc=\$?
-          echo "REMOTE: sabotage run rc=\$bad_rc (must be non-zero)"
-          if [ \$bad_rc -eq 0 ]; then
-            echo "REMOTE: CONTROL_FAIL witness passed under sabotaged mul"
-            wit_rc=2
-            continue
+      if [ "\$WITNESS_GLOB" = 'tests/compiler/epistemic_payload_gate/*.sio' ]; then
+        MADAROS_RAW_BIN="\$W/madaros.elf" \
+          SOUNIO_WITNESS_GLOB="\$WITNESS_GLOB" \
+          bash scripts/ci/madaros_epistemic_payload_gate.sh 2>&1
+        wit_rc=\$?
+      else
+        wit_rc=0
+        for src in \$W/\$WITNESS_GLOB; do
+          echo "REMOTE: witness src=\$src"
+          # Positive control: sabotaged mul MUST fail the fixture.
+          out_bad=/tmp/witness-bad-\$\$.elf
+          SOUNIO_WIDE_MUL_SABOTAGE=1 "\$W/madaros.elf" build "\$src" "\$out_bad"
+          if [ \$? -eq 0 ]; then
+            chmod +x "\$out_bad"
+            "\$out_bad"
+            bad_rc=\$?
+            echo "REMOTE: sabotage run rc=\$bad_rc (must be non-zero)"
+            if [ \$bad_rc -eq 0 ]; then
+              echo "REMOTE: CONTROL_FAIL witness passed under sabotaged mul"
+              wit_rc=2
+              continue
+            fi
+            echo "REMOTE: CONTROL_PASS"
+          else
+            echo "REMOTE: sabotage build failed; treating as control pass (compile refused)"
           fi
-          echo "REMOTE: CONTROL_PASS"
-        else
-          echo "REMOTE: sabotage build failed; treating as control pass (compile refused)"
-        fi
-        out=/tmp/witness-\$\$.elf
-        unset SOUNIO_WIDE_MUL_SABOTAGE
-        "\$W/madaros.elf" build "\$src" "\$out"
-        b_rc=\$?
-        echo "REMOTE: witness build rc=\$b_rc"
-        if [ \$b_rc -ne 0 ]; then wit_rc=\$b_rc; continue; fi
-        chmod +x "\$out"
-        "\$out"
-        r_rc=\$?
-        echo "REMOTE: witness run rc=\$r_rc"
-        if [ \$r_rc -ne 0 ]; then wit_rc=\$r_rc; fi
-      done
+          out=/tmp/witness-\$\$.elf
+          unset SOUNIO_WIDE_MUL_SABOTAGE
+          "\$W/madaros.elf" build "\$src" "\$out"
+          b_rc=\$?
+          echo "REMOTE: witness build rc=\$b_rc"
+          if [ \$b_rc -ne 0 ]; then wit_rc=\$b_rc; continue; fi
+          chmod +x "\$out"
+          "\$out"
+          r_rc=\$?
+          echo "REMOTE: witness run rc=\$r_rc"
+          if [ \$r_rc -ne 0 ]; then wit_rc=\$r_rc; fi
+        done
+      fi
       echo "REMOTE: witness_gate rc=\$wit_rc"
       if [ \$wit_rc -ne 0 ]; then exit \$wit_rc; fi
       ;;
@@ -184,7 +193,7 @@ REMOTE
 )
 
 # tests/ is included only when a gate needs it -- it is the bulk of the payload.
-PAYLOAD="self-hosted stdlib bin/souc-linux-x86_64 scripts"
+PAYLOAD="self-hosted stdlib bin/souc bin/souc-linux-x86_64 scripts"
 case "$GATES" in *full*|*corpus*|*witness*) PAYLOAD="$PAYLOAD tests bin/madaros bin/madaros-linux-x86_64" ;; esac
 
 tar czf - $PAYLOAD 2>/dev/null \

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -1013,6 +1013,7 @@ fn setup_intrinsics(tbl: *mut FnSigTable) with Mut, Panic, Div, Alloc {
         is_linear_closure: false,
         linear_capture_count: 0,
         epistemic_epsilon: 0.0 - 1.0,
+        epistemic_min_confidence: 0 - 1,
         visibility_kind: VISIBILITY_PUB,
         defining_module_seg_count: 0,
         defining_module_id: 0,
@@ -1057,6 +1058,7 @@ fn setup_intrinsics(tbl: *mut FnSigTable) with Mut, Panic, Div, Alloc {
         is_linear_closure: false,
         linear_capture_count: 0,
         epistemic_epsilon: 0.0 - 1.0,
+        epistemic_min_confidence: 0 - 1,
         visibility_kind: VISIBILITY_PUB,
         defining_module_seg_count: 0,
         defining_module_id: 0,
@@ -1099,6 +1101,7 @@ fn setup_intrinsics(tbl: *mut FnSigTable) with Mut, Panic, Div, Alloc {
         is_linear_closure: false,
         linear_capture_count: 0,
         epistemic_epsilon: 0.0 - 1.0,
+        epistemic_min_confidence: 0 - 1,
         visibility_kind: VISIBILITY_PUB,
         defining_module_seg_count: 0,
         defining_module_id: 0,
@@ -1150,6 +1153,7 @@ fn setup_intrinsics(tbl: *mut FnSigTable) with Mut, Panic, Div, Alloc {
         is_linear_closure: false,
         linear_capture_count: 0,
         epistemic_epsilon: 0.0 - 1.0,
+        epistemic_min_confidence: 0 - 1,
         visibility_kind: VISIBILITY_PUB,
         defining_module_seg_count: 0,
         defining_module_id: 0,
@@ -1189,6 +1193,7 @@ fn setup_intrinsics(tbl: *mut FnSigTable) with Mut, Panic, Div, Alloc {
         is_linear_closure: false,
         linear_capture_count: 0,
         epistemic_epsilon: 0.0 - 1.0,
+        epistemic_min_confidence: 0 - 1,
         visibility_kind: VISIBILITY_PUB,
         defining_module_seg_count: 0,
         defining_module_id: 0,
@@ -1222,6 +1227,7 @@ fn setup_intrinsics(tbl: *mut FnSigTable) with Mut, Panic, Div, Alloc {
         is_linear_closure: false,
         linear_capture_count: 0,
         epistemic_epsilon: 0.0 - 1.0,
+        epistemic_min_confidence: 0 - 1,
         visibility_kind: VISIBILITY_PUB,
         defining_module_seg_count: 0,
         defining_module_id: 0,
@@ -2193,6 +2199,7 @@ fn checker_lower_fn_type_expr_mut(c: *mut Checker, te: TypeExpr) -> TypeEntry wi
     }
 
     let eff_pair = checker_extract_effects_mut(c, te.effects)
+    let epistemic_min_confidence = epistemic_min_confidence_from_effects(te.effects)
     let sig = FnSig {
         name: Name { buf: [0; 128], len: 0 },
         params: params,
@@ -2209,6 +2216,7 @@ fn checker_lower_fn_type_expr_mut(c: *mut Checker, te: TypeExpr) -> TypeEntry wi
         is_linear_closure: false,
         linear_capture_count: 0,
         epistemic_epsilon: 0.0 - 1.0,
+        epistemic_min_confidence: epistemic_min_confidence,
         visibility_kind: VISIBILITY_PUB,
         defining_module_seg_count: 0,
         defining_module_id: 0,
@@ -3778,6 +3786,22 @@ fn checker_extract_effects_mut(c: *mut Checker, opt: Option<Box<EffectList> >) -
     }
 }
 
+fn epistemic_min_confidence_from_effects(opt: Option<Box<EffectList> >) -> i64 with Mut, Panic, Div {
+    var cursor = opt
+    while true {
+        match cursor {
+            Some(list) => {
+                if effect_name_to_id((*list).head.name_buf, (*list).head.name_len) == 8 && (*list).head.payload >= 0 {
+                    return (*list).head.payload
+                }
+                cursor = (*list).tail
+            }
+            None => return 0 - 1
+        }
+    }
+    0 - 1
+}
+
 fn checker_collect_fn_param_list_mut(c: *mut Checker, pl: ParamList) -> MutParamListResult with Mut, Panic, Div, Alloc, IO {
     let head_ty = checker_lower_type_expr_mut(c, pl.head.ty)
     let head_param = FnParamInfo { name: pl.head.name, ty: head_ty }
@@ -3825,6 +3849,7 @@ fn checker_collect_fn_def_inplace(c: *mut Checker, opt: Option<Box<FnDef> >, vis
             (*c).current_effect_count = saved_effect_count
             let fn_effects = eff_pair.effects
             let fn_effect_count = eff_pair.count
+            let epistemic_min_confidence = epistemic_min_confidence_from_effects((*fd).effects)
 
             let is_kernel_fn = (*fd).is_kernel
             var kernel_effects = fn_effects
@@ -3899,6 +3924,7 @@ fn checker_collect_fn_def_inplace(c: *mut Checker, opt: Option<Box<FnDef> >, vis
                 is_linear_closure: false,
                 linear_capture_count: 0,
                 epistemic_epsilon: 0.0 - 1.0,
+                epistemic_min_confidence: epistemic_min_confidence,
                 visibility_kind: visibility.kind,
                 defining_module_seg_count: defining_module.seg_count,
                 defining_module_id: (*c).current_module_id,
@@ -4901,6 +4927,7 @@ fn checker_collect_impl_method_inplace(c: *mut Checker, item: Item, type_name: N
             (*c).current_effect_count = saved_effect_count
             let fn_effects = eff_pair_early.effects
             let fn_effect_count = eff_pair_early.count
+            let epistemic_min_confidence = epistemic_min_confidence_from_effects((*fd).effects)
             let sig = FnSig {
                 name: item.name,
                 params: params,
@@ -4917,6 +4944,7 @@ fn checker_collect_impl_method_inplace(c: *mut Checker, item: Item, type_name: N
                 is_linear_closure: false,
                 linear_capture_count: 0,
                 epistemic_epsilon: 0.0 - 1.0,
+                epistemic_min_confidence: epistemic_min_confidence,
                 visibility_kind: item.visibility.kind,
                 defining_module_seg_count: (*c).current_module.seg_count,
                 defining_module_id: (*c).current_module_id,
@@ -7129,6 +7157,7 @@ fn checker_check_closure_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry wit
         is_linear_closure: capture_linear,
         linear_capture_count: capture_linear_count,
         epistemic_epsilon: capture_epsilon,
+        epistemic_min_confidence: 0 - 1,
         visibility_kind: VISIBILITY_PRIVATE,
         defining_module_seg_count: (*c).current_module.seg_count,
         defining_module_id: (*c).current_module_id,
@@ -7698,13 +7727,65 @@ fn checker_check_acknowledge_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry
     ty_error()
 }
 
+fn knowledge_confidence_label(name: Name) -> bool with Panic, Div {
+    if name_matches_str1(name, 101) { return true } // e
+    if name_matches_str7(name, 101, 112, 115, 105, 108, 111, 110) { return true } // epsilon
+    // UTF-8 epsilon (U+03B5): 0xCE 0xB5, stored in the parser's i8 name buffer.
+    name.len == 2 && name.buf[0] == 206 as i8 && name.buf[1] == 181 as i8
+}
+
+fn knowledge_ctor_confidence(args: Option<Box<ExprList> >) -> f64 with Mut, Panic, Div, Alloc {
+    var cursor = args
+    var position: i64 = 0
+    while true {
+        match cursor {
+            Some(list) => {
+                // The lexer recovery path accepts the Unicode epsilon label but
+                // may not preserve its bytes in ExprList.label. The constructor
+                // ABI is stable: confidence is argument 2, so position is the
+                // authoritative fallback when the label is unavailable.
+                if knowledge_confidence_label((*list).label) || position == 1 {
+                    if (*list).head.kind == ExprKind::ExprFloatLit {
+                        return (*list).head.float_val
+                    }
+                    if (*list).head.kind == ExprKind::ExprIntLit {
+                        return (*list).head.int_val as f64
+                    }
+                    return 0.0 - 1.0
+                }
+                cursor = (*list).tail
+                position = position + 1
+            }
+            None => return 0.0 - 1.0
+        }
+    }
+    0.0 - 1.0
+}
+
+fn checker_current_epistemic_min_inplace(c: *mut Checker) -> i64 with Mut, Panic, Div {
+    let sig_id = (*c).current_sig_id
+    if sig_id < 0 { return 0 - 1 }
+    let sig = fn_sig_table_get((*c).fn_sigs, sig_id)
+    if !name_eq(sig.name, (*c).current_sig_name) { return 0 - 1 }
+    sig.epistemic_min_confidence
+}
+
+fn checker_enforce_knowledge_confidence_inplace(c: *mut Checker, args: Option<Box<ExprList> >, span: Span) -> f64 with Mut, Panic, Div, Alloc, IO {
+    let confidence = knowledge_ctor_confidence(args)
+    let minimum = checker_current_epistemic_min_inplace(c)
+    let confidence_milli = if confidence < 0.0 { 1 } else { (confidence * 1000.0 + 0.5) as i64 }
+    if minimum > 0 && confidence_milli < minimum {
+        checker_report_error_at_inplace(c, span, 215, confidence_milli, minimum, 0)
+    }
+    confidence
+}
+
 fn checker_check_knowledge_ctor_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
     // Knowledge(v, e=<confidence>, prov=<provenance>) -> Knowledge<T>.
-    // Same shape as checker_check_measure_expr_inplace: T comes from the first argument,
-    // epsilon is left unspecified at the type level (-1) exactly as measure() does.
     let first_arg = expr_list_head(e.args)
     let v_ty = checker_check_opt_expr_inplace(c, first_arg)
-    ty_knowledge(v_ty, 0.0 - 1.0)
+    let confidence = checker_enforce_knowledge_confidence_inplace(c, e.args, e.span)
+    ty_knowledge(v_ty, confidence)
 }
 
 fn checker_check_variance_metric_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
@@ -13651,6 +13732,7 @@ fn print_error_message(code: i64) with IO, Mut, Panic, Div {
     else if code == 207 { print("Interpretable<T> requires ZD effect: the 168-class canonical basis is the projective ZD-graph of sedenions. Without the ZD effect the compiler cannot guarantee that decomposition/reconstruction is fp-exact. Add `with ZD` to your function signature.") }
     else if code == 208 { print("ZD locus is not a well-formed sedenion pair eIeJ with 1 <= I < J <= 15") }
     else if code == 213 { print("tuple destructure arity mismatch") }
+    else if code == 215 { print("EpistemicComplete violation") }
     else if code == 216 { print("infinite recursive type") }
     else if code == 217 { print("f128/f256 value conversion is not implemented; wide-float casts fail closed") }
     else if code == 218 { print("f128/f256 is reserved for compiler-owned format identity; source values are unavailable in V0-A") }
@@ -16865,6 +16947,7 @@ impl Checker {
         // 3. Extract effects from te.effects (EffectList)
         var effects: [i64; 8] = [0; 8]
         var effect_count: i64 = 0
+        let epistemic_min_confidence = epistemic_min_confidence_from_effects(te.effects)
         match te.effects {
             Some(eff_list) => {
                 let ep = c.extract_effect_ids(*eff_list)
@@ -16890,6 +16973,7 @@ impl Checker {
             is_linear_closure: false,
             linear_capture_count: 0,
             epistemic_epsilon: 0.0 - 1.0,
+            epistemic_min_confidence: epistemic_min_confidence,
             visibility_kind: VISIBILITY_PUB,
             defining_module_seg_count: 0,
             defining_module_id: 0,
@@ -18883,6 +18967,7 @@ impl Checker {
                 c = eff_pair.checker
                 let fn_effects = eff_pair.effects
                 let fn_effect_count = eff_pair.count
+                let epistemic_min_confidence = epistemic_min_confidence_from_effects((*fd).effects)
 
                 // Kernel function enforcement
                 let is_kernel_fn = (*fd).is_kernel
@@ -19028,6 +19113,7 @@ impl Checker {
                     is_linear_closure: false,
                     linear_capture_count: 0,
                     epistemic_epsilon: 0.0 - 1.0,
+                    epistemic_min_confidence: epistemic_min_confidence,
                     visibility_kind: visibility.kind,
                     defining_module_seg_count: defining_module.seg_count,
                     defining_module_id: c.current_module_id,
@@ -20010,6 +20096,7 @@ impl Checker {
                 c = eff_pair.checker
                 let fn_effects = eff_pair.effects
                 let fn_effect_count = eff_pair.count
+                let epistemic_min_confidence = epistemic_min_confidence_from_effects((*fd).effects)
 
                 let sig = FnSig {
                     name: item.name,
@@ -20027,6 +20114,7 @@ impl Checker {
                     is_linear_closure: false,
                     linear_capture_count: 0,
                     epistemic_epsilon: 0.0 - 1.0,
+                    epistemic_min_confidence: epistemic_min_confidence,
                     visibility_kind: item.visibility.kind,
                     defining_module_seg_count: c.current_module.seg_count,
                     defining_module_id: c.current_module_id,
@@ -23911,9 +23999,21 @@ impl Checker {
         // checker_check_knowledge_ctor_expr_inplace.
         let first_arg = expr_list_head(e.args)
         let v_pair = self.check_opt_expr(first_arg)
-        let c = v_pair.0
+        var c = v_pair.0
         let v_ty = v_pair.1
-        (c, ty_knowledge(v_ty, 0.0 - 1.0))
+        let confidence = knowledge_ctor_confidence(e.args)
+        var minimum: i64 = 0 - 1
+        if c.current_sig_id >= 0 {
+            let sig = fn_sig_table_get(c.fn_sigs, c.current_sig_id)
+            if name_eq(sig.name, c.current_sig_name) {
+                minimum = sig.epistemic_min_confidence
+            }
+        }
+        let confidence_milli = if confidence < 0.0 { 1 } else { (confidence * 1000.0 + 0.5) as i64 }
+        if minimum > 0 && confidence_milli < minimum {
+            c = c.report_error_at(e.span, 215, confidence_milli, minimum, 0)
+        }
+        (c, ty_knowledge(v_ty, confidence))
     }
 
     fn check_variance_metric_expr(self, e: Expr) -> (Checker, TypeEntry) with Mut, Panic, Div, Alloc, IO {
@@ -25216,6 +25316,7 @@ impl Checker {
             is_linear_closure: capture_linear,
             linear_capture_count: capture_linear_count,
             epistemic_epsilon: capture_epsilon,
+            epistemic_min_confidence: 0 - 1,
             visibility_kind: VISIBILITY_PRIVATE,
             defining_module_seg_count: c.current_module.seg_count,
             defining_module_id: c.current_module_id,

--- a/self-hosted/check/defs.sio
+++ b/self-hosted/check/defs.sio
@@ -1295,6 +1295,7 @@ pub struct FnSig {
     is_linear_closure: bool,      // true if captures linear resources => call exactly once
     linear_capture_count: i64,    // number of linear captures
     epistemic_epsilon: f64,       // combined GUM epsilon from Knowledge captures (-1.0 = none)
+    epistemic_min_confidence: i64, // Epistemic(N) floor on the 1..1000 scale (-1 = absent)
     visibility_kind: i64,
     defining_module_seg_count: i64,
     defining_module_id: i64,
@@ -1319,6 +1320,7 @@ fn empty_fn_sig() -> FnSig {
         is_linear_closure: false,
         linear_capture_count: 0,
         epistemic_epsilon: 0.0 - 1.0,
+        epistemic_min_confidence: 0 - 1,
         visibility_kind: VISIBILITY_PRIVATE,
         defining_module_seg_count: 0,
         defining_module_id: 0,

--- a/self-hosted/parser/ast.sio
+++ b/self-hosted/parser/ast.sio
@@ -138,6 +138,11 @@ pub struct AstPathList {
 pub struct EffectRef {
     name_buf: [i8; 64],
     name_len: i64,
+    // Payload of a parameterised effect, e.g. the 950 in `with Epistemic(950)`.
+    // -1 means the effect was written without one. Before this field existed the
+    // payload was parsed and discarded, so Epistemic(950) and Epistemic(400) were
+    // the same effect to the compiler.
+    payload: i64,
 }
 
 // ============================================================

--- a/self-hosted/parser/types.sio
+++ b/self-hosted/parser/types.sio
@@ -784,10 +784,12 @@ impl Parser {
     fn parse_effect_list(self) -> (Parser, EffectList) with Mut, IO, Panic, Div, Alloc {
         var p = self.advance()  // skip 'with'
         let first_name = p.current_name()
-        let first_eff = EffectRef { name_buf: [0; 64], name_len: first_name.len }
+        let first_eff = EffectRef { name_buf: [0; 64], name_len: first_name.len, payload: 0 - 1 }
         var first = copy_name_to_effect(first_name, first_eff)
         p = p.advance()  // skip effect name
-        p = p.parse_effect_payload()
+        let fpay = p.parse_effect_payload()
+        p = fpay.0
+        first.payload = fpay.1
 
         var rev_list = EffectList { head: first, tail: None }
 
@@ -799,20 +801,36 @@ impl Parser {
             }
             p = p.advance()  // skip ,
             let eff_name = p.current_name()
-            let eff = EffectRef { name_buf: [0; 64], name_len: eff_name.len }
+            let eff = EffectRef { name_buf: [0; 64], name_len: eff_name.len, payload: 0 - 1 }
             var e = copy_name_to_effect(eff_name, eff)
-            rev_list = EffectList { head: e, tail: Some(Box::new(rev_list)) }
             p = p.advance()  // skip effect name
-            p = p.parse_effect_payload()
+            let npay = p.parse_effect_payload()
+            p = npay.0
+            e.payload = npay.1
+            rev_list = EffectList { head: e, tail: Some(Box::new(rev_list)) }
         }
 
         (p, reverse_effect_list(rev_list))
     }
 
-    fn parse_effect_payload(self) -> Parser with Mut, IO, Panic, Div, Alloc {
+    // Returns the parser and the payload of a parameterised effect, or -1 when the
+    // effect carries none. Balanced-paren skipping is kept for payload shapes this
+    // does not yet model; what is new is that a single integer literal is now
+    // RETAINED. It used to be counted and thrown away, which made Epistemic(950)
+    // and Epistemic(400) the same effect.
+    fn parse_effect_payload(self) -> (Parser, i64) with Mut, IO, Panic, Div, Alloc {
         var p = self
+        var value: i64 = 0 - 1
         if parser_peek(p) != TokenKind::LParen {
-            return p
+            return (p, value)
+        }
+        if parser_peek_ahead(p, 1) == TokenKind::IntLit && parser_peek_ahead(p, 2) == TokenKind::RParen {
+            p = p.advance()
+            let tok = p.current()
+            value = tok.int_value
+            p = p.advance()
+            p = p.advance()
+            return (p, value)
         }
 
         var depth: i64 = 0
@@ -825,14 +843,14 @@ impl Parser {
                 depth = depth - 1
                 p = p.advance()
                 if depth == 0 {
-                    return p
+                    return (p, value)
                 }
             } else {
                 p = p.advance()
             }
         }
 
-        p
+        (p, value)
     }
 
     // ============================================================

--- a/tests/compiler/epistemic_payload_gate/n400.sio
+++ b/tests/compiler/epistemic_payload_gate/n400.sio
@@ -1,0 +1,8 @@
+fn gated_value() -> f64 with Epistemic(400), Mut, Div, Panic {
+    let k: Knowledge[f64] = Knowledge(1.0, ε=0.40, prov="epistemic_payload_gate");
+    k.value
+}
+
+fn main() with IO, Mut, Div, Panic, Epistemic {
+    println(gated_value());
+}

--- a/tests/compiler/epistemic_payload_gate/n401.sio
+++ b/tests/compiler/epistemic_payload_gate/n401.sio
@@ -1,0 +1,8 @@
+fn gated_value() -> f64 with Epistemic(401), Mut, Div, Panic {
+    let k: Knowledge[f64] = Knowledge(1.0, ε=0.40, prov="epistemic_payload_gate");
+    k.value
+}
+
+fn main() with IO, Mut, Div, Panic, Epistemic {
+    println(gated_value());
+}

--- a/tests/compiler/epistemic_payload_gate/n950.sio
+++ b/tests/compiler/epistemic_payload_gate/n950.sio
@@ -1,0 +1,8 @@
+fn gated_value() -> f64 with Epistemic(950), Mut, Div, Panic {
+    let k: Knowledge[f64] = Knowledge(1.0, ε=0.40, prov="epistemic_payload_gate");
+    k.value
+}
+
+fn main() with IO, Mut, Div, Panic, Epistemic {
+    println(gated_value());
+}

--- a/tests/compiler/epistemic_payload_gate/n999.sio
+++ b/tests/compiler/epistemic_payload_gate/n999.sio
@@ -1,0 +1,8 @@
+fn gated_value() -> f64 with Epistemic(999), Mut, Div, Panic {
+    let k: Knowledge[f64] = Knowledge(1.0, ε=0.40, prov="epistemic_payload_gate");
+    k.value
+}
+
+fn main() with IO, Mut, Div, Panic, Epistemic {
+    println(gated_value());
+}


### PR DESCRIPTION
## Summary

- consume the parsed `Epistemic(N)` payload in both Madaros function-signature collectors and both function-type lowerers
- preserve literal `Knowledge` confidence and emit E215 when it falls below the active function floor
- add four byte-normalized witnesses, a two-engine oracle, remote witness-gate support, and a side-by-side Slurm receipt

This PR intentionally includes the prerequisite `feat/effect-payload` commit `0e523d064`, because the dispatch required that exact branch as its base and it is not on `main` yet.

## Verification

`SOUNIO_WITNESS_GLOB='tests/compiler/epistemic_payload_gate/*.sio' bash scripts/dev/souc-build-remote.sh --partition gpu-orangefs --node gpuorangefs-r770-proxmox --cpus 32 --gate witness`

Current-source Madaros build: rc 0, 227 s, 100574016-byte ELF.

| Engine | N=400 | N=401 | N=950 | N=999 |
|---|---|---|---|---|
| rebuilt Madaros | accept | E215 reject | E215 reject | E215 reject |
| lean_single | accept | reject | reject | reject |

The non-vacuous control temporarily forced any parameterized floor to reject. After rebuild, Madaros rejected N=400 with E215 while lean_single accepted it. The real comparison was restored and the final 8/8 oracle passed.

## Boundary

This closes the measured literal-constructor payload-consumer divergence. It does not claim the full general lean_single `EXPR_CONF` algebra or cross-call `FN_EFF_CONF` certificate system; that broader propagation remains separate work.