### PR TITLE
Give Input the provenance keyword

### DIFF
--- a/docs/audit/INPUT_KEYWORD_2026-08-19.md
+++ b/docs/audit/INPUT_KEYWORD_2026-08-19.md
@@ -1,0 +1,91 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.input-keyword-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-21
+validated_by: cursor-2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.input-keyword-2026-08-19
+-->
+
+# Input keyword
+
+Founder ruling 2026-08-19: withdraw example `label` vocabulary and map `asserted → Input`. `AstProvInput` already had `PROVENANCE_KIND_INPUT` and a branch in `check/epistemic.sio` `provenance_from_ast`. It lacked a token and a parser arm. This change gives `Input` the keyword.
+
+Forensic sources (read before the edit): #2001, #2011.
+
+## Copies measured before the edit
+
+`fn keyword_lookup` / sibling tables, counted on `6ce6e4dafd`:
+
+| Path | Role | Changed? |
+|---|---|---|
+| `self-hosted/lexer/tables.sio` | full PascalCase table (`keyword_lookup`) | **yes** |
+| `self-hosted/parser/parser.sio` `pt_read_kind` | **this is the live peek path**; `parser_peek` re-derives the kind from source text and ignores stored `PT_KIND` | **yes — len-5 `"Input"`** |
+| `self-hosted/lexer/mod.sio` `lex_source_to_globals` | writes token kinds; peek does not read them | **yes — now calls `keyword_lookup`** |
+| `self-hosted/lexer/mod.sio` `keyword_lookup_code` | frozen i64 protocol; unknown → 123 → Ident | left in place |
+| `self-hosted/compiler/render_native_compile_driver_lean.sio` `keyword_lookup_cs` | lean driver render | no |
+| `stdlib/compiler/lexer/scanner.sio` | stdlib copy | no |
+| `self-hosted/bootstrap/bootstrap_v0.sio` | seed-era mirror | **no — seed** |
+| `bootstrap/bootstrap_stage1.sio` | older bootstrap | no |
+
+Provenance parser loops (Derived / Computed / Measured):
+
+| Path | Loops | Changed? |
+|---|---|---|
+| `self-hosted/parser/types.sio` | 2 (angle ~1107, bracket ~1378) | **yes, both** |
+| `self-hosted/bootstrap/bootstrap_v0.sio` | 2 | no |
+| `bootstrap/bootstrap_stage1.sio` | 2 | no |
+
+`self-hosted/compiler/lean_single.sio` has **no** `TokenKind::Measured` and **no** `keyword_lookup`. Knowledge annotation tags are any identifier (`TK == 3`): “Accept ignorable provenance/evidence tags like Derived.” The seed does not store `PROVENANCE_KIND_*` from those tags.
+
+## Does lean_single need the same edit?
+
+**No, not to compile the program.** Baseline on prebuilt engines, Slurm `cpuops-t560-proxmox`, `workspace_visible=no`, SHA `6ce6e4dafd`:
+
+| Engine | program | check rc |
+|---|---|---:|
+| **madaros** | `Knowledge[f64, Input]` | 0 (Ident; bracket else-arm skips it) |
+| **madaros** | `Knowledge<f64, Input>` | **1** parse error `expected=147 actual=175` (`>` eaten as `CmpGt`) |
+| **madaros** | `Knowledge[f64, Measured]` | 0 |
+| **madaros** | `let input = 7` | 0 |
+| **lean_single** | all four | 0 |
+
+lean_single already accepts `Input` as an ignorable Ident. Adding the keyword only to Madaros does **not** create a program that compiles on one engine and fails on the other. The angle form currently **diverges the other way** (Madaros refuses, lean_single accepts). The keyword closes that gap.
+
+The seed is not edited. That is a founder decision; this lane does not take it.
+
+## What landed (Madaros)
+
+1. `TokenKind::Input` next to `Measured` in `self-hosted/lexer/token.sio`, plus `tk_is_keyword`.
+2. `keyword_lookup` length-5 PascalCase `"Input"` in `self-hosted/lexer/tables.sio`.
+3. **Live peek:** `"Input"` in `pt_read_kind` length-5 in `self-hosted/parser/parser.sio` (same reconstructive table that already had `Measured` at length 8). Two source-built Madaros rebuilds that only patched the lexer still failed `Knowledge<f64, Input>` with `expected=Gt actual=RParen` — `parser_peek` never read the stored kind.
+4. Parser arms in **both** Knowledge component loops in `self-hosted/parser/types.sio` → `AstProvInput`.
+5. `print_token_kind` arms in `self-hosted/main.sio` and `self-hosted/main_bootstrap.sio` (those matches have no wildcard).
+6. Tests: `tests/run-pass/knowledge_provenance_input.sio`, `knowledge_provenance_measured.sio`, `knowledge_input_lowercase_ident.sio`.
+
+Not in this change: `Source`, `Literature`, the absent-versus-`derived` collision, the silent `else` skip, `bootstrap_v0.sio`, `lean_single.sio`.
+
+`TypeEntry` still does not persist provenance (`check/epistemic.sio`: “TypeEntry does not yet persist full validity/provenance metadata.”). `provenance_from_ast` maps `AstProvInput` → `PROVENANCE_KIND_INPUT` (5). The user-visible proof that the token exists is that `Knowledge<f64, Input>` parses: before the keyword that form failed on Madaros because `Input` was `Ident` and `>` was read as `CmpGt`.
+
+## Verification
+
+Edited modules `souc check` under **prebuilt** Madaros v0.80.0: `token.sio` rc=0, `tables.sio` rc=0, `types.sio` rc=0, `parser.sio` rc=0.
+
+Patched-compiler cells — Slurm job on `gpuorangefs-multi-r740-proxmox`, 32 CPUs, `workspace_visible=no`, source-built Madaros (`scripts/ci/build_modular_madaros.sh`, build_rc=0, elapsed=549s, ELF 100564677 bytes). lean_single remains the committed seed ELF.
+
+| Engine | program | check rc | run rc | stdout |
+|---|---|---:|---:|---|
+| **madaros** (source-built) | `knowledge_provenance_input` | 0 | 0 | `INPUT_KEYWORD_OK` |
+| **madaros** (source-built) | `knowledge_provenance_measured` | 0 | 0 | `MEASURED_KEYWORD_OK` |
+| **madaros** (source-built) | `knowledge_input_lowercase_ident` | 0 | 7 | (return `7`; intended) |
+| **lean_single** (seed ELF) | `knowledge_provenance_input` | 0 | 0 | `INPUT_KEYWORD_OK` |
+| **lean_single** (seed ELF) | `knowledge_provenance_measured` | 0 | 0 | `MEASURED_KEYWORD_OK` |
+| **lean_single** (seed ELF) | `knowledge_input_lowercase_ident` | 0 | 7 | (return `7`; intended) |
+
+Two earlier source-built rebuilds that patched only the lexer/`keyword_lookup` path still failed `Knowledge<f64, Input>` (`expected=Gt actual=RParen`). The third rebuild, after `pt_read_kind` gained `"Input"`, is the green matrix above.
+
+## What this file is not
+
+- Not a seed / `lean_single` change.
+- Not E220 for unknown components.
+- Not a claim that TypeEntry now stores provenance kind.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -198,6 +198,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.hypercomplex-651-rootcause-2026-07-14 | repo_only | docs/audit/HYPERCOMPLEX_651_ROOTCAUSE_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.hypercomplex-algebra-audit-2026-07-14 | repo_only | docs/audit/HYPERCOMPLEX_ALGEBRA_AUDIT_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.imported-native-139-residual-census-2026-08-18 | repo_only | docs/audit/IMPORTED_NATIVE_139_RESIDUAL_CENSUS_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.input-keyword-2026-08-19 | repo_only | docs/audit/INPUT_KEYWORD_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kaxi-ptx-golden-drop-not-mismatch-2026-08-19 | repo_only | docs/audit/KAXI_PTX_GOLDEN_DROP_NOT_MISMATCH_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kaxi-ptx-target-sm-audit-2026-06-17 | repo_only | docs/audit/KAXI_PTX_TARGET_SM_AUDIT_2026-06-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kconf-bitcast-apply-package-2026-08-18 | repo_only | docs/audit/KCONF_BITCAST_APPLY_PACKAGE_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -4018,6 +4018,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.input-keyword-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/INPUT_KEYWORD_2026-08-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.kaxi-ptx-golden-drop-not-mismatch-2026-08-19",
       "collection": "repo",
       "repo_doc_path": "docs/audit/KAXI_PTX_GOLDEN_DROP_NOT_MISMATCH_2026-08-19.md",

--- a/self-hosted/lexer/mod.sio
+++ b/self-hosted/lexer/mod.sio
@@ -615,7 +615,7 @@ pub fn lex_source_to_globals(source_len: i64) -> i64 with Mut, Div, Panic {
                 pos = pos + 1
                 col = col + 1
             }
-            parser_set_token_flat(tc, keyword_lookup_code(text, text_idx), start, pos, line, start_col, 0)
+            parser_set_token_scalar(tc, keyword_lookup(text, text_idx), start, pos, line, start_col)
             tc = tc + 1
             continue
         }

--- a/self-hosted/lexer/tables.sio
+++ b/self-hosted/lexer/tables.sio
@@ -88,6 +88,7 @@ pub fn keyword_lookup(text: [i8; 256], len: i64) -> TokenKind with Panic {
         if text[0] == 115 as i8 && text[1] == 99 as i8 && text[2] == 111 as i8 && text[3] == 112 as i8 && text[4] == 101 as i8 { return TokenKind::Scope }     // "scope"
         if text[0] == 99 as i8 && text[1] == 108 as i8 && text[2] == 111 as i8 && text[3] == 115 as i8 && text[4] == 101 as i8 { return TokenKind::Close }     // "close"
         if text[0] == 115 as i8 && text[1] == 116 as i8 && text[2] == 117 as i8 && text[3] == 100 as i8 && text[4] == 121 as i8 { return TokenKind::Study }     // "study"
+        if text[0] == 73 as i8 && text[1] == 110 as i8 && text[2] == 112 as i8 && text[3] == 117 as i8 && text[4] == 116 as i8 { return TokenKind::Input }     // "Input"
     }
 
     // Length 6: struct, return, effect, handle, linear, affine, kernel, resume, unsafe, extern, static, module, import, export, sample, belief, models

--- a/self-hosted/lexer/token.sio
+++ b/self-hosted/lexer/token.sio
@@ -151,6 +151,7 @@ pub enum TokenKind {
     Derived,
     Computed,
     Measured,
+    Input,
     Super,
     Crate,
 
@@ -458,6 +459,7 @@ pub fn tk_is_keyword(kind: TokenKind) -> bool {
         TokenKind::Derived => true,
         TokenKind::Computed => true,
         TokenKind::Measured => true,
+        TokenKind::Input => true,
         TokenKind::Super => true,
         TokenKind::Crate => true,
         TokenKind::Model => true,

--- a/self-hosted/main.sio
+++ b/self-hosted/main.sio
@@ -91,6 +91,7 @@ fn print_token_kind(kind: TokenKind) with IO {
         TokenKind::Derived => print("Derived")
         TokenKind::Computed => print("Computed")
         TokenKind::Measured => print("Measured")
+        TokenKind::Input => print("Input")
         TokenKind::Super => print("Super")
         TokenKind::Crate => print("Crate")
         TokenKind::Ident => print("Ident")

--- a/self-hosted/main_bootstrap.sio
+++ b/self-hosted/main_bootstrap.sio
@@ -90,6 +90,7 @@ fn print_token_kind(kind: TokenKind) with IO {
         TokenKind::Derived => print("Derived")
         TokenKind::Computed => print("Computed")
         TokenKind::Measured => print("Measured")
+        TokenKind::Input => print("Input")
         TokenKind::Super => print("Super")
         TokenKind::Crate => print("Crate")
         TokenKind::Ident => print("Ident")

--- a/self-hosted/parser/parser.sio
+++ b/self-hosted/parser/parser.sio
@@ -717,6 +717,7 @@ pub fn pt_read_kind(idx: i64) -> TokenKind with Mut, Panic, Div {
             let d = CURSOR_SOURCE[(start + 3) as usize]
             let e = CURSOR_SOURCE[(start + 4) as usize]
             if a == (86 as i8) && b == (97 as i8) && c == (108 as i8) && d == (105 as i8) && e == (100 as i8) { return TokenKind::Valid }
+            if a == (73 as i8) && b == (110 as i8) && c == (112 as i8) && d == (117 as i8) && e == (116 as i8) { return TokenKind::Input }
             if a == (77 as i8) && b == (111 as i8) && c == (100 as i8) && d == (101 as i8) && e == (108 as i8) { return TokenKind::Model }
             // `crate` and `super`: absent here, so parse_pub_visibility fell
             // past its Crate/Super branches into pub(path) and produced

--- a/self-hosted/parser/types.sio
+++ b/self-hosted/parser/types.sio
@@ -1131,6 +1131,9 @@ impl Parser {
             } else if ck == TokenKind::Measured {
                 p = p.advance()
                 provenance_opt = Some(Box::new(AstProvenanceKind::AstProvMeasured))
+            } else if ck == TokenKind::Input {
+                p = p.advance()
+                provenance_opt = Some(Box::new(AstProvenanceKind::AstProvInput))
             } else {
                 // Unknown component — skip
                 p = p.advance()
@@ -1413,6 +1416,9 @@ impl Parser {
                 } else if component_tok == TokenKind::Measured {
                     p = p.advance()
                     provenance_opt = Some(Box::new(AstProvenanceKind::AstProvMeasured))
+                } else if component_tok == TokenKind::Input {
+                    p = p.advance()
+                    provenance_opt = Some(Box::new(AstProvenanceKind::AstProvInput))
                 } else {
                     p = p.advance()
                 }

--- a/tests/run-pass/knowledge_input_lowercase_ident.sio
+++ b/tests/run-pass/knowledge_input_lowercase_ident.sio
@@ -1,0 +1,7 @@
+//@ run-pass
+// Negative control: lowercase `input` remains an identifier.
+
+fn main() -> i64 {
+    let input = 7
+    input
+}

--- a/tests/run-pass/knowledge_provenance_input.sio
+++ b/tests/run-pass/knowledge_provenance_input.sio
@@ -1,0 +1,16 @@
+//@ run-pass
+// Input is a provenance keyword. Both annotation delimiters must parse.
+// TypeEntry does not persist provenance; the observable is that Input is
+// not treated as Ident (angle form used to fail: `>` eaten as CmpGt).
+
+fn keep_bracket(x: Knowledge[f64, Input]) -> i64 {
+    0
+}
+
+fn keep_angle(x: Knowledge<f64, Input>) -> i64 {
+    0
+}
+
+fn main() with IO {
+    println("INPUT_KEYWORD_OK")
+}

--- a/tests/run-pass/knowledge_provenance_measured.sio
+++ b/tests/run-pass/knowledge_provenance_measured.sio
@@ -1,0 +1,14 @@
+//@ run-pass
+// Positive control: Measured must still parse after Input is added.
+
+fn keep_bracket(x: Knowledge[f64, Measured]) -> i64 {
+    0
+}
+
+fn keep_angle(x: Knowledge<f64, Measured>) -> i64 {
+    0
+}
+
+fn main() with IO {
+    println("MEASURED_KEYWORD_OK")
+}


### PR DESCRIPTION
## Summary

- Founder ruling 2026-08-19 maps `asserted → Input`. `AstProvInput` and `PROVENANCE_KIND_INPUT` already existed; the token and parser arm did not.
- The live peek path is `pt_read_kind` in `self-hosted/parser/parser.sio` (`parser_peek` re-derives the kind from source text). Two source-built Madaros rebuilds that only patched `keyword_lookup` still failed `Knowledge<f64, Input>` (`expected=Gt actual=RParen`) because `>` was eaten as `CmpGt` while `Input` remained `Ident`.
- This change adds `TokenKind::Input`, the length-5 reconstructive arm, both Knowledge component loops → `AstProvInput`, and three run-pass tests (angle+bracket Input, Measured control, lowercase `input` ident). The seed / `lean_single` is not edited: it already accepts `Input` as an ignorable Ident.

Not in this PR: `Source` / `Literature`, the absent-versus-`derived` collision, the silent unknown-component skip.

Receipt: `docs/audit/INPUT_KEYWORD_2026-08-19.md`.

## Test plan

- [x] Slurm `gpuorangefs-multi-r740-proxmox`, 32 CPUs, `workspace_visible=no`, source-built Madaros (`build_rc=0`, 549s, ELF 100564677 bytes)
- [x] madaros `knowledge_provenance_input`: check 0, run 0, `INPUT_KEYWORD_OK`
- [x] madaros `knowledge_provenance_measured`: check 0, run 0, `MEASURED_KEYWORD_OK`
- [x] madaros `knowledge_input_lowercase_ident`: check 0, run 7 (return value)
- [x] lean_single seed ELF: same three cells, same codes
- [ ] Contracts / docs registry on the PR (topic `repo.docs.audit.input-keyword-2026-08-19` synced)