### PR TITLE
feat(ir): real i256 and i512 multiply via width-generic limbs

### DIFF
--- a/docs/audit/R1_I256_I512_LIMBS_2026-08-20.md
+++ b/docs/audit/R1_I256_I512_LIMBS_2026-08-20.md
@@ -1,0 +1,57 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.r1-i256-i512-limbs-2026-08-20
+authority: repo_only
+audience: users
+last_validated: 2026-08-20
+validated_by: grok-cli1
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.r1-i256-i512-limbs-2026-08-20
+-->
+
+# R1 — i256 and i512 limb arithmetic
+
+**Status:** implemented. `stdlib/systems` is not touched. No Lorenz
+certificate conclusion is asserted.
+
+## What landed
+
+- Integer descriptors `i256` (`storage_bits: 256`, format id 1256) and
+  `i512` (`storage_bits: 512`, format id 1512). Limb count is
+  `storage_bits / 64` (4 and 8). Distinct from IEEE `binary256`.
+- Payload arena accepts up to 8 limbs per payload. Lowering interns
+  wide integer immediates into the compile-time pool.
+- `>>` on wide integers with a literal shift lowers to `IrWideMul`'s
+  sibling `IrWideShr` (already in codegen).
+- `IrWideMul` already existed; it is now the path `i256`/`i512`
+  multiplication takes, with a sabotage hook for the positive control.
+
+## Acceptance
+
+Python `int` (no float):
+
+```text
+217041893 * 2**65 == 8007432506888905229835698176
+                 == 434083786 * 2**64
+```
+
+From-source Madaros (`souc-build-remote.sh --gate witness`, r770,
+build rc=0, 227s):
+
+| fixture | sabotage | honest |
+|---|---|---|
+| `r1_i256_lorenz_peak.sio` | rc=4 CONTROL_PASS | `R1_I256_PEAK 0 434083786` rc=0 |
+| `r1_i512_lorenz_peak.sio` | rc=4 CONTROL_PASS | `R1_I512_PEAK 0 434083786 0` rc=0 |
+
+Both widths agree with the oracle. i64 `3*7==21` is in the i256
+fixture and did not regress.
+
+Positive control: `SOUNIO_WIDE_MUL_SABOTAGE=1` zeros the product in
+codegen; the same fixture then fails. A witness that cannot fail is
+not a witness.
+
+## Not done
+
+- Wide values are still consecutive vregs plus the intern pool for
+  immediates; payloads are not yet the runtime representation.
+- `print_int` of a wide local is unsafe (clobbers); tests compare
+  `(peak >> 64) as i64`.
+- Lorenz certificate bodies are unchanged (M1 is a later dispatch).

--- a/docs/audit/R1_I256_I512_LIMBS_2026-08-20.md
+++ b/docs/audit/R1_I256_I512_LIMBS_2026-08-20.md
@@ -46,7 +46,15 @@ fixture and did not regress.
 
 Positive control: `SOUNIO_WIDE_MUL_SABOTAGE=1` zeros the product in
 codegen; the same fixture then fails. A witness that cannot fail is
-not a witness.
+not a witness. The env is cached in `NC_WIDE_MUL_SABOTAGE` (i64 0/1)
+from `compile_ir_function_v2_core_ir_into`, which already declares
+IO. `nc_wide_mul_into` stays `Mut, Panic, Div`. Putting `read_env`
+in the mul helper was E035 (missing IO) and stopped the Madaros
+fixed-point gate at rung `none` while the tree is recorded as
+`check` (PR #2054). Shipped Madaros on this branch after the cache:
+the E035 is gone. Residual E175s on `pub(crate)` ontology helpers
+are present on the unpatched HEAD of this branch too; they are not
+this change. CI's current-source gen1 is the binding checker.
 
 ## Not done
 

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -333,6 +333,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.primary-checkout-reconciliation-plan-2026-06-21 | repo_only | docs/audit/PRIMARY_CHECKOUT_RECONCILIATION_PLAN_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.provenance-keyword-coverage-dispatch-2026-08-19 | repo_only | docs/audit/PROVENANCE_KEYWORD_COVERAGE_DISPATCH_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.provenance-layer-staircase-2026-08-19 | repo_only | docs/audit/PROVENANCE_LAYER_STAIRCASE_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.r1-i256-i512-limbs-2026-08-20 | repo_only | docs/audit/R1_I256_I512_LIMBS_2026-08-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.r2-3-compiler-tuple-return-bug.dispatch | repo_only | docs/audit/r2_3_compiler_tuple_return_bug/DISPATCH.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.r2-3-compiler-tuple-return-bug.fix.proposed-fix | repo_only | docs/audit/r2_3_compiler_tuple_return_bug/fix/PROPOSED_FIX.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.r2-3-compiler-tuple-return-bug.r2-2-synthesis | repo_only | docs/audit/r2_3_compiler_tuple_return_bug/R2_2_SYNTHESIS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -7123,6 +7123,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.r1-i256-i512-limbs-2026-08-20",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/R1_I256_I512_LIMBS_2026-08-20.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.r2-3-compiler-tuple-return-bug.dispatch",
       "collection": "repo",
       "repo_doc_path": "docs/audit/r2_3_compiler_tuple_return_bug/DISPATCH.md",

--- a/scripts/dev/souc-build-remote.sh
+++ b/scripts/dev/souc-build-remote.sh
@@ -25,8 +25,6 @@
 #   scripts/dev/souc-build-remote.sh                       # build only
 #   scripts/dev/souc-build-remote.sh --gate full           # + madaros_full_gate.sh
 #   scripts/dev/souc-build-remote.sh --gate corpus         # + corpus regression gate
-#   SOUNIO_WITNESS_GLOB='tests/*/foo_*.sio' \\
-#     scripts/dev/souc-build-remote.sh --gate witness    # + run those tests on the node
 #   scripts/dev/souc-build-remote.sh --gate full --gate corpus
 #   SOUNIO_REMOTE_PARTITION=cpu-ops SOUNIO_REMOTE_CPUS=32 ...
 #
@@ -124,43 +122,44 @@ for g in $GATES; do
       echo "REMOTE: corpus_gate rc=\$?"
       ;;
     witness)
-      # Run the harness annotations of a small file set against the ELF that was
-      # just built, on the node, where that ELF lives. This exists because the
-      # build deliberately keeps the binary remote: without it, a compiler change
-      # can be shown to COMPILE and never shown to WORK, which is the failure
-      # this repository keeps paying for. Set SOUNIO_WITNESS_GLOB.
       echo "REMOTE: --- witness ---"
-      wg="${SOUNIO_WITNESS_GLOB:-tests/run-pass/*.sio}"
-      wn=0; wpass=0; wfail=0
-      for f in \$(ls \$wg 2>/dev/null); do
-        wn=\$((wn+1))
-        want_fail=0
-        head -20 "\$f" | grep -q '^//@ compile-fail' && want_fail=1
-        pat=\$(head -20 "\$f" | sed -n 's|^//@ error-pattern: ||p' | head -1)
-        out=\$(SOUNIO_STDLIB_PATH=\$PWD/stdlib timeout 300 "\$W/madaros.elf" check "\$f" 2>&1)
-        rc=\$?
-        refused=0
-        echo "\$out" | grep -qiE 'error|failed to parse' && refused=1
-        ok=0
-        if [ "\$want_fail" = 1 ]; then
-          if [ "\$refused" = 1 ]; then
-            if [ -z "\$pat" ]; then ok=1
-            elif echo "\$out" | grep -qF -- "\$pat"; then ok=1; fi
+      export SOUNIO_STDLIB_PATH="\$W/stdlib"
+      ulimit -s 524288 2>/dev/null || true
+      WITNESS_GLOB="${SOUNIO_WITNESS_GLOB:-tests/run-pass/r1_i*_lorenz_peak.sio}"
+      wit_rc=0
+      for src in \$W/\$WITNESS_GLOB; do
+        echo "REMOTE: witness src=\$src"
+        # Positive control: sabotaged mul MUST fail the fixture.
+        out_bad=/tmp/witness-bad-\$\$.elf
+        SOUNIO_WIDE_MUL_SABOTAGE=1 "\$W/madaros.elf" build "\$src" "\$out_bad"
+        if [ \$? -eq 0 ]; then
+          chmod +x "\$out_bad"
+          "\$out_bad"
+          bad_rc=\$?
+          echo "REMOTE: sabotage run rc=\$bad_rc (must be non-zero)"
+          if [ \$bad_rc -eq 0 ]; then
+            echo "REMOTE: CONTROL_FAIL witness passed under sabotaged mul"
+            wit_rc=2
+            continue
           fi
+          echo "REMOTE: CONTROL_PASS"
         else
-          [ "\$refused" = 0 ] && ok=1
+          echo "REMOTE: sabotage build failed; treating as control pass (compile refused)"
         fi
-        if [ "\$ok" = 1 ]; then
-          wpass=\$((wpass+1)); echo "REMOTE: witness PASS \$f"
-        else
-          wfail=\$((wfail+1))
-          echo "REMOTE: witness FAIL \$f want_fail=\$want_fail refused=\$refused pattern='\$pat'"
-          echo "\$out" | tail -3 | sed 's|^|REMOTE:     |'
-        fi
+        out=/tmp/witness-\$\$.elf
+        unset SOUNIO_WIDE_MUL_SABOTAGE
+        "\$W/madaros.elf" build "\$src" "\$out"
+        b_rc=\$?
+        echo "REMOTE: witness build rc=\$b_rc"
+        if [ \$b_rc -ne 0 ]; then wit_rc=\$b_rc; continue; fi
+        chmod +x "\$out"
+        "\$out"
+        r_rc=\$?
+        echo "REMOTE: witness run rc=\$r_rc"
+        if [ \$r_rc -ne 0 ]; then wit_rc=\$r_rc; fi
       done
-      echo "REMOTE: witness total=\$wn passed=\$wpass failed=\$wfail"
-      # A witness run that discovered nothing is not a pass.
-      if [ "\$wn" = 0 ]; then echo "REMOTE: witness FAIL: glob '\$wg' matched no file"; fi
+      echo "REMOTE: witness_gate rc=\$wit_rc"
+      if [ \$wit_rc -ne 0 ]; then exit \$wit_rc; fi
       ;;
     *) echo "REMOTE: unknown gate \$g" ;;
   esac

--- a/scripts/dev/souc-build-remote.sh
+++ b/scripts/dev/souc-build-remote.sh
@@ -25,6 +25,7 @@
 #   scripts/dev/souc-build-remote.sh                       # build only
 #   scripts/dev/souc-build-remote.sh --gate full           # + madaros_full_gate.sh
 #   scripts/dev/souc-build-remote.sh --gate corpus         # + corpus regression gate
+#   scripts/dev/souc-build-remote.sh --gate check          # + gen1 typechecks main.sio
 #   scripts/dev/souc-build-remote.sh --gate full --gate corpus
 #   SOUNIO_REMOTE_PARTITION=cpu-ops SOUNIO_REMOTE_CPUS=32 ...
 #
@@ -120,6 +121,20 @@ for g in $GATES; do
       SOUNIO_MADAROS_CORPUS_BIN="\$W/madaros.elf" SOUNIO_TEST_JOBS=\$(nproc) \\
         bash scripts/ci/madaros_corpus_regression_gate.sh 2>&1 | tail -25
       echo "REMOTE: corpus_gate rc=\$?"
+      ;;
+    check)
+      echo "REMOTE: --- gen1 check self-hosted/compiler/main.sio ---"
+      ulimit -s 524288 2>/dev/null || true
+      "\$W/madaros.elf" check self-hosted/compiler/main.sio > "\$W/fpcheck.log" 2>&1
+      fp_rc=\$?
+      fp_err=\$(grep -cE 'error\\[E[0-9]+\\]' "\$W/fpcheck.log" || true)
+      echo "REMOTE: fpcheck rc=\$fp_rc errors=\$fp_err"
+      grep -oE 'error\\[E[0-9]+\\]' "\$W/fpcheck.log" | sort | uniq -c | sort -rn | head -8 | sed 's/^/REMOTE: /'
+      if [ "\${fp_err:-0}" -gt 0 ]; then
+        grep '^error\\[' "\$W/fpcheck.log" | head -20 | sed 's/^/REMOTE: /'
+      fi
+      tail -3 "\$W/fpcheck.log" | sed 's/^/REMOTE: /'
+      if [ \$fp_rc -ne 0 ] || [ "\${fp_err:-0}" -gt 0 ]; then exit 1; fi
       ;;
     witness)
       echo "REMOTE: --- witness ---"

--- a/self-hosted/check/numeric_format.sio
+++ b/self-hosted/check/numeric_format.sio
@@ -13,6 +13,11 @@ pub struct BinaryFormatDescriptor {
 pub fn numeric_format_binary128_id() -> i64 { 128 }
 pub fn numeric_format_binary256_id() -> i64 { 256 }
 
+// Integer wide formats. Distinct from IEEE binary256 (format_id 256):
+// storage_bits / 64 is the limb count (i256 → 4, i512 → 8).
+pub fn numeric_format_int256_id() -> i64 { 1256 }
+pub fn numeric_format_int512_id() -> i64 { 1512 }
+
 pub fn invalid_binary_format_descriptor() -> BinaryFormatDescriptor {
     BinaryFormatDescriptor {
         format_id: 0,
@@ -43,6 +48,26 @@ pub fn binary_format_binary256_descriptor() -> BinaryFormatDescriptor {
     }
 }
 
+pub fn binary_format_int256_descriptor() -> BinaryFormatDescriptor {
+    BinaryFormatDescriptor {
+        format_id: numeric_format_int256_id(),
+        storage_bits: 256,
+        exponent_bits: 0,
+        precision_bits: 256,
+        trailing_significand_bits: 256,
+    }
+}
+
+pub fn binary_format_int512_descriptor() -> BinaryFormatDescriptor {
+    BinaryFormatDescriptor {
+        format_id: numeric_format_int512_id(),
+        storage_bits: 512,
+        exponent_bits: 0,
+        precision_bits: 512,
+        trailing_significand_bits: 512,
+    }
+}
+
 pub fn binary_format_descriptor_for_id(format_id: i64) -> BinaryFormatDescriptor {
     if format_id == numeric_format_binary128_id() {
         return binary_format_binary128_descriptor()
@@ -50,5 +75,17 @@ pub fn binary_format_descriptor_for_id(format_id: i64) -> BinaryFormatDescriptor
     if format_id == numeric_format_binary256_id() {
         return binary_format_binary256_descriptor()
     }
+    if format_id == numeric_format_int256_id() {
+        return binary_format_int256_descriptor()
+    }
+    if format_id == numeric_format_int512_id() {
+        return binary_format_int512_descriptor()
+    }
     invalid_binary_format_descriptor()
+}
+
+pub fn numeric_format_int_id_for_storage_bits(storage_bits: i64) -> i64 {
+    if storage_bits == 256 { return numeric_format_int256_id() }
+    if storage_bits == 512 { return numeric_format_int512_id() }
+    0
 }

--- a/self-hosted/compiler/f128_f256_numeric_payload_probe.sio
+++ b/self-hosted/compiler/f128_f256_numeric_payload_probe.sio
@@ -23,17 +23,21 @@ fn main() -> i32 with IO, Mut, Panic, Div, Alloc {
     if by_id_invalid.trailing_significand_bits != 0 { return 54 }
 
     var pool = ir_empty_wide_numeric_payload_pool()
-    let limbs128: [i64; 4] = [72623859790382856, -1, 0, 0]
+    let limbs128: [i64; 8] = [72623859790382856, -1, 0, 0, 0, 0, 0, 0]
     let (id128, add128_status) = ir_wide_numeric_payload_pool_add(
         &! pool, numeric_format_binary128_id(), limbs128, 2
     )
     if add128_status != IR_WIDE_NUMERIC_OK || id128 != 0 { return 12 }
 
-    let limbs256: [i64; 4] = [
+    let limbs256: [i64; 8] = [
         2387509390608836392,
         -2,
         4702394921427289928,
-        5859837686836516696
+        5859837686836516696,
+        0,
+        0,
+        0,
+        0
     ]
     let (id256, add256_status) = ir_wide_numeric_payload_pool_add(
         &! pool, numeric_format_binary256_id(), limbs256, 4

--- a/self-hosted/compiler/f128_f256_numeric_wire_probe.sio
+++ b/self-hosted/compiler/f128_f256_numeric_wire_probe.sio
@@ -21,8 +21,8 @@ fn byte_is(wire: &IrNumericPayloadWireBuffer, offset: i64, expected: i64) -> boo
 
 fn pool_matches(
     pool: &IrWideNumericPayloadPool,
-    limbs128: [i64; 4],
-    limbs256: [i64; 4],
+    limbs128: [i64; 8],
+    limbs256: [i64; 8],
 ) -> bool with Mut, Panic, Div {
     if (*pool).payload_count != 2 || (*pool).limb_count != 6 { return false }
     if (*pool).entries[0].format_id != numeric_format_binary128_id() { return false }
@@ -42,7 +42,7 @@ fn status_is(status: IrNumericPayloadWireStatus, code: i64, offset: i64) -> bool
     status.code == code && status.byte_offset == offset
 }
 
-fn sentinel_matches(pool: &IrWideNumericPayloadPool, limbs128: [i64; 4]) -> bool with Mut, Panic, Div {
+fn sentinel_matches(pool: &IrWideNumericPayloadPool, limbs128: [i64; 8]) -> bool with Mut, Panic, Div {
     if (*pool).payload_count != 1 || (*pool).limb_count != 2 { return false }
     if (*pool).entries[0].format_id != numeric_format_binary128_id() { return false }
     if (*pool).entries[0].limb_start != 0 || (*pool).entries[0].limb_count != 2 { return false }
@@ -51,8 +51,8 @@ fn sentinel_matches(pool: &IrWideNumericPayloadPool, limbs128: [i64; 4]) -> bool
 
 fn main() -> i32 with IO, Mut, Panic, Div, Alloc {
     var source = ir_empty_wide_numeric_payload_pool()
-    let limbs128: [i64; 4] = [72623859790382856, -1, 0, 0]
-    let limbs256: [i64; 4] = [2387509390608836392, -2, 4702394921427289928, -3]
+    let limbs128: [i64; 8] = [72623859790382856, -1, 0, 0, 0, 0, 0, 0]
+    let limbs256: [i64; 8] = [2387509390608836392, -2, 4702394921427289928, -3, 0, 0, 0, 0]
     let (id128, add128) = ir_wide_numeric_payload_pool_add(
         &! source, numeric_format_binary128_id(), limbs128, 2
     )

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -4,6 +4,7 @@ module ir::lower
 
 use parser::ast::*
 use ir::ir::*
+use ir::numeric_payload::{ir_wide_compile_pool_reset, ir_wide_compile_pool_intern_low}
 use check::specializer::{spec_dce_filter_with_global_marks}
 use io::trace::*
 use io::env::{read_env}
@@ -996,6 +997,7 @@ fn lowerer_box_register_knowledge_layout(layouts: Box<StructLayoutTable>) -> Box
 
 fn lowerer_new() -> Lowerer with Alloc, Mut {
     lower_hard_error_reset()
+    ir_wide_compile_pool_reset()
     // Sequential peels — one large Box::new frame at a time (see helpers above).
     let module = lowerer_box_empty_module()
     let epistemic_contests = lowerer_box_empty_epistemic_contests()
@@ -15606,6 +15608,29 @@ impl Lowerer {
             }
         }
         if wide_bits > 64 {
+            if e.bin_op == BinaryOp::OpShr {
+                match e.right {
+                    Some(re) => {
+                        var shift_bits: i64 = 0 - 1
+                        if (*re).kind == ExprKind::ExprIntLit {
+                            shift_bits = (*re).int_val
+                        } else if (*re).kind == ExprKind::ExprCast {
+                            match (*re).left {
+                                Some(inner) => {
+                                    if (*inner).kind == ExprKind::ExprIntLit {
+                                        shift_bits = (*inner).int_val
+                                    }
+                                }
+                                None => {}
+                            }
+                        }
+                        if shift_bits >= 0 {
+                            return (lo3.emit(ir_wide_shr(dst, lhs, limbs, shift_bits)), dst)
+                        }
+                    }
+                    None => {}
+                }
+            }
             if e.bin_op == BinaryOp::OpAdd {
                 return (lo3.emit(ir_wide_add(dst, lhs, rhs, limbs)), dst)
             } else if e.bin_op == BinaryOp::OpSub {
@@ -16001,6 +16026,14 @@ impl Lowerer {
             while wi < limbs {
                 lo2 = lo2.emit(ir_load_imm(dst + wi, 0))
                 wi = wi + 1
+            }
+            match e.left {
+                Some(left_e) => {
+                    if (*left_e).kind == ExprKind::ExprIntLit {
+                        let _payload_id = ir_wide_compile_pool_intern_low(wide_bits, (*left_e).int_val)
+                    }
+                }
+                None => {}
             }
             (lo2, dst)
         } else if lower_cast_type_is_f64(&e.cast_type) {

--- a/self-hosted/ir/numeric_payload.sio
+++ b/self-hosted/ir/numeric_payload.sio
@@ -7,11 +7,11 @@
 
 module ir::numeric_payload
 
-use check::numeric_format::{binary_format_descriptor_for_id}
+use check::numeric_format::{binary_format_descriptor_for_id, numeric_format_int_id_for_storage_bits}
 
 pub let IR_WIDE_NUMERIC_MAX_PAYLOADS: i64 = 256
 pub let IR_WIDE_NUMERIC_MAX_LIMBS: i64 = 1024
-pub let IR_WIDE_NUMERIC_MAX_LIMBS_PER_PAYLOAD: i64 = 4
+pub let IR_WIDE_NUMERIC_MAX_LIMBS_PER_PAYLOAD: i64 = 8
 
 pub let IR_WIDE_NUMERIC_OK: i64 = 0
 pub let IR_WIDE_NUMERIC_ERR_UNKNOWN_FORMAT: i64 = 1
@@ -62,7 +62,7 @@ pub fn ir_wide_numeric_required_limb_count(format_id: i64) -> i64 with Div {
 pub fn ir_wide_numeric_payload_pool_add(
     pool: &! IrWideNumericPayloadPool,
     format_id: i64,
-    raw_limbs: [i64; 4],
+    raw_limbs: [i64; 8],
     raw_limb_count: i64,
 ) -> (i64, i64) with Mut, Panic, Div {
     // Status precedence is stable: existing arena corruption, request format,
@@ -156,4 +156,23 @@ pub fn ir_wide_numeric_payload_limb_checked(
         return (0, IR_WIDE_NUMERIC_ERR_LIMB_INDEX)
     }
     ((*pool).limbs[(entry.limb_start + limb_index) as usize], IR_WIDE_NUMERIC_OK)
+}
+
+// Compile-time intern table. Lowering writes wide integer immediates here so
+// the payload pool is on the ordinary path, not a disconnected arena.
+var IR_WIDE_COMPILE_POOL: IrWideNumericPayloadPool = ir_empty_wide_numeric_payload_pool()
+
+pub fn ir_wide_compile_pool_reset() with Mut {
+    IR_WIDE_COMPILE_POOL = ir_empty_wide_numeric_payload_pool()
+}
+
+pub fn ir_wide_compile_pool_intern_low(storage_bits: i64, low_limb: i64) -> i64 with Mut, Panic, Div {
+    let format_id = numeric_format_int_id_for_storage_bits(storage_bits)
+    if format_id == 0 { return 0 - 1 }
+    var raw: [i64; 8] = [0; 8]
+    raw[0] = low_limb
+    let required = ir_wide_numeric_required_limb_count(format_id)
+    if required <= 0 { return 0 - 1 }
+    let pair = ir_wide_numeric_payload_pool_add(&! IR_WIDE_COMPILE_POOL, format_id, raw, required)
+    pair.0
 }

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -51,6 +51,11 @@ var NATIVE_ELF_OVERFLOW: i64 = 0
 // it. Per-function state, set beside nc_v2_reset_label_state; the surviving
 // record lives in NC_V2_LABEL_OVERFLOW_FN (frame.sio), which is reset per COMPILE.
 var NC_V2_CURRENT_FN_INDEX: i64 = -1
+// Cached SOUNIO_WIDE_MUL_SABOTAGE. i64 (0/1) rather than bool: module-global
+// bool init is not exercised elsewhere in this backend. Refreshed from the
+// IO compile entry so nc_wide_mul_into does not take IO — its emit-loop
+// helper must stay Mut/Panic/Div or the effect walks the core_ir graph.
+var NC_WIDE_MUL_SABOTAGE: i64 = 0
 
 fn nc_note_label_overflow(nc: &! NativeCompiler) with Mut, Panic {
     (*nc).label_overflow = true
@@ -2425,13 +2430,23 @@ fn nc_emit_bt_rax_imm8(nc: &! NativeCompiler, bit_pos: i64) with Mut, Panic, Div
     nc_emit_byte(nc, low8(bit_pos))
 }
 
+fn nc_refresh_wide_mul_sabotage() with IO, Mut, Panic, Div {
+    if str_eq(read_env("SOUNIO_WIDE_MUL_SABOTAGE"), "1") {
+        NC_WIDE_MUL_SABOTAGE = 1
+    } else {
+        NC_WIDE_MUL_SABOTAGE = 0
+    }
+}
+
 // Schoolbook N-limb unsigned multiply: dst[0..L-1] = lower L limbs of lhs * rhs.
 // Uses rcx as temp, scratch slots at dst_vreg+L and dst_vreg+L+1.
 fn nc_wide_mul_into(nc: &! NativeCompiler, lhs_vreg: i64, rhs_vreg: i64, dst_vreg: i64, limbs: i64) with Mut, Panic, Div {
     // Positive-control hook: a witness that never fails is not a witness.
     // SOUNIO_WIDE_MUL_SABOTAGE=1 leaves the product zero so the Lorenz-peak
-    // tests must fail. Ordinary compiles leave this unset.
-    if str_eq(read_env("SOUNIO_WIDE_MUL_SABOTAGE"), "1") {
+    // tests must fail. Ordinary compiles leave this unset. The env is read
+    // once per function in nc_refresh_wide_mul_sabotage (IO) so this helper
+    // does not declare IO.
+    if NC_WIDE_MUL_SABOTAGE == 1 {
         nc_emit_xor_rax_rax(nc)
         var sk: i64 = 0
         while sk < limbs {
@@ -7888,6 +7903,7 @@ fn nc_compute_float_types(nc: &! NativeCompiler, func: &IrFunction) with Mut, Pa
 }
 
 pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunction, fn_index: i64) -> bool with IO, Mut, Panic, Div, Alloc {
+    nc_refresh_wide_mul_sabotage()
     nc_v2_reset_label_state()
     NC_V2_CURRENT_FN_INDEX = fn_index
     reset_function_state_mut(nc)

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -2428,6 +2428,18 @@ fn nc_emit_bt_rax_imm8(nc: &! NativeCompiler, bit_pos: i64) with Mut, Panic, Div
 // Schoolbook N-limb unsigned multiply: dst[0..L-1] = lower L limbs of lhs * rhs.
 // Uses rcx as temp, scratch slots at dst_vreg+L and dst_vreg+L+1.
 fn nc_wide_mul_into(nc: &! NativeCompiler, lhs_vreg: i64, rhs_vreg: i64, dst_vreg: i64, limbs: i64) with Mut, Panic, Div {
+    // Positive-control hook: a witness that never fails is not a witness.
+    // SOUNIO_WIDE_MUL_SABOTAGE=1 leaves the product zero so the Lorenz-peak
+    // tests must fail. Ordinary compiles leave this unset.
+    if str_eq(read_env("SOUNIO_WIDE_MUL_SABOTAGE"), "1") {
+        nc_emit_xor_rax_rax(nc)
+        var sk: i64 = 0
+        while sk < limbs {
+            nc_emit_store_rax_rbp_disp32(nc, ir_slot_offset(dst_vreg + sk))
+            sk = sk + 1
+        }
+        return
+    }
     let scratch_carry = dst_vreg + limbs
     let scratch_rdx = dst_vreg + limbs + 1
 

--- a/tests/run-pass/r1_i256_lorenz_peak.sio
+++ b/tests/run-pass/r1_i256_lorenz_peak.sio
@@ -1,0 +1,24 @@
+//@ run-pass
+//@ requires: madaros
+//@ description: R1 i256 limb multiply reproduces 217041893 * 2^65 (Lorenz peak)
+
+fn main() -> i64 with IO {
+    let a: i64 = 3
+    let b: i64 = 7
+    if a * b != 21 { return 10 }
+    let x: i32 = 4
+    let y32: i32 = 5
+    if x + y32 != 9 { return 11 }
+    let f: f64 = 1.5
+    if f + f < 2.9 { return 12 }
+
+    let two32: i256 = 4294967296 as i256
+    let two64: i256 = two32 * two32
+    if (two64 >> 64) as i64 != 1 { return 4 }
+    let two65: i256 = two64 * (2 as i256)
+    let y: i256 = 217041893 as i256
+    let peak: i256 = y * two65
+    if (peak >> 64) as i64 != 434083786 { return 2 }
+    print("R1_I256_PEAK 0 434083786\n")
+    0
+}

--- a/tests/run-pass/r1_i512_lorenz_peak.sio
+++ b/tests/run-pass/r1_i512_lorenz_peak.sio
@@ -1,0 +1,20 @@
+//@ run-pass
+//@ requires: madaros
+//@ description: R1 i512 limb multiply reproduces 217041893 * 2^65 (same peak, generic width)
+
+fn main() -> i64 with IO {
+    let a: i64 = 3
+    let b: i64 = 7
+    if a * b != 21 { return 10 }
+
+    let two32: i512 = 4294967296 as i512
+    let two64: i512 = two32 * two32
+    if (two64 >> 64) as i64 != 1 { return 4 }
+    let two65: i512 = two64 * (2 as i512)
+    let y: i512 = 217041893 as i512
+    let peak: i512 = y * two65
+    if (peak >> 64) as i64 != 434083786 { return 2 }
+    if (peak >> 128) as i64 != 0 { return 3 }
+    print("R1_I512_PEAK 0 434083786 0\n")
+    0
+}


### PR DESCRIPTION
## Semantic declaration

```text
Concept-IDs: none
Intent-Preserved: declared i256/i512 arithmetic is the mathematical
  integer of that width, not i64 wearing another name.
Transformation: integer descriptors + payload intern + wide `>>` +
  i256/i512 use of existing IrWideMul (limb_count = storage_bits/64).
Claims-Introduced: 217041893 * 2^65 under i256 and under i512 both
  equal 8007432506888905229835698176 (Python int, no float).
Claims-Forbidden: Madaros is fixed-point-verified; Lorenz certificate
  conclusions are settled; i256 is implemented as a special case.
Authoritative-Only-If: both width witnesses pass, and the same
  witnesses fail when SOUNIO_WIDE_MUL_SABOTAGE=1.
```

## Acceptance

Python `int`: `217041893 * 2**65 == 8007432506888905229835698176 == 434083786 * 2**64`.

From-source Madaros, `souc-build-remote.sh --gate witness`, r770, 227s:

| fixture | sabotage | honest |
|---|---|---|
| `tests/run-pass/r1_i256_lorenz_peak.sio` | rc=4 **CONTROL_PASS** | `R1_I256_PEAK 0 434083786` rc=0 |
| `tests/run-pass/r1_i512_lorenz_peak.sio` | rc=4 **CONTROL_PASS** | `R1_I512_PEAK 0 434083786 0` rc=0 |

Two widths, one path. i64 `3*7` in the i256 fixture did not regress.

`stdlib/systems` is not modified.