### PR TITLE
feat(algebra): sedenion left-action annihilation with octonion control

### DIFF
--- a/docs/audit/SEDENION_ZD_ACTION_2026-08-23.md
+++ b/docs/audit/SEDENION_ZD_ACTION_2026-08-23.md
@@ -1,0 +1,100 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.sedenion-zd-action-2026-08-23
+authority: repo_only
+audience: users
+last_validated: 2026-08-23
+validated_by: grok-cli2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.sedenion-zd-action-2026-08-23
+-->
+
+# Sedenion left action — canonical zero-divisor annihilation
+
+```text
+Semantic-Lane-ID: sedenion-zd-action-20260823
+Owner: grok-cli2
+Concept-IDs: SOUNIO-NONASSOCIATIVE-ORDER
+Intent-Preserved: parenthesization remains explicit where the algebra is
+  nonassociative; a zero divisor is not a physical ontology; this is not
+  a consciousness allegory
+Transformation: expose L_z(w)=0 for the canonical pair as an action
+  protocol; composed (zw)v vanishes for every v; sequential z*(w*v)
+  need not; octonion embedding (o,0) cannot annihilate
+Types-Changed: none
+Effects-Changed: none (sed_mul is Mut-only; no new ZD effect)
+IR-Changed: none
+Claims-Introduced: Sounio computes z*w=0 with ||z||²=||w||²=2 on the
+  canonical pair; composed action on e1 vanishes; sequential does not;
+  embedded e1*e2 has norm² 1
+Claims-Forbidden: new physics; sedenion consciousness; ZD solves g-2;
+  Sounio proved a new theorem beyond Cayley-Dickson; NonAssoc is Mut;
+  Madaros is fixed-point-verified
+Assumptions: Convention X in algebra::sedenion; canonical pair
+  z=e3+e10, w=e6−e15 as documented there; octonion subalgebra is
+  the first half via sed_from_pair
+Write-Set: stdlib/algebra/sedenion_action.sio,
+  examples/physics/sedenion_zd_action.sio,
+  tests/run-pass/sedenion_zd_action.sio, this file
+Read-Set: stdlib/algebra/sedenion.sio,
+  stdlib/algebra/octonion_action.sio,
+  docs/audit/OCTONION_ACTION_R7_2026-08-23.md
+Positive-Witness: souc run prints ZD_PRODUCT_NSQ 0, sequential > 0,
+  OCT_EMBED_PRODUCT_NSQ 1
+Negative-Witness: octonion embedding of e1,e2 does not annihilate;
+  g-2 pins are not this lane
+Acceptance-Gate: tests/run-pass/sedenion_zd_action.sio exit 0 under
+  Madaros; example exit 0
+Integration-Target: origin/main
+Authoritative-Only-If: the nsqs are produced by Madaros running Sounio
+```
+
+## What was already there
+
+`sed_mul` and `sed_zd_z` / `sed_zd_w` already exist. Inline tests in
+`sedenion.sio` check the product. `octonion_action` is the two-protocol
+story for O. Conversational OSSM reads ZD *proximity*; this lane is
+not that.
+
+## What this lane does
+
+It names two protocols on a vector in S ≅ R¹⁶:
+
+1. compose then act: \(L_{ab}(v)=(ab)v\)
+2. act then act: \((L_a\circ L_b)(v)=a(bv)\)
+
+On the canonical pair, (1) annihilates because \(zw=0\). (2) is the
+falsifier: if it also vanishes for the probe \(v=e_1\), the
+“composed-only annihilation” claim is dead. The octonion embedding is
+the division-algebra control.
+
+## Receipts (2026-08-23)
+
+Control ELF `/workspace/sounio/bin/madaros-linux-x86_64` (100902241 B).
+
+Madaros `souc check` verdict=0. Example and test **rc=0**.
+
+```
+ZD_Z_NSQ 2.000000
+ZD_W_NSQ 2.000000
+ZD_PRODUCT_NSQ 0.000000
+ZD_COMPOSED_NSQ 0.000000
+ZD_SEQUENTIAL_NSQ 8.000000
+OCT_EMBED_PRODUCT_NSQ 1.000000
+OCT_EMBED_COMPOSED_NSQ 1.000000
+OCT_EMBED_SEQUENTIAL_NSQ 1.000000
+OCT_EMBED_DISCREPANCY_NSQ 4.000000
+VERDICT_ZD_ANNIHILATES_COMPOSED 1
+VERDICT_ZD_SEQUENTIAL_SURVIVES 1
+VERDICT_OCT_EMBED_DIVIDES 1
+VERDICT_OCT_EMBED_ASSOCIATOR 1
+```
+
+Composed annihilation is \(zw=0\), so \((zw)e_1=0\). Sequential
+\(z*(w*e_1)\) has norm² 8. The octonion embedding of \((e_1,e_2,e_4)\)
+keeps the associator: discrepancy norm² 4, both protocols length 1.
+
+LLM-offload math-review (`/tmp/llm-offload-cOpBlg`):
+
+- xAI grok-4.3: five `[OK]` (canonical pair, composed annihilation,
+  sequential witness, octonion embedding, associator 4).
+- Z.AI: weekly quota exhausted until 2026-08-25.
+- Outcome: **PASS_SINGLE_PROVIDER_DEGRADED**.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -378,6 +378,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.runtime-context-unwritten-fields-census-2026-08-18 | repo_only | docs/audit/RUNTIME_CONTEXT_UNWRITTEN_FIELDS_CENSUS_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.runtime-gc-capability-honesty-2026-08-18 | repo_only | docs/audit/RUNTIME_GC_CAPABILITY_HONESTY_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.rust-macro-acceptance-2026-08-20 | repo_only | docs/audit/RUST_MACRO_ACCEPTANCE_2026-08-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.sedenion-zd-action-2026-08-23 | repo_only | docs/audit/SEDENION_ZD_ACTION_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.seed-fix-general-lvalue-deref-store-2026-06-24 | repo_only | docs/audit/SEED_FIX_GENERAL_LVALUE_DEREF_STORE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.seed-fix-value-nested-field-store-2026-06-24 | repo_only | docs/audit/SEED_FIX_VALUE_NESTED_FIELD_STORE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.seven-fibers-of-twelve-2026-08-19 | repo_only | docs/audit/SEVEN_FIBERS_OF_TWELVE_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8158,6 +8158,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.sedenion-zd-action-2026-08-23",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/SEDENION_ZD_ACTION_2026-08-23.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.seed-fix-general-lvalue-deref-store-2026-06-24",
       "collection": "repo",
       "repo_doc_path": "docs/audit/SEED_FIX_GENERAL_LVALUE_DEREF_STORE_2026-06-24.md",

--- a/examples/physics/sedenion_zd_action.sio
+++ b/examples/physics/sedenion_zd_action.sio
@@ -1,0 +1,97 @@
+//@ run-pass
+//@ description: sedenion left action: canonical ZD annihilates; octonion embed does not
+//
+// Sequential left multiplication on S ≅ R¹⁶. Canonical z=e3+e10,
+// w=e6−e15: z*w = 0 with both nonzero. Composed (zw)v is then 0 for
+// every v. Sequential z*(w*v) need not be. Octonion embedding (o,0)
+// cannot annihilate a nonzero vector (division algebra).
+//
+// Not a consciousness allegory. Not g-2. Not conversational_ossm.
+//
+// Run:
+//   export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+//   ./bin/souc run examples/physics/sedenion_zd_action.sio
+
+use algebra::sedenion::{sed_norm_sq, sed_basis}
+use algebra::octonion::{oct_basis}
+use algebra::sedenion_action::{
+    sed_embed_oct, sed_lmul_composed_nsq, sed_lmul_sequential_nsq,
+    sed_lmul_product_nsq, sed_lmul_discrepancy_nsq, sed_canonical_zd_pair,
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var z: [f64; 16] = [0.0; 16]
+    var w: [f64; 16] = [0.0; 16]
+    sed_canonical_zd_pair(&!z, &!w)
+    var e1s: [f64; 16] = [0.0; 16]
+    sed_basis(1, &!e1s)
+
+    let nsq_z = sed_norm_sq(&z)
+    let nsq_w = sed_norm_sq(&w)
+    let nsq_zw = sed_lmul_product_nsq(&z, &w)
+    let nsq_comp = sed_lmul_composed_nsq(&z, &w, &e1s)
+    let nsq_seq = sed_lmul_sequential_nsq(&z, &w, &e1s)
+
+    var e1o = oct_basis(1)
+    var e2o = oct_basis(2)
+    var e4o = oct_basis(4)
+    var e1e: [f64; 16] = [0.0; 16]
+    var e2e: [f64; 16] = [0.0; 16]
+    var e4e: [f64; 16] = [0.0; 16]
+    sed_embed_oct(&e1o, &!e1e)
+    sed_embed_oct(&e2o, &!e2e)
+    sed_embed_oct(&e4o, &!e4e)
+
+    let nsq_oct_prod = sed_lmul_product_nsq(&e1e, &e2e)
+    let nsq_oct_comp = sed_lmul_composed_nsq(&e1e, &e2e, &e4e)
+    let nsq_oct_seq = sed_lmul_sequential_nsq(&e1e, &e2e, &e4e)
+    let nsq_oct_disc = sed_lmul_discrepancy_nsq(&e1e, &e2e, &e4e)
+
+    print("ZD_Z_NSQ ")
+    print_f64(nsq_z)
+    print("\nZD_W_NSQ ")
+    print_f64(nsq_w)
+    print("\nZD_PRODUCT_NSQ ")
+    print_f64(nsq_zw)
+    print("\nZD_COMPOSED_NSQ ")
+    print_f64(nsq_comp)
+    print("\nZD_SEQUENTIAL_NSQ ")
+    print_f64(nsq_seq)
+    print("\nOCT_EMBED_PRODUCT_NSQ ")
+    print_f64(nsq_oct_prod)
+    print("\nOCT_EMBED_COMPOSED_NSQ ")
+    print_f64(nsq_oct_comp)
+    print("\nOCT_EMBED_SEQUENTIAL_NSQ ")
+    print_f64(nsq_oct_seq)
+    print("\nOCT_EMBED_DISCREPANCY_NSQ ")
+    print_f64(nsq_oct_disc)
+    print("\n")
+
+    var ok: i64 = 1
+    if nsq_z <= 1.0 { ok = 0 }
+    if nsq_w <= 1.0 { ok = 0 }
+    if nsq_zw > 1.0e-9 { ok = 0 }
+    if nsq_comp > 1.0e-9 { ok = 0 }
+    if nsq_seq <= 1.0e-9 { ok = 0 }
+    if abs_f(nsq_oct_prod - 1.0) > 1.0e-9 { ok = 0 }
+    if abs_f(nsq_oct_disc - 4.0) > 1.0e-9 { ok = 0 }
+
+    print("VERDICT_ZD_ANNIHILATES_COMPOSED ")
+    if nsq_zw <= 1.0e-9 {
+        if nsq_comp <= 1.0e-9 { print("1\n") } else { print("0\n") }
+    } else {
+        print("0\n")
+    }
+    print("VERDICT_ZD_SEQUENTIAL_SURVIVES ")
+    if nsq_seq > 1.0e-9 { print("1\n") } else { print("0\n") }
+    print("VERDICT_OCT_EMBED_DIVIDES ")
+    if abs_f(nsq_oct_prod - 1.0) <= 1.0e-9 { print("1\n") } else { print("0\n") }
+    print("VERDICT_OCT_EMBED_ASSOCIATOR ")
+    if abs_f(nsq_oct_disc - 4.0) <= 1.0e-9 { print("1\n") } else { print("0\n") }
+
+    if ok == 1 { 0 } else { 1 }
+}

--- a/stdlib/algebra/sedenion_action.sio
+++ b/stdlib/algebra/sedenion_action.sio
@@ -1,0 +1,109 @@
+// stdlib/algebra/sedenion_action.sio
+//
+// Left multiplication as an action of S on S ≅ R¹⁶.
+//
+// Octonions are a normed division algebra: L_a is invertible for a ≠ 0.
+// Sedenions are not. There exist nonzero z, w with L_z(w) = z*w = 0.
+//
+// Two protocols, same as octonion_action:
+//   L_{ab}(v) = (ab)v          composed
+//   (L_a ∘ L_b)(v) = a*(b*v)   sequential
+// On a canonical zero-divisor pair (z, w), composed annihilates every v
+// because zw = 0. Sequential need not. That is the observable.
+//
+// Octonion embedding control: (o, 0) ⊂ S. The same protocols on
+// embedded octonions cannot annihilate a nonzero vector.
+//
+// No new algebra. Convention X via algebra::sedenion (Cayley-Dickson k=4).
+// Canonical pair: z = e3+e10, w = e6−e15, z*w = 0 exactly.
+//
+// Claims forbidden: new physics; sedenion consciousness; ZD solves g-2;
+// NonAssoc is an ontology. sed_mul is Mut-only today; this module does
+// not invent a ZD effect. This is not examples/octonionic_relativity.sio
+// and not examples/conversational_ossm/.
+
+use algebra::sedenion::{sed_mul, sed_norm_sq, sed_from_pair, sed_zd_z, sed_zd_w}
+
+fn sed_zero8(out: &![f64; 8]) with Mut {
+    var i: i64 = 0
+    while i < 8 {
+        out[i] = 0.0
+        i = i + 1
+    }
+}
+
+pub fn sed_embed_oct(o: &[f64; 8], out: &![f64; 16]) with Mut {
+    var z8: [f64; 8] = [0.0; 8]
+    sed_zero8(&!z8)
+    sed_from_pair(o, &z8, out)
+}
+
+pub fn sed_lmul(a: &[f64; 16], v: &[f64; 16], out: &![f64; 16]) with Mut {
+    sed_mul(a, v, out)
+}
+
+pub fn sed_lmul_composed(
+    a: &[f64; 16], b: &[f64; 16], v: &[f64; 16], out: &![f64; 16]
+) with Mut {
+    var ab: [f64; 16] = [0.0; 16]
+    sed_mul(a, b, &!ab)
+    sed_lmul(&ab, v, out)
+}
+
+pub fn sed_lmul_sequential(
+    a: &[f64; 16], b: &[f64; 16], v: &[f64; 16], out: &![f64; 16]
+) with Mut {
+    var bv: [f64; 16] = [0.0; 16]
+    sed_lmul(b, v, &!bv)
+    sed_lmul(a, &bv, out)
+}
+
+pub fn sed_lmul_composed_nsq(
+    a: &[f64; 16], b: &[f64; 16], v: &[f64; 16]
+) -> f64 with Mut {
+    var out: [f64; 16] = [0.0; 16]
+    sed_lmul_composed(a, b, v, &!out)
+    sed_norm_sq(&out)
+}
+
+pub fn sed_lmul_sequential_nsq(
+    a: &[f64; 16], b: &[f64; 16], v: &[f64; 16]
+) -> f64 with Mut {
+    var out: [f64; 16] = [0.0; 16]
+    sed_lmul_sequential(a, b, v, &!out)
+    sed_norm_sq(&out)
+}
+
+pub fn sed_lmul_product_nsq(a: &[f64; 16], b: &[f64; 16]) -> f64 with Mut {
+    var out: [f64; 16] = [0.0; 16]
+    sed_mul(a, b, &!out)
+    sed_norm_sq(&out)
+}
+
+pub fn sed_lmul_discrepancy(
+    a: &[f64; 16], b: &[f64; 16], v: &[f64; 16], out: &![f64; 16]
+) with Mut {
+    var composed: [f64; 16] = [0.0; 16]
+    var sequential: [f64; 16] = [0.0; 16]
+    sed_lmul_composed(a, b, v, &!composed)
+    sed_lmul_sequential(a, b, v, &!sequential)
+    var i: i64 = 0
+    while i < 16 {
+        out[i] = composed[i] - sequential[i]
+        i = i + 1
+    }
+}
+
+pub fn sed_lmul_discrepancy_nsq(
+    a: &[f64; 16], b: &[f64; 16], v: &[f64; 16]
+) -> f64 with Mut {
+    var d: [f64; 16] = [0.0; 16]
+    sed_lmul_discrepancy(a, b, v, &!d)
+    sed_norm_sq(&d)
+}
+
+/// Canonical pair into caller buffers.
+pub fn sed_canonical_zd_pair(z: &![f64; 16], w: &![f64; 16]) with Mut {
+    sed_zd_z(z)
+    sed_zd_w(w)
+}

--- a/tests/run-pass/sedenion_zd_action.sio
+++ b/tests/run-pass/sedenion_zd_action.sio
@@ -1,0 +1,47 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 0
+//@ description: canonical sedenion ZD annihilates composed action; octonion embed does not
+// Full Test Suite CI uses souc-stage2 (lean_single). Madaros runs this graph.
+
+use algebra::sedenion::{sed_norm_sq, sed_basis}
+use algebra::octonion::{oct_basis}
+use algebra::sedenion_action::{
+    sed_embed_oct, sed_lmul_composed_nsq, sed_lmul_sequential_nsq,
+    sed_lmul_product_nsq, sed_lmul_discrepancy_nsq, sed_canonical_zd_pair,
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var z: [f64; 16] = [0.0; 16]
+    var w: [f64; 16] = [0.0; 16]
+    sed_canonical_zd_pair(&!z, &!w)
+    var e1s: [f64; 16] = [0.0; 16]
+    sed_basis(1, &!e1s)
+
+    var ok: i64 = 1
+    if abs_f(sed_norm_sq(&z) - 2.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_norm_sq(&w) - 2.0) > 1.0e-9 { ok = 0 }
+    if sed_lmul_product_nsq(&z, &w) > 1.0e-9 { ok = 0 }
+    if sed_lmul_composed_nsq(&z, &w, &e1s) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_lmul_sequential_nsq(&z, &w, &e1s) - 8.0) > 1.0e-9 { ok = 0 }
+
+    var e1o = oct_basis(1)
+    var e2o = oct_basis(2)
+    var e4o = oct_basis(4)
+    var e1e: [f64; 16] = [0.0; 16]
+    var e2e: [f64; 16] = [0.0; 16]
+    var e4e: [f64; 16] = [0.0; 16]
+    sed_embed_oct(&e1o, &!e1e)
+    sed_embed_oct(&e2o, &!e2e)
+    sed_embed_oct(&e4o, &!e4e)
+    if abs_f(sed_lmul_product_nsq(&e1e, &e2e) - 1.0) > 1.0e-9 { ok = 0 }
+    // Embedded (e1,e2,e4): both protocols preserve length, but the
+    // vector discrepancy is the octonion associator (norm² = 4).
+    if abs_f(sed_lmul_discrepancy_nsq(&e1e, &e2e, &e4e) - 4.0) > 1.0e-9 { ok = 0 }
+
+    if ok == 1 { 0 } else { 1 }
+}


### PR DESCRIPTION
## What

Class B+ of the octonion action lane. Octonions are a division algebra: \(L_a\) is invertible for \(a\neq 0\). Sedenions are not.

Two protocols on \(S\cong\mathbb{R}^{16}\):

1. Compose then act: \(L_{ab}(v)=(ab)v\)
2. Act then act: \((L_a\circ L_b)(v)=a(bv)\)

Canonical pair \(z=e_3+e_{10}\), \(w=e_6-e_{15}\) (already in `sed_zd_z` / `sed_zd_w`):

| protocol | nsq |
|---|---:|
| \(\|z\|^2\), \(\|w\|^2\) | 2 |
| \(z*w\) | **0** |
| composed \((zw)e_1\) | **0** |
| sequential \(z*(w*e_1)\) | **8** |

Octonion embedding \((o,0)\):

| protocol | nsq |
|---|---:|
| \(e_1*e_2\) | 1 |
| composed / sequential on \((e_1,e_2,e_4)\) | 1 / 1 |
| vector discrepancy | **4** (octonion associator) |

No new product. Convention X. Not `octonionic_relativity`. Not OSSM proximity. Not g-2.

## Receipts (Madaros control ELF 100902241 B)

`souc run examples/physics/sedenion_zd_action.sio` rc=0. Test rc=0 (`//@ requires: madaros`).

## Claims-forbidden

New physics; sedenion consciousness; ZD solves g-2; new theorem beyond Cayley–Dickson; Madaros is fixed-point-verified.

Do not merge until asked.