### PR TITLE
docs(research): the oracle is modular, not rational — the numbers survive, and the structure extends to n=128

### DIFF
--- a/docs/audit/KERNEL_SPECTRUM_ORACLE_DOMAIN_2026-08-23.md
+++ b/docs/audit/KERNEL_SPECTRUM_ORACLE_DOMAIN_2026-08-23.md
@@ -134,8 +134,53 @@ Not one pair failed certification. The spectrum `{0} ∪ {4 + 8i}` and its
 maximum `n/2 − 4` now rest on integer arithmetic across the whole published
 range, not on a claim about the alphabet of the entries.
 
+## Second addendum: the STRUCTURE, exactly, for n = 32, 64 and 128
+
+`scripts/research/cd_zd_kernel_structure_exact.py`. Each of the three structure
+claims fails in a DIFFERENT direction under a modular computation, and two of
+them turn out to need no extra work at all:
+
+**Distinct kernels — the modular count is a lower bound, and it is tight.**
+Equal over ℚ implies equal modular key, because the lifted modular basis is (by
+the certificate above) an exact basis of `ker_ℚ`, so equal ℚ-spaces reduce to
+equal `F_P`-spaces. Distinct keys therefore mean distinct over ℚ, and the only
+thing left to check is whether any key bucket secretly holds two different
+ℚ-subspaces. Rank test, integers only. **Zero non-uniform buckets in every
+dimension.**
+
+**Clique — already exact, and nobody had noticed.** `zero_pair` sums four ±1
+table entries, so every component satisfies `|v_k| ≤ 4 < P`, and `v % P == 0`
+is *equivalent* to `v == 0` over ℤ. The modular test was never approximate here.
+
+**Maximum independent set — the modular value is a lower bound.** Independent
+mod `P` implies independent over ℚ, so confirming a maximum requires showing no
+set of size `max+1` is independent over ℚ. That is genuine combinatorial search
+and is the one claim with no shortcut; it is still running for `n = 32` and is
+not reported here.
+
+| n | pairs | `ker = 0` | `ker > 0` | distinct kernels | non-uniform buckets | clique |
+|---:|---:|---:|---:|---:|---:|---:|
+| 16 | 56 | 14 | 42 | **42** | 0 | 2 |
+| 32 | 240 | 30 | 210 | **210** | 0 | 3 |
+| 64 | 992 | 62 | 930 | **930** | 0 | 3 |
+| 128 | 4032 | 126 | 3906 | **3906** | 0 | 3 |
+
+Three facts the published document does not state:
+
+1. **The map pair → kernel is injective** on non-degenerate pairs, in every
+   dimension measured. Two *primitives* share a subspace (`e_a + e_b` and
+   `e_a − e_b`); two *pairs* never do. The document observes this at `n = 16`
+   and treats it as a remark; it holds across all 5,208 pairs.
+2. **The clique rises from 2 to 3 and stops.** `n = 16` gives 2; `n = 32`, 64
+   and 128 all give 3. The document only speaks of `n = 16`, so this is new
+   ground rather than verification.
+3. **`ker = 0` count is exactly `n − 2`** in every dimension, which confirms the
+   degeneracy rule `c₊ = 0 ⟺ b′ = 0 ∨ a = b′` by an independent count.
+
 ## Not claimed
 
+- The maximum-independent-set value at `n ≥ 32` is NOT established. The modular
+  search gives a lower bound and the exact confirmation is still running.
 - The certificate covers the kernel DIMENSIONS. The n = 16 structure numbers —
   42 distinct kernels, clique 2, max 3 independent — were verified separately
   over Q by `cd_zd_kernel_spectrum_exact_check.py`; the analogous structure at

--- a/docs/audit/KERNEL_SPECTRUM_ORACLE_DOMAIN_2026-08-23.md
+++ b/docs/audit/KERNEL_SPECTRUM_ORACLE_DOMAIN_2026-08-23.md
@@ -1,0 +1,147 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.kernel-spectrum-oracle-domain-2026-08-23
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.kernel-spectrum-oracle-domain-2026-08-23
+-->
+
+# The numbers in #1466 are right. The reason given for them is not.
+
+**Date:** 2026-08-23
+**Status:** corrective. #1466 stays merged; no published number changes.
+
+## The objection
+
+`docs/research/cayley_dickson_zd_kernel_spectrum_2026-07-26.md:155` says the
+oracle
+
+> computes `dim ker(L_u)` by rank over a prime field (entries are `0, ±1`, so
+> the rank equals the rational rank)
+
+and `scripts/research/cd_zd_kernel_spectrum.py:70` implements exactly that,
+with `pow(R[r][c], P - 2, P)` and `P = 2^31 - 1`.
+
+**The parenthetical is false.** An integer matrix with entries `0, ±1` can have
+a minor that is nonzero over Q and divisible by P; the rank then drops mod P.
+Entry magnitude bounds nothing about the determinant.
+
+Nor does the size rescue it. For a 16×16 matrix with `|a_ij| ≤ 1` the Hadamard
+bound is `16^8 = 2^32 = 4,294,967,296` against `P = 2,147,483,647` — a factor of
+exactly **2.00**. A single minor can be twice P, so nothing forbids one being an
+exact multiple.
+
+The doc also describes this path as "exact rational arithmetic". It is modular.
+
+## The recomputation
+
+`scripts/research/cd_zd_kernel_spectrum_exact_check.py` redoes the whole n = 16
+structure with `fractions.Fraction` — no modulus in the rank, none in the kernel
+identity, none in the independence search — and diffs it against the modular
+oracle.
+
+| claim | modular F_P | exact Q |
+|---|---:|---:|
+| index pairs with `dim ker = 4` | 42 | **42** |
+| distinct kernels | 42 | **42** |
+| maximum linearly independent kernels | 3 | **3** |
+
+**Every published number survives.** No claim in #1466 changes.
+
+## What this does and does not settle
+
+It settles the numbers. It does not settle the justification, and the two are
+not the same thing.
+
+The implication "entries are `0, ±1`, therefore rank over F_P equals rank over
+Q" is false, and it would still be false if the numbers had agreed in every
+dimension. What actually happened is narrower and luckier: none of the 56
+relevant minors at n = 16 happened to be a multiple of this particular prime.
+That is a fact about `2^31 - 1` and these 56 matrices, not a theorem about
+0,±1 matrices.
+
+So the correct form of the claim is:
+
+- the spectrum, its maximum and the degeneracy rule stand on the combinatorial
+  derivation, and never depended on the oracle's arithmetic;
+- the three structural numbers at n = 16 are now verified **over Q**, and that
+  is what should be cited;
+- the modular path stays, as a fast check, and is no longer the authority.
+
+If some property of these operators does guarantee the modular rank equals the
+rational rank, it is a lemma and has to be proved. It cannot be inferred from
+the alphabet of the entries.
+
+## The architectural point
+
+An oracle's arithmetic domain is a claim-bearing property:
+
+```
+mathematical claim -> oracle arithmetic domain -> proved correspondence -> evidence
+```
+
+A modular computation does not acquire the identity of a rational computation by
+being described as one. This repository already refuses a green that has never
+been red; it should equally refuse an "exact" that was computed mod P.
+
+That belongs in the same family as the inert-surface ratchet landed today: a
+thing that claims a property must be able to be refuted on it.
+
+## Addendum, same day: n ≤ 128 certified exactly
+
+The gap above is closed. `scripts/research/cd_zd_kernel_spectrum_exact_certificate.py`
+certifies every kernel dimension for n = 8, 16, 32, 64, 128 — all 5,208 index
+pairs — with integer arithmetic only.
+
+Redoing the elimination over Q was not the way. At n = 128 there are 4,032
+pairs and Fraction numerators explode; and no single-prime result can be made
+safe by a bound, since the Hadamard bound for a 128×128 matrix with
+`|a_ij| ≤ 2` is astronomically beyond any word-sized prime. The certificate
+uses a fact that holds for EVERY prime instead:
+
+```
+rank over F_P  ≤  rank over Q        (a Q-dependency stays dependent mod P;
+                                      the converse can fail)
+so   dim ker over Q  ≤  dim ker over F_P
+```
+
+The modular dimension is therefore an **upper bound for free, with no
+assumption about the entries at all** — which is precisely what the false
+parenthetical was trying and failing to supply. Pinning the value then needs
+only a lower bound, and that is exhibited rather than computed:
+
+1. take the modular kernel basis,
+2. lift each vector to integers in the symmetric range,
+3. verify `M · v == 0` **exactly over Z**, no modulus,
+4. verify the lifted vectors are independent over Q by integer-only Bareiss
+   elimination.
+
+Step 3 gives `dim ker_Q ≥ k`; the inequality above gives `≤ k`. Equality
+follows, and every step is integer arithmetic.
+
+Result — the published spectrum, certified:
+
+| n | dim ker multiset | pairs | certified |
+|---:|---|---:|---|
+| 8 | {0: 12} | 12 | yes |
+| 16 | {0: 14, 4: 42} | 56 | yes |
+| 32 | {0: 30, 4: 84, 12: 126} | 240 | yes |
+| 64 | {0: 62, 4: 252, 12: 168, 20: 168, 28: 342} | 992 | yes |
+| 128 | {0: 126, 4: 684, 12: 504, 20: 336, 28: 336, 36: 336, 44: 336, 52: 504, 60: 870} | 4032 | yes |
+
+Not one pair failed certification. The spectrum `{0} ∪ {4 + 8i}` and its
+maximum `n/2 − 4` now rest on integer arithmetic across the whole published
+range, not on a claim about the alphabet of the entries.
+
+## Not claimed
+
+- The certificate covers the kernel DIMENSIONS. The n = 16 structure numbers —
+  42 distinct kernels, clique 2, max 3 independent — were verified separately
+  over Q by `cd_zd_kernel_spectrum_exact_check.py`; the analogous structure at
+  n ≥ 32 was not computed and is not claimed.
+- The false parenthetical is still in the merged document text and still needs
+  removing. Certifying the numbers does not repair the sentence.
+- The exact check is Python, matching the oracle it verifies. Porting the
+  science path to Sounio is a separate and larger piece of work; introducing a
+  second language here would have been the drift, not the check.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -201,6 +201,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.kaxi-ptx-golden-drop-not-mismatch-2026-08-19 | repo_only | docs/audit/KAXI_PTX_GOLDEN_DROP_NOT_MISMATCH_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kaxi-ptx-target-sm-audit-2026-06-17 | repo_only | docs/audit/KAXI_PTX_TARGET_SM_AUDIT_2026-06-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kconf-bitcast-apply-package-2026-08-18 | repo_only | docs/audit/KCONF_BITCAST_APPLY_PACKAGE_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.kernel-spectrum-oracle-domain-2026-08-23 | repo_only | docs/audit/KERNEL_SPECTRUM_ORACLE_DOMAIN_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.knowledge-annotation-parser-coverage-2026-08-19 | repo_only | docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.knowledge-annotation-surface-madaros-only-2026-08-19 | repo_only | docs/audit/KNOWLEDGE_ANNOTATION_SURFACE_MADAROS_ONLY_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.known-failure-needs-an-engine-2026-08-19 | repo_only | docs/audit/KNOWN_FAILURE_NEEDS_AN_ENGINE_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -4087,6 +4087,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.kernel-spectrum-oracle-domain-2026-08-23",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/KERNEL_SPECTRUM_ORACLE_DOMAIN_2026-08-23.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.knowledge-annotation-parser-coverage-2026-08-19",
       "collection": "repo",
       "repo_doc_path": "docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md",

--- a/docs/research/cayley_dickson_zd_kernel_spectrum_2026-07-26.md
+++ b/docs/research/cayley_dickson_zd_kernel_spectrum_2026-07-26.md
@@ -119,7 +119,9 @@ group.
 For `n = 16` this reproduces the validity conditions used in `formal/lean4/SounioZeroDivisorBridge.lean`
 (`hi ≠ 8` and `lo⊕hi ≠ 8`), which the repository states as a definition.
 
-**Cross-validation.** An independent reconstruction of the algebra in exact rational arithmetic
+**Cross-validation.** An independent reconstruction of the algebra — modular in
+`F_P` for the rank step, with every reported kernel dimension separately
+certified over ℤ (see the Reproduction note below) —
 reproduces the repository's Lean results: 84 valid primitives in 𝕊, each with exactly 4 annihilators
 (`prim_count_84`, `every_primitive_has_4_annihilators`). It further shows `dim ker(L_u) = 0` for a
 generic element such as `1 + e₃` — annihilation is a rare, structured property, not a generic one.
@@ -152,8 +154,32 @@ kernel dimensions up the tower.
 
 `scripts/research/cd_zd_kernel_spectrum.py` is self-contained and independent of the repository's
 Lean corpus: it builds the CD multiplication table by recursion on the construction, computes
-`dim ker(L_u)` by rank over a prime field (entries are `0, ±1`, so the rank equals the rational
-rank), and enumerates cycle structures. Running it reproduces, in order:
+`dim ker(L_u)` by rank over the prime field `F_P`, `P = 2^31 - 1`, and enumerates
+cycle structures.
+
+> **Correction, 2026-08-23.** This sentence previously read "(entries are
+> `0, ±1`, so the rank equals the rational rank)". **That implication is false.**
+> An integer matrix with entries `0, ±1` can have a minor that is nonzero over
+> ℚ and divisible by `P`, and the rank then drops mod `P`; entry magnitude
+> bounds nothing about a determinant. Size does not rescue it either — the
+> Hadamard bound for a 16×16 matrix with `|a_ij| ≤ 1` is `16^8 = 2^32`, exactly
+> **2.00×** `P`, so a single minor can be twice the prime.
+>
+> The modular computation is kept, because `rank_{F_P} ≤ rank_ℚ` holds for every
+> prime, which makes the reported kernel dimension a genuine **upper bound** at
+> no cost and with no assumption about the entries. The lower bound is supplied
+> separately, by exhibiting the kernel vectors and verifying `M · v = 0`
+> **exactly over ℤ** plus independence over ℚ by integer-only Bareiss
+> elimination — see `scripts/research/cd_zd_kernel_spectrum_exact_certificate.py`,
+> which certifies all 5,208 index pairs for `n ≤ 128` with no pair failing.
+> The `n = 16` structure numbers are separately recomputed over ℚ in
+> `scripts/research/cd_zd_kernel_spectrum_exact_check.py` and are unchanged: 42
+> distinct kernels, clique 2, maximum 3 independent.
+>
+> No published number changed. What changed is which of them is load-bearing:
+> the numbers now rest on integer arithmetic, not on a claim about the alphabet
+> of the entries. Full record:
+> `docs/audit/KERNEL_SPECTRUM_ORACLE_DOMAIN_2026-08-23.md`. Running it reproduces, in order:
 
 | output | claim it checks | scope |
 |---|---|---|

--- a/scripts/research/cd_zd_kernel_spectrum_exact_certificate.py
+++ b/scripts/research/cd_zd_kernel_spectrum_exact_certificate.py
@@ -1,0 +1,98 @@
+"""Exact certification of dim ker(L_u) at n = 64 and n = 128, without ever
+doing rational elimination on a 128x128 matrix.
+
+Why not just redo the RREF with Fraction: at n = 128 there are 4032 index pairs
+and each elimination blows the numerators up. And a single-prime modular result
+can never be made safe by a bound here -- the Hadamard bound for a 128x128
+matrix with |a_ij| <= 2 is astronomically beyond any word-sized prime.
+
+The certificate instead uses a fact that holds for EVERY prime:
+
+    rank over F_P  <=  rank over Q          (a Q-dependency stays dependent mod P;
+                                             the converse can fail)
+
+so                dim ker over Q  <=  dim ker over F_P.
+
+The modular kernel dimension is therefore an UPPER bound, for free and with no
+assumption about the entries. To pin the value exactly it is enough to exhibit
+that many kernel vectors and verify them over the integers:
+
+  1. take the modular kernel basis,
+  2. lift each vector to integers in the symmetric range and clear denominators,
+  3. verify  M . v == 0  EXACTLY over Z  -- no modulus,
+  4. verify the lifted vectors are independent over Q, by integer-only
+     Bareiss elimination on the 4 x n stack.
+
+(3) gives dim ker_Q >= (number of verified vectors); (1) gives <=. Equality
+follows, and every step is integer arithmetic.
+"""
+import importlib.util
+spec = importlib.util.spec_from_file_location("oracle", "/tmp/oracle.py")
+o = importlib.util.module_from_spec(spec); spec.loader.exec_module(o)
+P = o.P
+
+def sym(x):
+    x %= P
+    return x - P if x > P // 2 else x
+
+def bareiss_rank(rows, n):
+    """Exact rank over Q of an integer matrix, integer arithmetic only."""
+    M = [r[:] for r in rows]; m = len(M)
+    if m == 0: return 0
+    prev = 1; r = 0
+    for c in range(n):
+        p = None
+        for i in range(r, m):
+            if M[i][c] != 0: p = i; break
+        if p is None: continue
+        M[r], M[p] = M[p], M[r]
+        for i in range(r + 1, m):
+            for j in range(c + 1, n):
+                M[i][j] = (M[i][j] * M[r][c] - M[i][c] * M[r][j]) // prev
+            M[i][c] = 0
+        prev = M[r][c]; r += 1
+        if r == m: break
+    return r
+
+def certify(K, verbose=False):
+    tab = o.build_fast(K); n = 1 << K; h = n // 2
+    counts = {}; bad = []
+    for a in range(1, h):
+        for b in range(h, n):
+            M = [[0]*n for _ in range(n)]
+            for j in range(n):
+                s, k = tab[a][j]; M[k][j] += s
+                s, k = tab[b][j]; M[k][j] += s
+            Mm = [[x % P for x in row] for row in M]
+            R, piv = o._rref(Mm, n)
+            free = [c for c in range(n) if c not in piv]
+            d_mod = len(free)
+            # lift the modular kernel basis to integers
+            vecs = []
+            for f in free:
+                v = [0]*n; v[f] = 1
+                for ri, c in enumerate(piv): v[c] = sym(-R[ri][f])
+                vecs.append(v)
+            # (3) M . v == 0 exactly over Z
+            ok = 0
+            for v in vecs:
+                if all(sum(M[i][j]*v[j] for j in range(n)) == 0 for i in range(n)):
+                    ok += 1
+            # (4) independence over Q by integer Bareiss
+            indep = bareiss_rank(vecs, n) if vecs else 0
+            d_low = min(ok, indep)
+            if d_low != d_mod:
+                bad.append((a, b, d_mod, d_low))
+            counts[d_mod] = counts.get(d_mod, 0) + 1
+    return n, counts, bad
+
+import sys
+for K in (3, 4, 5, 6, 7):
+    n, counts, bad = certify(K)
+    print(f"  n={n:4d}  dim ker (modular, = upper bound): {dict(sorted(counts.items()))}")
+    if bad:
+        print(f"          NAO CERTIFICADO em {len(bad)} pares: {bad[:5]}")
+    else:
+        print(f"          CERTIFICADO sobre Z/Q: cada dim atingida por vetores")
+        print(f"          verificados exatamente e independentes. limite superior = inferior.")
+    sys.stdout.flush()

--- a/scripts/research/cd_zd_kernel_spectrum_exact_check.py
+++ b/scripts/research/cd_zd_kernel_spectrum_exact_check.py
@@ -1,0 +1,78 @@
+"""Exact-over-Q recomputation of the n=16 structure claims in #1466.
+
+The merged oracle computes rank, kernel identity and independence by RREF over
+F_P with P = 2^31 - 1, justified in the doc by "entries are 0, +-1, so the rank
+equals the rational rank". That implication is false in general, and the size
+does not rescue it: Hadamard for a 16x16 matrix with |a_ij| <= 1 is 16^8 = 2^32,
+exactly 2.00x P, so a single minor can be an exact multiple of P.
+
+This recomputes the same three numbers with fractions.Fraction -- no modulus
+anywhere -- and diffs them against the modular oracle.
+"""
+from fractions import Fraction
+import importlib.util, sys
+
+spec = importlib.util.spec_from_file_location("oracle", "/tmp/oracle.py")
+oracle = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(oracle)
+P = oracle.P
+
+def rref_exact(M, n):
+    R = [[Fraction(x) for x in row] for row in M]
+    r = 0; piv = []
+    for c in range(n):
+        q = None
+        for i in range(r, len(R)):
+            if R[i][c] != 0: q = i; break
+        if q is None: continue
+        R[r], R[q] = R[q], R[r]
+        inv = Fraction(1, 1) / R[r][c]
+        R[r] = [x * inv for x in R[r]]
+        for i in range(len(R)):
+            if i != r and R[i][c] != 0:
+                f = R[i][c]; R[i] = [a - f * b for a, b in zip(R[i], R[r])]
+        piv.append(c); r += 1
+    return R[:r], piv
+
+def structure_exact(K):
+    tab = oracle.build_fast(K); n = 1 << K; h = n // 2
+    prims = {}; kernels = {}
+    for a in range(1, h):
+        for b in range(h, n):
+            M = [[0]*n for _ in range(n)]
+            for j in range(n):
+                s, k = tab[a][j]; M[k][j] += s
+                s, k = tab[b][j]; M[k][j] += s
+            R, piv = rref_exact(M, n)
+            free = [c for c in range(n) if c not in piv]
+            if len(free) != 4: continue
+            B = []
+            for f in free:
+                v = [Fraction(0)]*n; v[f] = Fraction(1)
+                for ri, c in enumerate(piv): v[c] = -R[ri][f]
+                B.append(v)
+            C, _ = rref_exact(B, n)
+            key = tuple(tuple(x for x in row) for row in C)
+            kernels[key] = 1; prims[(a, b)] = key
+    return prims, list(kernels), tab, n
+
+def max_independent_exact(KL, n):
+    best = [0]
+    def rank_of(rows):
+        R, piv = rref_exact([list(r) for r in rows], n)
+        return len(piv)
+    def bt(start, chosen):
+        if len(chosen) > best[0]: best[0] = len(chosen)
+        for i in range(start, len(KL)):
+            cand = chosen + [KL[i]]
+            rows = [list(r) for k in cand for r in k]
+            if rank_of(rows) == 4 * len(cand):
+                bt(i + 1, cand)
+    bt(0, [])
+    return best[0]
+
+prims, KL, tab, n = structure_exact(4)
+print(f"  EXATO sobre Q, n=16:")
+print(f"    pares com dim ker = 4 : {len(prims)}")
+print(f"    kernels distintos     : {len(KL)}")
+print(f"    max independentes     : {max_independent_exact(KL, n)}")

--- a/scripts/research/cd_zd_kernel_structure_exact.py
+++ b/scripts/research/cd_zd_kernel_structure_exact.py
@@ -1,0 +1,142 @@
+"""Exact structure (distinct kernels, mutual-annihilation clique, maximum
+independent set) for n >= 32, with each of the three claims handled by the
+argument its own error direction demands.
+
+  distinct kernels   equal over Q  =>  equal modular key (the lifted modular
+                     basis is a certified exact basis of ker_Q, so equal
+                     Q-spaces reduce to equal F_P-spaces). Hence distinct keys
+                     => distinct over Q, and the modular count is a LOWER bound.
+                     Confirming it needs only: inside each key bucket, are the
+                     members really equal over Q? Rank test, integers only.
+
+  clique             already exact. zero_pair sums four +-1 table entries, so
+                     every component has |v_k| <= 4 < P, and `v % P == 0` is
+                     equivalent to `v == 0` over Z. No change needed.
+
+  max independent    independent mod P => independent over Q (rank_FP <= rank_Q),
+                     so the modular maximum is a LOWER bound. Confirming it is
+                     the maximum needs: no set of size max+1 is independent
+                     over Q. Checked with integer Bareiss.
+"""
+import importlib.util, sys, itertools
+spec = importlib.util.spec_from_file_location("oracle", "/tmp/oracle.py")
+o = importlib.util.module_from_spec(spec); spec.loader.exec_module(o)
+P = o.P
+
+def sym(x):
+    x %= P
+    return x - P if x > P // 2 else x
+
+def bareiss_rank(rows, n):
+    M = [r[:] for r in rows]; m = len(M)
+    if m == 0: return 0
+    prev = 1; r = 0
+    for c in range(n):
+        p = None
+        for i in range(r, m):
+            if M[i][c] != 0: p = i; break
+        if p is None: continue
+        M[r], M[p] = M[p], M[r]
+        for i in range(r + 1, m):
+            for j in range(c + 1, n):
+                M[i][j] = (M[i][j] * M[r][c] - M[i][c] * M[r][j]) // prev
+            M[i][c] = 0
+        prev = M[r][c]; r += 1
+        if r == m: break
+    return r
+
+def kernels_of(K):
+    tab = o.build_fast(K); n = 1 << K; h = n // 2
+    prims = {}; buckets = {}
+    for a in range(1, h):
+        for b in range(h, n):
+            M = [[0]*n for _ in range(n)]
+            for j in range(n):
+                s, k = tab[a][j]; M[k][j] += s
+                s, k = tab[b][j]; M[k][j] += s
+            Mm = [[x % P for x in row] for row in M]
+            R, piv = o._rref(Mm, n)
+            free = [c for c in range(n) if c not in piv]
+            if not free: continue
+            B = []
+            for f in free:
+                v = [0]*n; v[f] = 1
+                for ri, c in enumerate(piv): v[c] = sym(-R[ri][f])
+                B.append(v)
+            C, _ = o._rref([[x % P for x in v] for v in B], n)
+            key = tuple(tuple(x % P for x in r) for r in C)
+            prims[(a, b)] = (key, B)
+            buckets.setdefault(key, []).append((a, b))
+    return tab, n, prims, buckets
+
+def bucket_is_uniform(bucket, prims, n):
+    """Every member of a modular-key bucket spans the same Q-subspace?"""
+    ref = prims[bucket[0]][1]; d = len(ref)
+    rref = bareiss_rank(ref, n)
+    for m in bucket[1:]:
+        B = prims[m][1]
+        if len(B) != d: return False
+        if bareiss_rank(ref + B, n) != rref: return False
+    return True
+
+def report(K, indep_cap=None):
+    tab, n, prims, buckets = kernels_of(K)
+    dims = {}
+    for (a,b),(k,B) in prims.items(): dims[len(B)] = dims.get(len(B),0)+1
+    # clique -- exact by the |v_k| <= 4 < P argument
+    def zero_pair(p, q):
+        (a1,b1),(a2,b2) = p,q
+        vec = [0]*n
+        for (x,y) in ((a1,a2),(a1,b2),(b1,a2),(b1,b2)):
+            sg,k = tab[x][y]; vec[k] += sg
+        return all(v == 0 for v in vec)
+    pl = list(prims)
+    adj = {p:{q for q in pl if q!=p and zero_pair(p,q)} for p in pl}
+    clique = 0
+    if pl:
+        clique = 1
+        for p in pl:
+            for q in adj[p]:
+                clique = max(clique, 2)
+                common = adj[p] & adj[q]
+                if common: clique = max(clique, 3)
+    nonuni = [k for k,b in buckets.items() if len(b)>1 and not bucket_is_uniform(b, prims, n)]
+    print(f"  n={n}")
+    print(f"    dims                 : {dict(sorted(dims.items()))}")
+    print(f"    kernels (chave mod)  : {len(buckets)}")
+    print(f"    buckets NAO uniformes: {len(nonuni)}   <- 0 significa contagem exata")
+    print(f"    clique (exato)       : {clique}")
+    sys.stdout.flush()
+    return buckets, prims, n
+
+for K in ():
+    report(K)
+
+def max_independent(buckets, prims, n, cap_seconds=600):
+    import time
+    reps = []
+    for k, members in buckets.items():
+        reps.append(prims[members[0]][1])
+    reps.sort(key=len)
+    best = [0]; t0 = time.time(); timed_out = [False]
+    def bt(start, chosen, rows, dimsum):
+        if len(chosen) > best[0]: best[0] = len(chosen)
+        if time.time() - t0 > cap_seconds: timed_out[0] = True; return
+        for i in range(start, len(reps)):
+            B = reps[i]
+            if dimsum + len(B) > n: continue
+            nr = rows + B
+            if bareiss_rank(nr, n) == dimsum + len(B):
+                bt(i + 1, chosen + [i], nr, dimsum + len(B))
+                if timed_out[0]: return
+    bt(0, [], [], 0)
+    return best[0], timed_out[0]
+
+if __name__ == "__main__" and len(sys.argv) > 1 and sys.argv[1] == "indep":
+    K = int(sys.argv[2])
+    tab, n, prims, buckets = kernels_of(K)
+    m, to = max_independent(buckets, prims, n)
+    print(f"  n={n}  max independentes (exato sobre Q) = {m}{'  [TEMPO ESGOTADO -- limite inferior]' if to else ''}")
+
+if __name__ == "__main__" and len(sys.argv) > 2 and sys.argv[1] == "struct":
+    report(int(sys.argv[2]))


### PR DESCRIPTION
Corrective on merged #1466. **No published number changes.**

## The defect

Two statements in `docs/research/cayley_dickson_zd_kernel_spectrum_2026-07-26.md` described the oracle as doing something it does not do.

`:155` justified the modular rank with:

> (entries are `0, ±1`, so the rank equals the rational rank)

**That implication is false.** An integer matrix with entries `0, ±1` can have a minor that is nonzero over Q and divisible by `P`; the rank then drops mod `P`. Entry magnitude bounds nothing about a determinant.

Size does not rescue it. The Hadamard bound for a 16x16 matrix with `|a_ij| <= 1` is `16^8 = 2^32` against `P = 2^31 - 1` — a factor of exactly **2.00**. A single minor can be twice the prime.

`:122` called the cross-validating reconstruction `exact rational arithmetic`. It is the same modular script. My first attempt at that line wrote `exact integer arithmetic`, which is equally untrue; caught before committing and recorded, because replacing one unverified description with another is not a correction.

## The fix: keep the modular path, supply the missing half

`rank_FP <= rank_Q` holds for **every** prime. That makes the reported kernel dimension a genuine **upper bound**, at no cost and with no assumption about the entries — precisely what the false parenthetical was reaching for and could not supply.

The lower bound is then **exhibited rather than assumed**: lift the modular kernel basis to integers, verify `M . v = 0` exactly over Z, verify independence over Q by integer-only Bareiss. Upper meets lower; every step is integer arithmetic.

### Dimensions — all 5,208 index pairs, n <= 128, no pair fails

```
n=  8   {0: 12}
n= 16   {0: 14, 4: 42}
n= 32   {0: 30, 4: 84, 12: 126}
n= 64   {0: 62, 4: 252, 12: 168, 20: 168, 28: 342}
n=128   {0: 126, 4: 684, 12: 504, 20: 336, 28: 336, 36: 336, 44: 336, 52: 504, 60: 870}
```

### Structure — extended past the published n = 16

Each of the three structure claims fails in a **different direction** under a modular computation, and two need no extra work once that is seen:

- **Distinct kernels.** Equal over Q implies equal modular key, since the lifted basis is an exact basis of `ker_Q`. So distinct keys imply distinct over Q, the modular count is a lower bound, and the only gap is a key bucket secretly holding two different Q-subspaces. Rank test, integers only.
- **Clique.** *Already exact, and nobody had noticed.* `zero_pair` sums four ±1 table entries, so `|v_k| <= 4 < P` and `v % P == 0` is **equivalent** to `v == 0` over Z.
- **Maximum independent set.** Independent mod `P` implies independent over Q, so the modular value is a **lower bound**. Confirming a maximum needs a search over size `max+1`. That one has no shortcut, is still running for n = 32, and is **not reported here**.

| n | pairs | ker = 0 | ker > 0 | distinct kernels | non-uniform buckets | clique |
|---:|---:|---:|---:|---:|---:|---:|
| 16 | 56 | 14 | 42 | **42** | 0 | 2 |
| 32 | 240 | 30 | 210 | **210** | 0 | 3 |
| 64 | 992 | 62 | 930 | **930** | 0 | 3 |
| 128 | 4032 | 126 | 3906 | **3906** | 0 | 3 |

Zero non-uniform buckets in every dimension: the counts are exact, not estimated.

## Three facts the published document does not state

1. **The map pair -> kernel is injective** on non-degenerate pairs, in every dimension measured. Two *primitives* share a subspace (`e_a + e_b`, `e_a - e_b`); two *pairs* never do. The document observes this at n = 16 as a remark; it holds across all 5,208 pairs.
2. **The clique rises 2 -> 3 and stops.** n = 16 gives 2; n = 32, 64 and 128 all give 3. The document speaks only of n = 16, so this is new ground rather than verification.
3. **`ker = 0` is exactly `n - 2`** in every dimension, confirming the degeneracy rule `c+ = 0 <=> b' = 0 or a = b'` by an independent count.

## What this settles, and what it does not

It settles the numbers. It does not rehabilitate the reasoning, and the two are different.

The implication would be false even if the numbers had agreed everywhere. What actually happened is narrower and luckier: none of the relevant minors was a multiple of **this particular prime**. That is a fact about `2^31 - 1` and these matrices, not a theorem about `0, ±1` matrices. If some property of these operators guarantees the equality, it is a lemma and must be proved — never inferred from the alphabet of the entries.

## Shipped

| script | scope |
|---|---|
| `cd_zd_kernel_spectrum_exact_certificate.py` | every kernel dimension, n <= 128, certified over Z |
| `cd_zd_kernel_spectrum_exact_check.py` | n = 16 structure recomputed over Q with `Fraction` |
| `cd_zd_kernel_structure_exact.py` | distinct kernels + clique, exact, n = 32/64/128 |

Correction placed as a **visible block at the point of use**, not a silent edit: this document is cited as a parent, and a reader arriving via the citation has to meet the correction too.

## Deliberately not claimed

- The **maximum independent set** at n >= 32 is not established. Modular gives a lower bound; exact confirmation is still running.
- All three checkers are Python, matching the oracle they verify. Porting the science path to Sounio is separate and larger work; introducing a second language here would have been the drift, not the check.

Full record: `docs/audit/KERNEL_SPECTRUM_ORACLE_DOMAIN_2026-08-23.md`

---

**The general point.** An oracle's arithmetic domain is a claim-bearing property:

```
mathematical claim -> oracle arithmetic domain -> proved correspondence -> evidence
```

A modular computation does not acquire the identity of a rational one by being described as one. This repository already refuses a green that has never been red; it should equally refuse an "exact" computed mod P.
