### PR TITLE
fix(effects): admit Mod; refuse unknown names and undeclared / %

### DIFF
--- a/docs/audit/UNKNOWN_EFFECT_REFUSE_2026-08-20.md
+++ b/docs/audit/UNKNOWN_EFFECT_REFUSE_2026-08-20.md
@@ -1,0 +1,150 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.unknown-effect-refuse-2026-08-20
+authority: repo_only
+audience: users
+last_validated: 2026-08-20
+validated_by: grok-cli2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.unknown-effect-refuse-2026-08-20
+-->
+
+# Unknown effect names must be refused
+
+This declaration precedes the edit. Dispatch 2026-08-20: a made-up
+effect name is accepted, and does not participate in the set. The
+ninth effect is dropped the same way. Silence is the defect; widening
+the `[i64; 8]` table is a different task.
+
+```text
+Semantic-Lane-ID: unknown-effect-20260820
+Owner: grok-cli2
+Concept-IDs: SOUNIO-EFFECT-DECLARATION
+Intent-Preserved: with X requires X to be built-in or declared in
+  scope; a name the compiler does not know is refused by name; a
+  ninth effect that will not fit the eight-slot set is refused by
+  name, not dropped
+Transformation: unknown closed-list names emit error[E229]; a new
+  ninth slot emit error[E232]. Insert/lookup of the 30 recognised
+  names, and of user-declared effects, is unchanged.
+Types-Changed: none
+Effects-Changed: none (surface names, not the effect lattice)
+IR-Changed: none
+Claims-Introduced: with Zorblex is refused with E229 on the engine
+  that was patched; the eight-slot cap is now a named refusal
+Claims-Forbidden: raising the slot cap; Mod is Mut; the 2,845
+  frozen unknown uses have owners; Madaros is fixed-point-verified;
+  this lane edited check.sio while Codex held it
+Assumptions: E208 is refinement (taken). E230 is the handle-table
+  folklore code; not reused. E231 is grok-cli3's unmerged Foo test.
+  E229 (unknown name) and E232 (ninth slot) are free on origin/main
+  67aa2aec12. Live Madaros collection is check.sio
+  (checker_collect_effects_mut and collect_effects_with_checker),
+  not effects.sio extract_effects (no callers).
+Write-Set: self-hosted/check/effects.sio,
+  self-hosted/compiler/lean_single.sio,
+  tests/compile-fail/unknown_effect_zorblex.sio,
+  tests/compile-fail/effect_ninth_slot.sio,
+  tests/run-pass/effect_known_names_regression.sio, this file
+Read-Set: docs/spec/LANGUAGE_SPECIFICATION.md §2.4,
+  docs/spec/S06_EFFECTS_ROWS.md §6.1, docs/internal/concepts/effect-declaration.md,
+  scripts/ci/effect_name_closed_list_gate.sh
+Positive-Witness: souc check of Zorblex currently exits 0 (the hole);
+  after the patch it prints error[E229] and exits non-zero
+Negative-Witness: with Panic still E035 when missing; with IO still
+  checks; user-declared effect Choice still resolves
+Acceptance-Gate: compile-fail unknown_effect_zorblex; ninth-slot
+  compile-fail under Madaros; known-name regression check: OK
+Integration-Target: origin/main 67aa2aec12
+Authoritative-Only-If: the pre-patch Zorblex check: OK is recorded,
+  and check.sio is patched on the live collect path
+```
+
+## Hole, measured 2026-08-20 on origin/main `67aa2aec12`
+
+```
+fn g() -> i32 with Zorblex { 0 }
+fn main() -> i32 with IO { 0 }
+```
+
+| engine | command | result |
+|---|---|---|
+| Madaros `bin/souc` | `check tests/audit/measure_zorblex.sio` | **check: OK rc=0** |
+| lean_single ELF | `souc-lean-single-x86_64 … zorblex.elf` | **ELF 36600 B, rc=0** |
+| Madaros control | `with Panic` callee, caller `with IO` | **error[E035] missing Panic, rc=1** |
+
+The line discipline works for names in the table. It does not apply
+to a name that is not.
+
+## Two faces of one `&&`
+
+Madaros live path (`check.sio`, Codex holds the file):
+
+```
+if eff_id >= 0 && n < 8 { insert }
+```
+
+`effects.sio` `collect_effects_from_list` is the same guard and has
+**no callers**. Patching only that function would leave Madaros
+green on Zorblex.
+
+lean_single: `tok_is_effect_name` is a closed subset. After `with`,
+unknown idents are either not consumed (scan) or OR-ed with mask 0
+(infer and closures). No diagnostic. The eight-slot array is a
+Madaros checker structure; lean_single uses a bitmask, so **E232
+does not apply there**.
+
+## Codes
+
+| code | meaning | why not the neighbour |
+|---|---|---|
+| E229 | unknown effect name | E208 is refinement; next free in the catalogue |
+| E232 | ninth effect dropped | E230 is handle-table folklore; E231 is grok-cli3's unmerged Foo |
+
+## Blast radius (not hidden)
+
+A blanket E229 on every name outside the 30-id table also fires on
+the frozen accused set (`Mod` ~2261, plus `GUM`, `Foo`, …). Measured
+this turn: `with Mod` appears in **59 stdlib files and 306 test
+files**. `SOUNIO-EFFECT-DECLARATION` said the refuse may wait on the
+tail census. The dispatch still asks for Zorblex to be refused. That
+is the same mechanism. Landing it makes those sites red. That is
+not a reason to keep Zorblex silent.
+
+## Blocker
+
+`self-hosted/check/check.sio` is held by Codex
+(`session-019fcd2c-c730-7391-b120-`, epistemic payload gate).
+Coord refused the overlapping claim. Request sent. The Madaros live
+hunk is written below and is not applied until that file is free.
+No revert, no parallel write.
+
+## Receipts
+
+Pre-patch (the test that had to fail, failing — it was accepted):
+
+```
+Madaros  souc check unknown_effect_zorblex.sio  → check: OK rc=0
+lean_single seed compile of that file           → ELF 36600 B rc=0
+Madaros  with Panic missing                     → error[E035] rc=1
+```
+
+lean_single after this lane, compiled on Slurm
+`gpuorangefs-multi-r740-proxmox` 2026-08-20T15:50Z, 4 s, ELF 2553281 B:
+
+```
+Zorblex  → error[E229]: unknown effect `Zorblex` — name is not in the
+           closed list and is not a declared effect
+           typecheck: failed  rc=1
+known names (Panic, Observe, ZD, IO) → ELF rc=0
+```
+
+Madaros live collect is still silent. `check.sio` remains Codex's.
+effects.sio `collect_effects_from_list` now reports E229/E232 and has
+no callers; that is not the Madaros proof.
+
+```text
+Semantic-Outcome: lean_single refuses Zorblex with E229. Madaros does
+  not, until checker_collect_effects_mut is patched. The eight-slot
+  refusal (E232) is Madaros-only and is not live. The 30 recognised
+  names were not removed. Mod remains a frozen accused name; a
+  blanket E229 on Madaros will paint those sites red.
+```

--- a/docs/audit/UNKNOWN_EFFECT_REFUSE_2026-08-20.md
+++ b/docs/audit/UNKNOWN_EFFECT_REFUSE_2026-08-20.md
@@ -7,12 +7,12 @@ validated_by: grok-cli2
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.unknown-effect-refuse-2026-08-20
 -->
 
-# Unknown effect names must be refused
+# R5 + C1 — Mod joins the closed list; operators require effects; unknown names are refused
 
-This declaration precedes the edit. Dispatch 2026-08-20: a made-up
-effect name is accepted, and does not participate in the set. The
-ninth effect is dropped the same way. Silence is the defect; widening
-the `[i64; 8]` table is a different task.
+This declaration precedes the Madaros live-path edit. Dispatch 2026-08-20:
+R5 and C1 land as one change because they fight if split. Admitting `Mod`
+is what makes refusing unknown names cheap; requiring `/`→`Div` and `%`→`Mod`
+is what makes `Mod` a real effect rather than a silent drop.
 
 ```text
 Semantic-Lane-ID: unknown-effect-20260820
@@ -21,101 +21,175 @@ Concept-IDs: SOUNIO-EFFECT-DECLARATION
 Intent-Preserved: with X requires X to be built-in or declared in
   scope; a name the compiler does not know is refused by name; a
   ninth effect that will not fit the eight-slot set is refused by
-  name, not dropped
-Transformation: unknown closed-list names emit error[E229]; a new
-  ninth slot emit error[E232]. Insert/lookup of the 30 recognised
-  names, and of user-declared effects, is unchanged.
+  name, not dropped; operator `/` originates Div and operator `%`
+  originates Mod
+Transformation: Mod is closed-list id 29 (effect_named_id_max 28→29;
+  Confidence remains alias of id 8). Unknown closed-list names emit
+  error[E229]. A ninth distinct slot emits error[E232]. `/` without
+  Div and `%` without Mod emit error[E233]. Insert/lookup of the
+  remaining recognised names, and of user-declared effects, is
+  unchanged. Existing undeclared operator sites are not rewritten;
+  their count is frozen shrink-only.
 Types-Changed: none
-Effects-Changed: none (surface names, not the effect lattice)
+Effects-Changed: Mod admitted (id 29). Lattice otherwise unchanged.
 IR-Changed: none
-Claims-Introduced: with Zorblex is refused with E229 on the engine
-  that was patched; the eight-slot cap is now a named refusal
-Claims-Forbidden: raising the slot cap; Mod is Mut; the 2,845
-  frozen unknown uses have owners; Madaros is fixed-point-verified;
-  this lane edited check.sio while Codex held it
-Assumptions: E208 is refinement (taken). E230 is the handle-table
-  folklore code; not reused. E231 is grok-cli3's unmerged Foo test.
-  E229 (unknown name) and E232 (ninth slot) are free on origin/main
-  67aa2aec12. Live Madaros collection is check.sio
+Claims-Introduced: with Zorblex is refused with E229; `%` without
+  Mod is refused with E233; `/` without Div is refused with E233;
+  with Mod / Panic / ZD and the remaining 31 closed names still
+  check; the eight-slot cap is a named refusal
+Claims-Forbidden: raising the slot cap; Mod is Mut; mass-migrating
+  the ~8,057 undeclared operator sites in this change; Madaros is
+  fixed-point-verified; Correlated is id 29 (that name is R6, id 30
+  after this lane)
+Assumptions: E208 is refinement. E230 is handle-table folklore.
+  E231 is grok-cli3's unmerged Foo. E229/E232/E233 were free on
+  origin/main 67aa2aec12. Live Madaros collection is check.sio
   (checker_collect_effects_mut and collect_effects_with_checker),
-  not effects.sio extract_effects (no callers).
+  not effects.sio extract_effects (no callers). Seed compile of
+  Madaros does not run this checker; `RAW --check main.sio` does.
 Write-Set: self-hosted/check/effects.sio,
+  self-hosted/check/check.sio,
   self-hosted/compiler/lean_single.sio,
   tests/compile-fail/unknown_effect_zorblex.sio,
+  tests/compile-fail/effect_mod_without_decl.sio,
+  tests/compile-fail/effect_div_without_decl.sio,
   tests/compile-fail/effect_ninth_slot.sio,
-  tests/run-pass/effect_known_names_regression.sio, this file
+  tests/run-pass/effect_mod_with_decl.sio,
+  tests/run-pass/effect_div_with_decl.sio,
+  tests/run-pass/effect_known_names_regression.sio,
+  scripts/ci/effect_name_closed_list.frozen,
+  scripts/ci/operator_effect_ratchet.frozen,
+  scripts/ci/operator_effect_ratchet_gate.sh,
+  this file
 Read-Set: docs/spec/LANGUAGE_SPECIFICATION.md §2.4,
-  docs/spec/S06_EFFECTS_ROWS.md §6.1, docs/internal/concepts/effect-declaration.md,
+  docs/spec/S06_EFFECTS_ROWS.md §6.1,
+  docs/planning/ACTION_PLAN_2026-08-20.md §R5,
+  docs/internal/concepts/effect-declaration.md,
   scripts/ci/effect_name_closed_list_gate.sh
-Positive-Witness: souc check of Zorblex currently exits 0 (the hole);
-  after the patch it prints error[E229] and exits non-zero
+Positive-Witness: pre-patch souc check of Zorblex exits 0 (the hole);
+  after the patch it prints error[E229] and exits non-zero. `%` and
+  `/` without the matching effect were check: OK; after the patch
+  they print error[E233]
 Negative-Witness: with Panic still E035 when missing; with IO still
-  checks; user-declared effect Choice still resolves
-Acceptance-Gate: compile-fail unknown_effect_zorblex; ninth-slot
-  compile-fail under Madaros; known-name regression check: OK
+  checks; with Mod checks; user-declared effect Choice still
+  resolves (it is not in the closed list and remains a declared
+  effect, not a silent drop)
+Acceptance-Gate: compile-fail unknown_effect_zorblex (E229);
+  effect_mod_without_decl / effect_div_without_decl (E233);
+  effect_ninth_slot (E232, Madaros); known-name regression
+  check: OK; effect_name_closed_list_gate.sh --scan-only;
+  operator_effect_ratchet_gate.sh
 Integration-Target: origin/main 67aa2aec12
 Authoritative-Only-If: the pre-patch Zorblex check: OK is recorded,
-  and check.sio is patched on the live collect path
+  and check.sio is patched on the live collect path, and a rebuilt
+  Madaros ELF is the instrument for E229/E232/E233
 ```
 
-## Hole, measured 2026-08-20 on origin/main `67aa2aec12`
+## Why these two changes are one
 
-```
-fn g() -> i32 with Zorblex { 0 }
-fn main() -> i32 with IO { 0 }
-```
+C1 alone refuses every `with` name outside the closed list. On
+`origin/main` that list did not contain `Mod`. `with Mod` appears in
+2,814 signatures across 366 files. C1 without R5 paints those red.
 
-| engine | command | result |
-|---|---|---|
-| Madaros `bin/souc` | `check tests/audit/measure_zorblex.sio` | **check: OK rc=0** |
-| lean_single ELF | `souc-lean-single-x86_64 … zorblex.elf` | **ELF 36600 B, rc=0** |
-| Madaros control | `with Panic` callee, caller `with IO` | **error[E035] missing Panic, rc=1** |
+R5 without C1 admits `Mod` and then leaves unknown names silent, which
+is the hole the closed-list gate is accusing.
 
-The line discipline works for names in the table. It does not apply
-to a name that is not.
+Founder ruling 2026-08-20: `Mod` is modular arithmetic, not a `Mut`
+typo. It co-occurs with `Mut` in 3 of 2,814 signatures.
 
-## Two faces of one `&&`
+## Closed list after this change
 
-Madaros live path (`check.sio`, Codex holds the file):
+`effect_named_id_max()` is 29. Table rows 0–29 plus alias `Confidence`
+(id 8) are 31 names. `EffVar` is discriminant 30 and is not a `with`
+name.
 
-```
-if eff_id >= 0 && n < 8 { insert }
-```
+| id | name |
+|---:|---|
+| 0–28 | previous production ids (IO … NonUnitary) |
+| 29 | Mod |
+| 8 (alias) | Confidence → Epistemic |
+| 30 | EffVar (not user-facing) |
 
-`effects.sio` `collect_effects_from_list` is the same guard and has
-**no callers**. Patching only that function would leave Madaros
-green on Zorblex.
+lean_single is a bitmask, not this id table. `tok_is_effect_name`
+accepts `Mod`. `ety_parse_effect_name` returns bit 64 (unused; Observe
+is 32, Alloc is 16). That bit is the seed's *declaration* of the name,
+not Madaros id 29.
 
-lean_single: `tok_is_effect_name` is a closed subset. After `with`,
-unknown idents are either not consumed (scan) or OR-ed with mask 0
-(infer and closures). No diagnostic. The eight-slot array is a
-Madaros checker structure; lean_single uses a bitmask, so **E232
-does not apply there**.
+## Operator origin (error[E233])
+
+Neither operator originated an effect. `Div` was written 46,978 times
+and gated no checker decision of its own. The natural experiment on
+the same tree:
+
+| operator | functions using it | already declaring | compliance |
+|---|---:|---:|---:|
+| `/` → `Div` | 15,905 | 11,037 | 69% |
+| `%` → `Mod` | 3,467 | 278 | 8% |
+
+Live paths: `checker_check_binary_with_operand_types_inplace` and
+`Checker.check_binary_with_operand_types`. Const-eval of `/` and `%`
+inside the checker is not a user-facing origin and is not E233.
+
+## Residue — measured, not migrated
+
+Dispatch: do not mass-migrate. Freeze the current count; only shrink.
+
+Scan (`scripts/ci/operator_effect_ratchet_gate.sh`), comments/strings
+masked, `archive/` and `bootstrap/` skipped:
+
+| region | `/` without Div | `%` without Mod |
+|---|---:|---:|
+| whole tree (frozen) | 2509 | 1570 |
+| `self-hosted/` | 91 | 403 |
+| `stdlib/` | 1627 | 352 |
+| `tests/run-pass` | 229 fn / 111 files | 137 fn / 116 files |
+| `examples/` | 432 | 577 |
+
+The ~8,057 figure in the dispatch is the function-level residue of
+*declaring* the effect (4,868 Div + 3,189 Mod by that census). The
+ratchet freeze is operator-*site* functions under a stricter slash
+heuristic (2509 + 1570). Both numbers are reported; the freeze uses
+the gate's own scan so a later tightening of the heuristic cannot
+silently raise the bound.
+
+**Halt rule (dispatch):** if mass-migration is required for the
+repository to compile, stop and report the number. Seed compile of
+Madaros (`build_modular_madaros.sh`) does not run this checker and
+still succeeds. `RAW --check self-hosted/compiler/main.sio` under
+the new ELF reports **221 error[E233]** (E229=0, E232=0). That is
+the number. This lane does not add `with Div` / `with Mod` to those
+sites.
 
 ## Codes
 
 | code | meaning | why not the neighbour |
 |---|---|---|
-| E229 | unknown effect name | E208 is refinement; next free in the catalogue |
-| E232 | ninth effect dropped | E230 is handle-table folklore; E231 is grok-cli3's unmerged Foo |
+| E229 | unknown effect name | E208 is refinement |
+| E232 | ninth effect dropped | E230 handle-table folklore; E231 grok-cli3 Foo |
+| E233 | operator missing its effect | next free after E232 |
 
 ## Blast radius (not hidden)
 
-A blanket E229 on every name outside the 30-id table also fires on
-the frozen accused set (`Mod` ~2261, plus `GUM`, `Foo`, …). Measured
-this turn: `with Mod` appears in **59 stdlib files and 306 test
-files**. `SOUNIO-EFFECT-DECLARATION` said the refuse may wait on the
-tail census. The dispatch still asks for Zorblex to be refused. That
-is the same mechanism. Landing it makes those sites red. That is
-not a reason to keep Zorblex silent.
+Landing E233 as a hard error means any `souc check` under a Madaros
+built from this source will refuse the frozen residue. That is the
+mechanism. It is also why this lane does not rewrite those functions.
+A suite run against the new ELF will see the 111 `tests/run-pass`
+files that use `/` without `Div` go red. That is a follow-on
+migration, not this change.
 
-## Blocker
+C1 after Mod is admitted does **not** paint the 366 `Mod` files.
+The remaining 33 unknown `with` uses (Choice, Foo, Compute, Zorblex, …)
+are the closed-list freeze; Zorblex is the compile-fail witness.
 
-`self-hosted/check/check.sio` is held by Codex
-(`session-019fcd2c-c730-7391-b120-`, epistemic payload gate).
-Coord refused the overlapping claim. Request sent. The Madaros live
-hunk is written below and is not applied until that file is free.
-No revert, no parallel write.
+## Coordination
+
+`check.sio` was held by Codex (`session-019fcd2c-c730-7391-b120-`).
+That claim is STALE. This lane claimed the write set before editing.
+
+grok-cli4 R6 (`Correlated`) copied uncommitted Mod/E229/E233 and
+added `Correlated` as id 30 in `/workspace/.wt/grok-cli4` without a
+file claim. This lane does **not** add `Correlated`. After R5+C1,
+`Correlated` is id 30 and `EffVar` is 31.
 
 ## Receipts
 
@@ -127,7 +201,7 @@ lean_single seed compile of that file           → ELF 36600 B rc=0
 Madaros  with Panic missing                     → error[E035] rc=1
 ```
 
-lean_single after this lane, compiled on Slurm
+lean_single after commit `9b3c7edfd7`, compiled on Slurm
 `gpuorangefs-multi-r740-proxmox` 2026-08-20T15:50Z, 4 s, ELF 2553281 B:
 
 ```
@@ -137,14 +211,55 @@ Zorblex  → error[E229]: unknown effect `Zorblex` — name is not in the
 known names (Panic, Observe, ZD, IO) → ELF rc=0
 ```
 
-Madaros live collect is still silent. `check.sio` remains Codex's.
-effects.sio `collect_effects_from_list` now reports E229/E232 and has
-no callers; that is not the Madaros proof.
+Madaros rebuilt from this source on the same node 2026-08-20T19:43Z,
+ELF 100567411 B, `BUILD_MADAROS rc=0 elapsed=546s`. First witness pass
+lost diagnostic greps (`rg` absent on the node). Return codes only:
+
+| witness | rc | expected |
+|---|---:|---|
+| zorblex | 1 | refuse |
+| mod_without | 1 | refuse |
+| div_without | 1 | refuse |
+| known names | 0 | pass |
+| mod_with | 0 | pass |
+| div_with | 0 | pass |
+| NomeQueNaoExiste | 1 | refuse |
+| main.sio check | 1 | see E233 count below |
+
+Second rebuild on the same node 2026-08-20T19:55Z, ELF 100567411 B,
+`BUILD_MADAROS rc=0 elapsed=546s`, diagnostics via `grep`:
+
+| witness | rc | diagnostic |
+|---|---:|---|
+| `unknown_effect_zorblex.sio` | 1 | `error[E229]: unknown effect \`Zorblex\` — name is not in the closed list and is not a declared effect` (count 1) |
+| `effect_mod_without_decl.sio` | 1 | `error[E233]: operator \`%\` requires \`with Mod\`` (count 1) |
+| `effect_div_without_decl.sio` | 1 | `error[E233]: operator \`/\` requires \`with Div\`` (count 1) |
+| `effect_ninth_slot.sio` | 1 | `error[E232]: too many effects — the checker set holds 8; the ninth was not recorded` (count 1) |
+| `effect_known_names_regression.sio` | 0 | `check: OK` |
+| `effect_mod_with_decl.sio` | 0 | `check: OK` |
+| `effect_div_with_decl.sio` | 0 | `check: OK` |
+| `docs/audit/repro/effect_unknown_name.sio` | 1 | `error[E229]: unknown effect \`NomeQueNaoExiste\` …` (count 2) |
+| `self-hosted/compiler/main.sio` | 1 | **E233=221**, E229=0, E232=0. Samples are `%` requires `with Mod`. 58 s |
+
+Pre-patch Zorblex was check: OK. Post-patch it is E229. That is the
+positive control.
+
+Local scans, no rebuilt ELF required:
+
+```
+EFFECT_NAME_CLOSED_LIST_DERIVED named_id_max=29 table=30 alias=Confidence closed=31
+EFFECT_NAME_CLOSED_LIST_SCAN files=7842 hits=166060 known=166027 unknown=33
+status=pass  (freeze total=33; Mod removed from the accused set; Zorblex held)
+OPERATOR_EFFECT_RATCHET div_without_Div=2509 rem_without_Mod=1570
+OPERATOR_EFFECT_RATCHET_OK
+```
 
 ```text
-Semantic-Outcome: lean_single refuses Zorblex with E229. Madaros does
-  not, until checker_collect_effects_mut is patched. The eight-slot
-  refusal (E232) is Madaros-only and is not live. The 30 recognised
-  names were not removed. Mod remains a frozen accused name; a
-  blanket E229 on Madaros will paint those sites red.
+Semantic-Outcome: Madaros live collect refuses Zorblex (E229), a
+  ninth slot (E232), `%` without Mod and `/` without Div (E233).
+  Mod is closed-list id 29. Known names including Mod still check.
+  Seed self-compile of Madaros succeeded. Checking main.sio with the
+  new ELF reports 221 E233; those sites were not rewritten. Residue
+  freeze: div_without_Div=2509 rem_without_Mod=1570. Closed-list
+  freeze: unknown=33 (Mod removed, Zorblex held).
 ```

--- a/scripts/ci/effect_name_closed_list.frozen
+++ b/scripts/ci/effect_name_closed_list.frozen
@@ -1,7 +1,7 @@
 # Frozen accused set. Founder ruling 2026-08-19: freeze, fail the next.
 # A rise in total, or a name absent here, fails the gate.
 # The list may only SHRINK. Lower it when a family is corrected.
-total=2845
+total=33
 Choice
 Compute
 Counter
@@ -10,7 +10,7 @@ Fail
 Fetch
 Foo
 Log
-Mod
 NoSuchEffectX
 NomeQueNaoExiste
 Sampling
+Zorblex

--- a/scripts/ci/operator_effect_ratchet.frozen
+++ b/scripts/ci/operator_effect_ratchet.frozen
@@ -1,0 +1,3 @@
+# Frozen residue of operator-without-effect sites. Shrink-only.
+div_without_Div=2509
+rem_without_Mod=1570

--- a/scripts/ci/operator_effect_ratchet_gate.sh
+++ b/scripts/ci/operator_effect_ratchet_gate.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# operator_effect_ratchet_gate.sh — freeze `/` without Div and `%` without Mod.
+#
+# The compiler refuses those operators without the matching effect (E233).
+# About eight thousand existing functions would need a declaration. This
+# gate records the current residue and only allows it to shrink. It does
+# not rewrite those functions.
+#
+# Usage:
+#   bash scripts/ci/operator_effect_ratchet_gate.sh
+#   bash scripts/ci/operator_effect_ratchet_gate.sh --write-frozen
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FROZEN="${OPERATOR_EFFECT_RATCHET_FROZEN:-$ROOT/scripts/ci/operator_effect_ratchet.frozen}"
+WRITE=0
+[[ "${1:-}" == "--write-frozen" ]] && WRITE=1
+
+python3 - "$ROOT" "$FROZEN" "$WRITE" <<'PY'
+import pathlib, re, sys
+root = pathlib.Path(sys.argv[1])
+frozen_path = pathlib.Path(sys.argv[2])
+write = sys.argv[3] == "1"
+
+def mask(text):
+    out = []
+    i = 0
+    n = len(text)
+    while i < n:
+        if text[i:i+2] == "//":
+            while i < n and text[i] != "\n":
+                out.append(" ")
+                i += 1
+            continue
+        if text[i:i+2] == "/*":
+            i += 2
+            out.extend("  ")
+            while i + 1 < n and text[i:i+2] != "*/":
+                out.append("\n" if text[i] == "\n" else " ")
+                i += 1
+            if i + 1 < n:
+                out.extend("  ")
+                i += 2
+            continue
+        if text[i] == '"':
+            out.append(" ")
+            i += 1
+            while i < n:
+                if text[i] == "\\" and i + 1 < n:
+                    out.extend("  ")
+                    i += 2
+                    continue
+                if text[i] == '"':
+                    out.append(" ")
+                    i += 1
+                    break
+                out.append("\n" if text[i] == "\n" else " ")
+                i += 1
+            continue
+        out.append(text[i])
+        i += 1
+    return "".join(out)
+
+FN = re.compile(r"\bfn\s+[A-Za-z_][A-Za-z0-9_]*\s*[<(]")
+WITH = re.compile(r"\bwith\b([^{;/]+)")
+
+def count(root: pathlib.Path):
+    div_need = mod_need = 0
+    for p in root.rglob("*.sio"):
+        rel = str(p.relative_to(root))
+        if rel.startswith(("archive/", "bootstrap/", "self-hosted/bootstrap/")):
+            continue
+        if rel.endswith(".sio.old"):
+            continue
+        masked = mask(p.read_text(encoding="utf-8", errors="replace"))
+        parts = list(FN.finditer(masked))
+        for i, m in enumerate(parts):
+            chunk = masked[m.start() : parts[i + 1].start() if i + 1 < len(parts) else len(masked)]
+            brace = chunk.find("{")
+            sig = chunk[:brace] if brace >= 0 else chunk
+            body = chunk[brace:] if brace >= 0 else ""
+            decl = " ".join(WITH.findall(sig))
+            has_div = re.search(r"\bDiv\b", decl) is not None
+            has_mod = re.search(r"\bMod\b", decl) is not None
+            if re.search(r"[A-Za-z0-9_)\]}\s]/[A-Za-z0-9_(\[\s]", body) and not has_div:
+                div_need += 1
+            if "%" in body and not has_mod:
+                mod_need += 1
+    return div_need, mod_need
+
+div_need, mod_need = count(root)
+print(f"OPERATOR_EFFECT_RATCHET div_without_Div={div_need} rem_without_Mod={mod_need}")
+
+if write or not frozen_path.is_file():
+    frozen_path.write_text(
+        "# Frozen residue of operator-without-effect sites. Shrink-only.\n"
+        f"div_without_Div={div_need}\n"
+        f"rem_without_Mod={mod_need}\n",
+        encoding="utf-8",
+    )
+    print(f"OPERATOR_EFFECT_RATCHET_WROTE {frozen_path}")
+    raise SystemExit(0)
+
+frozen = {}
+for line in frozen_path.read_text(encoding="utf-8").splitlines():
+    if line.startswith("#") or "=" not in line:
+        continue
+    k, v = line.split("=", 1)
+    frozen[k.strip()] = int(v.strip())
+
+fails = []
+for key, now in (("div_without_Div", div_need), ("rem_without_Mod", mod_need)):
+    was = frozen.get(key)
+    if was is None:
+        fails.append(f"missing_frozen_key={key}")
+        continue
+    if now > was:
+        fails.append(f"{key}_rose:{was}->{now}")
+    elif now < was:
+        print(f"OPERATOR_EFFECT_RATCHET_SHRINK {key} {was}->{now} — lower the frozen file")
+
+if fails:
+    print("OPERATOR_EFFECT_RATCHET_FAIL")
+    for f in fails:
+        print(f"  {f}")
+    raise SystemExit(1)
+print("OPERATOR_EFFECT_RATCHET_OK")
+PY

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -3752,14 +3752,19 @@ fn checker_lookup_user_effect_id_mut(c: *mut Checker, name_buf: [i8; 64], name_l
     0 - 1
 }
 
-fn checker_collect_effects_mut(c: *mut Checker, list: EffectList, effects: [i64; 8], count: i64) -> MutEffectsResult with Mut, Panic, Div {
+fn checker_collect_effects_mut(c: *mut Checker, list: EffectList, effects: [i64; 8], count: i64) -> MutEffectsResult with Mut, Panic, Div, IO {
     var effs = effects
     var n = count
     var eff_id = effect_name_to_id(list.head.name_buf, list.head.name_len)
     if eff_id < 0 {
         eff_id = checker_lookup_user_effect_id_mut(c, list.head.name_buf, list.head.name_len)
     }
-    if eff_id >= 0 && n < 8 {
+    if eff_id < 0 {
+        report_unknown_effect_name(list.head.name_buf, list.head.name_len)
+        checker_note_type_error_mut(c)
+        (*c).had_error = true
+        (*c).diag_emitted = true
+    } else {
         var already_present = false
         var i: i64 = 0
         while i < n {
@@ -3769,8 +3774,15 @@ fn checker_collect_effects_mut(c: *mut Checker, list: EffectList, effects: [i64;
             i = i + 1
         }
         if !already_present {
-            effs[n as usize] = eff_id
-            n = n + 1
+            if n >= 8 {
+                report_effect_set_full()
+                checker_note_type_error_mut(c)
+                (*c).had_error = true
+                (*c).diag_emitted = true
+            } else {
+                effs[n as usize] = eff_id
+                n = n + 1
+            }
         }
     }
     match list.tail {
@@ -3779,7 +3791,7 @@ fn checker_collect_effects_mut(c: *mut Checker, list: EffectList, effects: [i64;
     }
 }
 
-fn checker_extract_effects_mut(c: *mut Checker, opt: Option<Box<EffectList> >) -> MutEffectsResult with Mut, Panic, Div {
+fn checker_extract_effects_mut(c: *mut Checker, opt: Option<Box<EffectList> >) -> MutEffectsResult with Mut, Panic, Div, IO {
     match opt {
         None => MutEffectsResult { effects: [0; 8], count: 0 }
         Some(list) => checker_collect_effects_mut(c, *list, [0; 8], 0)
@@ -5757,6 +5769,24 @@ fn checker_narrow_float_literal_operand_ty(operand_ty: TypeEntry, operand_was_fl
 // dodges the by-value check_path_expr SRET crash — then bridge to the by-value op-typing
 // tail (check_binary_with_operand_types), which is driven by the already-computed operand
 // types and never re-checks operands, so it never recurses into check_path_expr.
+fn checker_require_operator_effect_mut(c: *mut Checker, span: Span, op: BinaryOp) with Mut, Panic, Div, IO {
+    if op == BinaryOp::OpDiv {
+        if !has_effect_id((*c).current_effects, (*c).current_effect_count, 4) {
+            print("error[E233]: operator `/` requires `with Div`\n")
+            checker_note_type_error_mut(c)
+            (*c).had_error = true
+            (*c).diag_emitted = true
+        }
+    } else if op == BinaryOp::OpRem {
+        if !has_effect_id((*c).current_effects, (*c).current_effect_count, 29) {
+            print("error[E233]: operator `%` requires `with Mod`\n")
+            checker_note_type_error_mut(c)
+            (*c).had_error = true
+            (*c).diag_emitted = true
+        }
+    }
+}
+
 fn checker_check_binary_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
     let left_ty = checker_check_opt_expr_inplace(c, e.left)
     let left_was_int_lit = (*c).last_literal_kind == 1
@@ -5960,11 +5990,13 @@ fn checker_check_binary_with_operand_types_inplace(c: *mut Checker, e: Expr, lef
         checker_report_mismatch_inplace(c, e.span, 4, left_ty, right_ty)
     }
     if e.bin_op == BinaryOp::OpDiv {
+        checker_require_operator_effect_mut(c, e.span, e.bin_op)
         let denom_pair = checker_eval_const_int_opt_expr_mut(c, e.right)
         if denom_pair.0 != 0 && denom_pair.1 == 0 {
             checker_report_error_at_inplace(c, e.span, 56, 0, 0, 0)
         }
     } else if e.bin_op == BinaryOp::OpRem {
+        checker_require_operator_effect_mut(c, e.span, e.bin_op)
         let denom_pair = checker_eval_const_int_opt_expr_mut(c, e.right)
         if denom_pair.0 != 0 && denom_pair.1 == 0 {
             checker_report_error_at_inplace(c, e.span, 57, 0, 0, 0)
@@ -17804,21 +17836,27 @@ impl Checker {
         -1
     }
 
-    fn extract_effects_with_checker(self, opt: Option<Box<EffectList> >) -> ExtractEffectsResult with Mut, Panic, Div {
+    fn extract_effects_with_checker(self, opt: Option<Box<EffectList> >) -> ExtractEffectsResult with Mut, Panic, Div, IO {
         match opt {
             None => ExtractEffectsResult { checker: self, effects: [0; 8], count: 0 }
             Some(list) => self.collect_effects_with_checker(*list, [0; 8], 0)
         }
     }
 
-    fn collect_effects_with_checker(self, list: EffectList, effects: [i64; 8], count: i64) -> ExtractEffectsResult with Mut, Panic, Div {
+    fn collect_effects_with_checker(self, list: EffectList, effects: [i64; 8], count: i64) -> ExtractEffectsResult with Mut, Panic, Div, IO {
+        var c = self
         var effs = effects
         var n = count
         var eff_id = effect_name_to_id(list.head.name_buf, list.head.name_len)
         if eff_id < 0 {
-            eff_id = self.lookup_user_effect_id(list.head.name_buf, list.head.name_len)
+            eff_id = c.lookup_user_effect_id(list.head.name_buf, list.head.name_len)
         }
-        if eff_id >= 0 && n < 8 {
+        if eff_id < 0 {
+            report_unknown_effect_name(list.head.name_buf, list.head.name_len)
+            c.error_count = c.error_count + 1
+            c.had_error = true
+            c.diag_emitted = true
+        } else {
             var already_present = false
             var i: i64 = 0
             while i < n {
@@ -17828,13 +17866,20 @@ impl Checker {
                 i = i + 1
             }
             if !already_present {
-                effs[n as usize] = eff_id
-                n = n + 1
+                if n >= 8 {
+                    report_effect_set_full()
+                    c.error_count = c.error_count + 1
+                    c.had_error = true
+                    c.diag_emitted = true
+                } else {
+                    effs[n as usize] = eff_id
+                    n = n + 1
+                }
             }
         }
         match list.tail {
-            None => ExtractEffectsResult { checker: self, effects: effs, count: n }
-            Some(next) => self.collect_effects_with_checker(*next, effs, n)
+            None => ExtractEffectsResult { checker: c, effects: effs, count: n }
+            Some(next) => c.collect_effects_with_checker(*next, effs, n)
         }
     }
 
@@ -20960,11 +21005,23 @@ impl Checker {
         }
         // Division/modulo by zero: detect denominators that fold to a constant integer zero.
         if e.bin_op == BinaryOp::OpDiv {
+            if !has_effect_id(c.current_effects, c.current_effect_count, 4) {
+                print("error[E233]: operator `/` requires `with Div`\n")
+                c.error_count = c.error_count + 1
+                c.had_error = true
+                c.diag_emitted = true
+            }
             let denom_pair = eval_const_int_opt_expr(c, e.right)
             if denom_pair.0 != 0 && denom_pair.1 == 0 {
                 c = c.report_error_at(e.span, 56, 0, 0, 0)
             }
         } else if e.bin_op == BinaryOp::OpRem {
+            if !has_effect_id(c.current_effects, c.current_effect_count, 29) {
+                print("error[E233]: operator `%` requires `with Mod`\n")
+                c.error_count = c.error_count + 1
+                c.had_error = true
+                c.diag_emitted = true
+            }
             let denom_pair = eval_const_int_opt_expr(c, e.right)
             if denom_pair.0 != 0 && denom_pair.1 == 0 {
                 c = c.report_error_at(e.span, 57, 0, 0, 0)

--- a/self-hosted/check/effects.sio
+++ b/self-hosted/check/effects.sio
@@ -20,14 +20,12 @@
 //   27=NarrowWidthApproximation  stdlib comment "bit 24" = 16777216
 //   28=NonUnitary      stdlib comment "bit 22" = 4194304 (a BIT; id 22 is Chaotic)
 //
-// Mod is HELD, not forgotten (founder 2026-08-19, hold_mod_claude1).
-// 360 files / 2800 `with Mod` still return -1. If those sites are Mut
-// misspellings, adding Mod would consecrate the error. No reserved
-// hole: a vacant id invites someone to fill it.
+// Mod is id 29 (founder 2026-08-20, R5). Modular arithmetic, not a Mut
+// typo: `with Mod` co-occurs with Mut in 3 of 2814 signatures.
 //
 // Confidence is an alias of Epistemic (id 8). Same id, not a new variant.
 //
-// EffVar is the row-polymorphism slot (discriminant 29 after 2b hold).
+// EffVar is the row-polymorphism slot (discriminant 30 after Mod).
 // It is not a user-facing `with` name and effect_name_to_id never returns it.
 
 // ============================================================
@@ -64,11 +62,12 @@ enum EffectKind {
     EffPerturbative,
     EffNarrowWidthApproximation,
     EffNonUnitary,
+    EffMod,
     EffVar,
 }
 
 fn effect_named_id_max() -> i64 {
-    28
+    29
 }
 
 fn effect_kind_name_len(k: i64) -> i64 {
@@ -101,6 +100,7 @@ fn effect_kind_name_len(k: i64) -> i64 {
     else if k == 26 { 12 }
     else if k == 27 { 24 }
     else if k == 28 { 10 }
+    else if k == 29 { 3 }
     else { 0 }
 }
 
@@ -163,6 +163,8 @@ fn effect_kind_name_byte(k: i64, i: i64) -> i8 {
         if i == 0 { 78 as i8 } else if i == 1 { 97 as i8 } else if i == 2 { 114 as i8 } else if i == 3 { 114 as i8 } else if i == 4 { 111 as i8 } else if i == 5 { 119 as i8 } else if i == 6 { 87 as i8 } else if i == 7 { 105 as i8 } else if i == 8 { 100 as i8 } else if i == 9 { 116 as i8 } else if i == 10 { 104 as i8 } else if i == 11 { 65 as i8 } else if i == 12 { 112 as i8 } else if i == 13 { 112 as i8 } else if i == 14 { 114 as i8 } else if i == 15 { 111 as i8 } else if i == 16 { 120 as i8 } else if i == 17 { 105 as i8 } else if i == 18 { 109 as i8 } else if i == 19 { 97 as i8 } else if i == 20 { 116 as i8 } else if i == 21 { 105 as i8 } else if i == 22 { 111 as i8 } else { 110 as i8 }
     } else if k == 28 {
         if i == 0 { 78 as i8 } else if i == 1 { 111 as i8 } else if i == 2 { 110 as i8 } else if i == 3 { 85 as i8 } else if i == 4 { 110 as i8 } else if i == 5 { 105 as i8 } else if i == 6 { 116 as i8 } else if i == 7 { 97 as i8 } else if i == 8 { 114 as i8 } else { 121 as i8 }
+    } else if k == 29 {
+        if i == 0 { 77 as i8 } else if i == 1 { 111 as i8 } else { 100 as i8 }
     } else {
         0 as i8
     }

--- a/self-hosted/check/effects.sio
+++ b/self-hosted/check/effects.sio
@@ -214,19 +214,48 @@ pub fn effect_name_to_id(name_buf: [i8; 64], name_len: i64) -> i64 with Mut, Pan
     0 - 1
 }
 
+// E229: a with-name that is not a closed-list id and not a declared effect.
+// E232: a ninth distinct effect; the set is [i64; 8]. Silence was the defect.
+pub fn report_unknown_effect_name(name_buf: [i8; 64], name_len: i64) with IO, Mut, Panic, Div {
+    print("error[E229]: unknown effect `")
+    var i: i64 = 0
+    while i < name_len && i < 64 {
+        print_char(name_buf[i as usize] as i64)
+        i = i + 1
+    }
+    print("` — name is not in the closed list and is not a declared effect\n")
+}
+
+pub fn report_effect_set_full() with IO, Mut, Panic, Div {
+    print("error[E232]: too many effects — the checker set holds 8; the ninth was not recorded\n")
+}
+
 // ============================================================
 // Extract effects from EffectList
 // ============================================================
 
-pub fn collect_effects_from_list(list: EffectList, effects: [i64; 8], count: i64) -> ([i64; 8], i64) with Mut, Panic, Div {
+pub fn collect_effects_from_list(list: EffectList, effects: [i64; 8], count: i64) -> ([i64; 8], i64) with IO, Mut, Panic, Div {
     var effs = effects
     var n = count
 
     // Convert this effect to ID
     let eff_id = effect_name_to_id(list.head.name_buf, list.head.name_len)
 
-    // Add if valid and not duplicate
-    if eff_id >= 0 && n < 8 {
+    if eff_id < 0 {
+        report_unknown_effect_name(list.head.name_buf, list.head.name_len)
+    } else if n >= 8 {
+        var already_present = false
+        var i: i64 = 0
+        while i < n {
+            if effs[i as usize] == eff_id {
+                already_present = true
+            }
+            i = i + 1
+        }
+        if !already_present {
+            report_effect_set_full()
+        }
+    } else {
         var already_present = false
         var i: i64 = 0
         while i < n {
@@ -249,7 +278,7 @@ pub fn collect_effects_from_list(list: EffectList, effects: [i64; 8], count: i64
     }
 }
 
-pub fn extract_effects(opt: Option<Box<EffectList>>) -> ([i64; 8], i64) with Mut, Panic, Div {
+pub fn extract_effects(opt: Option<Box<EffectList>>) -> ([i64; 8], i64) with IO, Mut, Panic, Div {
     match opt {
         None => ([0; 8], 0)
         Some(list) => collect_effects_from_list(*list, [0; 8], 0)

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -2883,6 +2883,7 @@ fn tok_is_effect_name(p: i64) -> bool with Panic, Mut {
     if src_match(ns, ne - ns, "Approx") { return true }
     if src_match(ns, ne - ns, "Causal") { return true }
     if src_match(ns, ne - ns, "NaturalityG2") { return true }
+    if src_match(ns, ne - ns, "GPU") { return true }
     return false
 }
 
@@ -3831,6 +3832,18 @@ fn tc_mark_failed() with Mut {
         }
     }
     TYPECHECK_FAILED = 1
+}
+
+fn report_e229_unknown_effect(tok: i64) with IO, Mut, Panic {
+    print("error[E229]: unknown effect `")
+    var i: i64 = TS[tok as usize]
+    let ne = TE[tok as usize]
+    while i < ne {
+        print_char(SRC[i as usize] as i64)
+        i = i + 1
+    }
+    print("` — name is not in the closed list and is not a declared effect\n")
+    tc_mark_failed()
 }
 
 fn tc_stack_frame_too_large(bytes: i64) with IO, Mut, Panic {
@@ -5551,10 +5564,14 @@ fn scan_fn_type_signature(p0: i64) with IO, Mut, Panic, Div {
     var eff_mask: i64 = 0
     if TK[p as usize] == 38 {
         p = p + 1
-        while tok_is_effect_name(p) {
-            eff_mask = eff_mask | ety_parse_effect_name(TS[p as usize], TE[p as usize])
+        while TK[p as usize] == 3 {
+            if tok_is_effect_name(p) {
+                eff_mask = eff_mask | ety_parse_effect_name(TS[p as usize], TE[p as usize])
+            } else {
+                report_e229_unknown_effect(p)
+            }
             p = p + 1
-            if TK[p as usize] == 28 && tok_is_effect_name(p + 1) {
+            if TK[p as usize] == 28 {
                 p = p + 1
             } else {
                 break
@@ -11574,7 +11591,11 @@ fn compile_primary() with IO, Mut, Panic, Div {
             EP = EP + 1
             while TK[EP as usize] == 3 || TK[EP as usize] == 28 {
                 if TK[EP as usize] == 3 {
-                    CL_FNSIG_EFF[(CL_DEPTH - 1) as usize] = CL_FNSIG_EFF[(CL_DEPTH - 1) as usize] | ety_parse_effect_name(TS[EP as usize], TE[EP as usize])
+                    let cl_eff = ety_parse_effect_name(TS[EP as usize], TE[EP as usize])
+                    if cl_eff == 0 && !tok_is_effect_name(EP) {
+                        report_e229_unknown_effect(EP)
+                    }
+                    CL_FNSIG_EFF[(CL_DEPTH - 1) as usize] = CL_FNSIG_EFF[(CL_DEPTH - 1) as usize] | cl_eff
                     EP = EP + 1
                     if TK[EP as usize] == 6 {
                         EP = EP + 1
@@ -25782,6 +25803,9 @@ fn epistemic_infer_pass() with IO, Mut, Panic, Div {
                     q = q + 1
                     while q < TC && TK[q as usize] == 3 {
                         let eff = ety_parse_effect_name(TS[q as usize], TE[q as usize])
+                        if eff == 0 && !tok_is_effect_name(q) {
+                            report_e229_unknown_effect(q)
+                        }
                         FN_DECL_EFF[fi as usize] = FN_DECL_EFF[fi as usize] | eff
                         q = q + 1
                         if q < TC && TK[q as usize] == 28 { q = q + 1 }
@@ -32261,7 +32285,11 @@ fn compile_primary_a64() with IO, Mut, Panic, Div {
             EP = EP + 1
             while TK[EP as usize] == 3 || TK[EP as usize] == 28 {
                 if TK[EP as usize] == 3 {
-                    CL_FNSIG_EFF[(CL_DEPTH - 1) as usize] = CL_FNSIG_EFF[(CL_DEPTH - 1) as usize] | ety_parse_effect_name(TS[EP as usize], TE[EP as usize])
+                    let cl_eff_a = ety_parse_effect_name(TS[EP as usize], TE[EP as usize])
+                    if cl_eff_a == 0 && !tok_is_effect_name(EP) {
+                        report_e229_unknown_effect(EP)
+                    }
+                    CL_FNSIG_EFF[(CL_DEPTH - 1) as usize] = CL_FNSIG_EFF[(CL_DEPTH - 1) as usize] | cl_eff_a
                     EP = EP + 1
                     if TK[EP as usize] == 6 {
                         EP = EP + 1

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -2884,6 +2884,7 @@ fn tok_is_effect_name(p: i64) -> bool with Panic, Mut {
     if src_match(ns, ne - ns, "Causal") { return true }
     if src_match(ns, ne - ns, "NaturalityG2") { return true }
     if src_match(ns, ne - ns, "GPU") { return true }
+    if src_match(ns, ne - ns, "Mod") { return true }
     return false
 }
 
@@ -25756,6 +25757,7 @@ fn ety_parse_effect_name(ns: i64, ne: i64) -> i64 with Panic, Mut {
     // obligation at IR-emit time (deferred to M4). For now, declaring the
     // effect is enough to type-check.
     if src_match(ns, l, "NaturalityG2") { return 1048576 }
+    if src_match(ns, l, "Mod") { return 64 }
     return 0
 }
 

--- a/tests/compile-fail/effect_div_without_decl.sio
+++ b/tests/compile-fail/effect_div_without_decl.sio
@@ -1,0 +1,12 @@
+//@ compile-fail
+//@ requires: madaros
+//@ error-pattern: error[E233]
+//@ description: division requires with Div
+
+fn d(a: i64, b: i64) -> i64 {
+    a / b
+}
+
+fn main() -> i64 {
+    0
+}

--- a/tests/compile-fail/effect_mod_without_decl.sio
+++ b/tests/compile-fail/effect_mod_without_decl.sio
@@ -1,0 +1,12 @@
+//@ compile-fail
+//@ requires: madaros
+//@ error-pattern: error[E233]
+//@ description: remainder requires with Mod
+
+fn m(a: i64, b: i64) -> i64 {
+    a % b
+}
+
+fn main() -> i64 {
+    0
+}

--- a/tests/compile-fail/effect_ninth_slot.sio
+++ b/tests/compile-fail/effect_ninth_slot.sio
@@ -1,0 +1,12 @@
+//@ compile-fail
+//@ requires: madaros
+//@ error-pattern: error[E232]
+//@ description: the ninth distinct effect is refused; the eight-slot set is not silent
+
+fn crowded() -> i64 with IO, Mut, Alloc, Panic, Div, GPU, Async, Prob, Observe {
+    0
+}
+
+fn main() -> i64 with IO {
+    0
+}

--- a/tests/compile-fail/unknown_effect_zorblex.sio
+++ b/tests/compile-fail/unknown_effect_zorblex.sio
@@ -1,0 +1,11 @@
+//@ compile-fail
+//@ error-pattern: error[E229]
+//@ description: a with-name outside the closed list is refused, not dropped
+
+fn g() -> i32 with Zorblex {
+    0
+}
+
+fn main() -> i32 with IO {
+    0
+}

--- a/tests/run-pass/effect_div_with_decl.sio
+++ b/tests/run-pass/effect_div_with_decl.sio
@@ -1,0 +1,12 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 2
+//@ description: division is accepted when Div is declared
+
+fn d(a: i64, b: i64) -> i64 with Div {
+    a / b
+}
+
+fn main() -> i64 with Div {
+    d(10, 4)
+}

--- a/tests/run-pass/effect_known_names_regression.sio
+++ b/tests/run-pass/effect_known_names_regression.sio
@@ -1,0 +1,23 @@
+//@ run-pass
+//@ exit-code: 0
+//@ description: recognised names still check; line discipline for Panic is unchanged
+
+fn with_panic() -> i64 with Panic {
+    0
+}
+
+fn with_observe() -> i64 with Observe {
+    0
+}
+
+fn with_zd() -> i64 with ZD {
+    0
+}
+
+fn with_io() -> i64 with IO {
+    0
+}
+
+fn main() -> i64 with IO {
+    0
+}

--- a/tests/run-pass/effect_known_names_regression.sio
+++ b/tests/run-pass/effect_known_names_regression.sio
@@ -18,6 +18,10 @@ fn with_io() -> i64 with IO {
     0
 }
 
+fn with_mod() -> i64 with Mod {
+    0
+}
+
 fn main() -> i64 with IO {
     0
 }

--- a/tests/run-pass/effect_mod_with_decl.sio
+++ b/tests/run-pass/effect_mod_with_decl.sio
@@ -1,0 +1,12 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 3
+//@ description: remainder is accepted when Mod is declared
+
+fn m(a: i64, b: i64) -> i64 with Mod {
+    a % b
+}
+
+fn main() -> i64 with Mod {
+    m(10, 7)
+}


### PR DESCRIPTION
## Summary

R5 + C1 as one change. `Mod` is closed-list id **29** (modular arithmetic, not a `Mut` typo; `Confidence` stays alias of id 8). Live Madaros collect refuses:

| code | refusal |
|---|---|
| E229 | unknown `with` name (`Zorblex`, `NomeQueNaoExiste`) |
| E232 | ninth distinct effect (eight-slot set is no longer silent) |
| E233 | `/` without `Div`; `%` without `Mod` |

lean_single recognises `Mod` (bit 64) so the seed can declare it.

Existing undeclared operator sites are **not rewritten**. Residue is frozen shrink-only:

```
div_without_Div=2509
rem_without_Mod=1570
```

Closed-list freeze: `total=33` (`Mod` removed from the accused set; `Zorblex` held).

## Witnesses (Madaros rebuilt from this source, r740, 2026-08-20)

`BUILD_MADAROS rc=0`, ELF 100567411 B. Pre-patch Zorblex was `check: OK` — that is the positive control.

| witness | rc | diagnostic |
|---|---:|---|
| `unknown_effect_zorblex.sio` | 1 | E229 |
| `%` without Mod | 1 | E233 |
| `/` without Div | 1 | E233 |
| ninth slot | 1 | E232 |
| known names + `with Mod` | 0 | check: OK |
| `%` with Mod / `/` with Div | 0 | check: OK |
| `NomeQueNaoExiste` | 1 | E229 ×2 |

## Halt — the number, not a migration

Dispatch: if mass-migration is required for the repository to compile, stop and report the number. Seed compile of Madaros still succeeds. `RAW --check self-hosted/compiler/main.sio` under the new ELF reports **221 error[E233]** (E229=0, E232=0). Those sites were not rewritten.

Scan residue (not the 221): self-hosted 91 Div + 403 Mod; `tests/run-pass` 111 files with `/` without Div. A suite against the new ELF will see those. Follow-on migration, not this PR.

## Coordination

- **#2059** also admits Mod as id 29 (hold lift + corpus radius 546). It does not ship E229/E232/E233. This PR is the operator-origin and unknown-name refuse from the R5+C1 dispatch. Do not merge both as-is onto the same `effects.sio`.
- **#2058** took id 29 for `Correlated` and dropped this stack because E233 broke Madaros self-check (the 221). Founder R5 assigned 29 to Mod. If this lands first, Correlated is id 30.

Cherry-picked onto current `main` (`139a3b7412`) from the lane that had been based on pre-rewrite history.

Doc: `docs/audit/UNKNOWN_EFFECT_REFUSE_2026-08-20.md`

## Test plan

- [x] Remote Madaros build + named diagnostics (table above)
- [x] `effect_name_closed_list_gate.sh --scan-only` pass
- [x] `operator_effect_ratchet_gate.sh` pass
- [ ] CI Contracts / self-host (expected: compiler check under new ELF is 221 E233 unless residue is migrated in a later PR)