### PR TITLE
feat(particle): CMD-3 2π LO HVP disagrees with the pre-CMD-3 average

### DIFF
--- a/docs/audit/A_MU_CMD3_2PI_SPLIT_2026-08-23.md
+++ b/docs/audit/A_MU_CMD3_2PI_SPLIT_2026-08-23.md
@@ -1,0 +1,130 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.a-mu-cmd3-2pi-split-2026-08-23
+authority: repo_only
+audience: users
+last_validated: 2026-08-23
+validated_by: grok-cli2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.a-mu-cmd3-2pi-split-2026-08-23
+-->
+
+# CMD-3 vs pre-CMD-3 2π LO HVP — the split WP25 refused to average
+
+```text
+Semantic-Lane-ID: a-mu-cmd3-2pi-split-20260823
+Owner: grok-cli2
+Concept-IDs: SOUNIO-EPISTEMIC-NUMERIC-VALUE
+Intent-Preserved: two incompatible 2π evaluations must not be averaged
+  into one data-driven HVP LO; a missing WP25 citation is not a latent
+  f64; Sounio does not integrate σ(e⁺e⁻→π⁺π⁻)
+Transformation: pin the two 2π numbers published in the CMD-3 Letter as
+  Epistemic; GUM pull via ep_sub; keep Wp25DdHvpLoAbsent unchanged
+Types-Changed: none
+Effects-Changed: none
+IR-Changed: none
+Claims-Introduced: Sounio can hold CMD-3 2π and the pre-CMD-3 2π average
+  without collapsing them; the GUM pull of those pins is computed in
+  Sounio; WP25 data-driven HVP LO remains absent
+Claims-Forbidden: Sounio computed HVP; new physics; the tension is
+  resolved; CMD-3 is the WP25 data-driven LO; 5260 is full HVP LO;
+  averaging 5260 with 5060 yields a TI combination; one SM a_μ;
+  Madaros is fixed-point-verified
+Assumptions: published centrals and quoted σ are citations
+  (Ignatov et al., PRL 132, 231903 (2024), arXiv:2309.12910).
+  CMD-3 5260(42) uses CMD-3 data for √s = 0.327–1.2 GeV and the
+  average of other measurements outside that window. The 42 is
+  systematics-dominated. The 5060(34) is the same Letter's citation
+  of the WP20 average of previous measurements with χ² inflation
+  (Aoyama et al. 2020). Independent GUM overstates σ_diff because
+  the pins share some out-of-window data; a surviving k95 split is
+  therefore conservative. Units 10⁻¹¹.
+Write-Set: stdlib/particle_physics/ew_precision.sio,
+  stdlib/particle_physics/mod.sio,
+  examples/particle_physics/a_mu_cmd3_2pi_split.sio,
+  tests/run-pass/a_mu_cmd3_2pi_split.sio, this file
+Read-Set: stdlib/epistemic/knowledge.sio,
+  docs/audit/A_MU_GUM_SPLIT_2026-08-23.md,
+  docs/audit/A_MU_WP25_DD_HVP_LO_ABSENT_2026-08-23.md,
+  docs/decisions/adr-008-claim-oracle-semantic-clock.md
+Positive-Witness: souc run of a_mu_cmd3_2pi_split.sio prints pull
+  > k95 and WP25_DD_HVP_LO_PROVIDED 0
+Negative-Witness: no a_mu_hvp_lo_2pi_combined; g_minus_2_muon_leading
+  still returns a collapsed f64
+Acceptance-Gate: tests/run-pass/a_mu_cmd3_2pi_split.sio exit 0 under
+  Madaros; example exit 0
+Integration-Target: origin/main
+Authoritative-Only-If: the pull is produced by Madaros running Sounio,
+  not by a peer runtime
+```
+
+## What this is
+
+WP25 (Aliberti et al., Phys. Rep. 1143 (2025) 1) will not quote a combined
+data-driven LO HVP. The reason it gives is the CMD-3 \(e^+e^-\to\pi^+\pi^-\)
+measurement, which "has increased the tensions among data-driven
+dispersive evaluations of the LO HVP contribution to a level that makes
+it impossible to combine the results in a meaningful way."
+
+This lane pins the comparison **as published by CMD-3**, not a WP25
+combination (there is none) and not a Sounio integral.
+
+| pin | value (\(10^{-11}\)) | source |
+|---|---:|---|
+| `a_mu_hvp_lo_2pi_cmd3` | 5260(42) | CMD-3 PRL 132, 231903 (2024) |
+| `a_mu_hvp_lo_2pi_pre_cmd3` | 5060(34) | same Letter, citing WP20 + χ² inflation |
+
+Independent GUM: \(\sigma=\sqrt{42^2+34^2}=\sqrt{2920}\), pull \(=200/\sigma>3\).
+k95 = 1.96. The split is the falsifier: if \(|\mathrm{pull}|\le 1.96\), the
+claim is dead.
+
+## What this is not
+
+- Full HVP LO. Lattice WP25 LO is 7132(61) for the **full** channel sum.
+  Adding 5260 to 7132 is a category error; the test refuses a 100-unit
+  coincidence.
+- WP25 data-driven HVP LO. That slot is still `Wp25DdHvpLoAbsent`.
+- A BaBar-vs-KLOE table. WP25 Fig. 26 / Table 5 (section 2.11) illustrates
+  the spread across experiments and methods in units \(10^{-10}\) and
+  **does not** derive a global \(e^+e^-\) number. Those per-experiment
+  rows were not extracted as machine-readable text here; inventing them
+  would be fabrication. The CMD-3 Letter's own pair is the citation.
+
+## Receipts (2026-08-23)
+
+Control ELF `/workspace/sounio/bin/madaros-linux-x86_64` (100902241 B),
+`SOUNIO_MADAROS_BIN` override. Worktree committed ELF is 99964676 B and
+is not this receipt.
+
+Madaros `souc check` of `ew_precision.sio`, the example, and the test:
+**verdict=0**.
+
+Madaros `souc run` of `examples/particle_physics/a_mu_cmd3_2pi_split.sio`
+and `tests/run-pass/a_mu_cmd3_2pi_split.sio`: **rc=0**.
+
+```
+A_MU_UNIT 1e-11
+A_MU_2PI_CMD3_VAL 5260.000000
+A_MU_2PI_CMD3_STD 42.000000
+A_MU_2PI_PRE_VAL 5060.000000
+A_MU_2PI_PRE_STD 34.000000
+A_MU_2PI_PULL_CMD3_PRE 3.701166
+A_MU_K95 1.960000
+WP25_DD_HVP_LO_PROVIDED 0
+VERDICT_2PI_SPLIT_SURVIVES 1
+VERDICT_WP25_DD_LO_STILL_ABSENT 1
+```
+
+\(\sqrt{42^2+34^2}=\sqrt{2920}\approx 54.037\); \(200/54.037=3.701166\).
+Sounio computed the pull. Sounio did not compute the cross section.
+
+This does not claim the imported-module native path is closed for every
+graph. It claims this four-module 2π graph runs.
+
+LLM-offload math-review (`bin/llm-offload -t math-review -i` this file,
+`/tmp/llm-offload-n3fN28`):
+
+- xAI grok-4.3: four `[OK]` (σ_diff, pull, conservative independent-GUM
+  caveat, no WP25 combination). No `[WRONG]`.
+- Z.AI: weekly quota exhausted until 2026-08-25 06:34:36 (code 1310).
+- Outcome: **PASS_SINGLE_PROVIDER_DEGRADED**.
+- `.claude/llm_offload_log.md` is claimed by ns-wire; this lane does not
+  write it.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -81,6 +81,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.archived.roadmap-v0.5.0-part3 | archived | docs/archived/ROADMAP_v0.5.0_PART3.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.archived.strategic-growth-plan | archived | docs/archived/STRATEGIC_GROWTH_PLAN.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.archived.todo-next | archived | docs/archived/TODO_NEXT.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.a-mu-cmd3-2pi-split-2026-08-23 | repo_only | docs/audit/A_MU_CMD3_2PI_SPLIT_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.a-mu-gum-split-2026-08-23 | repo_only | docs/audit/A_MU_GUM_SPLIT_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.a-mu-wp25-dd-hvp-lo-absent-2026-08-23 | repo_only | docs/audit/A_MU_WP25_DD_HVP_LO_ABSENT_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.affine-nonassoc-uncertainty-2026-06-13 | repo_only | docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1327,6 +1327,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.a-mu-cmd3-2pi-split-2026-08-23",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/A_MU_CMD3_2PI_SPLIT_2026-08-23.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.a-mu-gum-split-2026-08-23",
       "collection": "repo",
       "repo_doc_path": "docs/audit/A_MU_GUM_SPLIT_2026-08-23.md",

--- a/examples/particle_physics/a_mu_cmd3_2pi_split.sio
+++ b/examples/particle_physics/a_mu_cmd3_2pi_split.sio
@@ -1,0 +1,65 @@
+//@ run-pass
+//@ description: CMD-3 vs pre-CMD-3 2π LO HVP — GUM split; not WP25 DD LO
+//
+// Citation witness. Sounio does not integrate σ(e⁺e⁻→π⁺π⁻).
+// CMD-3 PRL 132, 231903 (2024): 5260(42) vs previous 5060(34), units 10⁻¹¹.
+// Averaging them is a caller choice that does not exist in this module.
+// The WP25 data-driven LO slot stays Absent.
+//
+// Run:
+//   export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+//   ./bin/souc run examples/particle_physics/a_mu_cmd3_2pi_split.sio
+
+use particle_physics::ew_precision::{
+    a_mu_hvp_lo_2pi_cmd3, a_mu_hvp_lo_2pi_pre_cmd3,
+    a_mu_pull, a_mu_k95,
+    a_mu_wp25_datadriven_hvp_lo_provided, a_mu_hvp_lo_datadriven_wp25,
+    Wp25DdHvpLoAbsent,
+}
+use epistemic::knowledge::{ep_val, ep_std}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn hold_absent(x: Wp25DdHvpLoAbsent) -> bool {
+    x.provided
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    let cmd3 = a_mu_hvp_lo_2pi_cmd3()
+    let prev = a_mu_hvp_lo_2pi_pre_cmd3()
+    let k95 = a_mu_k95()
+    let pull = a_mu_pull(cmd3, prev)
+    let provided = a_mu_wp25_datadriven_hvp_lo_provided()
+    let slot = a_mu_hvp_lo_datadriven_wp25()
+
+    print("A_MU_UNIT 1e-11\n")
+    print("A_MU_2PI_CMD3_VAL ")
+    print_f64(ep_val(&cmd3))
+    print("\nA_MU_2PI_CMD3_STD ")
+    print_f64(ep_std(&cmd3))
+    print("\nA_MU_2PI_PRE_VAL ")
+    print_f64(ep_val(&prev))
+    print("\nA_MU_2PI_PRE_STD ")
+    print_f64(ep_std(&prev))
+    print("\nA_MU_2PI_PULL_CMD3_PRE ")
+    print_f64(pull)
+    print("\nA_MU_K95 ")
+    print_f64(k95)
+    print("\nWP25_DD_HVP_LO_PROVIDED ")
+    if provided { print("1\n") } else { print("0\n") }
+
+    var ok: i64 = 1
+    if ep_val(&cmd3) <= ep_val(&prev) { ok = 0 }
+    if abs_f(pull) <= k95 { ok = 0 }
+    if provided { ok = 0 }
+    if hold_absent(slot) { ok = 0 }
+
+    print("VERDICT_2PI_SPLIT_SURVIVES ")
+    if abs_f(pull) > k95 { print("1\n") } else { print("0\n") }
+    print("VERDICT_WP25_DD_LO_STILL_ABSENT ")
+    if provided { print("0\n") } else { print("1\n") }
+
+    if ok == 1 { 0 } else { 1 }
+}

--- a/stdlib/particle_physics/ew_precision.sio
+++ b/stdlib/particle_physics/ew_precision.sio
@@ -708,12 +708,46 @@ pub fn a_mu_hvp_wp25_assembled() -> Epistemic with Mut, Div, Panic {
 }
 
 // ============================================================================
+// CMD-3 vs PRE-CMD-3 2π LO HVP (units: 10⁻¹¹)
+// ============================================================================
+// This is the open discrepancy WP25 cites as the reason it will not quote a
+// combined data-driven LO HVP. It is not that combination.
+//
+// Ignatov et al. (CMD-3), Phys. Rev. Lett. 132, 231903 (2024)
+// arXiv:2309.12910:
+//   a_μ^{had;LO}(2π; CMD-3) = 5260(42)×10⁻¹¹
+//     CMD-3 data for √s = 0.327–1.2 GeV; average of other measurements
+//     outside that window. The 42 is systematics-dominated.
+//   compared to 5060(34)×10⁻¹¹, "a value based on the average of all
+//     previous measurements with the χ² inflation of error to account
+//     for data inconsistencies" (Aoyama et al. 2020 / WP20).
+//
+// Same quantity, as defined in that Letter. Not full HVP LO (do not add
+// to lattice 7132). Not WP25 data-driven HVP LO. There is no
+// a_mu_hvp_lo_2pi_combined: averaging is a caller choice WP25 refused.
+// Independent GUM: the two pins share some out-of-window data, so
+// Var(X−Y)=Var(X)+Var(Y) overstates σ_diff and understates the pull.
+// If the split still exceeds k95, that is conservative.
+
+/// CMD-3 2π contribution to LO HVP. Citation, not a Sounio integral.
+pub fn a_mu_hvp_lo_2pi_cmd3() -> Epistemic with Mut, Div, Panic {
+    Epistemic::measured(5260.0, 42.0)
+}
+
+/// Pre-CMD-3 2π average quoted in the same CMD-3 Letter (WP20 combination
+/// of previous measurements, χ²-inflated). Same quantity as the CMD-3 pin.
+pub fn a_mu_hvp_lo_2pi_pre_cmd3() -> Epistemic with Mut, Div, Panic {
+    Epistemic::measured(5060.0, 34.0)
+}
+
+// ============================================================================
 // WP25 DATA-DRIVEN HVP LO IS ABSENT (not a latent float)
 // ============================================================================
 // Table 5: "Estimates not provided at this point".
 // That is ignorance, not uncertainty. Madaros is the claim oracle (ADR-008).
-// Filling Unobserved<f64> with 6931, 7132, 7045, or 0.0 would be fabrication,
-// and Madaros does not inhabit Unobserved from a literal here (E008).
+// Filling Unobserved<f64> with 6931, 7132, 7045, 5260, 5060, or 0.0 would
+// be fabrication, and Madaros does not inhabit Unobserved from a literal
+// here (E008). The 2π pins above are not a substitute for this slot.
 //
 // The slot is a distinct type with no HVP number field. Collapsing it to
 // f64 is E008. The Table 5 citation is the bool. This lane does not claim

--- a/stdlib/particle_physics/mod.sio
+++ b/stdlib/particle_physics/mod.sio
@@ -327,6 +327,7 @@ pub use particle_physics::ew_precision::{
     a_mu_hvp_lo_wp20, a_mu_hvp_nlo_wp20, a_mu_hvp_nnlo_wp20,
     a_mu_hvp_lo_lattice_wp25, a_mu_hvp_nlo_epem_wp25, a_mu_hvp_nnlo_epem_wp25,
     a_mu_hvp_wp25_assembled,
+    a_mu_hvp_lo_2pi_cmd3, a_mu_hvp_lo_2pi_pre_cmd3,
     Wp25DdHvpLoAbsent,
     a_mu_wp25_datadriven_hvp_lo_provided, a_mu_hvp_lo_datadriven_wp25,
 }

--- a/tests/run-pass/a_mu_cmd3_2pi_split.sio
+++ b/tests/run-pass/a_mu_cmd3_2pi_split.sio
@@ -1,0 +1,50 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 0
+//@ description: CMD-3 2π LO HVP disagrees with the pre-CMD-3 average at k95
+// Full Test Suite CI uses souc-stage2 (lean_single), which does not
+// execute this imported Epistemic graph. Madaros does.
+
+use particle_physics::ew_precision::{
+    a_mu_hvp_lo_2pi_cmd3, a_mu_hvp_lo_2pi_pre_cmd3,
+    a_mu_pull, a_mu_k95,
+    a_mu_wp25_datadriven_hvp_lo_provided, a_mu_hvp_lo_datadriven_wp25,
+    a_mu_hvp_lo_lattice_wp25, Wp25DdHvpLoAbsent,
+}
+use epistemic::knowledge::{ep_val, ep_std}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn hold_absent(x: Wp25DdHvpLoAbsent) -> bool {
+    x.provided
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    let cmd3 = a_mu_hvp_lo_2pi_cmd3()
+    let prev = a_mu_hvp_lo_2pi_pre_cmd3()
+    let k95 = a_mu_k95()
+    let pull = a_mu_pull(cmd3, prev)
+
+    var ok: i64 = 1
+    // Citation values (CMD-3 PRL 132, 231903 (2024)), not a fitted sigma.
+    if abs_f(ep_val(&cmd3) - 5260.0) > 1.0e-9 { ok = 0 }
+    if abs_f(ep_std(&cmd3) - 42.0) > 1.0e-9 { ok = 0 }
+    if abs_f(ep_val(&prev) - 5060.0) > 1.0e-9 { ok = 0 }
+    if abs_f(ep_std(&prev) - 34.0) > 1.0e-9 { ok = 0 }
+    if ep_val(&cmd3) <= ep_val(&prev) { ok = 0 }
+    if abs_f(pull) <= k95 { ok = 0 }
+
+    // Independent GUM: σ = sqrt(42²+34²) = sqrt(2920). Pull = 200/σ > 3.
+    if abs_f(pull) <= 3.0 { ok = 0 }
+
+    // Category error refused: 2π is not full lattice LO.
+    if abs_f(ep_val(&cmd3) - ep_val(&a_mu_hvp_lo_lattice_wp25())) < 100.0 { ok = 0 }
+
+    // WP25 still has no combined data-driven LO.
+    if a_mu_wp25_datadriven_hvp_lo_provided() { ok = 0 }
+    if hold_absent(a_mu_hvp_lo_datadriven_wp25()) { ok = 0 }
+
+    if ok == 1 { 0 } else { 1 }
+}


### PR DESCRIPTION
## What

The open discrepancy WP25 cites as the reason it will not quote a combined data-driven LO HVP: CMD-3 vs the pre-CMD-3 2π average, pinned as two `Epistemic` values. Averaging them is a caller choice that does not exist in this module. `Wp25DdHvpLoAbsent` is unchanged.

Citations (Ignatov et al., PRL 132, 231903 (2024), arXiv:2309.12910), units 10⁻¹¹:

| pin | value |
|---|---:|
| `a_mu_hvp_lo_2pi_cmd3` | 5260(42) |
| `a_mu_hvp_lo_2pi_pre_cmd3` | 5060(34) |

Independent GUM: σ=√(42²+34²)=√2920, pull = 200/σ = **3.701166**. k95 = 1.96. Shared out-of-window data makes this σ conservative (overstates σ_diff).

## Receipts (Madaros control ELF 100902241 B)

`souc run examples/particle_physics/a_mu_cmd3_2pi_split.sio` rc=0:

```
A_MU_2PI_CMD3_VAL 5260.000000
A_MU_2PI_PRE_VAL 5060.000000
A_MU_2PI_PULL_CMD3_PRE 3.701166
WP25_DD_HVP_LO_PROVIDED 0
VERDICT_2PI_SPLIT_SURVIVES 1
VERDICT_WP25_DD_LO_STILL_ABSENT 1
```

Test `tests/run-pass/a_mu_cmd3_2pi_split.sio` rc=0 (`//@ requires: madaros`).

## Claims-forbidden

Sounio computed HVP; new physics; tension resolved; CMD-3 is the WP25 data-driven LO; 5260 is full HVP LO; averaging yields a TI combination; Madaros is fixed-point-verified.

Do not merge until asked.