### PR TITLE
ci: teach souc-build-remote a witness mode, so a compiler change can be shown to WORK

### DIFF
--- a/scripts/dev/souc-build-remote.sh
+++ b/scripts/dev/souc-build-remote.sh
@@ -25,6 +25,8 @@
 #   scripts/dev/souc-build-remote.sh                       # build only
 #   scripts/dev/souc-build-remote.sh --gate full           # + madaros_full_gate.sh
 #   scripts/dev/souc-build-remote.sh --gate corpus         # + corpus regression gate
+#   SOUNIO_WITNESS_GLOB='tests/*/foo_*.sio' \\
+#     scripts/dev/souc-build-remote.sh --gate witness    # + run those tests on the node
 #   scripts/dev/souc-build-remote.sh --gate full --gate corpus
 #   SOUNIO_REMOTE_PARTITION=cpu-ops SOUNIO_REMOTE_CPUS=32 ...
 #
@@ -121,6 +123,45 @@ for g in $GATES; do
         bash scripts/ci/madaros_corpus_regression_gate.sh 2>&1 | tail -25
       echo "REMOTE: corpus_gate rc=\$?"
       ;;
+    witness)
+      # Run the harness annotations of a small file set against the ELF that was
+      # just built, on the node, where that ELF lives. This exists because the
+      # build deliberately keeps the binary remote: without it, a compiler change
+      # can be shown to COMPILE and never shown to WORK, which is the failure
+      # this repository keeps paying for. Set SOUNIO_WITNESS_GLOB.
+      echo "REMOTE: --- witness ---"
+      wg="${SOUNIO_WITNESS_GLOB:-tests/run-pass/*.sio}"
+      wn=0; wpass=0; wfail=0
+      for f in \$(ls \$wg 2>/dev/null); do
+        wn=\$((wn+1))
+        want_fail=0
+        head -20 "\$f" | grep -q '^//@ compile-fail' && want_fail=1
+        pat=\$(head -20 "\$f" | sed -n 's|^//@ error-pattern: ||p' | head -1)
+        out=\$(SOUNIO_STDLIB_PATH=\$PWD/stdlib timeout 300 "\$W/madaros.elf" check "\$f" 2>&1)
+        rc=\$?
+        refused=0
+        echo "\$out" | grep -qiE 'error|failed to parse' && refused=1
+        ok=0
+        if [ "\$want_fail" = 1 ]; then
+          if [ "\$refused" = 1 ]; then
+            if [ -z "\$pat" ]; then ok=1
+            elif echo "\$out" | grep -qF -- "\$pat"; then ok=1; fi
+          fi
+        else
+          [ "\$refused" = 0 ] && ok=1
+        fi
+        if [ "\$ok" = 1 ]; then
+          wpass=\$((wpass+1)); echo "REMOTE: witness PASS \$f"
+        else
+          wfail=\$((wfail+1))
+          echo "REMOTE: witness FAIL \$f want_fail=\$want_fail refused=\$refused pattern='\$pat'"
+          echo "\$out" | tail -3 | sed 's|^|REMOTE:     |'
+        fi
+      done
+      echo "REMOTE: witness total=\$wn passed=\$wpass failed=\$wfail"
+      # A witness run that discovered nothing is not a pass.
+      if [ "\$wn" = 0 ]; then echo "REMOTE: witness FAIL: glob '\$wg' matched no file"; fi
+      ;;
     *) echo "REMOTE: unknown gate \$g" ;;
   esac
 done
@@ -130,7 +171,7 @@ REMOTE
 
 # tests/ is included only when a gate needs it -- it is the bulk of the payload.
 PAYLOAD="self-hosted stdlib bin/souc-linux-x86_64 scripts"
-case "$GATES" in *full*|*corpus*) PAYLOAD="$PAYLOAD tests bin/madaros bin/madaros-linux-x86_64" ;; esac
+case "$GATES" in *full*|*corpus*|*witness*) PAYLOAD="$PAYLOAD tests bin/madaros bin/madaros-linux-x86_64" ;; esac
 
 tar czf - $PAYLOAD 2>/dev/null \
   | srun --partition="$PARTITION" ${NODE:+--nodelist="$NODE"} --ntasks=1 \


### PR DESCRIPTION
The remote build deliberately keeps the ELF on the node — only text comes back. That is right for a compile check and **wrong for everything else**: a compiler change can be shown to *compile* and never shown to *work*, which is the failure this tree keeps paying for.

`--gate witness` runs the harness annotations of a file set against the ELF that was just built, **on the node where it lives**. It honours `//@ compile-fail` and `//@ error-pattern:`, so a test that refuses for the wrong reason is a FAIL, not a pass. Set `SOUNIO_WITNESS_GLOB` to choose the files.

A run whose glob matched nothing prints FAIL rather than reporting a clean sweep of zero tests.

Costs no pod CPU, and any lane touching `self-hosted/` can use it.

### Why this is opening late, and it matters

The branch was pushed hours ago and **the PR was never opened** — my mistake. In the meantime three dispatches told lanes to use `--gate witness`, and one of them (#2055) correctly reported in its *"Not done (honest)"* section that the flag does not exist:

> `--gate witness` was not run. `scripts/dev/souc-build-remote.sh` accepts `full` and `corpus` only.

That lane was right and the tool was missing. It found the gap by reporting honestly what it could not do, which is exactly the behaviour the dispatches ask for — and it caught an omission of mine that nothing else would have.

### Proven in use

It has already earned itself twice on `feat/exactly-private-ta`, both times against its author: a witness written without a live caller (the void probe catalogued that same morning), and then one with a caller that did not typecheck. Both would have shipped as *"the source compiles"* standing in for *"the feature works"*.