### PR TITLE
feat(particle): lattice a_μ^W(ud) disagrees with KNT pre-CMD-3

### DIFF
--- a/docs/audit/A_MU_HVP_WINDOW_UD_2026-08-23.md
+++ b/docs/audit/A_MU_HVP_WINDOW_UD_2026-08-23.md
@@ -1,0 +1,107 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.a-mu-hvp-window-ud-2026-08-23
+authority: repo_only
+audience: users
+last_validated: 2026-08-23
+validated_by: grok-cli2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.a-mu-hvp-window-ud-2026-08-23
+-->
+
+# Intermediate window \(a_\mu^W(ud)\) — lattice vs KNT, same quantity
+
+```text
+Semantic-Lane-ID: a-mu-hvp-window-ud-20260823
+Owner: grok-cli2
+Concept-IDs: SOUNIO-EPISTEMIC-NUMERIC-VALUE
+Intent-Preserved: two evaluations of the same Euclidean window must not
+  be averaged into one HVP LO; a missing WP25 data-driven LO is not a
+  latent f64; Sounio does not compute lattice QCD
+Transformation: pin WP25 Table 8 last-row lattice a_μ^W(ud) and
+  Eq. (2.43) pre-CMD-3 KNT a_μ^W(ud) as Epistemic; GUM pull via ep_sub
+Types-Changed: none
+Effects-Changed: none
+IR-Changed: none
+Claims-Introduced: Sounio can hold the lattice and KNT window-ud pins
+  without collapsing them; the GUM pull of those pins is computed in
+  Sounio
+Claims-Forbidden: Sounio computed HVP; new physics; the tension is
+  resolved; 2069.7 is full HVP LO; this is WP25 data-driven HVP LO;
+  the exploratory CMD-3 window replacement is a TI combination;
+  Madaros is fixed-point-verified
+Assumptions: published centrals and quoted σ are citations (Aliberti
+  et al., Phys. Rep. 1143 (2025) 1). Lattice: Table 8 last row
+  206.97(41)×10⁻¹⁰ in isoQCD. Data-driven: Eq. (2.43) 199.0(1.1)×10⁻¹⁰
+  pre-CMD-3 purely KNT-based (Benton et al. 2025). Stored here as
+  10⁻¹¹ (×10) to match the other a_μ pins. Same RBC/UKQCD window
+  (t0=0.4 fm, t1=1.0 fm, Δ=0.15 fm), isospin-limit ud-connected.
+  Independent GUM: the methods do not share a dataset. The CMD-3
+  replacement in the same paragraph is labelled exploratory and is
+  not pinned.
+Write-Set: stdlib/particle_physics/ew_precision.sio,
+  stdlib/particle_physics/mod.sio,
+  examples/particle_physics/a_mu_hvp_window_ud.sio,
+  tests/run-pass/a_mu_hvp_window_ud.sio, this file
+Read-Set: stdlib/epistemic/knowledge.sio,
+  docs/audit/A_MU_GUM_SPLIT_2026-08-23.md,
+  docs/audit/A_MU_CMD3_2PI_SPLIT_2026-08-23.md,
+  docs/decisions/adr-008-claim-oracle-semantic-clock.md
+Positive-Witness: souc run prints pull > k95 and WP25_DD_HVP_LO_PROVIDED 0
+Negative-Witness: no combined window function; full lattice LO remains 7132
+Acceptance-Gate: tests/run-pass/a_mu_hvp_window_ud.sio exit 0 under Madaros
+Integration-Target: origin/main
+Authoritative-Only-If: the pull is produced by Madaros running Sounio
+```
+
+## Why this quantity
+
+WP25 will not quote a combined data-driven *full* LO HVP. The Euclidean
+intermediate window is the quantity both methods actually publish for a
+common kernel. The split lives in the light-quark connected piece, not
+in the short-distance window.
+
+| pin | WP25 (10⁻¹⁰) | stored (10⁻¹¹) |
+|---|---:|---:|
+| `a_mu_hvp_window_ud_lattice_wp25` | 206.97(41) Table 8 last row | 2069.7(4.1) |
+| `a_mu_hvp_window_ud_knt_pre_cmd3` | 199.0(1.1) Eq. (2.43) | 1990.0(11.0) |
+
+Independent GUM: \(\sigma=\sqrt{4.1^2+11.0^2}=\sqrt{137.81}\),
+pull \(=79.7/\sigma>5\). k95 = 1.96.
+
+Not Eq. (3.26) full-flavour \(a_\mu^W=236.58(43)\times 10^{-10}\). That
+includes s, c, disconnected, and IB. Adding 2069.7 to 7132 is a
+category error.
+
+## Receipts (2026-08-23)
+
+Control ELF `/workspace/sounio/bin/madaros-linux-x86_64` (100902241 B).
+
+Madaros `souc check` of `ew_precision.sio`, the example, and the test:
+**verdict=0**.
+
+Madaros `souc run` of the example and the test: **rc=0**.
+
+```
+A_MU_UNIT 1e-11
+A_MU_W_UD_LAT_VAL 2069.699999
+A_MU_W_UD_LAT_STD 4.099999
+A_MU_W_UD_KNT_VAL 1990.000000
+A_MU_W_UD_KNT_STD 11.000000
+A_MU_W_UD_PULL_LAT_KNT 6.789189
+A_MU_K95 1.960000
+WP25_DD_HVP_LO_PROVIDED 0
+VERDICT_WINDOW_UD_SPLIT_SURVIVES 1
+VERDICT_WP25_DD_LO_STILL_ABSENT 1
+```
+
+\(\sqrt{4.1^2+11.0^2}=\sqrt{137.81}\approx 11.739\); \(79.7/11.739=6.789189\).
+Sounio computed the pull. Sounio did not compute the window.
+
+The printed 2069.699999 is the f64 encoding of the citation 2069.7.
+The test matches the citation at \(10^{-9}\) relative to the stored literal.
+
+LLM-offload math-review (`/tmp/llm-offload-NUWA8K`):
+
+- xAI grok-4.3: four `[OK]` (difference, σ, pull, category vs 7132 / Eq. 3.26).
+- Z.AI: weekly quota exhausted until 2026-08-25.
+- Outcome: **PASS_SINGLE_PROVIDER_DEGRADED**.
+- `.claude/llm_offload_log.md` is claimed by ns-wire; this lane does not write it.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -83,6 +83,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.archived.todo-next | archived | docs/archived/TODO_NEXT.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.a-mu-cmd3-2pi-split-2026-08-23 | repo_only | docs/audit/A_MU_CMD3_2PI_SPLIT_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.a-mu-gum-split-2026-08-23 | repo_only | docs/audit/A_MU_GUM_SPLIT_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.a-mu-hvp-window-ud-2026-08-23 | repo_only | docs/audit/A_MU_HVP_WINDOW_UD_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.a-mu-wp25-dd-hvp-lo-absent-2026-08-23 | repo_only | docs/audit/A_MU_WP25_DD_HVP_LO_ABSENT_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.affine-nonassoc-uncertainty-2026-06-13 | repo_only | docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.branch-audit-2026-08-15 | repo_only | docs/audit/BRANCH_AUDIT_2026-08-15.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1373,6 +1373,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.a-mu-hvp-window-ud-2026-08-23",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/A_MU_HVP_WINDOW_UD_2026-08-23.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.a-mu-wp25-dd-hvp-lo-absent-2026-08-23",
       "collection": "repo",
       "repo_doc_path": "docs/audit/A_MU_WP25_DD_HVP_LO_ABSENT_2026-08-23.md",

--- a/examples/particle_physics/a_mu_hvp_window_ud.sio
+++ b/examples/particle_physics/a_mu_hvp_window_ud.sio
@@ -1,0 +1,57 @@
+//@ run-pass
+//@ description: lattice vs KNT pre-CMD-3 a_μ^W(ud) — GUM split; not full HVP LO
+//
+// Citation witness. Sounio does not compute a Euclidean window.
+// WP25 Table 8 last row vs Eq. (2.43), converted 10⁻¹⁰ → 10⁻¹¹.
+//
+// Run:
+//   export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+//   ./bin/souc run examples/particle_physics/a_mu_hvp_window_ud.sio
+
+use particle_physics::ew_precision::{
+    a_mu_hvp_window_ud_lattice_wp25, a_mu_hvp_window_ud_knt_pre_cmd3,
+    a_mu_pull, a_mu_k95,
+    a_mu_wp25_datadriven_hvp_lo_provided, a_mu_hvp_lo_lattice_wp25,
+}
+use epistemic::knowledge::{ep_val, ep_std}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    let lat = a_mu_hvp_window_ud_lattice_wp25()
+    let knt = a_mu_hvp_window_ud_knt_pre_cmd3()
+    let k95 = a_mu_k95()
+    let pull = a_mu_pull(lat, knt)
+    let provided = a_mu_wp25_datadriven_hvp_lo_provided()
+
+    print("A_MU_UNIT 1e-11\n")
+    print("A_MU_W_UD_LAT_VAL ")
+    print_f64(ep_val(&lat))
+    print("\nA_MU_W_UD_LAT_STD ")
+    print_f64(ep_std(&lat))
+    print("\nA_MU_W_UD_KNT_VAL ")
+    print_f64(ep_val(&knt))
+    print("\nA_MU_W_UD_KNT_STD ")
+    print_f64(ep_std(&knt))
+    print("\nA_MU_W_UD_PULL_LAT_KNT ")
+    print_f64(pull)
+    print("\nA_MU_K95 ")
+    print_f64(k95)
+    print("\nWP25_DD_HVP_LO_PROVIDED ")
+    if provided { print("1\n") } else { print("0\n") }
+
+    var ok: i64 = 1
+    if ep_val(&lat) <= ep_val(&knt) { ok = 0 }
+    if abs_f(pull) <= k95 { ok = 0 }
+    if provided { ok = 0 }
+    if abs_f(ep_val(&lat) - ep_val(&a_mu_hvp_lo_lattice_wp25())) < 100.0 { ok = 0 }
+
+    print("VERDICT_WINDOW_UD_SPLIT_SURVIVES ")
+    if abs_f(pull) > k95 { print("1\n") } else { print("0\n") }
+    print("VERDICT_WP25_DD_LO_STILL_ABSENT ")
+    if provided { print("0\n") } else { print("1\n") }
+
+    if ok == 1 { 0 } else { 1 }
+}

--- a/stdlib/particle_physics/ew_precision.sio
+++ b/stdlib/particle_physics/ew_precision.sio
@@ -741,6 +741,33 @@ pub fn a_mu_hvp_lo_2pi_pre_cmd3() -> Epistemic with Mut, Div, Panic {
 }
 
 // ============================================================================
+// INTERMEDIATE WINDOW, LIGHT-QUARK CONNECTED (units: 10⁻¹¹)
+// ============================================================================
+// RBC/UKQCD window (t0=0.4 fm, t1=1.0 fm, Δ=0.15 fm). Same quantity on
+// both pins: isospin-limit ud-connected a_μ^W. Not full HVP LO. Not the
+// full-flavour window of Eq. (3.26). WP25 quotes lattice in 10⁻¹⁰;
+// this module stores 10⁻¹¹ (×10) to match the other a_μ pins.
+//
+// Lattice: WP25 Table 8 last row (isoQCD average)
+//   a_μ^W(ud) = 206.97(41)×10⁻¹⁰ = 2069.7(4.1)×10⁻¹¹
+// Data-driven: WP25 Eq. (2.43), pre-CMD-3 purely KNT-based
+//   (Benton et al. 2025), a_μ^W(ud) = 199.0(1.1)×10⁻¹⁰
+//   = 1990.0(11.0)×10⁻¹¹
+// The CMD-3 replacement in that paragraph is labelled exploratory
+// ("ignores all other π⁺π⁻ data"); this lane does not pin it.
+// Independent GUM: the two methods do not share a dataset.
+
+/// WP25 Table 8 last-row lattice average, isoQCD a_μ^W(ud). Citation.
+pub fn a_mu_hvp_window_ud_lattice_wp25() -> Epistemic with Mut, Div, Panic {
+    Epistemic::measured(2069.7, 4.1)
+}
+
+/// WP25 Eq. (2.43) pre-CMD-3 KNT data-driven a_μ^W(ud). Citation.
+pub fn a_mu_hvp_window_ud_knt_pre_cmd3() -> Epistemic with Mut, Div, Panic {
+    Epistemic::measured(1990.0, 11.0)
+}
+
+// ============================================================================
 // WP25 DATA-DRIVEN HVP LO IS ABSENT (not a latent float)
 // ============================================================================
 // Table 5: "Estimates not provided at this point".

--- a/stdlib/particle_physics/mod.sio
+++ b/stdlib/particle_physics/mod.sio
@@ -328,6 +328,7 @@ pub use particle_physics::ew_precision::{
     a_mu_hvp_lo_lattice_wp25, a_mu_hvp_nlo_epem_wp25, a_mu_hvp_nnlo_epem_wp25,
     a_mu_hvp_wp25_assembled,
     a_mu_hvp_lo_2pi_cmd3, a_mu_hvp_lo_2pi_pre_cmd3,
+    a_mu_hvp_window_ud_lattice_wp25, a_mu_hvp_window_ud_knt_pre_cmd3,
     Wp25DdHvpLoAbsent,
     a_mu_wp25_datadriven_hvp_lo_provided, a_mu_hvp_lo_datadriven_wp25,
 }

--- a/tests/run-pass/a_mu_hvp_window_ud.sio
+++ b/tests/run-pass/a_mu_hvp_window_ud.sio
@@ -1,0 +1,47 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 0
+//@ description: lattice a_μ^W(ud) disagrees with KNT pre-CMD-3 at k95
+// Full Test Suite CI uses souc-stage2 (lean_single). Madaros runs this graph.
+
+use particle_physics::ew_precision::{
+    a_mu_hvp_window_ud_lattice_wp25, a_mu_hvp_window_ud_knt_pre_cmd3,
+    a_mu_pull, a_mu_k95,
+    a_mu_wp25_datadriven_hvp_lo_provided, a_mu_hvp_lo_lattice_wp25,
+    a_mu_hvp_lo_datadriven_wp25, Wp25DdHvpLoAbsent,
+}
+use epistemic::knowledge::{ep_val, ep_std}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn hold_absent(x: Wp25DdHvpLoAbsent) -> bool {
+    x.provided
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    let lat = a_mu_hvp_window_ud_lattice_wp25()
+    let knt = a_mu_hvp_window_ud_knt_pre_cmd3()
+    let k95 = a_mu_k95()
+    let pull = a_mu_pull(lat, knt)
+
+    var ok: i64 = 1
+    // Citations after 10⁻¹⁰ → 10⁻¹¹ (×10). Not a fitted sigma.
+    if abs_f(ep_val(&lat) - 2069.7) > 1.0e-9 { ok = 0 }
+    if abs_f(ep_std(&lat) - 4.1) > 1.0e-9 { ok = 0 }
+    if abs_f(ep_val(&knt) - 1990.0) > 1.0e-9 { ok = 0 }
+    if abs_f(ep_std(&knt) - 11.0) > 1.0e-9 { ok = 0 }
+    if ep_val(&lat) <= ep_val(&knt) { ok = 0 }
+    if abs_f(pull) <= k95 { ok = 0 }
+    // Independent GUM: σ = sqrt(4.1²+11²) = sqrt(137.81). Pull > 5.
+    if abs_f(pull) <= 5.0 { ok = 0 }
+
+    // Category error refused: window ud is not full lattice LO 7132.
+    if abs_f(ep_val(&lat) - ep_val(&a_mu_hvp_lo_lattice_wp25())) < 100.0 { ok = 0 }
+
+    if a_mu_wp25_datadriven_hvp_lo_provided() { ok = 0 }
+    if hold_absent(a_mu_hvp_lo_datadriven_wp25()) { ok = 0 }
+
+    if ok == 1 { 0 } else { 1 }
+}


### PR DESCRIPTION
## What

The Euclidean intermediate window is the quantity lattice and e⁺e⁻ both publish for a common kernel. This pins the **same** observable: isospin-limit light-quark-connected \(a_\mu^W(ud)\) (RBC/UKQCD window).

WP25 citations, stored as 10⁻¹¹ (×10 from the paper's 10⁻¹⁰):

| pin | WP25 | stored |
|---|---:|---:|
| `a_mu_hvp_window_ud_lattice_wp25` | Table 8 last row 206.97(41)×10⁻¹⁰ | 2069.7(4.1) |
| `a_mu_hvp_window_ud_knt_pre_cmd3` | Eq. (2.43) 199.0(1.1)×10⁻¹⁰ | 1990.0(11.0) |

Independent GUM pull **6.789189**. k95 = 1.96.

Not Eq. (3.26) full-flavour \(a_\mu^W\). Not WP25 data-driven HVP LO (still `Wp25DdHvpLoAbsent`). The CMD-3 window replacement in the same paragraph is labelled exploratory and is **not** pinned.

## Receipts (Madaros control ELF 100902241 B)

`souc run examples/particle_physics/a_mu_hvp_window_ud.sio` rc=0:

```
A_MU_W_UD_LAT_VAL 2069.699999
A_MU_W_UD_KNT_VAL 1990.000000
A_MU_W_UD_PULL_LAT_KNT 6.789189
WP25_DD_HVP_LO_PROVIDED 0
VERDICT_WINDOW_UD_SPLIT_SURVIVES 1
```

Test rc=0 (`//@ requires: madaros`).

## Claims-forbidden

Sounio computed HVP; new physics; tension resolved; 2069.7 is full HVP LO; averaging yields a TI combination; Madaros is fixed-point-verified.

Do not merge until asked.