### PR TITLE
fix(check): imported type-position names are ty_named, not TyUnknown

### DIFF
--- a/docs/audit/IMPORTED_TYPE_NAMED_2026-08-23.md
+++ b/docs/audit/IMPORTED_TYPE_NAMED_2026-08-23.md
@@ -1,0 +1,59 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.imported-type-named-2026-08-23
+authority: repo_only
+audience: users
+last_validated: 2026-08-23
+validated_by: grok-cli2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.imported-type-named-2026-08-23
+-->
+
+# Imported type-position names are `ty_named`, not TyUnknown
+
+```text
+Semantic-Lane-ID: imported-type-named-20260823
+Owner: grok-cli2
+Concept-IDs: SOUNIO-EPISTEMIC-NUMERIC-VALUE
+Intent-Preserved: a named type in a signature is that type; Unknown is
+  not a universal sink; Madaros is the claim oracle
+Transformation: checker_lower_named_type_mut treats TyUnknown env
+  bindings as uninformative even when the struct is not yet in the
+  local table, matching the by-value lower_named_type spine
+Types-Changed: none (resolution of existing named types)
+Effects-Changed: none
+IR-Changed: none
+Claims-Introduced: `fn forge() -> Epistemic { 1.0 }` is E008 under
+  Madaros; WP25 DD HVP LO cannot be returned as Epistemic
+Claims-Forbidden: Madaros is fixed-point-verified; every imported name
+  is fully typed; this closes all D3/D4 import holes
+Assumptions: use-item collection still binds imported names as
+  TyUnknown for E137 suppression; type position must not honour that
+Write-Set: self-hosted/check/check.sio, the three tests, this file
+Read-Set: self-hosted/check/check.sio lower_named_type (by-value spine)
+Positive-Witness: tests/run-pass/imported_epistemic_pin_ok.sio
+Negative-Witness: imported_epistemic_is_not_a_float.sio;
+  a_mu_wp25_dd_hvp_lo_is_not_epistemic.sio
+Acceptance-Gate: rebuilt Madaros check of the two compile-fails is
+  verdict=1 with Epistemic in the diagnostic; pin_ok exit 0; existing
+  a_mu_gum_split example still rc=0
+Integration-Target: origin/main
+Authoritative-Only-If: produced by a Madaros ELF built from this source
+```
+
+The in-place named-type lowerer kept a TyUnknown import binding when the
+struct was absent from the local table. The by-value spine already fell
+through to `ty_named`. Multi-module check uses the in-place path, so
+imported `Epistemic` was a universal sink.
+
+## Receipts (2026-08-23)
+
+Rebuilt Madaros from this source: `/tmp/madaros-imported-type-named-out/madaros`
+(100641310 B). Control ELF 100902241 B still accepts
+`forge() -> Epistemic { 1.0 }` (verdict=0). New ELF:
+
+| program | verdict |
+|---|---|
+| `imported_epistemic_is_not_a_float.sio` | **1** E008 expected Epistemic found f64 |
+| `a_mu_wp25_dd_hvp_lo_is_not_epistemic.sio` | **1** E008 expected Epistemic found Wp25DdHvpLoAbsent |
+| `imported_epistemic_pin_ok.sio` check+run | **0** / rc=0 |
+| `ew_precision.sio` check | **0** |
+| `a_mu_gum_split.sio` check | **0** |

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -200,6 +200,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.hypercomplex-651-rootcause-2026-07-14 | repo_only | docs/audit/HYPERCOMPLEX_651_ROOTCAUSE_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.hypercomplex-algebra-audit-2026-07-14 | repo_only | docs/audit/HYPERCOMPLEX_ALGEBRA_AUDIT_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.imported-native-139-residual-census-2026-08-18 | repo_only | docs/audit/IMPORTED_NATIVE_139_RESIDUAL_CENSUS_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.imported-type-named-2026-08-23 | repo_only | docs/audit/IMPORTED_TYPE_NAMED_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kaxi-ptx-golden-drop-not-mismatch-2026-08-19 | repo_only | docs/audit/KAXI_PTX_GOLDEN_DROP_NOT_MISMATCH_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kaxi-ptx-target-sm-audit-2026-06-17 | repo_only | docs/audit/KAXI_PTX_TARGET_SM_AUDIT_2026-06-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kconf-bitcast-apply-package-2026-08-18 | repo_only | docs/audit/KCONF_BITCAST_APPLY_PACKAGE_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -4064,6 +4064,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.imported-type-named-2026-08-23",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/IMPORTED_TYPE_NAMED_2026-08-23.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.kaxi-ptx-golden-drop-not-mismatch-2026-08-19",
       "collection": "repo",
       "repo_doc_path": "docs/audit/KAXI_PTX_GOLDEN_DROP_NOT_MISMATCH_2026-08-19.md",

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -1638,11 +1638,13 @@ fn checker_lower_named_type_mut(c: *mut Checker, path: AstPath) -> TypeEntry wit
         // this looked like a let/var bug for hours.
         //
         // A binding that carries no information must not outrank a type that
-        // does.
+        // does. Imported names are bound as TyUnknown even when the struct is
+        // not yet in this module's table — treating that Unknown as informative
+        // made `fn forge() -> Epistemic { 1.0 }` typecheck. Match the
+        // by-value spine: Unknown/Error/Never fall through to ty_named.
         let bound_is_informative = bound_ty.kind != TypeKind::TyError
-            && !(bound_ty.kind == TypeKind::TyUnknown
-                 && (struct_table_find((*c).structs, name) >= 0
-                     || enum_table_find((*c).enums, name) >= 0))
+            && bound_ty.kind != TypeKind::TyUnknown
+            && bound_ty.kind != TypeKind::TyNever
         if bound_is_informative || bound_ty.ontology_id >= 0 {
             bound_ty
         } else {

--- a/tests/compile-fail/a_mu_wp25_dd_hvp_lo_is_not_epistemic.sio
+++ b/tests/compile-fail/a_mu_wp25_dd_hvp_lo_is_not_epistemic.sio
@@ -1,0 +1,15 @@
+//@ typecheck-fail
+//@ requires: madaros
+//@ error-pattern: Epistemic
+// WP25 data-driven HVP LO is Wp25DdHvpLoAbsent, not an Epistemic pin.
+
+use particle_physics::ew_precision::{a_mu_hvp_lo_datadriven_wp25}
+use epistemic::knowledge::{Epistemic}
+
+fn as_pin() -> Epistemic {
+    a_mu_hvp_lo_datadriven_wp25()
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    0
+}

--- a/tests/compile-fail/imported_epistemic_is_not_a_float.sio
+++ b/tests/compile-fail/imported_epistemic_is_not_a_float.sio
@@ -1,0 +1,14 @@
+//@ typecheck-fail
+//@ requires: madaros
+//@ error-pattern: Epistemic
+// Imported Epistemic is a named type, not TyUnknown. A float is not a pin.
+
+use epistemic::knowledge::{Epistemic}
+
+fn forge() -> Epistemic {
+    1.0
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    0
+}

--- a/tests/run-pass/imported_epistemic_pin_ok.sio
+++ b/tests/run-pass/imported_epistemic_pin_ok.sio
@@ -1,0 +1,15 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 0
+//@ description: imported Epistemic return type still accepts a real pin
+
+use epistemic::knowledge::{Epistemic, ep_measured, ep_val}
+
+fn pin() -> Epistemic with Mut, Div, Panic {
+    ep_measured(1.0, 0.1)
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    let e = pin()
+    if ep_val(&e) < 0.5 { 1 } else { 0 }
+}


### PR DESCRIPTION
## What

Imported `Epistemic` was a **TyUnknown sink** under Madaros: `fn forge() -> Epistemic { 1.0 }` typechecked. The in-place named-type lowerer (`checker_lower_named_type_mut`) treated a TyUnknown import binding as informative unless the struct was already in the local table. Multi-module check uses that path. The by-value spine already fell through to `ty_named`.

This PR matches the in-place path to the by-value spine: Unknown/Error/Never are uninformative.

## Receipts (Madaros rebuilt from this source, 100641310 B)

Control ELF still accepts the forge (verdict=0).

| program | new ELF |
|---|---|
| `forge() -> Epistemic { 1.0 }` | **E008** expected Epistemic found f64 |
| WP25 DD HVP LO as Epistemic | **E008** expected Epistemic found Wp25DdHvpLoAbsent |
| `ep_measured` pin run | **rc=0** |
| `ew_precision.sio` / `a_mu_gum_split.sio` check | **verdict=0** |

Hunk is disjoint from ns-wire's dirty `check.sio` (they did not touch this lookup).

Do not merge until CI is green if you want a second look; the hole is closed on this ELF.