### PR TITLE
feat(check): add binary512 (IEEE 754-2008) descriptor and TyF512

### DIFF
--- a/scripts/ci/madaros_f512_format_identity_gate.sh
+++ b/scripts/ci/madaros_f512_format_identity_gate.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Source-owned identity gate for the f512 (IEEE 754-2008 binary512) format
+# family. Mirrors scripts/ci/madaros_f128_f256_format_identity_gate.sh so the
+# V0-A identity contract is asserted per format; the sibling covers f128/f256.
+#
+# What this gate asserts:
+#   * self-hosted/compiler/f512_format_descriptor_probe.sio compiles under the
+#     bootstrap seed compiler (bin/souc-lean-single-x86_64).
+#   * The probe returns rc=0 and prints the exact `PASS f512_format_descriptor_probe`
+#     receipt — anything else (probe missing the PASS line, or a probe-side
+#     failure encoded as a non-zero rc) is reported FAIL.
+#
+# What this gate does NOT assert (explicitly deferred):
+#   * Source-level use of f512. The parser/checker treat it as a wide-float
+#     reserved keyword today, same shape as f128/f256 in V0-A.
+#   * f512 value semantics, arithmetic, normalisation, or RNE rounding. Those
+#     are owned by the V0-D ladder (docs/architecture/F128_F256_LADDER.md).
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+STRUCTURAL_ONLY=0
+if [[ "${1:-}" == "--structural-only" ]]; then
+  STRUCTURAL_ONLY=1
+elif [[ $# -ne 0 ]]; then
+  echo "usage: $0 [--structural-only]" >&2
+  exit 64
+fi
+
+if [[ "$STRUCTURAL_ONLY" -eq 0 && -z "${SOUNIO_F512_COMPILER:-}" ]]; then
+  echo "BLOCKED manual gate requires SOUNIO_F512_COMPILER=/path/to/source-fresh-madaros-elf" >&2
+  exit 2
+fi
+COMPILER=""
+COMPILER_CLI="$ROOT_DIR/bin/madaros"
+if [[ "$STRUCTURAL_ONLY" -eq 0 ]]; then
+  COMPILER="$(realpath "$SOUNIO_F512_COMPILER")"
+fi
+SEED_COMPILER="$(realpath "${SOUNIO_F512_SEED_COMPILER:-$ROOT_DIR/bin/souc-lean-single-x86_64}")"
+SOURCE_HEAD="$(git rev-parse HEAD)"
+COMPILER_SOURCE_SHA="${SOUNIO_F512_COMPILER_SOURCE_SHA:-}"
+
+for binary in "$SEED_COMPILER" ${COMPILER:+"$COMPILER"}; do
+  if [[ ! -x "$binary" ]]; then
+    echo "FAIL compiler is not executable: $binary" >&2
+    exit 2
+  fi
+  if [[ "$(head -c2 "$binary" 2>/dev/null)" == '#!' ]]; then
+    echo "FAIL gate requires a resolved ELF, not a wrapper: $binary" >&2
+    exit 2
+  fi
+done
+if [[ "$STRUCTURAL_ONLY" -eq 0 && ! -x "$COMPILER_CLI" ]]; then
+  echo "FAIL canonical Madaros CLI is not executable: $binary" >&2
+  exit 2
+fi
+if [[ "$STRUCTURAL_ONLY" -eq 0 && -z "$COMPILER_SOURCE_SHA" ]]; then
+  echo "BLOCKED set SOUNIO_F512_COMPILER_SOURCE_SHA to the source SHA used to build the Madaros ELF" >&2
+  exit 2
+fi
+if [[ "$STRUCTURAL_ONLY" -eq 0 && "$COMPILER_SOURCE_SHA" != "$SOURCE_HEAD" ]]; then
+  echo "FAIL compiler/source pin mismatch: compiler=$COMPILER_SOURCE_SHA source=$SOURCE_HEAD" >&2
+  exit 2
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [[ "$STRUCTURAL_ONLY" -eq 0 ]]; then
+  echo "compiler_elf=$COMPILER"
+  echo "compiler_sha256=$(sha256sum "$COMPILER" | awk '{print $1}')"
+  echo "compiler_source_sha=$COMPILER_SOURCE_SHA"
+  echo "compiler_cli=$COMPILER_CLI"
+fi
+echo "seed_elf=$SEED_COMPILER"
+echo "seed_sha256=$(sha256sum "$SEED_COMPILER" | awk '{print $1}')"
+echo "source_head=$SOURCE_HEAD"
+if [[ "$STRUCTURAL_ONLY" -eq 1 ]]; then
+  echo "gate_mode=structural_only"
+else
+  echo "gate_mode=manual_source_fresh_evidence"
+fi
+
+DESCRIPTOR="self-hosted/compiler/f512_format_descriptor_probe.sio"
+probe_elf="$TMP_DIR/f512-identity-probe.elf"
+probe_build_log="$TMP_DIR/identity-probe-build.log"
+probe_run_log="$TMP_DIR/identity-probe-run.log"
+if ! "$SEED_COMPILER" "$DESCRIPTOR" "$probe_elf" >"$probe_build_log" 2>&1; then
+  echo "FAIL source-owned identity probe did not compile with the bootstrap seed" >&2
+  cat "$probe_build_log" >&2
+  exit 1
+fi
+chmod +x "$probe_elf"
+if ! "$probe_elf" >"$probe_run_log" 2>&1; then
+  echo "FAIL source-owned identity probe returned nonzero" >&2
+  cat "$probe_run_log" >&2
+  exit 1
+fi
+if ! grep -Fxq 'PASS f512_format_descriptor_probe' "$probe_run_log"; then
+  echo "FAIL source-owned identity probe omitted exact PASS receipt" >&2
+  cat "$probe_run_log" >&2
+  exit 1
+fi
+echo "PASS internal identity: TyRawPtr=96 TyF128=97 TyF256=98 TyF512=99 descriptors=exact compatibility=identity-only names=distinct limbs=8"

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -1606,6 +1606,8 @@ fn checker_lower_named_type_mut(c: *mut Checker, path: AstPath) -> TypeEntry wit
         ty_f128()
     } else if name_is_f256(name) {
         ty_f256()
+    } else if name_is_f512(name) {
+        ty_f512()
     } else if name_is_bool(name) {
         ty_bool()
     } else if name_is_string(name) {
@@ -2332,7 +2334,7 @@ fn checker_type_expr_list_contains_reserved_wide_float(
 fn checker_type_expr_contains_reserved_wide_float(te: &TypeExpr) -> bool with Mut, Panic, Div, Alloc {
     if (*te).kind == TypeExprKind::TypeNamed {
         let source_name = checker_copy_string_list_to_name((*te).path.segments)
-        if name_is_f128(source_name) || name_is_f256(source_name) { return true }
+        if name_is_f128(source_name) || name_is_f256(source_name) || name_is_f512(source_name) { return true }
     }
     match (*te).inner {
         Some(inner) => {
@@ -16804,6 +16806,8 @@ impl Checker {
             (self, ty_f128())
         } else if name_is_f256(name) {
             (self, ty_f256())
+        } else if name_is_f512(name) {
+            (self, ty_f512())
         } else if name_is_bool(name) {
             (self, ty_bool())
         } else if name_is_string(name) {

--- a/self-hosted/check/compat.sio
+++ b/self-hosted/check/compat.sio
@@ -861,21 +861,29 @@ pub fn is_float_type(ty: TypeEntry) -> bool {
 // Wide-float identity exists before its value semantics. Keep these types out
 // of is_numeric_type until operations, status, and rounding are implemented.
 pub fn is_wide_float_type(ty: TypeEntry) -> bool {
-    ty.kind == TypeKind::TyF128 || ty.kind == TypeKind::TyF256
+    ty.kind == TypeKind::TyF128 || ty.kind == TypeKind::TyF256 || ty.kind == TypeKind::TyF512
 }
 
 pub fn f128_f256_compatibility_probe_code() -> i64 with Mut, Panic, Div, Alloc {
     let t128 = ty_f128()
     let t256 = ty_f256()
+    let t512 = ty_f512()
     let f64 = ty_f64()
     if !types_compatible(t128, t128) { return 40 }
     if !types_compatible(t256, t256) { return 41 }
+    if !types_compatible(t512, t512) { return 41 -1 }
     if types_compatible(t128, t256) || types_compatible(t256, t128) { return 42 }
+    if types_compatible(t128, t512) || types_compatible(t512, t128) { return 42 -1 }
+    if types_compatible(t256, t512) || types_compatible(t512, t256) { return 42 -2 }
     if types_compatible(t128, f64) || types_compatible(f64, t128) { return 43 }
     if types_compatible(t256, f64) || types_compatible(f64, t256) { return 44 }
+    if types_compatible(t512, f64) || types_compatible(f64, t512) { return 44 -1 }
     if is_numeric_type(t128) || is_numeric_type(t256) { return 45 }
+    if is_numeric_type(t512) { return 45 -1 }
     if is_float_type(t128) || is_float_type(t256) { return 46 }
+    if is_float_type(t512) { return 46 -1 }
     if !is_wide_float_type(t128) || !is_wide_float_type(t256) { return 47 }
+    if !is_wide_float_type(t512) { return 47 -1 }
     0
 }
 
@@ -1440,6 +1448,11 @@ pub fn name_is_f128(n: Name) -> bool with Panic, Div {
 // "f256" = [102, 50, 53, 54]
 pub fn name_is_f256(n: Name) -> bool with Panic, Div {
     name_matches_str4(n, 102, 50, 53, 54)
+}
+
+// "f512" = [102, 53, 49, 50]
+pub fn name_is_f512(n: Name) -> bool with Panic, Div {
+    name_matches_str4(n, 102, 53, 49, 50)
 }
 
 // "bool" = [98, 111, 111, 108]

--- a/self-hosted/check/numeric_format.sio
+++ b/self-hosted/check/numeric_format.sio
@@ -13,6 +13,13 @@ pub struct BinaryFormatDescriptor {
 pub fn numeric_format_binary128_id() -> i64 { 128 }
 pub fn numeric_format_binary256_id() -> i64 { 256 }
 
+// IEEE 754-2008 binary512: storage_bits 512, exponent_bits 23,
+// precision_bits 489, trailing_significand_bits 488. Limb count
+// (storage_bits / 64) is 8 — within the multi-limb pool cap of 8.
+// V0-A owns format identity only; values, operations, status, and
+// rounding are deliberately deferred (see V0-D ladder).
+pub fn numeric_format_binary512_id() -> i64 { 512 }
+
 // Integer wide formats. Distinct from IEEE binary256 (format_id 256):
 // storage_bits / 64 is the limb count (i256 → 4, i512 → 8).
 pub fn numeric_format_int256_id() -> i64 { 1256 }
@@ -48,6 +55,16 @@ pub fn binary_format_binary256_descriptor() -> BinaryFormatDescriptor {
     }
 }
 
+pub fn binary_format_binary512_descriptor() -> BinaryFormatDescriptor {
+    BinaryFormatDescriptor {
+        format_id: numeric_format_binary512_id(),
+        storage_bits: 512,
+        exponent_bits: 23,
+        precision_bits: 489,
+        trailing_significand_bits: 488,
+    }
+}
+
 pub fn binary_format_int256_descriptor() -> BinaryFormatDescriptor {
     BinaryFormatDescriptor {
         format_id: numeric_format_int256_id(),
@@ -74,6 +91,9 @@ pub fn binary_format_descriptor_for_id(format_id: i64) -> BinaryFormatDescriptor
     }
     if format_id == numeric_format_binary256_id() {
         return binary_format_binary256_descriptor()
+    }
+    if format_id == numeric_format_binary512_id() {
+        return binary_format_binary512_descriptor()
     }
     if format_id == numeric_format_int256_id() {
         return binary_format_int256_descriptor()

--- a/self-hosted/check/types.sio
+++ b/self-hosted/check/types.sio
@@ -130,6 +130,10 @@ pub enum TypeKind {
     // V0-A owns format identity only; values and operations remain fail-closed.
     TyF128,
     TyF256,
+    // IEEE 754-2008 binary512 (8 limbs). Appended after TyF256 so existing
+    // discriminants 97 and 98 are preserved; TyF512 takes the next slot (99).
+    // Value semantics deferred to V0-D ladder (see docs/architecture/F128_F256_LADDER.md).
+    TyF512,
 }
 
 // ============================================================
@@ -167,12 +171,16 @@ pub fn binary_format_for_type(ty: TypeEntry) -> BinaryFormatDescriptor {
     if ty.kind == TypeKind::TyF256 {
         return binary_format_binary256_descriptor()
     }
+    if ty.kind == TypeKind::TyF512 {
+        return binary_format_binary512_descriptor()
+    }
     invalid_binary_format_descriptor()
 }
 
 pub fn wide_float_format_identity_compatible(a: TypeEntry, b: TypeEntry) -> bool {
     (a.kind == TypeKind::TyF128 && b.kind == TypeKind::TyF128)
         || (a.kind == TypeKind::TyF256 && b.kind == TypeKind::TyF256)
+        || (a.kind == TypeKind::TyF512 && b.kind == TypeKind::TyF512)
 }
 
 pub fn wide_float_format_identity_name(ty: TypeEntry) -> Name {
@@ -194,25 +202,51 @@ pub fn wide_float_format_identity_name(ty: TypeEntry) -> Name {
         n256.len = 4
         return n256
     }
+    if ty.kind == TypeKind::TyF512 {
+        var n512 = empty_name()
+        n512.buf[0] = 102 as i8
+        n512.buf[1] = 53 as i8
+        n512.buf[2] = 49 as i8
+        n512.buf[3] = 50 as i8
+        n512.len = 4
+        return n512
+    }
     empty_name()
 }
 
 // Executable ownership probe. Keeping this inside check::types lets it inspect
 // private enum discriminants without widening the compiler's historical API.
+//
+// Discriminant contract asserted here:
+//   TyRawPtr == 96
+//   TyF128   == 97
+//   TyF256   == 98
+//   TyF512   == 99   (appended after TyF256 — existing slots preserved)
+//
+// Rename note: the function is still called `f128_f256_internal_identity_probe_code`
+// for source-history continuity; the body now also exercises TyF512.
 pub fn f128_f256_internal_identity_probe_code() -> i64 with Mut, Panic, Div {
     let t128 = ty_f128()
     let t256 = ty_f256()
+    let t512 = ty_f512()
     let f64 = ty_f64()
     if (TypeKind::TyRawPtr as i64) != 96 { return 20 }
     if (t128.kind as i64) != 97 { return 21 }
     if (t256.kind as i64) != 98 { return 22 }
+    if (t512.kind as i64) != 99 { return 22 -1 }
     if binary_format_for_type(t128).format_id != numeric_format_binary128_id() { return 23 }
     if binary_format_for_type(t256).format_id != numeric_format_binary256_id() { return 24 }
+    if binary_format_for_type(t512).format_id != numeric_format_binary512_id() { return 24 -1 }
     if binary_format_for_type(f64).format_id != 0 { return 25 }
     if !wide_float_format_identity_compatible(t128, t128) { return 26 }
     if !wide_float_format_identity_compatible(t256, t256) { return 27 }
+    if !wide_float_format_identity_compatible(t512, t512) { return 27 -1 }
     if wide_float_format_identity_compatible(t128, t256) { return 28 }
     if wide_float_format_identity_compatible(t256, t128) { return 29 }
+    if wide_float_format_identity_compatible(t128, t512) { return 29 -1 }
+    if wide_float_format_identity_compatible(t512, t128) { return 29 -2 }
+    if wide_float_format_identity_compatible(t256, t512) { return 29 -3 }
+    if wide_float_format_identity_compatible(t512, t256) { return 29 -4 }
     if wide_float_format_identity_compatible(t128, f64) { return 30 }
     if wide_float_format_identity_compatible(f64, t128) { return 31 }
     if wide_float_format_identity_compatible(t256, f64) { return 32 }
@@ -514,6 +548,27 @@ pub fn ty_f128() -> TypeEntry {
 pub fn ty_f256() -> TypeEntry {
     TypeEntry {
         kind: TypeKind::TyF256,
+        name: Name { buf: [0; 128], len: 0 },
+        inner: None,
+        array_size: -1,
+        fn_sig_id: -1,
+        tuple_elems: None,
+        knowledge_epsilon: -1.0,
+        algebra_kind: -1,
+        clifford_p: -1,
+        clifford_q: -1,
+        unit_id: -1,
+        refinement_id: -1,
+        epistemic_meta_id: -1,
+        robustness_level_id: -1,
+        robustness_scope_id: -1,
+        ontology_id: -1,
+    }
+}
+
+pub fn ty_f512() -> TypeEntry {
+    TypeEntry {
+        kind: TypeKind::TyF512,
         name: Name { buf: [0; 128], len: 0 },
         inner: None,
         array_size: -1,

--- a/self-hosted/compiler/f512_format_descriptor_probe.sio
+++ b/self-hosted/compiler/f512_format_descriptor_probe.sio
@@ -1,0 +1,95 @@
+// Source-owned executable identity probe for the f512 (IEEE 754-2008 binary512)
+// format family. Mirrors f128_f256_format_descriptor_probe.sio so the V0-A
+// identity contract is asserted per format; the sibling covers f128/f256.
+//
+// What this probe asserts:
+//   1. The numeric_format::BinaryFormatDescriptor for binary512 is exact
+//      (format_id 512, storage_bits 512, exponent_bits 23, precision_bits 489,
+//       trailing_significand_bits 488).
+//   2. The TypeKind discriminant for TyF512 is 99 — appended after TyF128 (97)
+//      and TyF256 (98) without disturbing either existing slot.
+//   3. binary_format_for_type(ty_f512()) returns the binary512 descriptor.
+//   4. wide_float_format_identity_compatible is identity-only for f512:
+//      t512==t512 (true), t512 vs t128/t256/f64 (all false, both directions).
+//   5. is_wide_float_type(ty_f512()) is true.
+//   6. name_is_f512 accepts the literal "f512" and rejects the sibling
+//      names "f128"/"f256".
+//   7. ir_wide_numeric_required_limb_count(format_id 512) returns 8
+//      (storage_bits / 64) — within the multi-limb pool's per-payload cap.
+//   8. The existing f128/f256 invariants still hold (probe re-asserts them
+//      so adding f512 cannot silently regress them).
+//
+// What this probe does NOT assert:
+//   * Value semantics, operations, status, or rounding for f512. Those are
+//     explicitly deferred to the V0-D ladder (see docs/architecture/F128_F256_LADDER.md).
+//   * Source-level use of f512. The parser/checker treat it as a wide-float
+//     reserved keyword today, same shape as f128/f256 in V0-A.
+
+use check::numeric_format::*
+use check::types::*
+use check::compat::*
+use ir::numeric_payload::{ir_wide_numeric_required_limb_count}
+
+fn main() -> i32 with IO, Mut, Panic, Div, Alloc {
+    // (1) descriptor exact — IEEE 754-2008 binary512, derived not invented.
+    let d512 = binary_format_binary512_descriptor()
+    if d512.format_id != numeric_format_binary512_id() { return 30 }
+    if d512.storage_bits != 512 { return 31 }
+    if d512.exponent_bits != 23 { return 32 }
+    if d512.precision_bits != 489 { return 33 }
+    if d512.trailing_significand_bits != 488 { return 34 }
+
+    // (2) discriminant contract — TyF512 must be 99 (after TyF128=97, TyF256=98).
+    let t512 = ty_f512()
+    if (TypeKind::TyRawPtr as i64) != 96 { return 35 }
+    if (TypeKind::TyF128   as i64) != 97 { return 36 }
+    if (TypeKind::TyF256   as i64) != 98 { return 37 }
+    if (t512.kind as i64) != 99 { return 38 }
+
+    // (3) type → descriptor routing.
+    if binary_format_for_type(t512).format_id != numeric_format_binary512_id() { return 39 }
+    if binary_format_for_type(t512).storage_bits != 512 { return 40 }
+
+    // (4) compatibility is identity-only.
+    if !wide_float_format_identity_compatible(t512, t512) { return 41 }
+    let t128 = ty_f128()
+    let t256 = ty_f256()
+    let f64 = ty_f64()
+    if wide_float_format_identity_compatible(t512, t128) { return 42 }
+    if wide_float_format_identity_compatible(t128, t512) { return 43 }
+    if wide_float_format_identity_compatible(t512, t256) { return 44 }
+    if wide_float_format_identity_compatible(t256, t512) { return 45 }
+    if wide_float_format_identity_compatible(t512, f64)  { return 46 }
+    if wide_float_format_identity_compatible(f64, t512)  { return 47 }
+
+    // (5) wide-float membership.
+    if !is_wide_float_type(t512) { return 48 }
+
+    // (6) name recognition — accept "f512", reject the siblings.
+    let n512 = wide_float_format_identity_name(t512)
+    if n512.len != 4 { return 49 }
+    if (n512.buf[0] as i64) != 102 { return 50 }   // 'f'
+    if (n512.buf[1] as i64) != 53  { return 51 }   // '5'
+    if (n512.buf[2] as i64) != 49  { return 52 }   // '1'
+    if (n512.buf[3] as i64) != 50  { return 53 }   // '2'
+    if !name_is_f512(n512) { return 54 }
+    let n128 = wide_float_format_identity_name(t128)
+    if name_is_f512(n128) { return 55 }
+    let n256 = wide_float_format_identity_name(t256)
+    if name_is_f512(n256) { return 56 }
+
+    // (7) multi-limb pool reports 8 limbs for f512 (storage_bits / 64).
+    // Pool cap is 8 limbs per payload (IR_WIDE_NUMERIC_MAX_LIMBS_PER_PAYLOAD),
+    // so f512 is at the cap — confirmed below.
+    let required = ir_wide_numeric_required_limb_count(numeric_format_binary512_id())
+    if required != 8 { return 57 }
+
+    // (8) the sibling identity probe still passes after adding f512.
+    let identity_probe = f128_f256_internal_identity_probe_code()
+    if identity_probe != 0 { return identity_probe }
+    let compatibility_probe = f128_f256_compatibility_probe_code()
+    if compatibility_probe != 0 { return compatibility_probe }
+
+    println("PASS f512_format_descriptor_probe")
+    0
+}


### PR DESCRIPTION
## R8 Phase A — binary512 V0-A identity contract

Adds the **V0-A identity contract** for the IEEE 754-2008 `binary512`
format family (storage_bits=512, exponent_bits=23, precision_bits=489,
trailing_significand_bits=488) on top of the multi-limb pool from
PR #2054, without touching `i256/i512` integer arithmetic or the
existing `f128/f256` V0-A contract.

This is **Phase A only** of the R8 dispatch. Per the dispatch:
> "A homemade implementation **will** get rounding wrong over 489
> bits, and a wide FP that lies on the last bit is worse than not
> existing."

Phase A asserts the **identity half** of the ladder (mirroring the
existing `f128/f256` V0-A pattern) and explicitly defers value
semantics, operations, status, normalisation, and RNE rounding to
the V0-D ladder.

---

## What this PR asserts

* **`numeric_format::binary512` descriptor is exact**
  (`format_id=512, storage_bits=512, exponent_bits=23,
  precision_bits=489, trailing_significand_bits=488`). Derived from
  IEEE 754-2008 §3.5.2, not invented.
* **`TypeKind::TyF512 == 99`** — appended after `TyRawPtr=96`,
  `TyF128=97`, `TyF256=98`. Existing discriminants preserved.
* **`binary_format_for_type(ty_f512())` returns the binary512
  descriptor**.
* **`wide_float_format_identity_compatible` is identity-only for
  f512**: `t512==t512` is `true`; `t512` vs `t128`, `t256`, `f64`
  is `false` in both directions.
* **`is_wide_float_type(ty_f512())` is `true`**.
* **`name_is_f512` accepts the literal `"f512"` and rejects the
  sibling names `"f128"` / `"f256"`**.
* **`ir_wide_numeric_required_limb_count(512) == 8`** — within the
  multi-limb pool's per-payload cap
  (`IR_WIDE_NUMERIC_MAX_LIMBS_PER_PAYLOAD = 8`). binary512 sits
  exactly at the cap.
* **Sibling `f128/f256` invariants still hold** — the new probe
  re-asserts them, so this PR cannot silently regress
  `TyRawPtr=96 / TyF128=97 / TyF256=98` or the
  `t128==t128 / t256==t256 / t128 vs t256 / t128 vs f64` identity
  contract.

---

## What this PR deliberately does NOT do (V0-D deferred)

* **Value semantics, operations, status, normalisation, or RNE
  rounding for `f512`.** These are owned by the V0-D ladder
  (`docs/architecture/F128_F256_LADDER.md`) and require a
  width-generic vector generator, IR opcode, lowering path, and
  codegen distinct from the integer `wide_bits` pipeline. The
  multi-limb pool from PR #2054 holds **compile-time immediates**,
  not runtime representation.
* **Source-level use of `f512`.** The parser/checker treat it as a
  wide-float reserved keyword today, same shape as `f128/f256` in
  V0-A.

Closing these gaps is the work of Phase B (generator refactor),
Phase C (IR opcode + lowering), Phase D (codegen with sabotage
hooks), Phase E (normalisation + RNE rounding), and Phase G (f512
EReg run-pass — coordinated with grok-cli5). They are scoped
follow-ups, not part of this PR.

---

## Files changed (6 files, +295 / -2)

```
 scripts/ci/madaros_f512_format_identity_gate.sh    | 106 +++++++++++++++++++++
 self-hosted/check/check.sio                        |   6 +-
 self-hosted/check/compat.sio                       |  15 ++-
 self-hosted/check/numeric_format.sio               |  20 ++++
 self-hosted/check/types.sio                        |  55 +++++++++++
 self-hosted/compiler/f512_format_descriptor_probe.sio | 95 ++++++++++++++++++
```

* `self-hosted/check/numeric_format.sio` — `numeric_format_binary512_id`,
  `binary_format_binary512_descriptor`, descriptor routing
* `self-hosted/check/types.sio` — `TyF512`, `ty_f512()`,
  `binary_format_for_type`, `wide_float_format_identity_*`,
  identity-probe assertions
* `self-hosted/check/compat.sio` — `name_is_f512`,
  `is_wide_float_type`, compatibility-probe assertions
* `self-hosted/check/check.sio` — three reservation sites for the
  `f512` keyword in the checker
* `self-hosted/compiler/f512_format_descriptor_probe.sio` (new) —
  source-owned executable probe, 8 assertion groups
* `scripts/ci/madaros_f512_format_identity_gate.sh` (new,
  executable) — source-owned identity gate mirroring the
  `madaros_f128_f256_format_identity_gate.sh` pattern, accepts
  `--structural-only` for pre-merge CI

---

## Verification

```
$ bash scripts/ci/madaros_f512_format_identity_gate.sh --structural-only
seed_elf=/workspace/.wt/minimax-cli1/bin/souc-lean-single-x86_64
seed_sha256=337d5a86f44ef9320a0485f181283df7d0662b944fe83ada3e536ca45ce48db7
source_head=139a3b74129ef6cccacb285b7cb042eeab27d4cf
gate_mode=structural_only
PASS internal identity: TyRawPtr=96 TyF128=97 TyF256=98 TyF512=99 descriptors=exact compatibility=identity-only names=distinct limbs=8
exit=0
```

Sibling gate:

```
$ bash scripts/ci/madaros_f128_f256_format_identity_gate.sh --structural-only
...
PASS internal identity: TyRawPtr=96 TyF128=97 TyF256=98 descriptors=exact compatibility=identity-only names=distinct
exit=0
```

The `f128_f256_internal_identity_probe_code()` block inside the new
`f512_format_descriptor_probe.sio` re-asserts the sibling
invariants end-to-end (descriminants 96/97/98, identity-only
compatibility, name distinctness). A change that broke
`f128/f256` would fail this PR's own probe, not just the sibling
gate.

---

## Open follow-ups (Phase B–H, not part of this PR)

* **Phase B** — width-generic refactor of `mpfr_vector_gen.c`,
  `literal_boundary_gen.c`, `wire_encoding_gen.c`,
  `arith_hard_gen.c` (preserve f128/f256 byte-identical sha256) +
  new `tests/vectors/f512/{f512.jsonl, literal_boundary_f512.jsonl}`
  + run-twice-diff for f128/f256 hashes
* **Phase C** — `IrWideFloatAdd/Sub/Mul/Div/Cmp` IR opcode +
  lowering distinct from `wide_bits` (integer-only)
* **Phase D** — `nc_wide_float_*_into` codegen with
  `SOUNIO_F512_<op>_SABOTAGE` env hooks
* **Phase E** — normalisation + RNE rounding, the part where
  "toda implementação caseira erra"
* **Phase F** — sibling gate `madaros_f512_ladder_gate.sh` with
  v0b/v0c/v0d/format_identity stages
* **Phase G** — `tests/run-pass/r8_f512_ereg.sio` showing f512
  carrying `err` and `origin` end-to-end — **requires coordination
  with grok-cli5 on the `EReg` struct shape and the `origin`
  discipline before writing**

Decision belongs to the founder.