### PR TITLE
feat(particle): LD(ud) splits; W pull is larger than LD, LD larger than SD

### DIFF
--- a/docs/audit/A_MU_HVP_LD_WINDOW_2026-08-23.md
+++ b/docs/audit/A_MU_HVP_LD_WINDOW_2026-08-23.md
@@ -1,0 +1,96 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.a-mu-hvp-ld-window-2026-08-23
+authority: repo_only
+audience: users
+last_validated: 2026-08-23
+validated_by: grok-cli2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.a-mu-hvp-ld-window-2026-08-23
+-->
+
+# Long-distance window \(a_\mu^{\mathrm{LD}}(ud)\) — split smaller than W, larger than SD
+
+```text
+Semantic-Lane-ID: a-mu-hvp-ld-window-20260823
+Owner: grok-cli2
+Concept-IDs: SOUNIO-EPISTEMIC-NUMERIC-VALUE
+Intent-Preserved: GUM pulls of published same-kernel pairs may be
+  ordered; Sounio does not compute lattice QCD; WP25 data-driven HVP
+  LO remains absent
+Transformation: pin WP25 Eq. (3.27) lattice a_μ^LD(ud) and Eq. (2.43)
+  KNT a_μ^LD(ud) as Epistemic; require |pull_LD| > k95 and
+  |pull_W| > |pull_LD| > |pull_SD|
+Types-Changed: none
+Effects-Changed: none
+IR-Changed: none
+Claims-Introduced: Sounio can hold the LD lattice and KNT pins without
+  collapsing them; their GUM pull is computed in Sounio and exceeds
+  k95; it is smaller than the W(ud) pull and larger than the SD pull
+Claims-Forbidden: Sounio computed HVP; new physics; the tension is
+  resolved; 4060 is full HVP LO; LD agreement; W is the only split;
+  Madaros is fixed-point-verified
+Assumptions: published centrals and quoted σ are citations (Aliberti
+  et al., Phys. Rep. 1143 (2025) 1). Lattice: Eq. (3.27)
+  406.0(4.9)×10⁻¹⁰; FLAG average with χ² rescaling 1.6 plus extra
+  3.1×10⁻¹⁰ systematic; w0 scheme uncertainty is not in (4.9).
+  Data-driven: Eq. (2.43) 389.9(1.7)×10⁻¹⁰ pre-CMD-3 KNT (Benton et
+  al. 2025). Stored as 10⁻¹¹ (×10). W and LD pins are ud-connected;
+  SD pins are full-flavour. Pull ordering is across those published
+  pairs. Independent GUM. CMD-3 window replacement not pinned.
+Write-Set: stdlib/particle_physics/ew_precision.sio,
+  stdlib/particle_physics/mod.sio,
+  examples/particle_physics/a_mu_hvp_ld_window.sio,
+  tests/run-pass/a_mu_hvp_ld_window.sio, this file
+Read-Set: docs/audit/A_MU_HVP_WINDOW_UD_2026-08-23.md,
+  docs/audit/A_MU_HVP_SD_CONTROL_2026-08-23.md,
+  docs/decisions/adr-008-claim-oracle-semantic-clock.md
+Positive-Witness: souc run prints |pull_LD| > 1.96 and
+  |pull_W| > |pull_LD| > |pull_SD|
+Negative-Witness: full lattice LO remains 7132; DD LO still Absent
+Acceptance-Gate: tests/run-pass/a_mu_hvp_ld_window.sio exit 0 under
+  Madaros
+Integration-Target: origin/main
+Authoritative-Only-If: the pulls are produced by Madaros running Sounio
+```
+
+## Why LD
+
+SD agrees (pull 1.24). W(ud) splits (pull 6.79). If LD also agreed, the
+discrepancy would be only the intermediate window. It does not: Eq.
+(3.27) vs Eq. (2.43) is a GUM split, smaller than W, larger than SD.
+
+| pin | WP25 (10⁻¹⁰) | stored (10⁻¹¹) |
+|---|---:|---:|
+| `a_mu_hvp_ld_ud_lattice_wp25` | Eq. (3.27) 406.0(4.9) | 4060.0(49.0) |
+| `a_mu_hvp_ld_ud_knt_pre_cmd3` | Eq. (2.43) 389.9(1.7) | 3899.0(17.0) |
+
+Independent GUM: \(\sigma=\sqrt{49^2+17^2}=\sqrt{2690}\),
+pull \(=161/\sigma\approx 3.10>1.96\).
+
+Falsifier: if \(|\mathrm{pull_{LD}}|\le 1.96\), the LD-split claim is
+dead. If \(|\mathrm{pull_W}|\le|\mathrm{pull_{LD}}|\), the “largest in
+W” ordering is dead.
+
+## Receipts (2026-08-23)
+
+Control ELF `/workspace/sounio/bin/madaros-linux-x86_64` (100902241 B).
+
+Madaros `souc check` verdict=0. Example and test **rc=0**.
+
+```
+A_MU_LD_UD_LAT_VAL 4060.000000
+A_MU_LD_UD_KNT_VAL 3899.000000
+A_MU_LD_UD_PULL_LAT_KNT 3.104200
+A_MU_W_UD_PULL_LAT_KNT 6.789189
+A_MU_SD_PULL_LAT_RR 1.242103
+VERDICT_LD_SPLIT_SURVIVES 1
+VERDICT_PULL_ORDER_W_LD_SD 1
+WP25_DD_HVP_LO_PROVIDED 0
+```
+
+\(\sqrt{49^2+17^2}=\sqrt{2690}\approx 51.865\); \(161/51.865=3.104200\).
+
+LLM-offload math-review (`/tmp/llm-offload-erbDnh`):
+
+- xAI grok-4.3: three `[OK]` (σ and pull, W>LD>SD order, independent GUM).
+- Z.AI: weekly quota exhausted until 2026-08-25.
+- Outcome: **PASS_SINGLE_PROVIDER_DEGRADED**.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -83,6 +83,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.archived.todo-next | archived | docs/archived/TODO_NEXT.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.a-mu-cmd3-2pi-split-2026-08-23 | repo_only | docs/audit/A_MU_CMD3_2PI_SPLIT_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.a-mu-gum-split-2026-08-23 | repo_only | docs/audit/A_MU_GUM_SPLIT_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.a-mu-hvp-ld-window-2026-08-23 | repo_only | docs/audit/A_MU_HVP_LD_WINDOW_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.a-mu-hvp-sd-control-2026-08-23 | repo_only | docs/audit/A_MU_HVP_SD_CONTROL_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.a-mu-hvp-window-ud-2026-08-23 | repo_only | docs/audit/A_MU_HVP_WINDOW_UD_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.a-mu-wp25-dd-hvp-lo-absent-2026-08-23 | repo_only | docs/audit/A_MU_WP25_DD_HVP_LO_ABSENT_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1373,6 +1373,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.a-mu-hvp-ld-window-2026-08-23",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/A_MU_HVP_LD_WINDOW_2026-08-23.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.a-mu-hvp-sd-control-2026-08-23",
       "collection": "repo",
       "repo_doc_path": "docs/audit/A_MU_HVP_SD_CONTROL_2026-08-23.md",

--- a/examples/particle_physics/a_mu_hvp_ld_window.sio
+++ b/examples/particle_physics/a_mu_hvp_ld_window.sio
@@ -1,0 +1,77 @@
+//@ run-pass
+//@ description: LD(ud) lattice vs KNT splits; W pull is larger; SD still agrees
+//
+// Citation witness. Sounio does not compute a Euclidean window.
+// WP25 Eq. (3.27) vs Eq. (2.43), converted 10⁻¹⁰ → 10⁻¹¹.
+//
+// Run:
+//   export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+//   ./bin/souc run examples/particle_physics/a_mu_hvp_ld_window.sio
+
+use particle_physics::ew_precision::{
+    a_mu_hvp_ld_ud_lattice_wp25, a_mu_hvp_ld_ud_knt_pre_cmd3,
+    a_mu_hvp_window_ud_lattice_wp25, a_mu_hvp_window_ud_knt_pre_cmd3,
+    a_mu_hvp_sd_lattice_wp25, a_mu_hvp_sd_rratio_pre_cmd3,
+    a_mu_pull, a_mu_k95,
+    a_mu_wp25_datadriven_hvp_lo_provided, a_mu_hvp_lo_lattice_wp25,
+}
+use epistemic::knowledge::{ep_val, ep_std}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    let lat = a_mu_hvp_ld_ud_lattice_wp25()
+    let knt = a_mu_hvp_ld_ud_knt_pre_cmd3()
+    let k95 = a_mu_k95()
+    let pull_ld = a_mu_pull(lat, knt)
+    let pull_w = a_mu_pull(
+        a_mu_hvp_window_ud_lattice_wp25(),
+        a_mu_hvp_window_ud_knt_pre_cmd3(),
+    )
+    let pull_sd = a_mu_pull(
+        a_mu_hvp_sd_lattice_wp25(),
+        a_mu_hvp_sd_rratio_pre_cmd3(),
+    )
+    let provided = a_mu_wp25_datadriven_hvp_lo_provided()
+
+    print("A_MU_UNIT 1e-11\n")
+    print("A_MU_LD_UD_LAT_VAL ")
+    print_f64(ep_val(&lat))
+    print("\nA_MU_LD_UD_LAT_STD ")
+    print_f64(ep_std(&lat))
+    print("\nA_MU_LD_UD_KNT_VAL ")
+    print_f64(ep_val(&knt))
+    print("\nA_MU_LD_UD_KNT_STD ")
+    print_f64(ep_std(&knt))
+    print("\nA_MU_LD_UD_PULL_LAT_KNT ")
+    print_f64(pull_ld)
+    print("\nA_MU_W_UD_PULL_LAT_KNT ")
+    print_f64(pull_w)
+    print("\nA_MU_SD_PULL_LAT_RR ")
+    print_f64(pull_sd)
+    print("\nA_MU_K95 ")
+    print_f64(k95)
+    print("\nWP25_DD_HVP_LO_PROVIDED ")
+    if provided { print("1\n") } else { print("0\n") }
+
+    var ok: i64 = 1
+    if abs_f(pull_ld) <= k95 { ok = 0 }
+    if abs_f(pull_w) <= abs_f(pull_ld) { ok = 0 }
+    if abs_f(pull_ld) <= abs_f(pull_sd) { ok = 0 }
+    if abs_f(pull_sd) > k95 { ok = 0 }
+    if provided { ok = 0 }
+    if abs_f(ep_val(&lat) - ep_val(&a_mu_hvp_lo_lattice_wp25())) < 100.0 { ok = 0 }
+
+    print("VERDICT_LD_SPLIT_SURVIVES ")
+    if abs_f(pull_ld) > k95 { print("1\n") } else { print("0\n") }
+    print("VERDICT_PULL_ORDER_W_LD_SD ")
+    if abs_f(pull_w) > abs_f(pull_ld) {
+        if abs_f(pull_ld) > abs_f(pull_sd) { print("1\n") } else { print("0\n") }
+    } else {
+        print("0\n")
+    }
+
+    if ok == 1 { 0 } else { 1 }
+}

--- a/stdlib/particle_physics/ew_precision.sio
+++ b/stdlib/particle_physics/ew_precision.sio
@@ -791,6 +791,32 @@ pub fn a_mu_hvp_sd_rratio_pre_cmd3() -> Epistemic with Mut, Div, Panic {
 }
 
 // ============================================================================
+// LONG-DISTANCE WINDOW, LIGHT-QUARK CONNECTED (units: 10⁻¹¹)
+// ============================================================================
+// Same quantity on both pins: isoQCD ud-connected a_μ^LD (RBC/UKQCD window).
+// Same conversion 10⁻¹⁰ → 10⁻¹¹. Not full HVP LO. Not the full-flavour
+// LD sum.
+//
+// Lattice: WP25 Eq. (3.27) FLAG average with χ² rescaling 1.6 and an
+//   extra 3.1×10⁻¹⁰ systematic: a_μ^LD(ud) = 406.0(4.9)×10⁻¹⁰
+//   = 4060.0(49.0)×10⁻¹¹. The w0 scheme-definition uncertainty is
+//   not included in (4.9).
+// Data-driven: WP25 Eq. (2.43) pre-CMD-3 purely KNT-based
+//   a_μ^LD(ud) = 389.9(1.7)×10⁻¹⁰ = 3899.0(17.0)×10⁻¹¹.
+// Independent GUM. The CMD-3 replacement in that paragraph is
+// exploratory and is not pinned.
+
+/// WP25 Eq. (3.27) lattice FLAG average, isoQCD a_μ^LD(ud). Citation.
+pub fn a_mu_hvp_ld_ud_lattice_wp25() -> Epistemic with Mut, Div, Panic {
+    Epistemic::measured(4060.0, 49.0)
+}
+
+/// WP25 Eq. (2.43) pre-CMD-3 KNT data-driven a_μ^LD(ud). Citation.
+pub fn a_mu_hvp_ld_ud_knt_pre_cmd3() -> Epistemic with Mut, Div, Panic {
+    Epistemic::measured(3899.0, 17.0)
+}
+
+// ============================================================================
 // WP25 DATA-DRIVEN HVP LO IS ABSENT (not a latent float)
 // ============================================================================
 // Table 5: "Estimates not provided at this point".

--- a/stdlib/particle_physics/mod.sio
+++ b/stdlib/particle_physics/mod.sio
@@ -330,6 +330,7 @@ pub use particle_physics::ew_precision::{
     a_mu_hvp_lo_2pi_cmd3, a_mu_hvp_lo_2pi_pre_cmd3,
     a_mu_hvp_window_ud_lattice_wp25, a_mu_hvp_window_ud_knt_pre_cmd3,
     a_mu_hvp_sd_lattice_wp25, a_mu_hvp_sd_rratio_pre_cmd3,
+    a_mu_hvp_ld_ud_lattice_wp25, a_mu_hvp_ld_ud_knt_pre_cmd3,
     Wp25DdHvpLoAbsent,
     a_mu_wp25_datadriven_hvp_lo_provided, a_mu_hvp_lo_datadriven_wp25,
 }

--- a/tests/run-pass/a_mu_hvp_ld_window.sio
+++ b/tests/run-pass/a_mu_hvp_ld_window.sio
@@ -1,0 +1,49 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 0
+//@ description: LD(ud) splits at k95; |pull_W| > |pull_LD| > |pull_SD|
+// Full Test Suite CI uses souc-stage2 (lean_single). Madaros runs this graph.
+
+use particle_physics::ew_precision::{
+    a_mu_hvp_ld_ud_lattice_wp25, a_mu_hvp_ld_ud_knt_pre_cmd3,
+    a_mu_hvp_window_ud_lattice_wp25, a_mu_hvp_window_ud_knt_pre_cmd3,
+    a_mu_hvp_sd_lattice_wp25, a_mu_hvp_sd_rratio_pre_cmd3,
+    a_mu_pull, a_mu_k95,
+    a_mu_wp25_datadriven_hvp_lo_provided, a_mu_hvp_lo_lattice_wp25,
+}
+use epistemic::knowledge::{ep_val, ep_std}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    let lat = a_mu_hvp_ld_ud_lattice_wp25()
+    let knt = a_mu_hvp_ld_ud_knt_pre_cmd3()
+    let k95 = a_mu_k95()
+    let pull_ld = a_mu_pull(lat, knt)
+    let pull_w = a_mu_pull(
+        a_mu_hvp_window_ud_lattice_wp25(),
+        a_mu_hvp_window_ud_knt_pre_cmd3(),
+    )
+    let pull_sd = a_mu_pull(
+        a_mu_hvp_sd_lattice_wp25(),
+        a_mu_hvp_sd_rratio_pre_cmd3(),
+    )
+
+    var ok: i64 = 1
+    if abs_f(ep_val(&lat) - 4060.0) > 1.0e-9 { ok = 0 }
+    if abs_f(ep_std(&lat) - 49.0) > 1.0e-9 { ok = 0 }
+    if abs_f(ep_val(&knt) - 3899.0) > 1.0e-9 { ok = 0 }
+    if abs_f(ep_std(&knt) - 17.0) > 1.0e-9 { ok = 0 }
+    if ep_val(&lat) <= ep_val(&knt) { ok = 0 }
+    if abs_f(pull_ld) <= k95 { ok = 0 }
+    if abs_f(pull_w) <= abs_f(pull_ld) { ok = 0 }
+    if abs_f(pull_ld) <= abs_f(pull_sd) { ok = 0 }
+    if abs_f(pull_sd) > k95 { ok = 0 }
+
+    if abs_f(ep_val(&lat) - ep_val(&a_mu_hvp_lo_lattice_wp25())) < 100.0 { ok = 0 }
+    if a_mu_wp25_datadriven_hvp_lo_provided() { ok = 0 }
+
+    if ok == 1 { 0 } else { 1 }
+}


### PR DESCRIPTION
## What

SD agrees. W(ud) splits. If LD agreed, the discrepancy would live only in the intermediate window. It does not.

Same quantity: isoQCD ud-connected \(a_\mu^{\mathrm{LD}}\). WP25 citations stored as 10⁻¹¹ (×10):

| pin | WP25 | stored |
|---|---:|---:|
| `a_mu_hvp_ld_ud_lattice_wp25` | Eq. (3.27) 406.0(4.9)×10⁻¹⁰ | 4060.0(49.0) |
| `a_mu_hvp_ld_ud_knt_pre_cmd3` | Eq. (2.43) 389.9(1.7)×10⁻¹⁰ | 3899.0(17.0) |

Independent GUM pull **3.104200**. Ordering |pull_W| **6.79** > |pull_LD| **3.10** > |pull_SD| **1.24**.

Eq. (3.27) includes FLAG χ² rescaling 1.6 and an extra 3.1×10⁻¹⁰ systematic. The w0 scheme-definition uncertainty is **not** in (4.9). W and LD pins are ud-connected; SD pins are full-flavour. CMD-3 window replacement is exploratory and is not pinned. Not full HVP LO. DD LO still Absent.

## Receipts (Madaros control ELF 100902241 B)

```
A_MU_LD_UD_PULL_LAT_KNT 3.104200
A_MU_W_UD_PULL_LAT_KNT 6.789189
A_MU_SD_PULL_LAT_RR 1.242103
VERDICT_LD_SPLIT_SURVIVES 1
VERDICT_PULL_ORDER_W_LD_SD 1
```

Example + test rc=0 (`//@ requires: madaros`).

## Claims-forbidden

Sounio computed HVP; new physics; tension resolved; LD agrees; W is the only split; 4060 is full HVP LO; Madaros is fixed-point-verified.

Do not merge until asked.