### PR TITLE
CI: a typo that became a contract, and two gates that asserted the wrong thing

### DIFF
--- a/demo/fregni/run.sh
+++ b/demo/fregni/run.sh
@@ -11,7 +11,7 @@ echo "--- 1. Reference arithmetic (Python) ---"
 python3 reference.py
 echo ""
 
-echo "--- 2. Confidence-gated dosing pipeline (Sounio/Madares) ---"
+echo "--- 2. Confidence-gated dosing pipeline (Sounio/Madaros) ---"
 "$SOUC" run fregni_demo.sio
 echo ""
 

--- a/scripts/ci/dyadic_non_reduction_gate.sh
+++ b/scripts/ci/dyadic_non_reduction_gate.sh
@@ -24,7 +24,7 @@ bin/souc --version >"$TMP_DIR/version.log" 2>&1 || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not report its version"
 }
-grep -Eq "Madares|Madaros" "$TMP_DIR/version.log" || {
+grep -Fq "Madaros" "$TMP_DIR/version.log" || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not resolve to Madaros"
 }

--- a/scripts/ci/dyadic_relational_associator_gate.sh
+++ b/scripts/ci/dyadic_relational_associator_gate.sh
@@ -20,7 +20,7 @@ bin/souc --version >"$TMP_DIR/version.log" 2>&1 || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not report its version"
 }
-grep -Eq "Madares|Madaros" "$TMP_DIR/version.log" || {
+grep -Fq "Madaros" "$TMP_DIR/version.log" || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not resolve to Madaros"
 }

--- a/scripts/ci/madaros_launcher_exit_status_gate.sh
+++ b/scripts/ci/madaros_launcher_exit_status_gate.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/madaros-a1.XXXXXX")"
 trap 'rm -rf "$WORK"' EXIT
+export SOUNIO_STDLIB_PATH="$ROOT_DIR/stdlib"
 
 set +e
 "$ROOT_DIR/bin/madaros" build "$WORK/does-not-exist.sio" -o "$WORK/out.elf" >"$WORK/log.txt" 2>&1
@@ -34,8 +35,62 @@ if grep -n 'ulimit -s unlimited' "$ROOT_DIR/bin/madaros" | grep -v MADAROS_STACK
     exit 1
   fi
 fi
-if ! grep -q 'compiler exited with status' "$ROOT_DIR/bin/madaros"; then
-  echo "FAIL: A1 exit-status message missing from launcher" >&2
+# The A1 exit-status message occurs twice in bin/madaros -- once in the GPU
+# backend branch and once in the native branch -- with byte-identical text, so
+# a bare `grep -q 'compiler exited with status'` was satisfied by either and
+# could not notice an edit to the one that actually runs. bin/madaros IS the
+# source (a checked-in shell launcher), so the two sites are distinguishable,
+# but only by the discard message that follows each. Pin both by that context,
+# and require the reachable one to be exercised for real below.
+mapfile -t MSG_LINES < <(
+  grep -nF 'error: madaros build: compiler exited with status' "$ROOT_DIR/bin/madaros" \
+    | cut -d: -f1
+)
+if [[ "${#MSG_LINES[@]}" -ne 2 ]]; then
+  echo "FAIL: expected 2 A1 exit-status messages in launcher, found ${#MSG_LINES[@]}" >&2
+  exit 1
+fi
+gpu_branch=0
+native_branch=0
+for n in "${MSG_LINES[@]}"; do
+  window="$(sed -n "$((n + 1)),$((n + 3))p" "$ROOT_DIR/bin/madaros")"
+  if grep -qF 'discarding partial GPU artifact at' <<<"$window"; then
+    gpu_branch=$((gpu_branch + 1))
+  elif grep -qF 'discarding partial ELF at' <<<"$window"; then
+    native_branch=$((native_branch + 1))
+  else
+    echo "FAIL: A1 exit-status message at bin/madaros:$n is in neither the GPU nor the native branch" >&2
+    exit 1
+  fi
+done
+if [[ "$gpu_branch" -ne 1 || "$native_branch" -ne 1 ]]; then
+  echo "FAIL: A1 exit-status message must appear once per branch (gpu=$gpu_branch native=$native_branch)" >&2
+  exit 1
+fi
+
+# Behavioural check on the occurrence that actually executes. The missing-source
+# probe above never reaches the compiler -- bin/madaros rejects it with a usage
+# error (rc=2) before RAW_MADAROS is invoked -- so it exercises neither site. A
+# source that exists but does not compile drives the native branch through the
+# real message.
+BAD_SRC="$WORK/a1-bad.sio"
+printf 'fn main() {\n  let x = \n}\n' >"$BAD_SRC"
+set +e
+"$ROOT_DIR/bin/madaros" build "$BAD_SRC" -o "$WORK/bad.elf" >"$WORK/bad-log.txt" 2>&1
+bad_rc=$?
+set -e
+if [[ $bad_rc -eq 0 ]]; then
+  echo "FAIL: madaros build of an ill-formed source returned 0" >&2
+  cat "$WORK/bad-log.txt" >&2
+  exit 1
+fi
+if ! grep -qF 'madaros build: compiler exited with status' "$WORK/bad-log.txt"; then
+  echo "FAIL: native build failure did not emit the A1 exit-status message" >&2
+  cat "$WORK/bad-log.txt" >&2
+  exit 1
+fi
+if [[ -s "$WORK/bad.elf" ]]; then
+  echo "FAIL: madaros left an artifact after a failed native build" >&2
   exit 1
 fi
 echo "MADAROS_LAUNCHER_EXIT_STATUS_GATE_PASS"

--- a/scripts/ci/proof_carrying_deployment_validity_revocable_authority_gate.sh
+++ b/scripts/ci/proof_carrying_deployment_validity_revocable_authority_gate.sh
@@ -29,7 +29,7 @@ bin/souc --version >"$TMP_DIR/version.log" 2>&1 || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not report its version"
 }
-grep -Eq "Madares|Madaros" "$TMP_DIR/version.log" || {
+grep -Fq "Madaros" "$TMP_DIR/version.log" || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not resolve to Madaros"
 }

--- a/scripts/ci/proof_carrying_endogenous_observability_gate.sh
+++ b/scripts/ci/proof_carrying_endogenous_observability_gate.sh
@@ -20,7 +20,7 @@ bin/souc --version >"$TMP_DIR/version.log" 2>&1 || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not report its version"
 }
-grep -Eq "Madares|Madaros" "$TMP_DIR/version.log" || {
+grep -Fq "Madaros" "$TMP_DIR/version.log" || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not resolve to Madaros"
 }

--- a/scripts/ci/proof_carrying_model_contest_gate.sh
+++ b/scripts/ci/proof_carrying_model_contest_gate.sh
@@ -20,7 +20,7 @@ bin/souc --version >"$TMP_DIR/version.log" 2>&1 || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not report its version"
 }
-grep -Eq "Madares|Madaros" "$TMP_DIR/version.log" || {
+grep -Fq "Madaros" "$TMP_DIR/version.log" || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not resolve to Madaros"
 }

--- a/scripts/ci/proof_carrying_path_conditioned_identification_gate.sh
+++ b/scripts/ci/proof_carrying_path_conditioned_identification_gate.sh
@@ -29,7 +29,7 @@ bin/souc --version >"$TMP_DIR/version.log" 2>&1 || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not report its version"
 }
-grep -Eq "Madares|Madaros" "$TMP_DIR/version.log" || {
+grep -Fq "Madaros" "$TMP_DIR/version.log" || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not resolve to Madaros"
 }

--- a/scripts/ci/proof_carrying_policy_observation_associator_gate.sh
+++ b/scripts/ci/proof_carrying_policy_observation_associator_gate.sh
@@ -20,7 +20,7 @@ bin/souc --version >"$TMP_DIR/version.log" 2>&1 || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not report its version"
 }
-grep -Eq "Madares|Madaros" "$TMP_DIR/version.log" || {
+grep -Fq "Madaros" "$TMP_DIR/version.log" || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not resolve to Madaros"
 }

--- a/scripts/ci/proof_carrying_policy_state_feedback_gate.sh
+++ b/scripts/ci/proof_carrying_policy_state_feedback_gate.sh
@@ -20,7 +20,7 @@ bin/souc --version >"$TMP_DIR/version.log" 2>&1 || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not report its version"
 }
-grep -Eq "Madares|Madaros" "$TMP_DIR/version.log" || {
+grep -Fq "Madaros" "$TMP_DIR/version.log" || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not resolve to Madaros"
 }

--- a/scripts/ci/proof_carrying_rebracketing_protocol_gate.sh
+++ b/scripts/ci/proof_carrying_rebracketing_protocol_gate.sh
@@ -29,7 +29,7 @@ bin/souc --version >"$TMP_DIR/version.log" 2>&1 || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not report its version"
 }
-grep -Eq "Madares|Madaros" "$TMP_DIR/version.log" || {
+grep -Fq "Madaros" "$TMP_DIR/version.log" || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not resolve to Madaros"
 }

--- a/scripts/ci/proof_carrying_reflexive_inquiry_gate.sh
+++ b/scripts/ci/proof_carrying_reflexive_inquiry_gate.sh
@@ -20,7 +20,7 @@ bin/souc --version >"$TMP_DIR/version.log" 2>&1 || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not report its version"
 }
-grep -Eq "Madares|Madaros" "$TMP_DIR/version.log" || {
+grep -Fq "Madaros" "$TMP_DIR/version.log" || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not resolve to Madaros"
 }

--- a/scripts/ci/proof_carrying_shift_robust_risk_transport_gate.sh
+++ b/scripts/ci/proof_carrying_shift_robust_risk_transport_gate.sh
@@ -29,7 +29,7 @@ bin/souc --version >"$TMP_DIR/version.log" 2>&1 || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not report its version"
 }
-grep -Eq "Madares|Madaros" "$TMP_DIR/version.log" || {
+grep -Fq "Madaros" "$TMP_DIR/version.log" || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not resolve to Madaros"
 }

--- a/scripts/ci/proof_carrying_statistical_coverage_empirical_binding_gate.sh
+++ b/scripts/ci/proof_carrying_statistical_coverage_empirical_binding_gate.sh
@@ -29,7 +29,7 @@ bin/souc --version >"$TMP_DIR/version.log" 2>&1 || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not report its version"
 }
-grep -Eq "Madares|Madaros" "$TMP_DIR/version.log" || {
+grep -Fq "Madaros" "$TMP_DIR/version.log" || {
     cat "$TMP_DIR/version.log" >&2
     fail "canonical bin/souc did not resolve to Madaros"
 }

--- a/scripts/ci/souc-native-wrapper.sh
+++ b/scripts/ci/souc-native-wrapper.sh
@@ -97,7 +97,7 @@ _detect_raw_mode() {
   fi
   local ident
   ident="$("$RAW_SOUC" /dev/null /dev/null 2>/dev/null | head -n 1 || true)"
-  if grep -q "Madares v" <<<"$ident"; then
+  if grep -q "Madaros v" <<<"$ident"; then
     echo "modular"
     return 0
   fi

--- a/scripts/ci/zd_deep_dive_gate.sh
+++ b/scripts/ci/zd_deep_dive_gate.sh
@@ -7,12 +7,13 @@
 #   B.6 multi-invariant equivalence spectrum
 #   B.7 iterated trajectory drift between different-z pairs
 #
-# This is *evidence-recording* -- the test always asserts ALL PASS as long
-# as it runs cleanly. The synthesis block at the end is the durable artifact
-# downstream readers (and future butterfly-shapers) consume.
+# The test asserts ALL PASS as long as it runs cleanly; that string alone is
+# not evidence, so this gate additionally pins the headline B.4 census. The
+# synthesis block at the end is the durable artifact downstream readers (and
+# future butterfly-shapers) consume.
 #
-# Reference baseline (2026-05-09):
-#   - 92 primitive ZDs enumerated
+# Reference baseline (count corrected 2026-08-23; see ZD_EXPECTED below):
+#   - 84 primitive ZDs enumerated
 #   - trivial dedup (same-z): structural, 2 per z, h-stable
 #   - cross-z dedup: h-coincidental; diverges ~2x per iterated step
 #   - recommendation: z-canonical hash, not orbit-class metadata
@@ -54,8 +55,27 @@ if [[ "$rc" -ne 0 ]]; then echo "FAIL: test exited $rc" >&2; exit 1; fi
 grep -q "ALL PASS" "$OUT_LOG" || { echo "FAIL: 'ALL PASS' missing" >&2; exit 1; }
 grep -q "Synthesis" "$OUT_LOG" || { echo "FAIL: synthesis block missing" >&2; exit 1; }
 
-# Surface the headline numbers for grep-ability.
+# Assert the headline number, not just the "ALL PASS" string. B.4 enumerates
+# z = e_i+e_j against w = e_k-e_l over i<j, k<l in 1..15 and must find exactly
+# 84 zero divisors. 84 is not this run's output taken as the baseline: it is
+# machine-checked in formal/lean4/SounioZeroDivisorBridge.lean
+# (`theorem prim_count_84 : validPrims.length = 84 := by native_decide`), it is
+# what tests/math/test_zd_deep_dive.sio's own header cites from the literature,
+# and it factors as the 42 distinct z values x 2 w-companions that B.5 reports.
+# The "92" this header carried from the gate's first commit (2c853c3088) matched
+# none of those and was never produced by the test, whose source has not changed
+# since that same commit -- it was a wrong comment, not a regression.
+ZD_EXPECTED=84
+
 zd_count="$(grep -E '^  ZDs found:' "$OUT_LOG" | awk '{print $NF}' | tr -d '\n')"
+if [[ ! "$zd_count" =~ ^[0-9]+$ ]]; then
+    echo "FAIL: could not extract the B.4 ZD count from the test output" >&2
+    exit 1
+fi
+if [[ "$zd_count" -ne "$ZD_EXPECTED" ]]; then
+    echo "FAIL: B.4 enumerated $zd_count zero divisors, expected $ZD_EXPECTED" >&2
+    exit 1
+fi
 echo "Phase B deep-dive: ZDs=$zd_count, $(grep -m1 recommendation "$OUT_LOG" | sed 's/^[[:space:]]*//')"
 
 exit 0

--- a/scripts/gates/g6_madaros_identity.sh
+++ b/scripts/gates/g6_madaros_identity.sh
@@ -18,8 +18,8 @@ if [[ -z "$IDENTITY" ]]; then
   exit 1
 fi
 
-if [[ "$VERSION_OUTPUT" != *"Madaros"* && "$VERSION_OUTPUT" != *"Madares"* ]]; then
-  echo "[g6] FAIL: expected Madaros/Madares identity, got:" >&2
+if [[ "$VERSION_OUTPUT" != *"Madaros"* ]]; then
+  echo "[g6] FAIL: expected Madaros identity, got:" >&2
   printf '%s\n' "$VERSION_OUTPUT" >&2
   exit 1
 fi

--- a/scripts/research/abide_checkpoint_persist.py
+++ b/scripts/research/abide_checkpoint_persist.py
@@ -650,7 +650,7 @@ def generate_native_verifier_source(ckpt: dict[str, Any], manifest_path: Path, r
         before_emit, rest = prefix.split(ckpt_emit_start, 1)
         _, after_emit = rest.split(ckpt_emit_end, 1)
         # The verifier loads an already-persisted checkpoint, so native CKPT
-        # emission helpers are dead code here. Dropping them avoids a Madares
+        # emission helpers are dead code here. Dropping them avoids a Madaros
         # backend crash in the unused checkpoint dispatch path.
         prefix = before_emit + ckpt_emit_end + after_emit
     ckpt_print_start = "fn print_i64_array("


### PR DESCRIPTION
Three fixes, all found by sabotage-testing CI gates on 2026-08-23.

## The typo

The compiler prints `Madaros v0.80.0`. `scripts/ci/souc-native-wrapper.sh:100` tested `grep -q "Madares v"` — a branch that can never match. The misspelling appears in **39 occurrences across 31 files**, and eight `proof_carrying_*` gates had grown `grep -Eq "Madares|Madaros"`: someone saw the divergence and encoded both spellings rather than fixing one.

Every occurrence was classified before anything was touched:

| class | occ. | action |
|---|---:|---|
| live pattern matched against the banner | 14 | all fixed |
| prose in a comment, doc, or emitted label | 9 | 3 fixed, 6 left |
| captured compiler output kept as dated evidence | 16 | left |

The six prose sites left are sentences *about* the misspelling — rewriting them makes them meaningless — and the sixteen transcripts are dated evidence; editing those would falsify a record.

**Proof it was not cosmetic.** With `SOUNIO_SOUC_BIN` pointed at a symlink whose basename lacks "madaros", detection falls through to the banner probe: `check` on a valid source reported `typecheck: failed` at **rc=1 before, rc=0 with `check: OK` after**. For the twelve alternation gates the verdict against the real binary is unchanged, and that is stated plainly rather than claimed as a fix — what changed is what they refuse: with `souc` stubbed to print `Madares`, they go from green to red.

## Two gates that asserted the wrong thing

`zd_deep_dive_gate` checked only that the string `ALL PASS` was printed. Its own header cited 92 zero-divisors; the live output is 84. It read neither.

**84 is proven, not chosen.** `formal/lean4/SounioZeroDivisorBridge.lean:156` carries `prim_count_84 : validPrims.length = 84 := by native_decide`, and `docs/EXACT_CORE.md` records the 84/336/168 census. The 92 entered in the gate's *first* commit, alongside the test that already emitted 84 — a wrong comment from day one, not a hidden regression. Sabotage: truncating the census buffer gave rc=0 printing `ZDs=80` before, rc=1 after.

`madaros_launcher_exit_status_gate` grepped a string that occurs twice in `bin/madaros`, so editing only the reachable occurrence still passed. Both sites are now pinned. **A second defect surfaced while fixing it:** the gate's only probe built a *non-existent* source, which `bin/madaros` rejects with a usage error before the compiler runs — so neither occurrence had ever been executed. It now builds an ill-formed but present source, driving the native branch through the real failure path.

Every fix verified by sabotage in both directions, with each rc recorded in its commit message.