### PR TITLE
docs(audit): empirically pin Knowledge annotation parser coverage

### DIFF
--- a/docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
+++ b/docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
@@ -76,3 +76,69 @@ Slurm jobs 10392/10394 were submitted per the standing directive, but the cluste
 was degraded (jobs failing with signal 53). The measurement is static text
 analysis over versioned files, performed as reads, so no pod compute was consumed
 and the directive's purpose was met by other means. Recorded rather than omitted.
+
+## Addendum 2026-08-23 — empirical Madaros discriminators; wrapper surface refined
+
+Continuation of the parser-*surface* measurement. Still no parser invention: no new surface words, no diagnostic, `self-hosted/` untouched. This does **not** reopen the anticipation-vs-lag verdict of #2015 / `PROVENANCE_LAYER_STAIRCASE_2026-08-19.md`. Parser surface remaining 3-of-6 is compatible with lag at the checker/runtime layer (those three cases already have consumer arms and runtime constants).
+
+Two clocks, labeled:
+
+| Clock | What it is | What it is not |
+|---|---|---|
+| **STATIC** | Current `self-hosted/parser/{ast,types,parser}.sio` + `self-hosted/lexer/tables.sio` | A claim that the shipped ELF was built from this SHA |
+| **DYNAMIC** | `env -u SOUC_BIN -u SOUNIO_SOUC_BIN ulimit -s 524288 ./bin/souc check` (Madaros v0.80.0 shipped ELF) | A from-source Madaros rebuild; not Slurm |
+
+Re-run: `bash scripts/dev/knowledge_annotation_parser_coverage.sh`. Probes live in `docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/` (not on the test-suite glob). Skip ELF checks with `SOUNIO_KCOV_SKIP_DYNAMIC=1`.
+
+### STATIC — pin (unchanged 3-of-6, now including the live Madaros lexer table)
+
+`AstProvenanceKind` still declares six cases; `types.sio` still constructs only `AstProvDerived` / `AstProvComputed` / `AstProvMeasured`. `self-hosted/lexer/tables.sio` (the Madaros keyword table) matches `parser.sio`: `Derived`, `Computed`, `Measured`, `Valid`, `ValidUntil`, `ValidWhile` are keywords; `Source`, `Literature`, `Input` are not. The original 2026-08-19 read of `parser.sio` alone was not the whole lexer.
+
+`parse_knowledge_type` runs the comma-component loop **unconditionally** after the inner type — the comment says “only in bracket form”, but `Knowledge<f64, Derived>` is a live angle-form path. `parse_epistemic_wrapper_type` still gates that loop on brackets, and still has no `ValidUntil` / `ValidWhile` arms.
+
+### DYNAMIC — discriminator matrix (shipped ELF, 2026-08-23)
+
+Command for each probe: `ulimit -s 524288`; `env -u SOUC_BIN -u SOUNIO_SOUC_BIN SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check <probe>`.
+
+| Probe | Type | ELF | Source interpretation |
+|---|---|---|---|
+| `derived.sio` | `Knowledge[f64, Derived]` | check OK | reachable provenance |
+| `computed.sio` | `Knowledge[f64, Computed]` | check OK | reachable; first versioned use of this word |
+| `measured.sio` | `Knowledge[f64, Measured]` | check OK | reachable; first versioned use of this word |
+| `valid.sio` | `Knowledge[f64, Valid(1.0)]` | check OK | reachable validity |
+| `validuntil.sio` | `Knowledge[f64, ValidUntil("2020-03-31")]` | check OK | already exercised by `covid_2020_kernel.sio` |
+| `validwhile.sio` | `Knowledge[f64, ValidWhile(true)]` | check OK | reachable, still unused in product code |
+| `knowledge_angle_derived.sio` | `Knowledge<f64, Derived>` | check OK | angle-form components are live for Knowledge |
+| `source.sio` | `Knowledge[f64, Source]` | check OK | **silent** — not `AstProvSource` |
+| `literature.sio` | `Knowledge[f64, Literature]` | check OK | **silent** |
+| `input.sio` | `Knowledge[f64, Input]` | check OK | **silent** |
+| `typo_ident.sio` | `Knowledge[f64, Sourc]` | check OK | misspelling is also silent |
+| `source_eps.sio` | `Knowledge[f64, Source < 0.05]` | check OK | `Source` is Ident, so this is an epsilon bound |
+| `derived_eps.sio` | `Knowledge[f64, Derived < 0.05]` | parse fail | `Derived` is a keyword; it cannot be an epsilon ident |
+| `int_skip.sio` | `Knowledge[f64, 123]` | check OK | non-ident unknown component is skipped |
+
+The pair `source_eps` (OK) vs `derived_eps` (parse fail) is the empirical discriminator for the Ident-epsilon sink. It does **not** prove which AST field `Source` occupies; it proves `Source` is not the `Derived`/`Computed`/`Measured` keyword class. Combined with the lexer having no `Source` word, the silent-OK probes are Ident capture or skip, not `AstProvSource`.
+
+### Wrapper surface — do not treat the 3-of-6 copy as independently exercised
+
+Under the same ELF:
+
+| Probe | ELF |
+|---|---|
+| `Intervention<f64>` | check OK |
+| `Intervention<f64, Derived>` | check OK |
+| `Intervention[f64]` | parse fail (8 parser errors) |
+| `Validated[f64, Derived]` | parse fail (13 parser errors) |
+| `Validated<f64>` | check OK |
+
+Current source sends `Intervention` / `Counterfactual` through `parse_epistemic_wrapper_type` (bracket component loop) and `Validated` through that loop only when the next token is `[`. Empirically the **bracket** form does not round-trip on this ELF, so the wrapper’s provenance arms are not a live Madaros surface in this measurement. `Intervention<f64, Derived>` checking OK is **not** evidence that `Derived` became `AstProvDerived` on an Intervention: the angle path in current source expects `>` immediately after the inner type, and the shipped ELF has no `--show-ast`. Possible readings (unresolved here): generic type-args (`knowledge_info: None`), ELF/source drift, or recovery. Do not collapse them.
+
+Wrapper probes are **not** in the census pin for that reason. Closing that question needs a source-built Madaros or an AST dump.
+
+### What this addendum does not do
+
+- Does not add `Source` / `Literature` / `Input` keywords or parser arms.
+- Does not add a diagnostic for the silent skip / Ident-epsilon sink (that remains the honesty gap).
+- Does not promote the silent-OK probes into `tests/run-pass/` — they are receipts of current behaviour, not features. The day `source.sio` starts failing check, the census fails and the gap has moved.
+- Does not claim the shipped ELF matches this checkout’s `self-hosted/` bit-for-bit.
+- Does not reopen #2015's lag verdict.

--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/computed.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/computed.sio
@@ -1,0 +1,4 @@
+// Coverage receipt for docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
+// Reachable: Computed -> AstProvComputed. Expect check OK.
+fn f(x: Knowledge[f64, Computed]) -> Knowledge[f64, Computed] { x }
+fn main() -> i32 { 0 }

--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/derived.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/derived.sio
@@ -1,0 +1,4 @@
+// Coverage receipt for docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
+// Reachable: Derived -> AstProvDerived. Expect check OK.
+fn f(x: Knowledge[f64, Derived]) -> Knowledge[f64, Derived] { x }
+fn main() -> i32 { 0 }

--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/derived_eps.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/derived_eps.sio
@@ -1,0 +1,4 @@
+// Coverage receipt for docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
+// Discriminator: Derived is a keyword, so it cannot be an epsilon ident. Expect parse fail.
+fn f(x: Knowledge[f64, Derived < 0.05]) -> Knowledge[f64, Derived < 0.05] { x }
+fn main() -> i32 { 0 }

--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/input.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/input.sio
@@ -1,0 +1,4 @@
+// Coverage receipt for docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
+// Unreachable provenance word. Ident epsilon-sink. Expect check OK (silent).
+fn f(x: Knowledge[f64, Input]) -> Knowledge[f64, Input] { x }
+fn main() -> i32 { 0 }

--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/int_skip.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/int_skip.sio
@@ -1,0 +1,4 @@
+// Coverage receipt for docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
+// Unknown non-ident component. Skip sink. Expect check OK (silent).
+fn f(x: Knowledge[f64, 123]) -> Knowledge[f64, 123] { x }
+fn main() -> i32 { 0 }

--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/knowledge_angle_derived.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/knowledge_angle_derived.sio
@@ -1,0 +1,4 @@
+// Coverage receipt for docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
+// Angle form still accepts comma components in parse_knowledge_type. Expect check OK.
+fn f(x: Knowledge<f64, Derived>) -> Knowledge<f64, Derived> { x }
+fn main() -> i32 { 0 }

--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/literature.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/literature.sio
@@ -1,0 +1,4 @@
+// Coverage receipt for docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
+// Unreachable provenance word. Ident epsilon-sink. Expect check OK (silent).
+fn f(x: Knowledge[f64, Literature]) -> Knowledge[f64, Literature] { x }
+fn main() -> i32 { 0 }

--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/measured.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/measured.sio
@@ -1,0 +1,4 @@
+// Coverage receipt for docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
+// Reachable: Measured -> AstProvMeasured. Expect check OK.
+fn f(x: Knowledge[f64, Measured]) -> Knowledge[f64, Measured] { x }
+fn main() -> i32 { 0 }

--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/source.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/source.sio
@@ -1,0 +1,4 @@
+// Coverage receipt for docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
+// Unreachable provenance word. Ident epsilon-sink. Expect check OK (silent).
+fn f(x: Knowledge[f64, Source]) -> Knowledge[f64, Source] { x }
+fn main() -> i32 { 0 }

--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/source_eps.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/source_eps.sio
@@ -1,0 +1,4 @@
+// Coverage receipt for docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
+// Discriminator: Source is Ident, so this is an epsilon bound. Expect check OK.
+fn f(x: Knowledge[f64, Source < 0.05]) -> Knowledge[f64, Source < 0.05] { x }
+fn main() -> i32 { 0 }

--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/typo_ident.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/typo_ident.sio
@@ -1,0 +1,4 @@
+// Coverage receipt for docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
+// Misspelled provenance. Ident epsilon-sink. Expect check OK (silent).
+fn f(x: Knowledge[f64, Sourc]) -> Knowledge[f64, Sourc] { x }
+fn main() -> i32 { 0 }

--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/valid.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/valid.sio
@@ -1,0 +1,4 @@
+// Coverage receipt for docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
+// Reachable: Valid -> ValidDuration. Expect check OK.
+fn f(x: Knowledge[f64, Valid(1.0)]) -> Knowledge[f64, Valid(1.0)] { x }
+fn main() -> i32 { 0 }

--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/validuntil.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/validuntil.sio
@@ -1,0 +1,4 @@
+// Coverage receipt for docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
+// Reachable: ValidUntil -> ValidUntilTime. Expect check OK.
+fn f(x: Knowledge[f64, ValidUntil("2020-03-31")]) -> Knowledge[f64, ValidUntil("2020-03-31")] { x }
+fn main() -> i32 { 0 }

--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/validwhile.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/validwhile.sio
@@ -1,0 +1,4 @@
+// Coverage receipt for docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
+// Reachable: ValidWhile -> ValidWhileCond. Unused in product code. Expect check OK.
+fn f(x: Knowledge[f64, ValidWhile(true)]) -> Knowledge[f64, ValidWhile(true)] { x }
+fn main() -> i32 { 0 }

--- a/scripts/dev/knowledge_annotation_parser_coverage.sh
+++ b/scripts/dev/knowledge_annotation_parser_coverage.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# scripts/dev/knowledge_annotation_parser_coverage.sh
+#
+# Executable pin for docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md
+#
+# Two clocks, labeled:
+#   STATIC  — current self-hosted/ text (declared enum cases vs parser
+#             construction sites vs lexer keywords). This is the authority
+#             for "what the source can produce".
+#   DYNAMIC — ./bin/souc check of the discriminator probes. This is the
+#             default user-facing ELF (Madaros), NOT a from-source rebuild.
+#             Skip with SOUNIO_KCOV_SKIP_DYNAMIC=1.
+#
+# Exit 1 if a pin moves. That is the tripwire: either the gap closed, or
+# the gap widened, and the audit must be re-read.
+#
+# Stack: Madaros raw ELF SEGVs under the pod default 8MB stack. Always
+# raise it. Unset SOUC_BIN so a poisoned env cannot silently measure a
+# different checkout.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+PROBE_DIR="docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19"
+AST="self-hosted/parser/ast.sio"
+TYPES="self-hosted/parser/types.sio"
+LEX_TABLES="self-hosted/lexer/tables.sio"
+LEX_PARSER="self-hosted/parser/parser.sio"
+
+fail=0
+note() { printf '%s\n' "$*"; }
+pin_fail() { printf 'PIN FAIL: %s\n' "$*" >&2; fail=1; }
+
+# ---------------------------------------------------------------------------
+# STATIC
+# ---------------------------------------------------------------------------
+
+declared=$(
+  awk '/^pub enum AstProvenanceKind/,/^}/ {
+    if ($1 ~ /^AstProv/ && $1 !~ /Kind/) {
+      gsub(/,/, "", $1)
+      print $1
+    }
+  }' "$AST" | sort
+)
+expected_declared=$'AstProvComputed\nAstProvDerived\nAstProvInput\nAstProvLiterature\nAstProvMeasured\nAstProvSource'
+if [[ "$declared" != "$expected_declared" ]]; then
+  pin_fail "AstProvenanceKind cases moved"
+  printf '  got:\n%s\n  expected:\n%s\n' "$declared" "$expected_declared" >&2
+fi
+
+# Construction sites in the Knowledge / wrapper parsers only.
+constructed=$(
+  grep -E 'AstProvenanceKind::AstProv[A-Za-z]+' "$TYPES" \
+    | sed -E 's/.*AstProvenanceKind:://' \
+    | sed -E 's/[^A-Za-z].*$//' \
+    | sort -u
+)
+expected_constructed=$'AstProvComputed\nAstProvDerived\nAstProvMeasured'
+if [[ "$constructed" != "$expected_constructed" ]]; then
+  pin_fail "parser construction sites for AstProvenanceKind moved"
+  printf '  got:\n%s\n  expected:\n%s\n' "$constructed" "$expected_constructed" >&2
+fi
+
+# The three unreachable cases must still have zero construction sites
+# under self-hosted/parser/.
+for dead in AstProvSource AstProvLiterature AstProvInput; do
+  if grep -q "AstProvenanceKind::${dead}" self-hosted/parser/*.sio; then
+    pin_fail "$dead gained a parser construction site"
+  fi
+done
+
+# Lexer keywords: live Madaros table + the parser.sio duplicate.
+# Presence.
+for word in Derived Computed Measured Valid ValidUntil ValidWhile; do
+  if ! grep -q "return TokenKind::${word}" "$LEX_TABLES"; then
+    pin_fail "lexer/tables.sio lost TokenKind::${word}"
+  fi
+  if ! grep -q "return TokenKind::${word}" "$LEX_PARSER"; then
+    pin_fail "parser.sio ident-table lost TokenKind::${word}"
+  fi
+done
+
+# Absence of the three unreachable provenance words as keywords.
+for word in Source Literature Input; do
+  if grep -q "return TokenKind::${word}" "$LEX_TABLES" "$LEX_PARSER"; then
+    pin_fail "$word became a lexer keyword — the Ident epsilon-sink may have closed"
+  fi
+done
+
+# Wrapper path still only constructs the same three (no ValidUntil/ValidWhile).
+# Bounded to parse_epistemic_wrapper_type by reading that function body.
+wrapper_body=$(
+  awk '/fn parse_epistemic_wrapper_type/,/fn parse_validated_type/' "$TYPES"
+)
+for word in ValidUntil ValidWhile; do
+  if printf '%s' "$wrapper_body" | grep -q "TokenKind::${word}"; then
+    pin_fail "parse_epistemic_wrapper_type gained a ${word} branch"
+  fi
+done
+
+note "STATIC: declared=6 constructed=3 unreachable=Source,Literature,Input lexer-keywords=Derived,Computed,Measured,Valid,ValidUntil,ValidWhile"
+
+# ---------------------------------------------------------------------------
+# DYNAMIC — default bin/souc ELF, labeled
+# ---------------------------------------------------------------------------
+
+if [[ "${SOUNIO_KCOV_SKIP_DYNAMIC:-0}" == "1" ]]; then
+  note "DYNAMIC: skipped (SOUNIO_KCOV_SKIP_DYNAMIC=1)"
+else
+  SOUC="$ROOT_DIR/bin/souc"
+  if [[ ! -x "$SOUC" ]]; then
+    pin_fail "bin/souc missing or not executable"
+  else
+    souc_ver=$(env -u SOUC_BIN -u SOUNIO_SOUC_BIN "$SOUC" --version 2>/dev/null | head -1 || true)
+    note "DYNAMIC compiler: ${souc_ver:-unknown} path=$SOUC (shipped ELF, not source-built)"
+
+    check_one() {
+      local file="$1"
+      ( ulimit -s 524288
+        env -u SOUC_BIN -u SOUNIO_SOUC_BIN \
+          SOUNIO_STDLIB_PATH="$ROOT_DIR/stdlib" \
+          "$SOUC" check "$file"
+      ) >/tmp/kcov_check.out 2>&1
+    }
+
+    pass_probes=(
+      derived computed measured valid validuntil validwhile
+      source literature input source_eps int_skip typo_ident
+      knowledge_angle_derived
+    )
+    for name in "${pass_probes[@]}"; do
+      f="$PROBE_DIR/${name}.sio"
+      if [[ ! -f "$f" ]]; then
+        pin_fail "missing pass probe $f"
+        continue
+      fi
+      if check_one "$f"; then
+        :
+      else
+        pin_fail "pass-probe $name: expected check OK, rc=$?"
+      fi
+    done
+
+    fail_probes=(derived_eps)
+    for name in "${fail_probes[@]}"; do
+      f="$PROBE_DIR/${name}.sio"
+      if [[ ! -f "$f" ]]; then
+        pin_fail "missing fail probe $f"
+        continue
+      fi
+      if check_one "$f"; then
+        pin_fail "fail-probe $name: expected parse/check failure, got check OK"
+      fi
+    done
+  fi
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  note "KNOWLEDGE_ANNOTATION_PARSER_COVERAGE: FAIL"
+  exit 1
+fi
+note "KNOWLEDGE_ANNOTATION_PARSER_COVERAGE: PASS"
+exit 0


### PR DESCRIPTION
## Summary

Addendum to the #2015 parser-surface measurement. Still no parser invention (`self-hosted/` untouched).

- Discriminator probes under `docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/` (not on the test-suite glob).
- Re-runnable census: `bash scripts/dev/knowledge_annotation_parser_coverage.sh`.
- Parser surface remains 3-of-6. `Source` / `Literature` / `Input` are Ident (epsilon-sink), not keywords: `Source < 0.05` checks OK, `Derived < 0.05` parse-fails.
- Wrapper bracket form (`Intervention[f64]`, `Validated[f64, Derived]`) is not a live Madaros surface on the shipped ELF.

Does **not** reopen the #2015 / `PROVENANCE_LAYER_STAIRCASE` lag verdict. Parser surface 3-of-6 is compatible with lag at the checker/runtime layer.

## Why a new branch

#2005/#2006 PR'd the parked `audit/knowledge-parser-coverage-2026-08-19` branch against `main` and were 1k+ files of freight. This branch is cut from current `origin/main` (the #2015 landing) plus the addendum only.

## Test plan

- [x] `bash scripts/dev/knowledge_annotation_parser_coverage.sh` → `KNOWLEDGE_ANNOTATION_PARSER_COVERAGE: PASS` on this SHA (shipped Madaros v0.80.0 ELF, `ulimit -s 524288`, `env -u SOUC_BIN`)
- [ ] CI docs registry / Contracts