### PR TITLE
feat(particle): SD window agrees; the GUM split lives in W(ud)

### DIFF
--- a/docs/audit/A_MU_HVP_SD_CONTROL_2026-08-23.md
+++ b/docs/audit/A_MU_HVP_SD_CONTROL_2026-08-23.md
@@ -1,0 +1,92 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.a-mu-hvp-sd-control-2026-08-23
+authority: repo_only
+audience: users
+last_validated: 2026-08-23
+validated_by: grok-cli2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.a-mu-hvp-sd-control-2026-08-23
+-->
+
+# Short-distance window — vanishing control for the W(ud) split
+
+```text
+Semantic-Lane-ID: a-mu-hvp-sd-control-20260823
+Owner: grok-cli2
+Concept-IDs: SOUNIO-EPISTEMIC-NUMERIC-VALUE
+Intent-Preserved: a GUM split that fires on every pair is not a
+  diagnostic; Sounio does not compute lattice QCD; WP25 data-driven
+  HVP LO remains absent
+Transformation: pin WP25 Eq. (3.22) lattice a_μ^SD and the
+  Colangelo 2022d R-ratio a_μ^SD as Epistemic; require |pull| ≤ k95
+  and |pull_W(ud)| > |pull_SD|
+Types-Changed: none
+Effects-Changed: none
+IR-Changed: none
+Claims-Introduced: Sounio can hold the SD lattice and R-ratio pins
+  without collapsing them; their GUM pull is computed in Sounio and
+  is consistent with 0 at k95; the W(ud) split is larger
+Claims-Forbidden: Sounio computed HVP; new physics; the tension is
+  resolved; 691.0 is full HVP LO; SD agreement implies W agreement;
+  Madaros is fixed-point-verified
+Assumptions: published centrals and quoted σ are citations (Aliberti
+  et al., Phys. Rep. 1143 (2025) 1). Lattice: Eq. (3.22)
+  69.10(26)×10⁻¹⁰. Data-driven: 68.4(5)×10⁻¹⁰ from Colangelo et al.
+  2022d in the pre-CMD-3 scenario, as quoted by WP25; (5) means
+  ±0.5 in 10⁻¹⁰. Stored here as 10⁻¹¹ (×10). Independent GUM.
+Write-Set: stdlib/particle_physics/ew_precision.sio,
+  stdlib/particle_physics/mod.sio,
+  examples/particle_physics/a_mu_hvp_sd_control.sio,
+  tests/run-pass/a_mu_hvp_sd_control.sio, this file
+Read-Set: docs/audit/A_MU_HVP_WINDOW_UD_2026-08-23.md,
+  docs/decisions/adr-008-claim-oracle-semantic-clock.md
+Positive-Witness: souc run prints |pull_SD| ≤ 1.96 and
+  |pull_W(ud)| > |pull_SD|
+Negative-Witness: full lattice LO remains 7132; DD LO still Absent
+Acceptance-Gate: tests/run-pass/a_mu_hvp_sd_control.sio exit 0 under
+  Madaros
+Integration-Target: origin/main
+Authoritative-Only-If: the pulls are produced by Madaros running Sounio
+```
+
+## Why a control
+
+The intermediate-window \(a_\mu^W(ud)\) split (PR #2077, pull 6.79) is
+only diagnostic if the same GUM protocol does not fire on a window WP25
+says is compatible. Short-distance is that window.
+
+| pin | WP25 (10⁻¹⁰) | stored (10⁻¹¹) |
+|---|---:|---:|
+| `a_mu_hvp_sd_lattice_wp25` | Eq. (3.22) 69.10(26) | 691.0(2.6) |
+| `a_mu_hvp_sd_rratio_pre_cmd3` | 68.4(5) Colangelo 2022d | 684.0(5.0) |
+
+Independent GUM: \(\sigma=\sqrt{2.6^2+5.0^2}=\sqrt{31.76}\),
+pull \(=7.0/\sigma\approx 1.24\le 1.96\).
+
+Falsifier: if \(|\mathrm{pull_{SD}}|>1.96\), the “SD agrees” control is
+dead. If \(|\mathrm{pull_W}|\le|\mathrm{pull_{SD}}|\), the claim that the
+split lives in W is dead.
+
+## Receipts (2026-08-23)
+
+Control ELF `/workspace/sounio/bin/madaros-linux-x86_64` (100902241 B).
+
+Madaros `souc check` verdict=0. Example and test **rc=0**.
+
+```
+A_MU_SD_LAT_VAL 691.000000
+A_MU_SD_RR_VAL 684.000000
+A_MU_SD_PULL_LAT_RR 1.242103
+A_MU_W_UD_PULL_LAT_KNT 6.789189
+A_MU_K95 1.960000
+VERDICT_SD_AGREES 1
+VERDICT_W_SPLIT_LARGER_THAN_SD 1
+WP25_DD_HVP_LO_PROVIDED 0
+```
+
+\(\sqrt{2.6^2+5.0^2}=\sqrt{31.76}\approx 5.635\); \(7.0/5.635=1.242103\le 1.96\).
+
+LLM-offload math-review (`/tmp/llm-offload-ShmQ67`):
+
+- xAI grok-4.3: five `[OK]` (σ, sqrt, pull, k95, W>SD).
+- Z.AI: weekly quota exhausted until 2026-08-25.
+- Outcome: **PASS_SINGLE_PROVIDER_DEGRADED**.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -83,6 +83,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.archived.todo-next | archived | docs/archived/TODO_NEXT.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.a-mu-cmd3-2pi-split-2026-08-23 | repo_only | docs/audit/A_MU_CMD3_2PI_SPLIT_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.a-mu-gum-split-2026-08-23 | repo_only | docs/audit/A_MU_GUM_SPLIT_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.a-mu-hvp-sd-control-2026-08-23 | repo_only | docs/audit/A_MU_HVP_SD_CONTROL_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.a-mu-hvp-window-ud-2026-08-23 | repo_only | docs/audit/A_MU_HVP_WINDOW_UD_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.a-mu-wp25-dd-hvp-lo-absent-2026-08-23 | repo_only | docs/audit/A_MU_WP25_DD_HVP_LO_ABSENT_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.affine-nonassoc-uncertainty-2026-06-13 | repo_only | docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1373,6 +1373,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.a-mu-hvp-sd-control-2026-08-23",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/A_MU_HVP_SD_CONTROL_2026-08-23.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.a-mu-hvp-window-ud-2026-08-23",
       "collection": "repo",
       "repo_doc_path": "docs/audit/A_MU_HVP_WINDOW_UD_2026-08-23.md",

--- a/examples/particle_physics/a_mu_hvp_sd_control.sio
+++ b/examples/particle_physics/a_mu_hvp_sd_control.sio
@@ -1,0 +1,65 @@
+//@ run-pass
+//@ description: SD window lattice vs R-ratio agrees; W(ud) split remains
+//
+// Citation witness. Sounio does not compute a Euclidean window.
+// WP25 Eq. (3.22) vs Colangelo 2022d, converted 10⁻¹⁰ → 10⁻¹¹.
+// Control: |pull_SD| ≤ k95 and |pull_W(ud)| > |pull_SD|.
+//
+// Run:
+//   export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+//   ./bin/souc run examples/particle_physics/a_mu_hvp_sd_control.sio
+
+use particle_physics::ew_precision::{
+    a_mu_hvp_sd_lattice_wp25, a_mu_hvp_sd_rratio_pre_cmd3,
+    a_mu_hvp_window_ud_lattice_wp25, a_mu_hvp_window_ud_knt_pre_cmd3,
+    a_mu_pull, a_mu_k95,
+    a_mu_wp25_datadriven_hvp_lo_provided, a_mu_hvp_lo_lattice_wp25,
+}
+use epistemic::knowledge::{ep_val, ep_std}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    let lat = a_mu_hvp_sd_lattice_wp25()
+    let rr = a_mu_hvp_sd_rratio_pre_cmd3()
+    let k95 = a_mu_k95()
+    let pull_sd = a_mu_pull(lat, rr)
+    let pull_w = a_mu_pull(
+        a_mu_hvp_window_ud_lattice_wp25(),
+        a_mu_hvp_window_ud_knt_pre_cmd3(),
+    )
+    let provided = a_mu_wp25_datadriven_hvp_lo_provided()
+
+    print("A_MU_UNIT 1e-11\n")
+    print("A_MU_SD_LAT_VAL ")
+    print_f64(ep_val(&lat))
+    print("\nA_MU_SD_LAT_STD ")
+    print_f64(ep_std(&lat))
+    print("\nA_MU_SD_RR_VAL ")
+    print_f64(ep_val(&rr))
+    print("\nA_MU_SD_RR_STD ")
+    print_f64(ep_std(&rr))
+    print("\nA_MU_SD_PULL_LAT_RR ")
+    print_f64(pull_sd)
+    print("\nA_MU_W_UD_PULL_LAT_KNT ")
+    print_f64(pull_w)
+    print("\nA_MU_K95 ")
+    print_f64(k95)
+    print("\nWP25_DD_HVP_LO_PROVIDED ")
+    if provided { print("1\n") } else { print("0\n") }
+
+    var ok: i64 = 1
+    if abs_f(pull_sd) > k95 { ok = 0 }
+    if abs_f(pull_w) <= abs_f(pull_sd) { ok = 0 }
+    if provided { ok = 0 }
+    if abs_f(ep_val(&lat) - ep_val(&a_mu_hvp_lo_lattice_wp25())) < 100.0 { ok = 0 }
+
+    print("VERDICT_SD_AGREES ")
+    if abs_f(pull_sd) <= k95 { print("1\n") } else { print("0\n") }
+    print("VERDICT_W_SPLIT_LARGER_THAN_SD ")
+    if abs_f(pull_w) > abs_f(pull_sd) { print("1\n") } else { print("0\n") }
+
+    if ok == 1 { 0 } else { 1 }
+}

--- a/stdlib/particle_physics/ew_precision.sio
+++ b/stdlib/particle_physics/ew_precision.sio
@@ -768,6 +768,29 @@ pub fn a_mu_hvp_window_ud_knt_pre_cmd3() -> Epistemic with Mut, Div, Panic {
 }
 
 // ============================================================================
+// SHORT-DISTANCE WINDOW (full SD) — vanishing control (units: 10⁻¹¹)
+// ============================================================================
+// WP25 §3.4.2: lattice and R-ratio SD agree; the tension is not here.
+// Same conversion 10⁻¹⁰ → 10⁻¹¹ as the W(ud) pins. Not full HVP LO.
+//
+// Lattice: WP25 Eq. (3.22) a_μ^SD = 69.10(26)×10⁻¹⁰ = 691.0(2.6)×10⁻¹¹
+//   (isoQCD average plus SIB+QED).
+// Data-driven: Colangelo et al. 2022d via WP25, pre-CMD-3 R-ratio
+//   68.4(5)×10⁻¹⁰ = 684.0(5.0)×10⁻¹¹. Here (5) is ±0.5 in 10⁻¹⁰.
+// Independent GUM: |pull| ≤ k95 is the control. The W(ud) split must
+// remain larger.
+
+/// WP25 Eq. (3.22) lattice world average, total a_μ^SD. Citation.
+pub fn a_mu_hvp_sd_lattice_wp25() -> Epistemic with Mut, Div, Panic {
+    Epistemic::measured(691.0, 2.6)
+}
+
+/// WP25-cited pre-CMD-3 R-ratio a_μ^SD (Colangelo et al. 2022d). Citation.
+pub fn a_mu_hvp_sd_rratio_pre_cmd3() -> Epistemic with Mut, Div, Panic {
+    Epistemic::measured(684.0, 5.0)
+}
+
+// ============================================================================
 // WP25 DATA-DRIVEN HVP LO IS ABSENT (not a latent float)
 // ============================================================================
 // Table 5: "Estimates not provided at this point".

--- a/stdlib/particle_physics/mod.sio
+++ b/stdlib/particle_physics/mod.sio
@@ -329,6 +329,7 @@ pub use particle_physics::ew_precision::{
     a_mu_hvp_wp25_assembled,
     a_mu_hvp_lo_2pi_cmd3, a_mu_hvp_lo_2pi_pre_cmd3,
     a_mu_hvp_window_ud_lattice_wp25, a_mu_hvp_window_ud_knt_pre_cmd3,
+    a_mu_hvp_sd_lattice_wp25, a_mu_hvp_sd_rratio_pre_cmd3,
     Wp25DdHvpLoAbsent,
     a_mu_wp25_datadriven_hvp_lo_provided, a_mu_hvp_lo_datadriven_wp25,
 }

--- a/tests/run-pass/a_mu_hvp_sd_control.sio
+++ b/tests/run-pass/a_mu_hvp_sd_control.sio
@@ -1,0 +1,43 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 0
+//@ description: SD window agrees at k95; W(ud) pull is larger
+// Full Test Suite CI uses souc-stage2 (lean_single). Madaros runs this graph.
+
+use particle_physics::ew_precision::{
+    a_mu_hvp_sd_lattice_wp25, a_mu_hvp_sd_rratio_pre_cmd3,
+    a_mu_hvp_window_ud_lattice_wp25, a_mu_hvp_window_ud_knt_pre_cmd3,
+    a_mu_pull, a_mu_k95,
+    a_mu_wp25_datadriven_hvp_lo_provided, a_mu_hvp_lo_lattice_wp25,
+}
+use epistemic::knowledge::{ep_val, ep_std}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    let lat = a_mu_hvp_sd_lattice_wp25()
+    let rr = a_mu_hvp_sd_rratio_pre_cmd3()
+    let k95 = a_mu_k95()
+    let pull_sd = a_mu_pull(lat, rr)
+    let pull_w = a_mu_pull(
+        a_mu_hvp_window_ud_lattice_wp25(),
+        a_mu_hvp_window_ud_knt_pre_cmd3(),
+    )
+
+    var ok: i64 = 1
+    if abs_f(ep_val(&lat) - 691.0) > 1.0e-9 { ok = 0 }
+    if abs_f(ep_std(&lat) - 2.6) > 1.0e-9 { ok = 0 }
+    if abs_f(ep_val(&rr) - 684.0) > 1.0e-9 { ok = 0 }
+    if abs_f(ep_std(&rr) - 5.0) > 1.0e-9 { ok = 0 }
+    if ep_val(&lat) <= ep_val(&rr) { ok = 0 }
+    if abs_f(pull_sd) > k95 { ok = 0 }
+    if abs_f(pull_w) <= abs_f(pull_sd) { ok = 0 }
+    if abs_f(pull_w) <= k95 { ok = 0 }
+
+    if abs_f(ep_val(&lat) - ep_val(&a_mu_hvp_lo_lattice_wp25())) < 100.0 { ok = 0 }
+    if a_mu_wp25_datadriven_hvp_lo_provided() { ok = 0 }
+
+    if ok == 1 { 0 } else { 1 }
+}


### PR DESCRIPTION
## What

A GUM split that fires on every pair is not a diagnostic. WP25 says the short-distance window is compatible with R-ratio data. This pins that control, and requires the already-shipped W(ud) split to be larger.

WP25 citations, stored as 10⁻¹¹ (×10 from the paper's 10⁻¹⁰):

| pin | WP25 | stored |
|---|---:|---:|
| `a_mu_hvp_sd_lattice_wp25` | Eq. (3.22) 69.10(26)×10⁻¹⁰ | 691.0(2.6) |
| `a_mu_hvp_sd_rratio_pre_cmd3` | 68.4(5)×10⁻¹⁰ Colangelo 2022d | 684.0(5.0) |

Independent GUM pull **1.242103** ≤ k95. W(ud) pull remains **6.789189**.

`(5)` is ±0.5 in 10⁻¹⁰. Not full HVP LO. DD LO still `Wp25DdHvpLoAbsent`.

## Receipts (Madaros control ELF 100902241 B)

```
A_MU_SD_PULL_LAT_RR 1.242103
A_MU_W_UD_PULL_LAT_KNT 6.789189
VERDICT_SD_AGREES 1
VERDICT_W_SPLIT_LARGER_THAN_SD 1
WP25_DD_HVP_LO_PROVIDED 0
```

Example + test rc=0 (`//@ requires: madaros`).

## Claims-forbidden

Sounio computed HVP; new physics; tension resolved; SD agreement implies W agreement; 691.0 is full HVP LO; Madaros is fixed-point-verified.

Do not merge until asked. Codex: additive registry topic `repo.docs.audit.a-mu-hvp-sd-control-2026-08-23`; rebase if you hold `topic-registry.v1.json`.