### PR TITLE
audit: salvage #1964 XPAS TSV and #1942 family-G rows

### DIFF
--- a/docs/audit/TYPEKIND_CONCEPT_CROSS_2026-08-19.md
+++ b/docs/audit/TYPEKIND_CONCEPT_CROSS_2026-08-19.md
@@ -1,0 +1,146 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.typekind-concept-cross-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: grok-cli5
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.typekind-concept-cross-2026-08-19
+-->
+
+# TypeKind × concept registry — spec skeleton
+
+**This is a census.** It does **not** reclassify `docs/internal/concepts/registry.tsv`. Rows below are observational. The founder decides whether a TypeKind is a missing Concept-ID, or a concept is a missing TypeKind.
+
+**SHA of `origin/main`:** `2b4d217a04` (v2 re-evaluation; v1 rows were at `98eb2b4f41`)  
+**Counts measured:** TypeKind = **99** (`self-hosted/check/types.sio`). TypeExprKind = **54** (`self-hosted/parser/ast.sio`). Concept-IDs on this worktree = **24**. `origin/main` at this SHA also carries `SOUNIO-EXACTNESS` (#1941) — a 25th row. This census does **not** add a cross for it and does **not** reclassify `registry.tsv`.
+
+Family G positions (protocol v2, run this turn): [`TYPE_ARCHAEOLOGY_FAMILY_G_2026-08-19.md`](TYPE_ARCHAEOLOGY_FAMILY_G_2026-08-19.md).  
+Machine table: [`TYPEKIND_CONCEPT_CROSS_2026-08-19.tsv`](TYPEKIND_CONCEPT_CROSS_2026-08-19.tsv).
+
+## The inversion
+
+The usual failure in this repository is documentation claiming more than the compiler does. The TypeKind enum is the other way around.
+
+- 99 TypeKinds in the checker.
+- 24 Concept-IDs in the registry.
+- 22 TypeKinds with no documentation (founder brief).
+- Family G adds the sharper cut: **privacy and justice have TypeKinds and no Concept-ID at all.** `DiffPrivate`, `DPBudget`, `FairPrediction`, `FairnessGap` do not appear in `registry.tsv`. The word "privacy" in the concept tree is a zero-event gate path, not ε. The word "transport" in the registry is D11 shift-robust *risk* transport, not Pearl/Bareinboim `TyTransportable`.
+
+If the suspicion is right — founder concepts that gained an enum variant and never gained a registry row — the concept registry is **under-representing the language**. That is the inverse of the problem we usually have. This table is the skeleton a spec would have to walk before it declared 99 types.
+
+`Fit` is not a promotion:
+
+| Fit | Meaning |
+|---|---|
+| embodies | a reader of the concept contract would look for this TypeKind first |
+| related | same neighbourhood; not the same object |
+| none | no TypeKind carries this concept |
+| undocumented-kind | TypeKind is in the 22; concept column is the best *name-level* neighbour, or `none` |
+
+## 1. For each of the 24 concepts: is there a TypeKind that embodies it?
+
+| Concept-ID | registry status | TypeKind that would embody it | fit | why this is not a promotion |
+|---|---|---|---|---|
+| SOUNIO-ZERO-PROVENANCE | executable | none | none | Surface is `stdlib/epistemic/zero_event.sio`. `TyUnobserved` is "not yet inspected", not "zero is not a value". |
+| SOUNIO-EPISTEMIC-NUMERIC-VALUE | executable | TyKnowledge | embodies | `Knowledge<T>` is the inhabited numeric carrier. Ran this turn: `measure` constructs it; coerce to f64 is E001. |
+| SOUNIO-NONASSOCIATIVE-ORDER | executable | TyHyper | related | Associator lives in stdlib algebra; Hyper is the algebra tag, not the order. |
+| SOUNIO-RNA-CD-INDUCTIVE-BIAS | hypothesis | none | none | Research manifest. No TypeKind. |
+| SOUNIO-EXPLICIT-DISCHARGE | executable | TyDeferred | related | Discharge is an act. Deferred is a certificate type. Family B owns the kind. |
+| SOUNIO-PHYSICAL-OBSERVATION | hypothesis | none | none | `stdlib/physics`. No observation TypeKind. |
+| SOUNIO-PRECISION-PRESERVATION | executable | TyF128, TyF256 | related | Format-identity kinds exist; the concept's surface is `qd128.sio`, not those kinds. |
+| SOUNIO-DYADIC-NONREDUCTION | executable | none | none | Stdlib epistemic. No TypeKind. |
+| SOUNIO-RELATIONAL-ASSOCIATOR | executable | none | none | Stdlib epistemic. No TypeKind. |
+| SOUNIO-PROOF-CARRYING-INFERENCE | executable | TyProof, TyContest, TyRobust | related | Proof/Contest/Robust are carriers; the concept's surface is a stdlib contest protocol. |
+| SOUNIO-SECOND-ORDER-COMPILATION | hypothesis | none | none | Architecture doc. No TypeKind. |
+| SOUNIO-HYPERCOMPLEX-ZD-EVIDENCE | executable | TyHyper | related | ZD evidence is stdlib/eisa; Hyper is the algebra tag. |
+| SOUNIO-SCIENCE-RESEARCH-BOUNDARY | executable | none | none | Docs/policy. No TypeKind. |
+| SOUNIO-REBRACKETING-AUTHORITY | hypothesis | none | none | IR (`opt_cleanup.sio`). No TypeKind. |
+| SOUNIO-ORDERED-PATH-PROVENANCE | executable | none | none | IR path. No TypeKind. Family G's import-FO work preserved this concept without adding a kind. |
+| SOUNIO-REFLEXIVE-INQUIRY | executable | none | none | Stdlib protocol. No TypeKind. |
+| SOUNIO-ENDOGENOUS-OBSERVABILITY | executable | TyUnobserved | related | Unobserved is type-state; the concept is a proof-carrying protocol. |
+| SOUNIO-POLICY-STATE-FEEDBACK | executable | TyPolicy, TyDecisionPolicy | related | Concept surface is stdlib proof-carrying policy. TypeKinds are Family B. DecisionPolicy is undocumented. |
+| SOUNIO-POLICY-OBSERVATION-ASSOCIATOR | executable | TyMonitoringPolicy, TyObservedTransition | related | Same split: stdlib protocol vs Family B kinds. Both kinds undocumented. |
+| SOUNIO-PROOF-CARRYING-REBRACKETING-PROTOCOL | executable | TyProof | related | Proof is a certificate kind; the concept is a protocol. |
+| SOUNIO-PATH-CONDITIONED-PARTIAL-IDENTIFICATION | executable | TyIntervention, TyCounterfactual, TyCausalEffect, TyCondIndep | related | Causal TypeKinds exist; CondIndep is undocumented; the concept's surface is a stdlib protocol, not those kinds. |
+| SOUNIO-PROOF-CARRYING-STATISTICAL-COVERAGE-EMPIRICAL-BINDING | executable | TyDistribution, TySample | related | Probabilistic kinds exist; the concept is a sealed-coverage protocol. |
+| SOUNIO-PROOF-CARRYING-DEPLOYMENT-VALIDITY-REVOCABLE-AUTHORITY | executable | TyValidated, TyValidation, TyAdmissible | related | Validity kinds exist; the concept is affine warrant + institutional authority. |
+| SOUNIO-PROOF-CARRYING-SHIFT-ROBUST-RISK-TRANSPORT | executable | TyTransportable, TySelectionDiagram | related **by name only** | Registry transport is D11 *risk* transport (`proof_carrying_shift_robust_risk_transport.sio`). TyTransportable is Pearl/Bareinboim S-admissibility. Same English word, two objects. Both TypeKinds are undocumented. |
+
+**Summary of 24:** embodies=1 (Knowledge). related=12. none=11.
+
+Eleven founder concepts have **no** TypeKind. That is the familiar direction (concept without a type). The inversion sits in the next table.
+
+## 2. For each of the 22 undocumented TypeKinds: is there a concept under another name?
+
+The 22 from the archaeology directive. "docs hits" this turn counted `docs/` excluding `training/` and `archive/`. A hit of 1 is almost always the June 2026 coverage map listing the kind as empty.
+
+| TypeKind | docs (excl. training/archive) | concept under another name | fit | note |
+|---|---|---|---|---|
+| ModelFamily | 2 | none | undocumented-kind | Sibling of TyModel. No Concept-ID for model families. |
+| AcquisitionPolicy | 1 | SOUNIO-POLICY-STATE-FEEDBACK | related | Family B Garden this turn. Policy concept is a stdlib protocol, not this kind. |
+| RecoursePolicy | 1 | SOUNIO-POLICY-STATE-FEEDBACK | related | Family B Garden. |
+| AlternativePolicy | 1 | SOUNIO-POLICY-STATE-FEEDBACK | related | Family B Garden. |
+| TransitionPolicy | 1 | SOUNIO-POLICY-STATE-FEEDBACK | related | Family B Garden. |
+| MonitoringPolicy | 1 | SOUNIO-POLICY-OBSERVATION-ASSOCIATOR | related | Family B Garden. |
+| DecisionPolicy | 1 | SOUNIO-POLICY-STATE-FEEDBACK | related | Family B Garden. |
+| DeferralPolicy | 2 | SOUNIO-EXPLICIT-DISCHARGE | related | Family B Hypothesis (E097 names the *item*, not the TypeKind). |
+| GradedEffect | 1 | none | undocumented-kind | Effect-row grade. No Concept-ID. Not an effect in CLAUDE.md's nine. |
+| SessionEnd | 1 | none | undocumented-kind | Session type-state. No Concept-ID. |
+| CondIndep | 1 | SOUNIO-PATH-CONDITIONED-PARTIAL-IDENTIFICATION | related | Conditional independence as a type. Concept is a path-identification protocol. |
+| Transportable | 1 | SOUNIO-PROOF-CARRYING-SHIFT-ROBUST-RISK-TRANSPORT | related by name only | Pearl transport ≠ D11 risk transport. Do not collapse. |
+| SelectionDiagram | 1 | SOUNIO-PROOF-CARRYING-SHIFT-ROBUST-RISK-TRANSPORT | related by name only | Same collision. |
+| FairnessGap | 1 | **none** | undocumented-kind | Family G Garden this turn. **No justice / fairness Concept-ID.** |
+| ConditionalDist | 1 | none | undocumented-kind | Sprint 23 P. No Concept-ID. |
+| VecShaped | 1 | none | undocumented-kind | Sprint 23 V. No Concept-ID. |
+| MatrixShaped | 1 | none | undocumented-kind | Sprint 23 V. No Concept-ID. |
+| VariationalFamily | 1 | none | undocumented-kind | Sprint 23 X. No Concept-ID. |
+| MarkovChain | 1 | none | undocumented-kind | Sprint 24 B. No Concept-ID. |
+| StationaryDist | 1 | none | undocumented-kind | Sprint 24 B. No Concept-ID. |
+| SliceMut | 0 | none | undocumented-kind | Language primitive. No Concept-ID, and none should be invented by this census. |
+| RawPtr | 0 | none | undocumented-kind | Language primitive (`*const T` / `*mut T`). Same. |
+
+**Family G kinds that are documented only as comments / lying tests, and still have no Concept-ID:**
+
+| TypeKind | family-G v2 | deepest named layer | Concept-ID | note |
+|---|---|---|---|---|
+| DiffPrivate | Executable | checker (no HLIR) | **none** | Privacy is not in the registry. Certo=`as`+id passes; meaning-errado (compose) also passes. |
+| DPBudget | Executable | checker (no HLIR) | **none** | Two queries do not spend. No concept to under-represent; the kind is ahead of both docs and registry. |
+| FairPrediction | Garden | checker (no TypeExpr, no HLIR) | **none** | Justice is not in the registry. Ghost-identical to NoSuchType. |
+| FairnessGap | Garden | checker (no TypeExpr, no HLIR) | **none** | In the 22. Zero docs. Zero concept. |
+
+## 3. Parser surface vs enum (why 99 ≠ 54)
+
+54 TypeExpr kinds parse. 99 TypeKinds exist. The 45 without a TypeExpr can only appear as `TyNamed("TheirName")` if the user writes the English word — which is what FairPrediction / FairnessGap / NoSuchType did this turn (all three check OK as signatures).
+
+TypeExpr present, relevant to the inversion (not a complete 54-list):
+
+- Present: Knowledge, DiffPrivate, DPBudget, Model, the Family B Policy/Plan cluster, Contest, Robust, Intervention, Counterfactual, Validated, Admissible, Deferred, Chan, Session, CausalEffect, Aleatoric, PotentialOutcome, Proof, Lemma, Axiom, RawPtr.
+- Absent (so the TypeKind is unreachable as itself): FairPrediction, FairnessGap, ModelFamily, GradedEffect, SessionEnd, CondIndep, Transportable, SelectionDiagram, Distribution, Sample, ConditionalDist, Entropic, MutualInfo, KLBounded, VecShaped, MatrixShaped, Broadcastable, ELBO, VariationalFamily, Differentiable, Gradient, Jacobian, MarkovChain, SDE, Martingale, StationaryDist, BigO, Amortized, Unobserved, plus most numeric aliases that share a primitive TypeExpr.
+
+A spec that listed the 99 would be listing the enum. A spec that listed the 24 would be listing the concepts the founder has claimed. Neither list is the language. The language is the intersection that survives the ladder **and** still has a name in every layer.
+
+## 3b. Layer debt (founder rule 3) — measured this turn
+
+Directive: every type must exist in every layer. A checker kind the IR does not name is erasure.
+
+| measure | n |
+|---|---:|
+| TypeKind | 99 |
+| HlirTypeKind unique | 42 (`Contest`/`Robust` duplicated in source → 44 variants) |
+| same stem checker→HLIR | **19** (Array Bool Contest Counterfactual F32 F64 I128 I32 I64 I8 Intervention Knowledge Robust Tuple U128 U32 U64 U8 Validated) |
+| HLIR-only unique | **23** (founder brief said 24; measured 23) |
+| of which algebra-only (Octonion, Sedenion, Quat*, Dual, Vec*, Mat*) | **17** |
+
+Family G is checker-only in the first direction: four TypeKinds, zero `HlirTypeKind` names, zero IR/codegen names. The inverse debt is the 17 algebra kinds the backend names and the language does not. Both directions are debt. Neither is a Family G Concept-ID.
+
+Compile of `1.0 as DiffPrivate<f64>` / `as DPBudget<f64>` / `as FairPrediction<f64>` all emitted 8648-byte ELFs this turn. The program survives; the name does not.
+
+## 4. What a spec may not say
+
+- That Sounio has differential privacy as a type. DiffPrivate is Executable under protocol v2 (certo passes, meaning-errado also passes). DPBudget does not spend.
+- That Sounio has fairness as a type. FairPrediction and FairnessGap are Garden.
+- That the (as, coerce) pair is Claim-ready. `NoSuchType` has the same pair.
+- That the 24 concepts cover the type system. Eleven concepts have no TypeKind; a cluster of privacy / justice / causal-transport / session / shape / process TypeKinds have no Concept-ID.
+- That `TyTransportable` is `SOUNIO-PROOF-CARRYING-SHIFT-ROBUST-RISK-TRANSPORT`. Same word, two objects.
+
+The decision to add Concept-IDs for privacy and justice, or to delete the TypeKinds, is the founder's. This census does not do either.

--- a/docs/audit/TYPEKIND_CONCEPT_CROSS_2026-08-19.tsv
+++ b/docs/audit/TYPEKIND_CONCEPT_CROSS_2026-08-19.tsv
@@ -1,0 +1,56 @@
+# CENSUS not a reclassification. origin/main sha=2b4d217a04 (v1 rows were 98eb2b4f41). TypeKind=99 TypeExprKind=54 Concept-ID=24 on this worktree; origin/main also has SOUNIO-EXACTNESS (#1941) — not crossed here.
+# fit: embodies | related | related-name-only | none | undocumented-kind
+# side=concept: one row per registry Concept-ID.
+# side=undoc-kind: one row per founder-brief 22 TypeKinds with no documentation.
+# side=family-g: the four assigned kinds (two of which are also in the 22).
+side	id	peer	fit	sha_main	notes
+concept	SOUNIO-ZERO-PROVENANCE	none	none	2b4d217a04	surface stdlib/epistemic/zero_event.sio; TyUnobserved is not zero-provenance
+concept	SOUNIO-EPISTEMIC-NUMERIC-VALUE	TyKnowledge	embodies	2b4d217a04	only embodies=1 of 24; measure constructs; coerce to f64 is E001 this turn
+concept	SOUNIO-NONASSOCIATIVE-ORDER	TyHyper	related	2b4d217a04	associator is stdlib; Hyper is the algebra tag
+concept	SOUNIO-RNA-CD-INDUCTIVE-BIAS	none	none	2b4d217a04	research manifest
+concept	SOUNIO-EXPLICIT-DISCHARGE	TyDeferred	related	2b4d217a04	discharge is an act; Deferred is Family B
+concept	SOUNIO-PHYSICAL-OBSERVATION	none	none	2b4d217a04	stdlib/physics
+concept	SOUNIO-PRECISION-PRESERVATION	TyF128,TyF256	related	2b4d217a04	format-identity kinds; concept surface is qd128.sio
+concept	SOUNIO-DYADIC-NONREDUCTION	none	none	2b4d217a04	stdlib epistemic
+concept	SOUNIO-RELATIONAL-ASSOCIATOR	none	none	2b4d217a04	stdlib epistemic
+concept	SOUNIO-PROOF-CARRYING-INFERENCE	TyProof,TyContest,TyRobust	related	2b4d217a04	carriers vs stdlib contest protocol
+concept	SOUNIO-SECOND-ORDER-COMPILATION	none	none	2b4d217a04	architecture doc
+concept	SOUNIO-HYPERCOMPLEX-ZD-EVIDENCE	TyHyper	related	2b4d217a04	ZD evidence is stdlib/eisa
+concept	SOUNIO-SCIENCE-RESEARCH-BOUNDARY	none	none	2b4d217a04	docs/policy
+concept	SOUNIO-REBRACKETING-AUTHORITY	none	none	2b4d217a04	IR opt_cleanup
+concept	SOUNIO-ORDERED-PATH-PROVENANCE	none	none	2b4d217a04	IR path; no TypeKind
+concept	SOUNIO-REFLEXIVE-INQUIRY	none	none	2b4d217a04	stdlib protocol
+concept	SOUNIO-ENDOGENOUS-OBSERVABILITY	TyUnobserved	related	2b4d217a04	type-state vs protocol
+concept	SOUNIO-POLICY-STATE-FEEDBACK	TyPolicy,TyDecisionPolicy	related	2b4d217a04	DecisionPolicy is undocumented; Family B
+concept	SOUNIO-POLICY-OBSERVATION-ASSOCIATOR	TyMonitoringPolicy,TyObservedTransition	related	2b4d217a04	both kinds undocumented; Family B
+concept	SOUNIO-PROOF-CARRYING-REBRACKETING-PROTOCOL	TyProof	related	2b4d217a04	certificate vs protocol
+concept	SOUNIO-PATH-CONDITIONED-PARTIAL-IDENTIFICATION	TyIntervention,TyCounterfactual,TyCausalEffect,TyCondIndep	related	2b4d217a04	CondIndep undocumented
+concept	SOUNIO-PROOF-CARRYING-STATISTICAL-COVERAGE-EMPIRICAL-BINDING	TyDistribution,TySample	related	2b4d217a04	probabilistic kinds vs sealed-coverage protocol
+concept	SOUNIO-PROOF-CARRYING-DEPLOYMENT-VALIDITY-REVOCABLE-AUTHORITY	TyValidated,TyValidation,TyAdmissible	related	2b4d217a04	validity kinds vs affine warrant
+concept	SOUNIO-PROOF-CARRYING-SHIFT-ROBUST-RISK-TRANSPORT	TyTransportable,TySelectionDiagram	related-name-only	2b4d217a04	D11 risk transport ≠ Pearl S-admissibility; do not collapse
+undoc-kind	ModelFamily	none	undocumented-kind	2b4d217a04	sibling of TyModel; no Concept-ID
+undoc-kind	AcquisitionPolicy	SOUNIO-POLICY-STATE-FEEDBACK	related	2b4d217a04	Family B Garden
+undoc-kind	RecoursePolicy	SOUNIO-POLICY-STATE-FEEDBACK	related	2b4d217a04	Family B Garden
+undoc-kind	AlternativePolicy	SOUNIO-POLICY-STATE-FEEDBACK	related	2b4d217a04	Family B Garden
+undoc-kind	TransitionPolicy	SOUNIO-POLICY-STATE-FEEDBACK	related	2b4d217a04	Family B Garden
+undoc-kind	MonitoringPolicy	SOUNIO-POLICY-OBSERVATION-ASSOCIATOR	related	2b4d217a04	Family B Garden
+undoc-kind	DecisionPolicy	SOUNIO-POLICY-STATE-FEEDBACK	related	2b4d217a04	Family B Garden
+undoc-kind	DeferralPolicy	SOUNIO-EXPLICIT-DISCHARGE	related	2b4d217a04	Family B Hypothesis (E097 names item)
+undoc-kind	GradedEffect	none	undocumented-kind	2b4d217a04	no Concept-ID; not in CLAUDE.md nine effects
+undoc-kind	SessionEnd	none	undocumented-kind	2b4d217a04	session type-state; no Concept-ID
+undoc-kind	CondIndep	SOUNIO-PATH-CONDITIONED-PARTIAL-IDENTIFICATION	related	2b4d217a04	independence-as-type vs path-identification protocol
+undoc-kind	Transportable	SOUNIO-PROOF-CARRYING-SHIFT-ROBUST-RISK-TRANSPORT	related-name-only	2b4d217a04	Pearl ≠ D11
+undoc-kind	SelectionDiagram	SOUNIO-PROOF-CARRYING-SHIFT-ROBUST-RISK-TRANSPORT	related-name-only	2b4d217a04	Pearl ≠ D11
+undoc-kind	FairnessGap	none	undocumented-kind	2b4d217a04	Family G Garden; no justice Concept-ID; zero docs
+undoc-kind	ConditionalDist	none	undocumented-kind	2b4d217a04	Sprint 23 P
+undoc-kind	VecShaped	none	undocumented-kind	2b4d217a04	Sprint 23 V
+undoc-kind	MatrixShaped	none	undocumented-kind	2b4d217a04	Sprint 23 V
+undoc-kind	VariationalFamily	none	undocumented-kind	2b4d217a04	Sprint 23 X
+undoc-kind	MarkovChain	none	undocumented-kind	2b4d217a04	Sprint 24 B
+undoc-kind	StationaryDist	none	undocumented-kind	2b4d217a04	Sprint 24 B
+undoc-kind	SliceMut	none	undocumented-kind	2b4d217a04	primitive; 0 docs files
+undoc-kind	RawPtr	none	undocumented-kind	2b4d217a04	primitive; has TypeExpr; 0 docs files
+family-g	DiffPrivate	none	undocumented-kind	2b4d217a04	v2 Executable; deepest=checker; no privacy Concept-ID; no HLIR name
+family-g	DPBudget	none	undocumented-kind	2b4d217a04	v2 Executable; deepest=checker; two queries do not spend; no Concept-ID
+family-g	FairPrediction	none	undocumented-kind	2b4d217a04	v2 Garden; deepest=checker; no TypeExpr; no justice Concept-ID
+family-g	FairnessGap	none	undocumented-kind	2b4d217a04	v2 Garden; also in the 22; no TypeExpr; no Concept-ID

--- a/docs/audit/TYPE_ARCHAEOLOGY_FAMILY_G_2026-08-19.md
+++ b/docs/audit/TYPE_ARCHAEOLOGY_FAMILY_G_2026-08-19.md
@@ -1,0 +1,154 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.type-archaeology-family-g-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: grok-cli5
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.type-archaeology-family-g-2026-08-19
+-->
+
+# Type archaeology family G — privacy and justice (protocol v2)
+
+**This is a census.** It does not reclassify `docs/internal/concepts/registry.tsv`. The founder decides promotions.
+
+**SHA of `origin/main` at this re-evaluation:** `2b4d217a043ca061f8d1156384de029b4847e872` (`2b4d217a04`)  
+**Engine:** this worktree `bin/souc` → Madaros v0.80.0. Inherited `SOUC_BIN` unset for the run. `SOUNIO_STDLIB_PATH` pinned here. lean_single was not used as a semantic authority.
+
+**Do not read a position from this file.** Positions are the output of
+`bash scripts/ci/kind_ladder_gate.sh`. Index (no position column):
+[`tests/archaeology/kind_ladder/index.tsv`](../../tests/archaeology/kind_ladder/index.tsv).
+
+**Table (historical v2 notes, not the ladder):** [`TYPE_ARCHAEOLOGY_FAMILY_G_2026-08-19.tsv`](TYPE_ARCHAEOLOGY_FAMILY_G_2026-08-19.tsv)
+
+**Cross table:** [`TYPEKIND_CONCEPT_CROSS_2026-08-19.md`](TYPEKIND_CONCEPT_CROSS_2026-08-19.md)
+
+**Assigned kinds (4):** DiffPrivate, DPBudget, FairPrediction, FairnessGap.
+
+v1 (same files, SHA `98eb2b4f41`) is superseded as a *protocol* reading, not as a measurement. The defect was the ladder, not the runs. Positions did **not** move: nobody had marked Claim-ready without a passing construction.
+
+## Protocol v2 (applied)
+
+1. **Monotone.** Claim-ready ⇒ Executable ⇒ Hypothesis ⇒ Garden. No program that constructs the *kind* and **passes** ⇒ maximum is Hypothesis, no matter how many refusals fire.
+2. **Reserva (off the ladder).** The compiler **actively** refuses every use with a **named** diagnostic, and no use passes. Name occupied, fail-closed, semantics unimplemented. Not Hypothesis (there the compiler is silent). Not Claim-ready (refusing everything is not discriminating). Honest, and worth more than Hypothesis. Control this turn: `f128` bind and signature-only are both **E218**. Family G is not Reserva — uses pass.
+3. **The two-program test.** One program that **must** pass, one that **must** fail. Both fail ⇒ Reserva. Certo passes and errado fails ⇒ Claim-ready (the only case that is). Certo passes and errado passes ⇒ Executable. Without both programs ⇒ no position above Hypothesis.
+4. **Layer (founder rule 3).** Every type must exist in every layer. Each row records the deepest layer that still **names** the kind: parser, checker, HLIR, IR, codegen. A checker kind the IR does not name is erasure, not design.
+
+Format: `kind | posição | camada_mais_profunda | prog_certo | prog_errado | sha_main`.
+
+## Corrections from v1
+
+| kind | v1 | v2 | why |
+|---|---|---|---|
+| DiffPrivate | Executable | **Executable** | Certo (`as` + id) passes. The errado that tests the declared meaning (sequential composition / ε) also **passes**. Not Claim-ready. Not Reserva. |
+| DPBudget | Executable | **Executable** | Certo (`as` + id) passes. Two queries, which **must** spend, pass with spent still 0. |
+| FairPrediction | Garden | **Garden** | No program constructs `TyFairPrediction`. Surface is ghost-identical to `NoSuchType`. Compiler silent on the TypeKind. |
+| FairnessGap | Garden | **Garden** | Same. `ty_fairness_gap` is not even `pub`. |
+
+No row was a false Claim-ready. F128-style refuse-only did not occur in this family.
+
+## Why the nominal pair is not Claim-ready
+
+This pair exists for every name, including ghosts:
+
+| program | DiffPrivate | DPBudget | FairPrediction | FairnessGap | NoSuchType |
+|---|---|---|---|---|---|
+| `1.0 as Kind<f64>` | rc=0 | rc=0 | rc=0 | rc=0 | rc=0 |
+| `fn id(x: Kind<f64>)` | rc=0 | rc=0 | rc=0 | rc=0 | rc=0 |
+| `let x: Kind<f64> = 1.0` | E001 expected DiffPrivate | E001 expected DPBudget | E001 expected FairPrediction | E001 expected FairnessGap | E001 expected NoSuchType |
+| `takes(a): f64` after `as` | E009 found DiffPrivate | E009 found DPBudget | E009 found FairPrediction | E009 found FairnessGap | E009 found NoSuchType |
+
+If (as, coerce) were enough, `NoSuchType` would be Claim-ready. It is not a type. That pair is therefore **not** the test. Control this turn: `let x: i64 = 1` passes and `let x: i64 = true` is E001 — that pair *is* Claim-ready, because `i64` is not ghost-identical to `NoSuchType`.
+
+`as DiffPrivate` / `as DPBudget` still count as constructing the **kind** (lexer keyword → `TypeExprKind` → `ty_diff_private` / `ty_dp_budget`). `as Fair*` does **not**: there is no TypeExpr; the checker never calls `ty_fair_prediction` / `ty_fairness_gap` from `check.sio`.
+
+## Tabela v2
+
+| kind | posição | camada_mais_profunda | prog_certo | prog_errado | sha_main |
+|---|---|---|---|---|---|
+| DiffPrivate | **Executable** | **checker** | `/tmp/archaeology-g-v2/dp_certo_id.sio` — `1.0 as DiffPrivate<f64>` then `id` — **rc=0** | `/tmp/archaeology-g-v2/dp_errado_compose.sio` — two sequential identity queries **must** compose ε or refuse — **rc=0** (they do neither) | 2b4d217a04 |
+| DPBudget | **Executable** | **checker** | `/tmp/archaeology-g-v2/bud_certo_id.sio` — `1000.0 as DPBudget<f64>` then `id` — **rc=0** | `/tmp/archaeology-g-v2/bud_errado_twoq.sio` — two queries **must** spend more than one — **rc=0** (spend stays 0) | 2b4d217a04 |
+| FairPrediction | **Garden** | **checker** | *none* that constructs `TyFairPrediction` (`as` / `id` are the NoSuchType twin) | *none* that names the TypeKind (`E001 expected FairPrediction` is the ghost wall) | 2b4d217a04 |
+| FairnessGap | **Garden** | **checker** | *none* | *none* | 2b4d217a04 |
+
+### Layer evidence (rule 3)
+
+| kind | parser | checker | HLIR | IR | codegen | deepest named |
+|---|---|---|---|---|---|---|
+| DiffPrivate | yes — `TokenKind::DiffPrivate`, `TypeExprKind::TypeDiffPrivate` | yes — `TyDiffPrivate`, `lower_diffprivate_type` → `ty_diff_private(_, 1000, -1)` | **no** | **no** | **no** | checker |
+| DPBudget | yes — `TokenKind::DPBudget`, `TypeExprKind::TypeDPBudget` | yes — `TyDPBudget`, `lower_dp_budget_type` → `ty_dp_budget(_, 1000, 0)` | **no** | **no** | **no** | checker |
+| FairPrediction | **no** TypeExpr | yes — `TyFairPrediction` in the enum; ctor never called from `check.sio` | **no** | **no** | **no** | checker |
+| FairnessGap | **no** TypeExpr | yes — `TyFairnessGap`; `ty_fairness_gap` is not `pub`; ctor never called from `check.sio` | **no** | **no** | **no** | checker |
+
+`souc compile` of the three `as` programs (DiffPrivate, DPBudget, FairPrediction) all succeeded this turn and emitted **8648-byte** ELFs. The name is erased. The backend never sees the kind. That is the checker→HLIR debt on a live program, not a missing file.
+
+## Runs this turn (Madaros v0.80.0, SHA `2b4d217a04`)
+
+| Probe | rc | diagnostic |
+|---|---:|---|
+| `ctrl_i64_certo` (`let x: i64 = 1; x+x`) | 0 | check OK — Claim-ready control, certo |
+| `ctrl_i64_errado` (`let x: i64 = true`) | 1 | E001 expected i64 found bool |
+| `ctrl_f128_bind` / `ctrl_f128_sig` | 1 / 1 | **E218** both — Reserva control |
+| `ctrl_knowledge_certo` (`measure`) | 0 | check OK |
+| `ctrl_knowledge_errado` (coerce to f64) | 1 | E001 expected f64 found Knowledge\<f64\> |
+| `dp_certo_as` / `dp_certo_id` | 0 / 0 | constructs `TyDiffPrivate` |
+| `dp_errado_bind` (mech→f64 into DiffPrivate) | 1 | E001 expected DiffPrivate found f64 |
+| `dp_errado_return` (`fn mech -> DiffPrivate { x }`) | 1 | E008 expected DiffPrivate found f64 |
+| `dp_errado_coerce` | 1 | E009 expected f64 found DiffPrivate — **ghost-shaped** (see above) |
+| `dp_errado_compose` (two identity queries) | 0 | **the meaning-errado passes** |
+| `bud_certo_as` / `bud_certo_id` | 0 / 0 | constructs `TyDPBudget` |
+| `bud_errado_bind` | 1 | E001 expected DPBudget found f64 |
+| `bud_errado_coerce` | 1 | E009 expected f64 found DPBudget — ghost-shaped |
+| `bud_errado_twoq` | 0 | **two queries spend the same as zero** |
+| `fp_*` / `fg_*` / `ghost_*` as, id, bind, coerce | identical | Fair* is TyNamed |
+| `tests/frontend/annotation_diffprivate_basic.sio` (`//@ run-pass`) | 1 | E001 expected DiffPrivate found f64 — official certo **fails** |
+| `tests/frontend/annotation_dp_budget_basic.sio` (`//@ run-pass`) | 1 | E001 expected DPBudget found f64 — official certo **fails** |
+
+E075 / E076 / E080 / E081 / E082 did not fire. `dp_budget_consume`, `dp_sequential_compose`, `dp_parallel_compose`, `check_fair_prediction_type`, `check_fairness_gap_type` have **zero** call sites in `self-hosted/check/check.sio`.
+
+## Does DPBudget spend?
+
+A differential-privacy budget is a quantity that is **spent**. Sequential composition (Dwork 2006, Thm 3.14) says two queries on the same dataset cost ε₁+ε₂.
+
+`bud_errado_twoq.sio` type-checks as the identity. `lower_dp_budget_type` always builds `ty_dp_budget(_, 1000, 0)` — ε_total hardcoded 1000, **ε_spent hardcoded 0**. `dp_budget_consume` is never called.
+
+Two consultations do not spend more than one. They spend the same as zero. DPBudget is a number with a pretty name plus a nominal wall. It is not a budget.
+
+That is why the position is Executable and not Claim-ready: the program that **must** fail (or at least change the type) **passes**.
+
+## Counts v2
+
+| posição | n | kinds |
+|---|---:|---|
+| Garden | 2 | FairPrediction, FairnessGap |
+| Hypothesis | 0 | — |
+| Executable | 2 | DiffPrivate, DPBudget |
+| **Reserva** | **0** | Family G occupies names that still accept `as` / `id`. That is not fail-closed. |
+| Claim-ready | 0 | no pair that constructs the kind **and** refuses the meaning-errado |
+
+Hypothesis remains empty on purpose. Promoting Fair* by reading `check_fair_prediction_type` would violate run-not-read. v2's ceiling without both programs is Hypothesis; Garden is still the honest floor when the compiler is silent on the TypeKind.
+
+## Dívida de camadas (Regra 3)
+
+Re-measured this turn on this worktree's `self-hosted/check/types.sio` + `self-hosted/hlir/ir.sio`:
+
+| measure | n | note |
+|---|---:|---|
+| TypeKind (checker) | 99 | including Family G |
+| HlirTypeKind variants in source | 44 | `Contest` and `Robust` each appear twice |
+| HlirTypeKind unique | 42 | |
+| same stem (`TyX` ↔ `HlirTypeX`) | **19** | Array Bool Contest Counterfactual F32 F64 I128 I32 I64 I8 Intervention Knowledge Robust Tuple U128 U32 U64 U8 Validated |
+| HLIR-only unique | **23** | founder brief said 24; measured 23. Dual Function I16 Mat2 Mat3 Mat4 Octonion Ptr Quat QuatConv2d QuatGate QuatLinear QuatRnnState Sedenion Struct U16 Vec2 Vec2d Vec3 Vec3d Vec4 Vec4d Void |
+| of which algebra (Octonion, Sedenion, Quat*, Dual, Vec*, Mat*) | **17** | backend knows them; checker TypeKind does not name them |
+
+Both directions are debt. Family G is the first direction: four checker names, zero HLIR names. The algebra set is the inverse: HLIR-only.
+
+A spec that declared DiffPrivate / DPBudget / FairPrediction / FairnessGap as language types would be writing the enum, not the language. A spec that declared Octonion as absent because it is not a TypeKind would be writing the checker, not the backend.
+
+## What a spec may not say
+
+- That Sounio has ε-differential privacy as a type. DiffPrivate is an Executable nominal wrapper. ε is hardcoded. E075 is silent.
+- That Sounio has a privacy budget. DPBudget does not spend.
+- That Sounio has fairness as a type. FairPrediction and FairnessGap are Garden.
+- That refusing `f64` as `DiffPrivate` is Claim-ready. `NoSuchType` does the same.
+
+The decision to add Concept-IDs for privacy and justice, or to delete the TypeKinds, is the founder's. This census does not do either.

--- a/docs/audit/TYPE_ARCHAEOLOGY_FAMILY_G_2026-08-19.tsv
+++ b/docs/audit/TYPE_ARCHAEOLOGY_FAMILY_G_2026-08-19.tsv
@@ -1,0 +1,8 @@
+# NOT the ladder. Positions are derived by scripts/ci/kind_ladder_gate.sh from tests/archaeology/kind_ladder/index.tsv.
+# This file keeps the v2 notes. Do not copy a position out of here.
+# METHOD v2 notes, sha_main at last prose pass = 2b4d217a04. See TYPE_ARCHAEOLOGY_FAMILY_G_2026-08-19.md.
+kind	posicao	camada_mais_profunda	prog_certo	prog_errado	sha_main	notas
+DiffPrivate	Executable	checker	/tmp/archaeology-g-v2/dp_certo_id.sio rc=0	/tmp/archaeology-g-v2/dp_errado_compose.sio rc=0 (must compose/refuse, does neither)	2b4d217a04	v1 Executable kept; as constructs TyDiffPrivate via TypeExpr; E075 silent; ε hardcoded 1000; no HLIR/IR/codegen name; compile of as emits 8648B ELF (kind erased)
+DPBudget	Executable	checker	/tmp/archaeology-g-v2/bud_certo_id.sio rc=0	/tmp/archaeology-g-v2/bud_errado_twoq.sio rc=0 (must spend, spent stays 0)	2b4d217a04	v1 Executable kept; ε_total=1000 ε_spent=0 hardcoded; dp_budget_consume 0 live callers; not a budget; no HLIR/IR/codegen name
+FairPrediction	Garden	checker	none (as/id is NoSuchType twin, not TyFairPrediction)	none (E001 expected FairPrediction is ghost wall)	2b4d217a04	v1 Garden kept; no TypeExpr; ty_fair_prediction never called from check.sio; E080/E082 unread; not Reserva (compiler silent)
+FairnessGap	Garden	checker	none	none	2b4d217a04	v1 Garden kept; no TypeExpr; ty_fairness_gap not pub; E081 unread; zero docs; no Concept-ID

--- a/docs/audit/XPAS21_KNOWN_FAILURE_AUDIT_2026-08-19.md
+++ b/docs/audit/XPAS21_KNOWN_FAILURE_AUDIT_2026-08-19.md
@@ -1,0 +1,229 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.xpas21-known-failure-audit-2026-08-19
+authority: repo_only
+audience: users
+last_validated: 2026-08-19
+validated_by: grok-cli3
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.xpas21-known-failure-audit-2026-08-19
+-->
+
+# 21 unexpected known-failure passes — which ones are real
+
+Date: 2026-08-19
+Lane: `xpas21-audit-20260819`
+Dispatch: `/tmp/dispatch_xpas21_claude1.md`
+Worktree: `/workspace/.wt/xpas21-audit` at `origin/main` `cdea9d7eef` (includes `#1939` / `7be969ed05`)
+Companion: [`XPAS21_KNOWN_FAILURE_AUDIT_2026-08-19.tsv`](XPAS21_KNOWN_FAILURE_AUDIT_2026-08-19.tsv)
+
+No `//@ known-failure` tag was edited. No sidecar row was removed. This is measurement.
+
+---
+
+## Semantic-Lane declaration
+
+```text
+Semantic-Lane-ID: xpas21-audit-20260819
+Owner: grok-cli3
+Concept-IDs: SOUNIO-EPISTEMIC-NUMERIC-VALUE, SOUNIO-ORDERED-PATH-PROVENANCE
+Intent-Preserved: uncertainty crosses a function boundary without being erased; a CI green is not a live variance; compile success != runtime parity
+Transformation: none — classification of 21 XPAS plus a re-run of the FO arity matrix
+Types-Changed: none
+Effects-Changed: none
+IR-Changed: none
+Claims-Introduced: CI Full Test Suite on PR #1960 ran lean_single stage2, not Madaros; on Madaros rebuilt from cdea9d7eef, ADD3=0.000000 and ADD4=0.000000; gum_fo_across_call prints CALL_var 0.000000
+Claims-Forbidden: "FO is fixed"; "the arity hole closed"; "gum_fo_across_call XPASS means first-order variance survives a 3-arg call on Madaros"; "supports N-arg FO transfer"; "the 21 defects are gone"; "drop the gum_fo_across_call tag"
+Assumptions: Madaros is the claim-oracle; lean_single is the bootstrap seed and has no semantic authority; #1939 claimed imported 1-2 arg only and did not lift the >2-param skip
+Write-Set: docs/audit/XPAS21_KNOWN_FAILURE_AUDIT_2026-08-19.md; docs/audit/XPAS21_KNOWN_FAILURE_AUDIT_2026-08-19.tsv
+Read-Set: tests/run-pass/gum_fo_across_call.sio; tests/run-pass/gum_fo_arity3_boundary.sio; tests/run-pass/gum_fo_import_boundary.sio; tests/run-pass/fo_call_boundary_arity3.sio; tests/run-pass/fo_call_boundary_neg.sio; docs/audit/repro/fo_var_{samefile,import,callee}.sio; self-hosted/ir/lower.sio fo_register_pure_fn_transfer; .github/workflows/ci.yml full-test-suite; tests/known_failures/hardened_diagnostics_full_suite.txt
+Positive-Witness: none claimed for FO
+Negative-Witness: ADD3=0 and ADD4=0 on rebuilt Madaros; gum_fo_across_call CALL_var=0; E001 still refuses
+Acceptance-Gate: every one of the 21 is named CORRIGIDO / TESTEMUNHA-MORTA / INDETERMINADO; the FO matrix is a measured table against lean_single and rebuilt Madaros; a cell that must still fail did fail
+Integration-Target: none
+Authoritative-Only-If: a later Madaros rebuilt from source prints ADD3=14.0 and ADD4=14.25 on fo_var_samefile.sio
+```
+
+---
+
+## What CI actually ran
+
+PR [#1960](https://github.com/Sounio-lang/sounio/pull/1960) Full Test Suite
+(`https://github.com/Sounio-lang/sounio/actions/runs/32246471872/job/96048482036`)
+printed `Unexpected passes (stale known-failure): 21`.
+
+That job is **not Madaros**. `.github/workflows/ci.yml` `full-test-suite` sets
+`SOUNIO_TEST_SOUC_BIN: /tmp/souc-stage2`, the artifact of
+`native-selfhost-linux-x86_64` / `scripts/ci/selfhost_host_gate.sh`. That is the
+lean_single stage2 seed. Harness known-failure comes from two places:
+
+1. in-file `//@ known-failure`
+2. `tests/known_failures/hardened_diagnostics_full_suite.txt` (loaded only when
+   `--format junit` and no filter — exactly the CI invocation)
+
+17 of the 21 are sidecar rows with **no** in-file tag. Four have in-file tags.
+`gum_fo_arity3_boundary.sio` still has an in-file tag, `requires: madaros`, and
+was **not** among the 21 (skipped on lean).
+
+The EffectKind enum on #1960 does not explain these 21. They XPASS on a
+lean_single suite.
+
+---
+
+## Compilers used (mandatory)
+
+| role | what | identity |
+|---|---|---|
+| Madaros (FO + 21) | **rebuilt from source** on Slurm | job **10338**, `gpuorangefs-r770-proxmox`, 32 CPUs, build rc=0 in 226s, ELF **100553240** bytes, source `cdea9d7eef` |
+| lean_single (FO + 21) | committed seed via wrapper | `/workspace/.wt/xpas21-audit/bin/souc` + `SOUNIO_SOUC_ENGINE=lean_single`; seed `bin/souc-lean-single-x86_64` 2555805 B |
+| shipped ELF | **not used** | `bin/madaros-linux-x86_64` is not today's tree |
+
+`#1939` is an ancestor of `cdea9d7eef`. `self-hosted/ir/lower.sio:8698` still
+reads `// >2 params: skip (unsupported transfer)` and returns without
+registering a transfer.
+
+---
+
+## FO arity matrix (today's main)
+
+Expected: ADD3 = 14.0, ADD4 = 14.25. Locals are variance of `measure` (u=2,1,3,0.5) → 4, 1, 9, 0.25.
+
+| cell | expected | lean_single | Madaros rebuilt `cdea9d7eef` |
+|---|---:|---:|---:|
+| LOCAL_a | 4.0 | 4.000000 | 4.000000 |
+| LOCAL_b | 1.0 | 1.000000 | 1.000000 |
+| LOCAL_c | 9.0 | 9.000000 | 9.000000 |
+| LOCAL_d | 0.25 | 0.250000 | 0.250000 |
+| ID1 | 4.0 | 4.000000 | 4.000000 |
+| RET_ONLY | 4.0 | 4.000000 | 4.000000 |
+| ADD2 | 5.0 | 5.000000 | 5.000000 |
+| **ADD3** | **14.0** | **14.000000** | **0.000000** |
+| **ADD4** | **14.25** | **14.250000** | **0.000000** |
+| IMP_ID1 | 4.0 | 4.000000 | 4.000000 |
+| IMP_ADD2 | 5.0 | 5.000000 | 5.000000 |
+| IMP_ADD3 | 14.0 | 14.000000 | **0.000000** |
+
+Witness files:
+
+| witness | lean | Madaros rebuilt |
+|---|---|---|
+| `gum_fo_across_call.sio` (3-arg `rhs`, same file) | CALL_var **0.000013** `GUM_FO_ACROSS_CALL_OK` rc=0 | CALL_var **0.000000** `GUM_FO_ACROSS_CALL_ZERO` rc=1 |
+| `gum_fo_arity3_boundary.sio` | ADD3=14.000000 rc=0 | ADD3=**0.000000** rc=1 |
+| `gum_fo_import_boundary.sio` (2-arg imported) | PEEL=4 IMP=5 rc=1 (peel window) | PEEL=5 IMP=5 `GUM_FO_IMPORT_BOUNDARY_OK` rc=0 |
+| `fo_call_boundary_arity3.sio` | id3_var=1.000000 rc=0 | id3_var=**0.000000** rc=1 |
+| `fo_call_boundary_neg.sio` | neg_var=1.000000 rc=0 | neg_var=**0.000000** rc=1 |
+
+`#1939` did what it claimed: imported 1–2 arg helpers keep variance
+(`IMP_ID1`, `IMP_ADD2`, `gum_fo_import_boundary`). It did **not** close the
+arity hole. `gum_fo_across_call` is a 3-arg same-file helper plus `OpSub`.
+On today's Madaros it is still exactly zero. The CI XPASS of that file is
+lean_single doing what lean_single has always done.
+
+The witness is not dead. Its assertion (`v > 1e-12`) still fires. It is
+just not the instrument CI ran.
+
+---
+
+## Mandatory still-fail controls (instrument is not lying)
+
+Written before the Madaros run:
+
+1. **ADD3 must stay 0** if `fo_register_pure_fn_transfer` still skips `>2` params.
+   Measured: ADD3=0.000000, ADD4=0.000000, IMP_ADD3=0.000000.
+2. **E001 must still refuse** `let x: i64 = true`.
+   Measured: Madaros compile rc=1 (incompatible types); lean compile rc=1
+   (`Type mismatch — expected i64, got bool`).
+3. **`gum_fo_arity3_boundary` must still fail on Madaros.**
+   Measured: rc=1, `GUM_FO_ARITY3_BOUNDARY_ZERO`.
+
+If ADD3 had printed 14.0, the hole would be closed and that would be said
+loudly. It printed 0. The instrument is live.
+
+A fourth control was *not* used as the honesty pin: Madaros **accepts**
+`tests/compile-fail/refinement_f64_return_violation.sio` (compile rc=0,
+run rc=0). Lean now rejects it. That is a real Madaros hole, recorded
+below. It is not evidence the runner is greenwashing.
+
+---
+
+## The 21, one by one
+
+Class is about **why the CI lean suite printed XPAS**. Madaros results sit
+beside that class so nobody drops a tag that is still true on the oracle.
+
+| # | file | tag | class | why |
+|---|---|---|---|---|
+| 1 | `parser_card_a_misc_patterns.sio` | sidecar | **CORRIGIDO** | Sidecar = native-artifact backlog 2026-06-12. Assertion is "it runs" (return 0). Runs on lean and on rebuilt Madaros. |
+| 2 | `parser_card_a_refinement_predicates.sio` | sidecar | **CORRIGIDO** | Same backlog. Compound refinement predicates parse and evaluate on both engines. |
+| 3 | `pbpk28_struct_return.sio` | sidecar | **INDETERMINADO** | Lean runs and prints `cl=12.400000` + `PASS`. Rebuilt Madaros compile fails (preflight). CI XPASS is lean-only; Madaros still cannot produce the ELF. |
+| 4 | `rapamycin_iso_budget.sio` | sidecar | **TESTEMUNHA-MORTA** | `print("PASS\n")` is unconditional (line 227) after a Knowledge/Budget64 cross-check that **printed out of [0.9,1.1]** on lean. Harness only greps `PASS` and `inf`. Lean executes; Madaros thin-link fails (`ir_into_acc_failed`). The ISO-budget claim is not gated. |
+| 5 | `rapamycin_rk4_budget.sio` | sidecar | **INDETERMINADO** | Stronger than #4: `FAMILY_A_VAR_LIVE` is gated on live `var_blood_k`. Lean prints it + `PASS`. Madaros thin-link fails. CI XPASS is lean execution, not a Madaros FO close. |
+| 6 | `darwin_compartments_coronary_smc_smoke.sio` | sidecar | **CORRIGIDO** | Mass-balance smoke. `CORONARY_SMC_SMOKE_PASS` on lean and Madaros with the three `f_local` regimes. |
+| 7 | `darwin_pd_coronary_smc_smoke.sio` | sidecar | **CORRIGIDO** | PD smoke. `PD_CORONARY_SMC_SMOKE_PASS` on both; N shrinks as `target_a` falls. |
+| 8 | `dissertation_pbpk28_confidence_gate.sio` | sidecar | **CORRIGIDO** | `PBPK28_CONFIDENCE_GATE_PASS` on both. Method demonstration, not a dosing engine. |
+| 9 | `refinement_f64_return_violation.sio` | sidecar + compile-fail | **CORRIGIDO** (lean only) | Lean now emits `refinement type violation` (the pattern the test names). Madaros **accepts** `return 1.7` and runs it. Dropping the sidecar from a lean XPASS would hide a live Madaros hole. |
+| 10 | `turbofish_concrete_type_mismatch.sio` | in-file, lean-only soundness | **CORRIGIDO** | Tag said lean accepts `identity::<bool>(42)`. Today's lean rejects E001. Madaros still rejects. The lean gap the tag named is closed on this seed. |
+| 11 | `test_pipeline_real_e2e.sio` | sidecar | **CORRIGIDO** | `SCIENCE_PBPK_OK` + live metrics on both engines. |
+| 12 | `fo_call_boundary_arity3.sio` | in-file, Madaros FO >2 params | **INDETERMINADO** | CI engine is lean, which the tag already said keeps a live variance (`id3_var=1`). Madaros still prints 0. The defect the tag names is **not** fixed. |
+| 13 | `fo_call_boundary_neg.sio` | in-file, Madaros no OpSub | **INDETERMINADO** | Same split: lean `neg_var=1`, Madaros 0. OpSub transfer is still absent. |
+| 14 | `test_kaxi_fuse.sio` | sidecar | **INDETERMINADO** | Lean prints `kaxi_fuse: PASS` against the 11.6 / 0.8944 window. Rebuilt Madaros **SEGV 139** in `lower_array` during compile. |
+| 15 | `test_core_e2e.sio` | sidecar | **INDETERMINADO** | Lean rc=0 (numeric `check_near` battery). Madaros compile preflight fails. |
+| 16 | `test_hyper_math_e2e.sio` | sidecar | **CORRIGIDO** | `HYPER_MATH_OK` on both; oct_mul / sed flags printed. |
+| 17 | `test_distributions_e2e.sio` | sidecar | **INDETERMINADO** | Lean `Passed: 7 Failed: 0`. Madaros compile preflight fails. |
+| 18 | `test_log_path_cmp.sio` | sidecar | **CORRIGIDO** | Numeric log/path/cmp guards; rc=0 on both. |
+| 19 | `gum_fo_across_call.sio` | in-file, Madaros Family A | **INDETERMINADO** | **This is the FO witness.** CI XPASS is lean (`CALL_var 0.000013`). Rebuilt Madaros: `CALL_var 0.000000`, `EPISTEMIC_FABRICATION`. Assertion is alive. Defect is alive. Do not drop the tag. |
+| 20 | `associator_field_octonion.sio` | sidecar | **CORRIGIDO** | `ALL PASS` on both (Fano / non-Fano windows). |
+| 21 | `knowledge_array.sio` | sidecar | **INDETERMINADO** | Lean prints `KNOWLEDGE_ARRAY_PASS` after the 800-slot stomp. Madaros compile ok, **run SEGV 139**. |
+
+Counts on the CI question: **CORRIGIDO 10**, **TESTEMUNHA-MORTA 1**,
+**INDETERMINADO 10**.
+
+The three FO in-file tags in the 21 (rows 12, 13, 19) are INDETERMINADO
+because the suite that printed XPAS was not the engine the tag accuses.
+On the oracle they still fail.
+
+---
+
+## What `#1939` did and did not close
+
+Title: `fix(madaros): imported 1-2 arg helpers keep first-order variance`.
+Receipt on this rebuild:
+
+- imported 1-arg and 2-arg: live (IMP_ID1=4, IMP_ADD2=5, import-boundary OK)
+- same-file 1-arg and 2-arg: live (already were)
+- same-file ≥3: **still zero**
+- imported ≥3: **still zero**
+- `0.0 - x` through a user fn: **still zero**
+- `rhs(c, cl, fu)` 20-step loop: **still zero**
+
+The 3-arg same-file witness did not start passing because `#1939` over-closed.
+It "passes" in CI because CI is lean.
+
+---
+
+## What not to do next
+
+- Do not drop `gum_fo_across_call`, `fo_call_boundary_arity3`,
+  `fo_call_boundary_neg`, or `gum_fo_arity3_boundary` tags.
+- Do not announce FO fixed. ADD3 is 0.000000 on rebuilt Madaros.
+- Sidecar rows that are CORRIGIDO on **both** engines (1, 2, 6, 7, 8, 11, 16,
+  18, 20) are the only ones a later lane may consider removing, and only after
+  someone else decides. This lane does not touch them.
+- `refinement_f64_return_violation` must not be removed from the sidecar on
+  the strength of a lean XPASS.
+
+---
+
+## Semantic-Outcome
+
+```text
+Semantic-Outcome: measurement only; FO not declared fixed
+Concept-Status-Before: #1939 claimed imported 1-2 arg FO; CI printed 21 XPAS including gum_fo_across_call
+Concept-Status-After: imported 1-2 confirmed on rebuilt Madaros; arity ≥3 and OpSub still erase; the 21 XPAS are a lean_single Full Suite signal
+Distinctions-Added: Full Test Suite stage2 != Madaros claim-oracle; CI XPASS != defect closed
+Distinctions-Preserved: uncertainty != ignorance; compile success != runtime parity; lean_single is not the oracle
+Distinctions-Erased: none
+Evidence-Run: Slurm job 10338 rebuild 226s ELF 100553240; local lean_single matrix; CI job 96048482036
+Fallback-Path: none
+Legacy-Kept: every known-failure tag and every sidecar row
+Conflicting-Lanes: grok-cli5 effect-enum-2a/2b (PR #1960 is the CI surface, not the FO surface)
+Next-Semantic-Interface: a later lane may drop sidecar rows that passed on both engines; FO tags stay until ADD3=14.0 and ADD4=14.25 on a source-rebuilt Madaros
+```

--- a/docs/audit/XPAS21_KNOWN_FAILURE_AUDIT_2026-08-19.tsv
+++ b/docs/audit/XPAS21_KNOWN_FAILURE_AUDIT_2026-08-19.tsv
@@ -1,0 +1,28 @@
+id	path	tag_source	ci_engine	lean_compile	lean_run	lean_note	madaros_compile	madaros_run	madaros_note	assertion_alive	class	why
+1	tests/run-pass/parser_card_a_misc_patterns.sio	sidecar	lean_stage2	0	0	runs return 0	0	0	runs return 0	weak_smoke	CORRIGIDO	native-artifact backlog; now runs on both
+2	tests/run-pass/parser_card_a_refinement_predicates.sio	sidecar	lean_stage2	0	0	bounded/nonzero/or predicates	0	0	same	yes	CORRIGIDO	native-artifact backlog; now runs on both
+3	tests/run-pass/pbpk28_struct_return.sio	sidecar	lean_stage2	0	0	cl=12.400000 PASS	1	-	preflight failed	yes_on_lean	INDETERMINADO	lean XPASS; Madaros still cannot compile
+4	tests/run-pass/rapamycin_iso_budget.sio	sidecar	lean_stage2	0	0	PASS unconditional; Knowledge/Budget64 out of [0.9,1.1]	1	-	ir_into_acc_failed	no_pass_unconditional	TESTEMUNHA-MORTA	PASS printed regardless of cross-check
+5	tests/run-pass/rapamycin_rk4_budget.sio	sidecar	lean_stage2	0	0	FAMILY_A_VAR_LIVE+PASS	1	-	ir_into_acc_failed	yes_on_lean	INDETERMINADO	live-var gate holds on lean; Madaros thin-link fails
+6	tests/run-pass/darwin_compartments_coronary_smc_smoke.sio	sidecar	lean_stage2	0	0	CORONARY_SMC_SMOKE_PASS	0	0	CORONARY_SMC_SMOKE_PASS	yes	CORRIGIDO	mass-balance smoke green on both
+7	tests/run-pass/darwin_pd_coronary_smc_smoke.sio	sidecar	lean_stage2	0	0	PD_CORONARY_SMC_SMOKE_PASS	0	0	PD_CORONARY_SMC_SMOKE_PASS	yes	CORRIGIDO	PD smoke green on both
+8	tests/run-pass/dissertation_pbpk28_confidence_gate.sio	sidecar	lean_stage2	0	0	PBPK28_CONFIDENCE_GATE_PASS	0	0	PBPK28_CONFIDENCE_GATE_PASS	yes	CORRIGIDO	method demo green on both
+9	tests/compile-fail/refinement_f64_return_violation.sio	sidecar+compile-fail	lean_stage2	1	-	refinement type violation	0	0	ACCEPTS return 1.7	yes_on_lean	CORRIGIDO	lean now rejects; Madaros still accepts — do not drop sidecar
+10	tests/compile-fail/turbofish_concrete_type_mismatch.sio	in-file lean-only	lean_stage2	1	-	E001 type mismatch	1	-	preflight type mismatch	yes	CORRIGIDO	lean soundness gap the tag named is closed
+11	tests/stdlib/darwin_pbpk/test_pipeline_real_e2e.sio	sidecar	lean_stage2	0	0	SCIENCE_PBPK_OK	0	0	SCIENCE_PBPK_OK	yes	CORRIGIDO	metrics+token on both
+12	tests/run-pass/fo_call_boundary_arity3.sio	in-file Madaros FO>2	lean_stage2	0	0	id3_var=1.000000	0	1	id3_var=0.000000	yes	INDETERMINADO	CI is lean; Madaros defect still live
+13	tests/run-pass/fo_call_boundary_neg.sio	in-file Madaros no-OpSub	lean_stage2	0	0	neg_var=1.000000	0	1	neg_var=0.000000	yes	INDETERMINADO	CI is lean; OpSub transfer still absent
+14	tests/stdlib/epistemic/test_kaxi_fuse.sio	sidecar	lean_stage2	0	0	kaxi_fuse PASS 11.6/0.8944	139	-	SEGV lower_array	yes_on_lean	INDETERMINADO	lean numeric pass; Madaros compiler crash
+15	tests/stdlib/math/test_core_e2e.sio	sidecar	lean_stage2	0	0	check_near battery rc=0	1	-	preflight failed	yes_on_lean	INDETERMINADO	lean pass; Madaros compile fail
+16	tests/stdlib/math/test_hyper_math_e2e.sio	sidecar	lean_stage2	0	0	HYPER_MATH_OK	0	0	HYPER_MATH_OK	yes	CORRIGIDO	oct/sed metrics on both
+17	tests/stdlib/random/test_distributions_e2e.sio	sidecar	lean_stage2	0	0	7/7 PASS	1	-	preflight failed	yes_on_lean	INDETERMINADO	lean pass; Madaros compile fail
+18	tests/stdlib/util/test_log_path_cmp.sio	sidecar	lean_stage2	0	0	log/path/cmp rc=0	0	0	rc=0	yes	CORRIGIDO	numeric guards on both
+19	tests/run-pass/gum_fo_across_call.sio	in-file Madaros Family A	lean_stage2	0	0	CALL_var=0.000013 OK	0	1	CALL_var=0.000000 ZERO	yes	INDETERMINADO	FO witness; CI XPASS is lean; Madaros still fabricates zero
+20	tests/run-pass/associator_field_octonion.sio	sidecar	lean_stage2	0	0	ALL PASS	0	0	ALL PASS	yes	CORRIGIDO	Fano/non-Fano windows on both
+21	tests/run-pass/knowledge_array.sio	sidecar	lean_stage2	0	0	KNOWLEDGE_ARRAY_PASS	0	139	run SEGV after compile	yes_on_lean	INDETERMINADO	lean stomp-survives; Madaros run crash
+FO_SAME_ADD3	docs/audit/repro/fo_var_samefile.sio	matrix	n/a	0	0	ADD3=14.000000	0	0	ADD3=0.000000	yes	n/a	arity hole still open on Madaros
+FO_SAME_ADD4	docs/audit/repro/fo_var_samefile.sio	matrix	n/a	0	0	ADD4=14.250000	0	0	ADD4=0.000000	yes	n/a	arity hole still open on Madaros
+FO_IMP_ADD2	docs/audit/repro/fo_var_import.sio	matrix	n/a	0	0	IMP_ADD2=5.000000	0	0	IMP_ADD2=5.000000	yes	n/a	#1939 imported 1-2 holds
+FO_IMP_ADD3	docs/audit/repro/fo_var_import.sio	matrix	n/a	0	0	IMP_ADD3=14.000000	0	0	IMP_ADD3=0.000000	yes	n/a	imported >=3 still zero
+CTRL_E001	must_fail_e001.sio	control	n/a	1	-	Type mismatch i64/bool	1	-	incompatible types	yes	n/a	instrument still refuses a real type error
+CTRL_ARITY3	tests/run-pass/gum_fo_arity3_boundary.sio	in-file requires:madaros	skipped_on_ci	0	0	ADD3=14	0	1	ADD3=0 ZERO	yes	n/a	mandatory still-fail control fired

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -385,8 +385,10 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.stats-shapiro-e2e-vertical-2026-07-18 | repo_only | docs/audit/STATS_SHAPIRO_E2E_VERTICAL_2026-07-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.surgical-calculus-disjoint-union-2026-08-19 | repo_only | docs/audit/SURGICAL_CALCULUS_DISJOINT_UNION_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.token-ceiling-blocked-runpass-census-2026-08-17 | repo_only | docs/audit/TOKEN_CEILING_BLOCKED_RUNPASS_CENSUS_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.type-archaeology-family-g-2026-08-19 | repo_only | docs/audit/TYPE_ARCHAEOLOGY_FAMILY_G_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.type-enum-denominator-2026-08-19 | repo_only | docs/audit/TYPE_ENUM_DENOMINATOR_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.typekind-archaeology-fh-2026-08-19 | repo_only | docs/audit/TYPEKIND_ARCHAEOLOGY_FH_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.typekind-concept-cross-2026-08-19 | repo_only | docs/audit/TYPEKIND_CONCEPT_CROSS_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.units-promise-measurement-2026-08-19 | repo_only | docs/audit/UNITS_PROMISE_MEASUREMENT_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.unlearning-quadrant-2026-08-19 | repo_only | docs/audit/UNLEARNING_QUADRANT_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.vec-new-path-call-fabrication-census-2026-08-17 | repo_only | docs/audit/VEC_NEW_PATH_CALL_FABRICATION_CENSUS_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -406,6 +408,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.worktree-branch-governance-audit-2026-06-20 | repo_only | docs/audit/WORKTREE_BRANCH_GOVERNANCE_AUDIT_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.ws-c2-lean-single-seed-only-surface-map-2026-08-19 | repo_only | docs/audit/WS_C2_LEAN_SINGLE_SEED_ONLY_SURFACE_MAP_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.ws-f-close-acceptance-2026-08-16 | repo_only | docs/audit/WS_F_CLOSE_ACCEPTANCE_2026-08-16.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.xpas21-known-failure-audit-2026-08-19 | repo_only | docs/audit/XPAS21_KNOWN_FAILURE_AUDIT_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.zd-annihilate-builtin-dispatch-2026-08-19 | repo_only | docs/audit/ZD_ANNIHILATE_BUILTIN_DISPATCH_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.zd-exactness-floating-point-boundary-2026-08-19 | repo_only | docs/audit/ZD_EXACTNESS_FLOATING_POINT_BOUNDARY_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.zd-family-call-path-2026-08-20 | repo_only | docs/audit/ZD_FAMILY_CALL_PATH_2026-08-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8319,6 +8319,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.type-archaeology-family-g-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/TYPE_ARCHAEOLOGY_FAMILY_G_2026-08-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.type-enum-denominator-2026-08-19",
       "collection": "repo",
       "repo_doc_path": "docs/audit/TYPE_ENUM_DENOMINATOR_2026-08-19.md",
@@ -8345,6 +8368,29 @@
       "topic_id": "repo.docs.audit.typekind-archaeology-fh-2026-08-19",
       "collection": "repo",
       "repo_doc_path": "docs/audit/TYPEKIND_ARCHAEOLOGY_FH_2026-08-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.audit.typekind-concept-cross-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/TYPEKIND_CONCEPT_CROSS_2026-08-19.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",
@@ -8782,6 +8828,29 @@
       "topic_id": "repo.docs.audit.ws-f-close-acceptance-2026-08-16",
       "collection": "repo",
       "repo_doc_path": "docs/audit/WS_F_CLOSE_ACCEPTANCE_2026-08-16.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.audit.xpas21-known-failure-audit-2026-08-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/XPAS21_KNOWN_FAILURE_AUDIT_2026-08-19.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",

--- a/tests/archaeology/kind_ladder/index.tsv
+++ b/tests/archaeology/kind_ladder/index.tsv
@@ -1,0 +1,9 @@
+# Kind-ladder index. Positions are NOT stored. The gate derives them.
+# kind	pass_path	refuse_path	expected_diagnostic	deepest_layer
+# Empty pass_path and refuse_path (or "-") = Garden, declared. Not judged.
+# Day-zero: Family G only. Other families append rows; the gate grows.
+kind	pass_path	refuse_path	expected_diagnostic	deepest_layer
+DiffPrivate	tests/archaeology/kind_ladder/DiffPrivate.pass.sio	tests/archaeology/kind_ladder/DiffPrivate.refuse.sio	E001	checker
+DPBudget	tests/archaeology/kind_ladder/DPBudget.pass.sio	tests/archaeology/kind_ladder/DPBudget.refuse.sio	E001	checker
+FairPrediction	-	-	-	checker
+FairnessGap	-	-	-	checker


### PR DESCRIPTION
## Why

L9 close-as-superseded left unique measurements off `main`. Prior salvage `9b9d003d7d` (`lane/cursor-1/l2-pr-close`) has no PR and is not an ancestor of `origin/main`.

## Salvaged

- `#1964` → 28-row `docs/audit/XPAS21_KNOWN_FAILURE_AUDIT_2026-08-19.{md,tsv}` (headline numbers already in `#1981` `07a55a068c` / `gating-engine.md`)
- `#1942` → four family-G index rows in `tests/archaeology/kind_ladder/index.tsv` plus `docs/audit/TYPE_ARCHAEOLOGY_FAMILY_G_2026-08-19.{md,tsv}` (gate path already in `#1945` `5b3c222aa1`)
- Extra found this lane: `docs/audit/TYPEKIND_CONCEPT_CROSS_2026-08-19.{md,tsv}` (24-concept × TypeKind census; not carried by `#1945`)

## Abandoned (not in this PR)

- `#1942` `kind_ladder_gate.sh` + DiffPrivate/DPBudget fixtures + `KIND_LADDER_GATE` declaration — parallel gate; `#1948` wires `#1945`'s `typekind_archaeology_gate.sh`
- `#1842` E137/RC182 measurement docs — compiler change is `setup_intrinsics` on main via `#1875` `fc3f91621d`; the four non-verbatim lines are stale `ty_unknown()` stubs that main already replaced with `ty_knowledge(...)`
- `#1929` `.scratch/e230_*` patches and `HANDLE_TABLE_CEILING_REFUSAL_*` — gate + E230 refutation already on main via `#1901`

Does **not** close `#1580`. Does **not** merge any of the L9 PRs.

Registry check: `node scripts/docs/check_docs_registry.mjs` passed after `sync_governance_metadata.mjs`.