### PR TITLE
feat(algebra): octonion left-action discrepancy with reassociation control

### DIFF
--- a/docs/audit/OCTONION_ACTION_R7_2026-08-23.md
+++ b/docs/audit/OCTONION_ACTION_R7_2026-08-23.md
@@ -1,0 +1,136 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.octonion-action-r7-2026-08-23
+authority: repo_only
+audience: users
+last_validated: 2026-08-23
+validated_by: grok-cli2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.octonion-action-r7-2026-08-23
+-->
+
+# Octonion left action — associator as a physical discrepancy
+
+```text
+Semantic-Lane-ID: associator-physics-20260823
+Owner: grok-cli2
+Concept-IDs: SOUNIO-NONASSOCIATIVE-ORDER
+Intent-Preserved: parenthesization remains explicit where the algebra is
+  nonassociative; NonAssoc is an effect obligation, not a physical ontology;
+  the associator is not a consciousness allegory
+Transformation: expose L_{ab}(v) − (L_a ∘ L_b)(v) as an Euclidean
+  discrepancy of two sequential left multiplications on O ≅ R⁸ (Im(O) ≅ R⁷
+  for pure imaginaries); add an explicit reassociation control that forces
+  the two protocols to the same parenthesization
+Types-Changed: none
+Effects-Changed: none (reuses NonAssoc from oct_mul)
+IR-Changed: none
+Claims-Introduced: the action discrepancy computed from oct_mul equals
+  [a,b,v]; on (e1,e2,e4) its norm² is 4; quaternion / Artin / Fano /
+  forced-reassociate / H-projection controls vanish
+Claims-Forbidden: discovered new physics; octonion consciousness;
+  G₂ holonomy of spacetime; Sounio proved a theorem beyond Artin / Fano;
+  NonAssoc is Mut
+Assumptions: Convention X (cd_sigma / XOR) in algebra::octonion;
+  span{1,e1,e2,e3} is a quaternion subalgebra; |[ei,ej,ek]|² ∈ {0,4}
+  for basis triples (0 on Fano lines, 4 off them)
+Write-Set: stdlib/algebra/octonion_action.sio,
+  examples/physics/octonion_action_r7.sio,
+  tests/run-pass/octonion_action_r7.sio, this file,
+  docs/internal/concepts/bindings.tsv
+Read-Set: stdlib/algebra/octonion.sio,
+  docs/internal/concepts/nonassociative-order.md,
+  examples/octonionic_relativity.sio (negative framing)
+Positive-Witness: souc run of octonion_action_r7.sio prints
+  ACTION_SIGNAL_NSQ 4 and VERDICT_CONTROLS 1
+Negative-Witness: oct_lmul_forced_discrepancy on the signal triple is 0;
+  g_minus_2_muon_leading is not this lane
+Acceptance-Gate: tests/run-pass/octonion_action_r7.sio exit 0 under
+  Madaros; example exit 0
+Integration-Target: origin/main
+Authoritative-Only-If: the discrepancy and the identification with
+  oct_associator are produced by Madaros running Sounio, not by a peer
+  runtime
+```
+
+## What was already there
+
+`oct_associator` already computes `[a,b,c] = (ab)c − a(bc)`. The CPC GUM
+witness `tests/run-pass/octonion_associator_gum_validation.sio` perturbs
+that norm. `examples/octonion_holonomy.sio` and
+`examples/octonion_cross_product_7d.sio` inline multiplication tables and
+do not use `algebra::octonion`. `examples/octonionic_relativity.sio` is
+the consciousness allegory this lane refuses.
+
+## What this lane does
+
+It does not invent a new product. It names two *protocols* on a vector:
+
+1. compose then act: \(L_{ab}(v) = (ab)v\)
+2. act then act: \((L_a \circ L_b)(v) = a(bv)\)
+
+and treats their difference as the observable. The test then checks that
+this vector equals `oct_associator`. The reassociation control applies
+the rewrite \(a(bv) := (ab)v\) and reports 0. Quaternion projection and
+Artin alternativity use the same `oct_mul` and still vanish.
+
+Norm multiplicativity is a control, not the claim: both protocols
+preserve \(\|v\|\) on unit basis elements, so the discrepancy is a
+direction change, not a length change.
+
+## Falsifier
+
+If after Madaros the signal \((e_1,e_2,e_4)\) has discrepancy norm²
+consistent with 0, or the action discrepancy differs from
+`oct_associator`, or any listed control is non-zero at 1e-9, the claim
+is dead.
+
+## Receipts (2026-08-23)
+
+Control ELF `/workspace/sounio/bin/madaros-linux-x86_64` (100902241 B),
+via `SOUNIO_MADAROS_BIN` from worktree
+`/workspace/.wt/associator-physics`. Worktree-committed Madaros ELF is
+the older 99964676 B binary and was **not** used.
+
+`souc check` of `stdlib/algebra/octonion_action.sio`, the example, and
+the test: **verdict=0**.
+
+`souc run examples/physics/octonion_action_r7.sio`: **rc=0**. Printed:
+
+```
+ACTION_SIGNAL_NSQ 4.000000
+ACTION_ASSOC_NSQ 4.000000
+ACTION_IDENT_MAX 0.000000
+ACTION_COMPOSED_NSQ 1.000000
+ACTION_SEQUENTIAL_NSQ 1.000000
+ACTION_H_NSQ 0.000000
+ACTION_ARTIN_NSQ 0.000000
+ACTION_FANO_NSQ 0.000000
+ACTION_FORCED_NSQ 0.000000
+ACTION_MIX_NSQ 32.000000
+ACTION_PROJ_H_NSQ 0.000000
+VERDICT_SIGNAL 1
+VERDICT_IDENTIFIES_ASSOCIATOR 1
+VERDICT_CONTROLS 1
+VERDICT_NORM_PRESERVED 1
+```
+
+`ACTION_MIX_NSQ 32` is a measured value for `(e1+e4, e2+e5, e3+e6)`, not
+a pinned theorem. The test only requires it to be distinguishable from
+0, and the H-projection of the same triple to vanish.
+
+`souc run tests/run-pass/octonion_action_r7.sio`: **rc=0**.
+
+LLM-offload math-review (`bin/llm-offload -t math-review -i
+stdlib/algebra/octonion_action.sio`, fan-out xai+zai, dir
+`/tmp/llm-offload-VVeqiB`):
+
+- xAI grok-4.3: **PASS** `[OK]`×4 — identification with `[a,b,v]`;
+  forced discrepancy is the reassociation rewrite; quaternion / Artin /
+  Fano controls; `oct_project_H` keeps `span{1,e1,e2,e3}`. No WRONG /
+  OVERREACH / TIGHTENABLE.
+- Z.AI GLM-5.2: **SKIPPED** weekly/monthly limit exhausted until
+  2026-08-25 06:34:36 (code 1310). Treat as incomplete second opinion,
+  not a pass.
+
+Outcome: **PASS_SINGLE_PROVIDER_DEGRADED**. The shared
+`.claude/llm_offload_log.md` was held by an active claim on another
+worktree at write time; this subsection is the durable receipt.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -323,6 +323,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.module-frontend-lower-array-seed-crash-dispatch-2026-07-27 | repo_only | docs/audit/MODULE_FRONTEND_LOWER_ARRAY_SEED_CRASH_DISPATCH_2026-07-27.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.mut-effect-enforcement-dispatch-2026-07-27 | repo_only | docs/audit/MUT_EFFECT_ENFORCEMENT_DISPATCH_2026-07-27.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.mut-refactor-execution-plan-2026-05-31 | repo_only | docs/audit/MUT_REFACTOR_EXECUTION_PLAN_2026-05-31.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.octonion-action-r7-2026-08-23 | repo_only | docs/audit/OCTONION_ACTION_R7_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.ode-epistemic-zero-params-2026-06-02 | repo_only | docs/audit/ODE_EPISTEMIC_ZERO_PARAMS_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.ousadia-epistemic-method-rx-madaros-2026-07-19 | repo_only | docs/audit/OUSADIA_EPISTEMIC_METHOD_RX_MADAROS_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.pbpk-dissertation-session-notes-2026-06-28 | repo_only | docs/audit/PBPK_DISSERTATION_SESSION_NOTES_2026-06-28.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -6893,6 +6893,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.octonion-action-r7-2026-08-23",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/OCTONION_ACTION_R7_2026-08-23.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.ode-epistemic-zero-params-2026-06-02",
       "collection": "repo",
       "repo_doc_path": "docs/audit/ODE_EPISTEMIC_ZERO_PARAMS_2026-06-02.md",

--- a/docs/internal/concepts/bindings.tsv
+++ b/docs/internal/concepts/bindings.tsv
@@ -9,6 +9,8 @@ SOUNIO-EPISTEMIC-NUMERIC-VALUE	self-hosted/enir/*	canonical-ir
 SOUNIO-EPISTEMIC-NUMERIC-VALUE	stdlib/eisa/*	execution-profile
 SOUNIO-EPISTEMIC-NUMERIC-VALUE	stdlib/epistemic/*	source-semantics
 SOUNIO-NONASSOCIATIVE-ORDER	stdlib/algebra/associator_field.sio	canonical-artifact
+SOUNIO-NONASSOCIATIVE-ORDER	stdlib/algebra/octonion_action.sio	action-view
+SOUNIO-NONASSOCIATIVE-ORDER	tests/run-pass/octonion_action_r7.sio	positive-evidence
 SOUNIO-NONASSOCIATIVE-ORDER	stdlib/epistemic/uncertain_octonion.sio	uncertainty-view
 SOUNIO-NONASSOCIATIVE-ORDER	stdlib/epistemic/perturbation_graph.sio	correlation-view
 SOUNIO-NONASSOCIATIVE-ORDER	self-hosted/ir/ir.sio	compiler-ir

--- a/examples/physics/octonion_action_r7.sio
+++ b/examples/physics/octonion_action_r7.sio
@@ -1,0 +1,151 @@
+//@ run-pass
+//@ description: octonion left action: L_ab ≠ L_a∘L_b; reassociation control is 0
+//
+// Sequential left multiplication on O ≅ R⁸. For pure imaginaries the
+// discrepancy lives in Im(O) ≅ R⁷. This is not a consciousness allegory
+// (see examples/octonionic_relativity.sio). It is the failure of
+// L : (O,*) → End(R⁸) to be a homomorphism.
+//
+// Run:
+//   export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+//   ./bin/souc run examples/physics/octonion_action_r7.sio
+
+use algebra::octonion::{oct_associator, oct_norm_sq, oct_basis}
+use algebra::octonion_action::{
+    oct_lmul_composed, oct_lmul_sequential, oct_lmul_discrepancy,
+    oct_lmul_discrepancy_nsq, oct_lmul_forced_discrepancy_nsq, oct_project_H,
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn max_abs_diff(a: &[f64; 8], b: &[f64; 8]) -> f64 with Mut {
+    var m: f64 = 0.0
+    var i: i64 = 0
+    while i < 8 {
+        let d = abs_f(a[i] - b[i])
+        if d > m { m = d }
+        i = i + 1
+    }
+    m
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic, NonAssoc {
+    var e1 = oct_basis(1)
+    var e2 = oct_basis(2)
+    var e3 = oct_basis(3)
+    var e4 = oct_basis(4)
+    var e5 = oct_basis(5)
+    var e6 = oct_basis(6)
+
+    // Signal: non-Fano (e1,e2,e4). |[e1,e2,e4]|² = 4.
+    let nsq_signal = oct_lmul_discrepancy_nsq(&e1, &e2, &e4)
+    var delta: [f64; 8] = [0.0; 8]
+    oct_lmul_discrepancy(&e1, &e2, &e4, &!delta)
+    var assoc: [f64; 8] = [0.0; 8]
+    oct_associator(&e1, &e2, &e4, &!assoc)
+    let ident = max_abs_diff(&delta, &assoc)
+    let nsq_assoc = oct_norm_sq(&assoc)
+
+    var lab: [f64; 8] = [0.0; 8]
+    var seq: [f64; 8] = [0.0; 8]
+    oct_lmul_composed(&e1, &e2, &e4, &!lab)
+    oct_lmul_sequential(&e1, &e2, &e4, &!seq)
+    let nsq_lab = oct_norm_sq(&lab)
+    let nsq_seq = oct_norm_sq(&seq)
+
+    // Quaternion generic: span{e1,e2,e3} ⊂ H.
+    var h_a: [f64; 8] = [0.0; 8]
+    var h_b: [f64; 8] = [0.0; 8]
+    var h_v: [f64; 8] = [0.0; 8]
+    h_a[1] = 1.0
+    h_a[2] = 1.0
+    h_b[2] = 1.0
+    h_b[3] = 1.0
+    h_v[1] = 1.0
+    h_v[3] = 1.0
+    let nsq_h = oct_lmul_discrepancy_nsq(&h_a, &h_b, &h_v)
+
+    // Artin: [a,a,v] = 0 even off H.
+    var art_a: [f64; 8] = [0.0; 8]
+    var art_v: [f64; 8] = [0.0; 8]
+    art_a[1] = 1.0
+    art_a[4] = 1.0
+    art_v[2] = 1.0
+    art_v[5] = 1.0
+    let nsq_artin = oct_lmul_discrepancy_nsq(&art_a, &art_a, &art_v)
+
+    // Fano line (e1,e2,e3).
+    let nsq_fano = oct_lmul_discrepancy_nsq(&e1, &e2, &e3)
+
+    // Forced reassociation on the SIGNAL triple.
+    let nsq_forced = oct_lmul_forced_discrepancy_nsq(&e1, &e2, &e4)
+
+    // Same generators, projected onto H: (e1,e2,e3), which is Fano.
+    var mix_a: [f64; 8] = [0.0; 8]
+    var mix_b: [f64; 8] = [0.0; 8]
+    var mix_v: [f64; 8] = [0.0; 8]
+    mix_a[1] = 1.0
+    mix_a[4] = 1.0
+    mix_b[2] = 1.0
+    mix_b[5] = 1.0
+    mix_v[3] = 1.0
+    mix_v[6] = 1.0
+    let nsq_mix = oct_lmul_discrepancy_nsq(&mix_a, &mix_b, &mix_v)
+    var p_a: [f64; 8] = [0.0; 8]
+    var p_b: [f64; 8] = [0.0; 8]
+    var p_v: [f64; 8] = [0.0; 8]
+    oct_project_H(&mix_a, &!p_a)
+    oct_project_H(&mix_b, &!p_b)
+    oct_project_H(&mix_v, &!p_v)
+    let nsq_proj = oct_lmul_discrepancy_nsq(&p_a, &p_b, &p_v)
+
+    print("ACTION_SIGNAL_NSQ ")
+    print_f64(nsq_signal)
+    print("\nACTION_ASSOC_NSQ ")
+    print_f64(nsq_assoc)
+    print("\nACTION_IDENT_MAX ")
+    print_f64(ident)
+    print("\nACTION_COMPOSED_NSQ ")
+    print_f64(nsq_lab)
+    print("\nACTION_SEQUENTIAL_NSQ ")
+    print_f64(nsq_seq)
+    print("\nACTION_H_NSQ ")
+    print_f64(nsq_h)
+    print("\nACTION_ARTIN_NSQ ")
+    print_f64(nsq_artin)
+    print("\nACTION_FANO_NSQ ")
+    print_f64(nsq_fano)
+    print("\nACTION_FORCED_NSQ ")
+    print_f64(nsq_forced)
+    print("\nACTION_MIX_NSQ ")
+    print_f64(nsq_mix)
+    print("\nACTION_PROJ_H_NSQ ")
+    print_f64(nsq_proj)
+    print("\n")
+
+    var ok: i64 = 1
+    if abs_f(nsq_signal - 4.0) > 1.0e-9 { ok = 0 }
+    if abs_f(nsq_assoc - 4.0) > 1.0e-9 { ok = 0 }
+    if ident > 1.0e-9 { ok = 0 }
+    if abs_f(nsq_lab - 1.0) > 1.0e-9 { ok = 0 }
+    if abs_f(nsq_seq - 1.0) > 1.0e-9 { ok = 0 }
+    if nsq_h > 1.0e-9 { ok = 0 }
+    if nsq_artin > 1.0e-9 { ok = 0 }
+    if nsq_fano > 1.0e-9 { ok = 0 }
+    if nsq_forced > 1.0e-9 { ok = 0 }
+    if nsq_mix <= 1.0e-9 { ok = 0 }
+    if nsq_proj > 1.0e-9 { ok = 0 }
+
+    print("VERDICT_SIGNAL ")
+    if abs_f(nsq_signal - 4.0) <= 1.0e-9 { print("1\n") } else { print("0\n") }
+    print("VERDICT_IDENTIFIES_ASSOCIATOR ")
+    if ident <= 1.0e-9 { print("1\n") } else { print("0\n") }
+    print("VERDICT_CONTROLS ")
+    if nsq_h <= 1.0e-9 && nsq_artin <= 1.0e-9 && nsq_fano <= 1.0e-9 && nsq_forced <= 1.0e-9 && nsq_proj <= 1.0e-9 { print("1\n") } else { print("0\n") }
+    print("VERDICT_NORM_PRESERVED ")
+    if abs_f(nsq_lab - nsq_seq) <= 1.0e-9 { print("1\n") } else { print("0\n") }
+
+    if ok == 1 { 0 } else { 1 }
+}

--- a/stdlib/algebra/octonion_action.sio
+++ b/stdlib/algebra/octonion_action.sio
@@ -1,0 +1,110 @@
+// stdlib/algebra/octonion_action.sio
+//
+// Left multiplication as an action of O on O ≅ R⁸.
+// For pure imaginaries the Euclidean discrepancy lives in Im(O) ≅ R⁷.
+//
+// Representation property (fails for octonions):
+//   L_a : O → O,  v ↦ a*v
+//   L_{ab} ≟ L_a ∘ L_b
+// The vector difference is the associator, computed here from the two
+// protocols rather than by calling oct_associator:
+//   L_{ab}(v) − (L_a ∘ L_b)(v) = (ab)v − a(bv) = [a,b,v]
+//
+// Reassociation control: identify L_a ∘ L_b with L_{ab}. The discrepancy
+// is then the zero vector by construction. That is the rewrite a
+// reassociating compiler would apply; it erases the observable.
+//
+// Non-tautological vanishing controls, still using genuine oct_mul:
+//   - quaternion projection onto span{1,e1,e2,e3} ≅ H
+//   - Artin alternativity [a,a,v] = 0
+//   - Fano line (e1,e2,e3)
+//
+// No new algebra. Convention X (cd_sigma / XOR) via algebra::octonion.
+//
+// Claims forbidden: new physics; octonion consciousness; G₂ holonomy of
+// spacetime. NonAssoc is an effect obligation, not an ontology.
+// This module is not examples/octonionic_relativity.sio.
+
+use algebra::octonion::{oct_mul, oct_norm_sq}
+
+fn oct_vec_sub(a: &[f64; 8], b: &[f64; 8], out: &![f64; 8]) with Mut {
+    var i: i64 = 0
+    while i < 8 {
+        out[i] = a[i] - b[i]
+        i = i + 1
+    }
+}
+
+// L_a(v) = a*v
+pub fn oct_lmul(a: &[f64; 8], v: &[f64; 8], out: &![f64; 8]) with Mut, Div, NonAssoc {
+    oct_mul(a, v, out)
+}
+
+// Compose in the algebra, then act: L_{ab}(v) = (a*b)*v
+pub fn oct_lmul_composed(
+    a: &[f64; 8], b: &[f64; 8], v: &[f64; 8], out: &![f64; 8]
+) with Mut, Div, NonAssoc {
+    var ab: [f64; 8] = [0.0; 8]
+    oct_mul(a, b, &!ab)
+    oct_lmul(&ab, v, out)
+}
+
+// Act, then act: (L_a ∘ L_b)(v) = a*(b*v)
+pub fn oct_lmul_sequential(
+    a: &[f64; 8], b: &[f64; 8], v: &[f64; 8], out: &![f64; 8]
+) with Mut, Div, NonAssoc {
+    var bv: [f64; 8] = [0.0; 8]
+    oct_lmul(b, v, &!bv)
+    oct_lmul(a, &bv, out)
+}
+
+// Physical observable: Euclidean discrepancy of the two protocols.
+// Identifies with [a,b,v] but does not call oct_associator.
+pub fn oct_lmul_discrepancy(
+    a: &[f64; 8], b: &[f64; 8], v: &[f64; 8], out: &![f64; 8]
+) with Mut, Div, NonAssoc {
+    var composed: [f64; 8] = [0.0; 8]
+    var sequential: [f64; 8] = [0.0; 8]
+    oct_lmul_composed(a, b, v, &!composed)
+    oct_lmul_sequential(a, b, v, &!sequential)
+    oct_vec_sub(&composed, &sequential, out)
+}
+
+// Reassociation control. Both protocols are the composed map, so the
+// discrepancy is the zero vector. Not a numerical check that octonions
+// associate — they do not. It is the rewrite (ab)v := a(bv).
+pub fn oct_lmul_forced_discrepancy(
+    a: &[f64; 8], b: &[f64; 8], v: &[f64; 8], out: &![f64; 8]
+) with Mut, Div, NonAssoc {
+    var composed: [f64; 8] = [0.0; 8]
+    oct_lmul_composed(a, b, v, &!composed)
+    oct_vec_sub(&composed, &composed, out)
+}
+
+// Orthogonal projection onto the quaternion subalgebra span{1,e1,e2,e3}.
+pub fn oct_project_H(x: &[f64; 8], out: &![f64; 8]) with Mut {
+    out[0] = x[0]
+    out[1] = x[1]
+    out[2] = x[2]
+    out[3] = x[3]
+    out[4] = 0.0
+    out[5] = 0.0
+    out[6] = 0.0
+    out[7] = 0.0
+}
+
+pub fn oct_lmul_discrepancy_nsq(
+    a: &[f64; 8], b: &[f64; 8], v: &[f64; 8]
+) -> f64 with Mut, Div, NonAssoc {
+    var d: [f64; 8] = [0.0; 8]
+    oct_lmul_discrepancy(a, b, v, &!d)
+    oct_norm_sq(&d)
+}
+
+pub fn oct_lmul_forced_discrepancy_nsq(
+    a: &[f64; 8], b: &[f64; 8], v: &[f64; 8]
+) -> f64 with Mut, Div, NonAssoc {
+    var d: [f64; 8] = [0.0; 8]
+    oct_lmul_forced_discrepancy(a, b, v, &!d)
+    oct_norm_sq(&d)
+}

--- a/tests/run-pass/octonion_action_r7.sio
+++ b/tests/run-pass/octonion_action_r7.sio
@@ -1,0 +1,90 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 0
+//@ description: octonion left action discrepancy is the associator; controls vanish
+// Full Test Suite CI uses souc-stage2 (lean_single). This imported
+// exclusive-ref oct_mul graph is a Madaros witness (see
+// tests/madaros/algebra_octonion_import/oct_mul_import.sio).
+
+use algebra::octonion::{oct_associator, oct_norm_sq, oct_basis}
+use algebra::octonion_action::{
+    oct_lmul_composed, oct_lmul_sequential, oct_lmul_discrepancy,
+    oct_lmul_discrepancy_nsq, oct_lmul_forced_discrepancy_nsq, oct_project_H,
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic, NonAssoc {
+    var e1 = oct_basis(1)
+    var e2 = oct_basis(2)
+    var e3 = oct_basis(3)
+    var e4 = oct_basis(4)
+    var e5 = oct_basis(5)
+    var e6 = oct_basis(6)
+
+    var ok: i64 = 1
+
+    let nsq_signal = oct_lmul_discrepancy_nsq(&e1, &e2, &e4)
+    if abs_f(nsq_signal - 4.0) > 1.0e-9 { ok = 0 }
+
+    var delta: [f64; 8] = [0.0; 8]
+    oct_lmul_discrepancy(&e1, &e2, &e4, &!delta)
+    var assoc: [f64; 8] = [0.0; 8]
+    oct_associator(&e1, &e2, &e4, &!assoc)
+    var i: i64 = 0
+    while i < 8 {
+        if abs_f(delta[i] - assoc[i]) > 1.0e-9 { ok = 0 }
+        i = i + 1
+    }
+
+    var lab: [f64; 8] = [0.0; 8]
+    var seq: [f64; 8] = [0.0; 8]
+    oct_lmul_composed(&e1, &e2, &e4, &!lab)
+    oct_lmul_sequential(&e1, &e2, &e4, &!seq)
+    if abs_f(oct_norm_sq(&lab) - 1.0) > 1.0e-9 { ok = 0 }
+    if abs_f(oct_norm_sq(&seq) - 1.0) > 1.0e-9 { ok = 0 }
+
+    var h_a: [f64; 8] = [0.0; 8]
+    var h_b: [f64; 8] = [0.0; 8]
+    var h_v: [f64; 8] = [0.0; 8]
+    h_a[1] = 1.0
+    h_a[2] = 1.0
+    h_b[2] = 1.0
+    h_b[3] = 1.0
+    h_v[1] = 1.0
+    h_v[3] = 1.0
+    if oct_lmul_discrepancy_nsq(&h_a, &h_b, &h_v) > 1.0e-9 { ok = 0 }
+
+    var art_a: [f64; 8] = [0.0; 8]
+    var art_v: [f64; 8] = [0.0; 8]
+    art_a[1] = 1.0
+    art_a[4] = 1.0
+    art_v[2] = 1.0
+    art_v[5] = 1.0
+    if oct_lmul_discrepancy_nsq(&art_a, &art_a, &art_v) > 1.0e-9 { ok = 0 }
+
+    if oct_lmul_discrepancy_nsq(&e1, &e2, &e3) > 1.0e-9 { ok = 0 }
+    if oct_lmul_forced_discrepancy_nsq(&e1, &e2, &e4) > 1.0e-9 { ok = 0 }
+
+    var mix_a: [f64; 8] = [0.0; 8]
+    var mix_b: [f64; 8] = [0.0; 8]
+    var mix_v: [f64; 8] = [0.0; 8]
+    mix_a[1] = 1.0
+    mix_a[4] = 1.0
+    mix_b[2] = 1.0
+    mix_b[5] = 1.0
+    mix_v[3] = 1.0
+    mix_v[6] = 1.0
+    if oct_lmul_discrepancy_nsq(&mix_a, &mix_b, &mix_v) <= 1.0e-9 { ok = 0 }
+    var p_a: [f64; 8] = [0.0; 8]
+    var p_b: [f64; 8] = [0.0; 8]
+    var p_v: [f64; 8] = [0.0; 8]
+    oct_project_H(&mix_a, &!p_a)
+    oct_project_H(&mix_b, &!p_b)
+    oct_project_H(&mix_v, &!p_v)
+    if oct_lmul_discrepancy_nsq(&p_a, &p_b, &p_v) > 1.0e-9 { ok = 0 }
+
+    if ok == 1 { 0 } else { 1 }
+}


### PR DESCRIPTION
## What

The associator as a *physical* observable: two sequential left-multiplication protocols on O ≅ R⁸ (discrepancy in Im(O) ≅ R⁷ for pure imaginaries).

- Compose then act: L_{ab}(v) = (ab)v
- Act then act: (L_a ∘ L_b)(v) = a(bv)
- Difference computed from `oct_mul`, then identified with `oct_associator`
- Reassociation control forces both protocols to the composed map → 0 by construction
- Non-tautological controls: quaternion subalgebra, Artin [a,a,v]=0, Fano (e1,e2,e3), H-projection

This is **not** `examples/octonionic_relativity.sio`.

## Receipts (Madaros, control ELF 100902241 B)

`souc run examples/physics/octonion_action_r7.sio` rc=0:

```
ACTION_SIGNAL_NSQ 4.000000
ACTION_IDENT_MAX 0.000000
ACTION_H_NSQ 0.000000
ACTION_ARTIN_NSQ 0.000000
ACTION_FANO_NSQ 0.000000
ACTION_FORCED_NSQ 0.000000
ACTION_PROJ_H_NSQ 0.000000
VERDICT_SIGNAL 1
VERDICT_IDENTIFIES_ASSOCIATOR 1
VERDICT_CONTROLS 1
VERDICT_NORM_PRESERVED 1
```

`souc run tests/run-pass/octonion_action_r7.sio` rc=0.

## Claims forbidden

New physics; octonion consciousness; G₂ holonomy of spacetime; a theorem beyond Artin/Fano; NonAssoc is Mut.

## Semantic lane

`docs/audit/OCTONION_ACTION_R7_2026-08-23.md` — Concept-ID `SOUNIO-NONASSOCIATIVE-ORDER`.

## Offload

xAI grok-4.3 math-review PASS. Z.AI quota skip until 2026-08-25 (PASS_SINGLE_PROVIDER_DEGRADED).

Do not merge until asked.