### PR TITLE
feat(algebra): two-sided sedenion ZD pair; Moufang probes fail

### DIFF
--- a/docs/audit/SEDENION_ZD_TWOSIDED_MOUFANG_2026-08-23.md
+++ b/docs/audit/SEDENION_ZD_TWOSIDED_MOUFANG_2026-08-23.md
@@ -1,0 +1,112 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.sedenion-zd-twosided-moufang-2026-08-23
+authority: repo_only
+audience: users
+last_validated: 2026-08-23
+validated_by: grok-cli2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.sedenion-zd-twosided-moufang-2026-08-23
+-->
+
+# Sedenion two-sided ZD pair and Moufang parenthesization
+
+```text
+Semantic-Lane-ID: sedenion-zd-moufang-20260823
+Owner: grok-cli2
+Concept-IDs: SOUNIO-NONASSOCIATIVE-ORDER
+Intent-Preserved: parenthesization remains explicit; a two-sided zero
+  divisor pair is not a physical ontology; Moufang is an algebraic
+  identity of O, not a new theorem on S
+Transformation: expose R_a(v)=v*a beside L_a; pin z*w=w*z=0 with
+  sequential survival on both sides; name the three Moufang
+  parenthesizations as action discrepancies with a witness that is
+  not the unit-in-x Artin reduction
+Types-Changed: none
+Effects-Changed: none (sed_mul remains Mut-only; no ZD effect)
+IR-Changed: none
+Claims-Introduced: Sounio computes z*w=w*z=0 and z*z, w*w nsq 4 on
+  the canonical pair; left and right sequential nsq 8 on v=e1;
+  Moufang (e1+e10, e1, e4) nsq 4/4/8; octonion embedding divides
+  both orders and Moufang-vanishes
+Claims-Forbidden: new physics; sedenion consciousness; ZD solves g-2;
+  Sounio proved Moufang independently of Artin; classification of
+  alternative subalgebras; dim ker L_z; Madaros is fixed-point-verified
+Assumptions: Convention X; canonical pair from algebra::sedenion;
+  unital alternative iff Moufang (standard, not a theorem number
+  claimed here); x=1 left-Moufang is Artin
+  and is not the pinned witness
+Write-Set: stdlib/algebra/sedenion_action.sio,
+  examples/physics/sedenion_zd_twosided.sio,
+  examples/physics/sedenion_moufang.sio,
+  tests/run-pass/sedenion_zd_twosided.sio,
+  tests/run-pass/sedenion_moufang.sio, this file
+Read-Set: stdlib/algebra/sedenion.sio,
+  docs/audit/SEDENION_ZD_ACTION_2026-08-23.md,
+  docs/audit/SEDENION_ARTIN_2026-08-23.md
+Positive-Witness: souc run prints ZD_ZW_NSQ 0, ZD_WZ_NSQ 0,
+  sequential 8 both sides, Moufang 4/4/8, oct embed 0
+Negative-Witness: octonion embedding does not annihilate; g-2 is not
+  this lane; ker L_z is not this lane
+Acceptance-Gate: both run-pass tests exit 0 under Madaros
+Integration-Target: origin/main
+Authoritative-Only-If: the nsqs are produced by Madaros running Sounio
+```
+
+## What this is
+
+A one-sided pair (`w*z ≠ 0`) was the working hypothesis. Madaros
+says otherwise: both products vanish. The observable that remains is
+**sequential survival on both sides**. Moufang is parenthesization,
+honestly a corollary of Artin in a unital algebra.
+
+## Two-sided pair (not dim ker)
+
+Canonical `z = e₃+e₁₀`, `w = e₆−e₁₅`. Left action was #2086.
+Right action `R_a(v)=v*a`:
+
+| quantity | nsq |
+|---|---:|
+| `z*w` | **0** |
+| `w*z` | **0** |
+| `z*z` | **4** |
+| `w*w` | **4** |
+| left composed `(zw)e₁` | **0** |
+| left sequential `z(w e₁)` | **8** |
+| right composed `e₁(zw)` | **0** |
+| right sequential `(e₁ z)w` | **8** |
+| embed `e₁*e₂` and `e₂*e₁` | **1** and **1** |
+
+Not nilpotent. Not dim ker `L_z`. The pair is two-sided as *products*;
+composed annihilation is the product being zero; sequential is the
+associator.
+
+## Moufang (not a new theorem)
+
+Identities:
+
+- left: `a(x(ay)) = ((ax)a)y`
+- middle: `(ax)(ya) = a((xy)a)`
+- right: `((xa)y)a = x(a(ya))`
+
+Witness found by Madaros scan over `a=e₁+e₁₀`, `x=e_i`, `y=e_j`.
+The first left hit `x=1`, `y=e₄` is Artin and is **not** used.
+Pinned triple: `a=e₁+e₁₀`, `x=e₁`, `y=e₄`.
+
+| probe | nsq |
+|---|---:|
+| left | **4** |
+| middle | **4** |
+| right | **8** |
+| octonion embed `(e₁,e₂,e₄)` all three | **0** |
+
+## Receipts (2026-08-23)
+
+Control ELF `/workspace/sounio/bin/madaros-linux-x86_64` (100902241 B).
+
+Example and test **rc=0** (`//@ requires: madaros` on the tests).
+
+LLM-offload math-review (`/tmp/llm-offload-JR0SpP`):
+
+- xAI grok-4.3: five `[OK]`; one `[TIGHTENABLE]` on naming Schafer without a
+  theorem number — parenthetical now says "standard", no invented citation.
+- Z.AI: error (quota/plan); weekly quota historically until 2026-08-25.
+- Outcome: **PASS_SINGLE_PROVIDER_DEGRADED**.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -380,6 +380,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.rust-macro-acceptance-2026-08-20 | repo_only | docs/audit/RUST_MACRO_ACCEPTANCE_2026-08-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-artin-2026-08-23 | repo_only | docs/audit/SEDENION_ARTIN_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-zd-action-2026-08-23 | repo_only | docs/audit/SEDENION_ZD_ACTION_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.sedenion-zd-twosided-moufang-2026-08-23 | repo_only | docs/audit/SEDENION_ZD_TWOSIDED_MOUFANG_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.seed-fix-general-lvalue-deref-store-2026-06-24 | repo_only | docs/audit/SEED_FIX_GENERAL_LVALUE_DEREF_STORE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.seed-fix-value-nested-field-store-2026-06-24 | repo_only | docs/audit/SEED_FIX_VALUE_NESTED_FIELD_STORE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.seven-fibers-of-twelve-2026-08-19 | repo_only | docs/audit/SEVEN_FIBERS_OF_TWELVE_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8204,6 +8204,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.sedenion-zd-twosided-moufang-2026-08-23",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/SEDENION_ZD_TWOSIDED_MOUFANG_2026-08-23.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.seed-fix-general-lvalue-deref-store-2026-06-24",
       "collection": "repo",
       "repo_doc_path": "docs/audit/SEED_FIX_GENERAL_LVALUE_DEREF_STORE_2026-06-24.md",

--- a/examples/physics/sedenion_moufang.sio
+++ b/examples/physics/sedenion_moufang.sio
@@ -1,0 +1,95 @@
+//@ run-pass
+//@ description: sedenion Moufang identities fail; octonion embedding holds
+//
+// Unital alternative iff Moufang, so Artin fail already implies this.
+// The probes still name the three parenthesizations. Witness
+// a=e1+e10, x=e1, y=e4 (not x=1, which would be Artin again):
+// left nsq 4, middle nsq 4, right nsq 8. Control: embedded (e1,e2,e4).
+//
+// Not a new theorem. Not consciousness. Not g-2.
+//
+// Run:
+//   export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+//   ./bin/souc run examples/physics/sedenion_moufang.sio
+
+use algebra::sedenion::{sed_basis}
+use algebra::octonion::{oct_basis}
+use algebra::sedenion_action::{
+    sed_embed_oct, sed_artin_witness_a, sed_artin_witness_v,
+    sed_moufang_left_nsq, sed_moufang_middle_nsq, sed_moufang_right_nsq,
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var a: [f64; 16] = [0.0; 16]
+    var x: [f64; 16] = [0.0; 16]
+    var y: [f64; 16] = [0.0; 16]
+    sed_artin_witness_a(&!a)
+    sed_basis(1, &!x)
+    sed_artin_witness_v(&!y)
+
+    let nsq_l = sed_moufang_left_nsq(&a, &x, &y)
+    let nsq_m = sed_moufang_middle_nsq(&a, &x, &y)
+    let nsq_r = sed_moufang_right_nsq(&a, &x, &y)
+
+    var e1o = oct_basis(1)
+    var e2o = oct_basis(2)
+    var e4o = oct_basis(4)
+    var e1e: [f64; 16] = [0.0; 16]
+    var e2e: [f64; 16] = [0.0; 16]
+    var e4e: [f64; 16] = [0.0; 16]
+    sed_embed_oct(&e1o, &!e1e)
+    sed_embed_oct(&e2o, &!e2e)
+    sed_embed_oct(&e4o, &!e4e)
+    let oct_l = sed_moufang_left_nsq(&e1e, &e2e, &e4e)
+    let oct_m = sed_moufang_middle_nsq(&e1e, &e2e, &e4e)
+    let oct_r = sed_moufang_right_nsq(&e1e, &e2e, &e4e)
+
+    print("MOUFANG_SED_LEFT_NSQ ")
+    print_f64(nsq_l)
+    print("\nMOUFANG_SED_MIDDLE_NSQ ")
+    print_f64(nsq_m)
+    print("\nMOUFANG_SED_RIGHT_NSQ ")
+    print_f64(nsq_r)
+    print("\nMOUFANG_OCT_EMBED_LEFT_NSQ ")
+    print_f64(oct_l)
+    print("\nMOUFANG_OCT_EMBED_MIDDLE_NSQ ")
+    print_f64(oct_m)
+    print("\nMOUFANG_OCT_EMBED_RIGHT_NSQ ")
+    print_f64(oct_r)
+    print("\n")
+
+    var ok: i64 = 1
+    if abs_f(nsq_l - 4.0) > 1.0e-9 { ok = 0 }
+    if abs_f(nsq_m - 4.0) > 1.0e-9 { ok = 0 }
+    if abs_f(nsq_r - 8.0) > 1.0e-9 { ok = 0 }
+    if oct_l > 1.0e-9 { ok = 0 }
+    if oct_m > 1.0e-9 { ok = 0 }
+    if oct_r > 1.0e-9 { ok = 0 }
+
+    print("VERDICT_SED_MOUFANG_FAILS ")
+    if nsq_l > 1.0e-9 {
+        if nsq_m > 1.0e-9 {
+            if nsq_r > 1.0e-9 { print("1\n") } else { print("0\n") }
+        } else {
+            print("0\n")
+        }
+    } else {
+        print("0\n")
+    }
+    print("VERDICT_OCT_EMBED_MOUFANG_HOLDS ")
+    if oct_l <= 1.0e-9 {
+        if oct_m <= 1.0e-9 {
+            if oct_r <= 1.0e-9 { print("1\n") } else { print("0\n") }
+        } else {
+            print("0\n")
+        }
+    } else {
+        print("0\n")
+    }
+
+    if ok == 1 { 0 } else { 1 }
+}

--- a/examples/physics/sedenion_zd_twosided.sio
+++ b/examples/physics/sedenion_zd_twosided.sio
@@ -1,0 +1,112 @@
+//@ run-pass
+//@ description: canonical sedenion ZD pair is two-sided as products; sequential survives both sides
+//
+// z=e3+e10, w=e6−e15. Madaros: z*w = w*z = 0, but z*z and w*w have
+// nsq 4 (not nilpotent). Left composed (zw)v and right composed v(zw)
+// vanish. Left sequential z(wv) and right sequential (vz)w do not
+// (nsq 8 on v=e1). Octonion embedding cannot annihilate either order.
+//
+// This is the pair, not dim ker L_z. Not consciousness. Not g-2.
+//
+// Run:
+//   export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+//   ./bin/souc run examples/physics/sedenion_zd_twosided.sio
+
+use algebra::sedenion::{sed_basis}
+use algebra::octonion::{oct_basis}
+use algebra::sedenion_action::{
+    sed_embed_oct, sed_lmul_product_nsq, sed_canonical_zd_pair,
+    sed_lmul_composed_nsq, sed_lmul_sequential_nsq,
+    sed_rmul_composed_nsq, sed_rmul_sequential_nsq,
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var z: [f64; 16] = [0.0; 16]
+    var w: [f64; 16] = [0.0; 16]
+    sed_canonical_zd_pair(&!z, &!w)
+    var e1s: [f64; 16] = [0.0; 16]
+    sed_basis(1, &!e1s)
+
+    let nsq_zw = sed_lmul_product_nsq(&z, &w)
+    let nsq_wz = sed_lmul_product_nsq(&w, &z)
+    let nsq_zz = sed_lmul_product_nsq(&z, &z)
+    let nsq_ww = sed_lmul_product_nsq(&w, &w)
+    let nsq_lcomp = sed_lmul_composed_nsq(&z, &w, &e1s)
+    let nsq_lseq = sed_lmul_sequential_nsq(&z, &w, &e1s)
+    let nsq_rcomp = sed_rmul_composed_nsq(&z, &w, &e1s)
+    let nsq_rseq = sed_rmul_sequential_nsq(&z, &w, &e1s)
+
+    var e1o = oct_basis(1)
+    var e2o = oct_basis(2)
+    var e1e: [f64; 16] = [0.0; 16]
+    var e2e: [f64; 16] = [0.0; 16]
+    sed_embed_oct(&e1o, &!e1e)
+    sed_embed_oct(&e2o, &!e2e)
+    let nsq_oct_12 = sed_lmul_product_nsq(&e1e, &e2e)
+    let nsq_oct_21 = sed_lmul_product_nsq(&e2e, &e1e)
+
+    print("ZD_ZW_NSQ ")
+    print_f64(nsq_zw)
+    print("\nZD_WZ_NSQ ")
+    print_f64(nsq_wz)
+    print("\nZD_ZZ_NSQ ")
+    print_f64(nsq_zz)
+    print("\nZD_WW_NSQ ")
+    print_f64(nsq_ww)
+    print("\nZD_LEFT_COMPOSED_NSQ ")
+    print_f64(nsq_lcomp)
+    print("\nZD_LEFT_SEQUENTIAL_NSQ ")
+    print_f64(nsq_lseq)
+    print("\nZD_RIGHT_COMPOSED_NSQ ")
+    print_f64(nsq_rcomp)
+    print("\nZD_RIGHT_SEQUENTIAL_NSQ ")
+    print_f64(nsq_rseq)
+    print("\nOCT_EMBED_E1E2_NSQ ")
+    print_f64(nsq_oct_12)
+    print("\nOCT_EMBED_E2E1_NSQ ")
+    print_f64(nsq_oct_21)
+    print("\n")
+
+    var ok: i64 = 1
+    if nsq_zw > 1.0e-9 { ok = 0 }
+    if nsq_wz > 1.0e-9 { ok = 0 }
+    if abs_f(nsq_zz - 4.0) > 1.0e-9 { ok = 0 }
+    if abs_f(nsq_ww - 4.0) > 1.0e-9 { ok = 0 }
+    if nsq_lcomp > 1.0e-9 { ok = 0 }
+    if abs_f(nsq_lseq - 8.0) > 1.0e-9 { ok = 0 }
+    if nsq_rcomp > 1.0e-9 { ok = 0 }
+    if abs_f(nsq_rseq - 8.0) > 1.0e-9 { ok = 0 }
+    if abs_f(nsq_oct_12 - 1.0) > 1.0e-9 { ok = 0 }
+    if abs_f(nsq_oct_21 - 1.0) > 1.0e-9 { ok = 0 }
+
+    print("VERDICT_PAIR_TWOSIDED_PRODUCT ")
+    if nsq_zw <= 1.0e-9 {
+        if nsq_wz <= 1.0e-9 { print("1\n") } else { print("0\n") }
+    } else {
+        print("0\n")
+    }
+    print("VERDICT_NOT_NILPOTENT ")
+    if abs_f(nsq_zz - 4.0) <= 1.0e-9 {
+        if abs_f(nsq_ww - 4.0) <= 1.0e-9 { print("1\n") } else { print("0\n") }
+    } else {
+        print("0\n")
+    }
+    print("VERDICT_SEQUENTIAL_SURVIVES_BOTH_SIDES ")
+    if abs_f(nsq_lseq - 8.0) <= 1.0e-9 {
+        if abs_f(nsq_rseq - 8.0) <= 1.0e-9 { print("1\n") } else { print("0\n") }
+    } else {
+        print("0\n")
+    }
+    print("VERDICT_OCT_EMBED_DIVIDES_BOTH_ORDERS ")
+    if abs_f(nsq_oct_12 - 1.0) <= 1.0e-9 {
+        if abs_f(nsq_oct_21 - 1.0) <= 1.0e-9 { print("1\n") } else { print("0\n") }
+    } else {
+        print("0\n")
+    }
+
+    if ok == 1 { 0 } else { 1 }
+}

--- a/stdlib/algebra/sedenion_action.sio
+++ b/stdlib/algebra/sedenion_action.sio
@@ -15,17 +15,29 @@
 // embedded octonions cannot annihilate a nonzero vector.
 //
 // No new algebra. Convention X via algebra::sedenion (Cayley-Dickson k=4).
-// Canonical pair: z = e3+e10, w = e6−e15, z*w = 0 exactly.
+// Canonical pair: z = e3+e10, w = e6−e15, z*w = w*z = 0 exactly.
 //
 // Artin/alternativity: octonions satisfy [a,a,v]=0. Sedenions do not.
 // The same two protocols with a=b probe that. The octonion embedding
 // is the vanishing control; a = e1+e10 (both Cayley-Dickson halves) is
 // the failing witness (Madaros: [a,a,e4] has norm² 4).
 //
+// Two-sided pair (measured, not assumed one-sided): z*w = w*z = 0
+// with ||z||²=||w||²=2 and z*z, w*w nonzero (nsq 4). Right
+// multiplication R_a(v)=v*a is a different map. Right composed
+// v*(zw) vanishes because zw=0; right sequential (v*z)*w need not
+// (Madaros nsq 8 on v=e1). That is the pair, not dim ker L_z.
+//
+// Moufang: a unital algebra is alternative iff it is Moufang, so the
+// Artin fail already implies Moufang fail. These probes still name
+// the three parenthesizations as action discrepancies. They are not
+// a new theorem. Octonion embedding is the vanishing control.
+//
 // Claims forbidden: new physics; sedenion consciousness; ZD solves g-2;
-// NonAssoc is an ontology. sed_mul is Mut-only today; this module does
-// not invent a ZD effect. This is not examples/octonionic_relativity.sio
-// and not examples/conversational_ossm/.
+// NonAssoc is an ontology; classification of alternative subalgebras;
+// Sounio proved Moufang independently of Artin. sed_mul is Mut-only
+// today; this module does not invent a ZD effect. This is not
+// examples/octonionic_relativity.sio and not examples/conversational_ossm/.
 
 use algebra::sedenion::{sed_mul, sed_norm_sq, sed_from_pair, sed_zd_z, sed_zd_w}
 
@@ -138,4 +150,115 @@ pub fn sed_artin_witness_v(out: &![f64; 16]) with Mut {
         i = i + 1
     }
     out[4] = 1.0
+}
+
+fn sed_vec_sub16(a: &[f64; 16], b: &[f64; 16], out: &![f64; 16]) with Mut {
+    var i: i64 = 0
+    while i < 16 {
+        out[i] = a[i] - b[i]
+        i = i + 1
+    }
+}
+
+/// Right multiplication: R_a(v) = v*a.
+pub fn sed_rmul(v: &[f64; 16], a: &[f64; 16], out: &![f64; 16]) with Mut {
+    sed_mul(v, a, out)
+}
+
+/// Compose in the algebra, then act on the right: R_{ab}(v) = v*(a*b).
+pub fn sed_rmul_composed(
+    a: &[f64; 16], b: &[f64; 16], v: &[f64; 16], out: &![f64; 16]
+) with Mut {
+    var ab: [f64; 16] = [0.0; 16]
+    sed_mul(a, b, &!ab)
+    sed_rmul(v, &ab, out)
+}
+
+/// Act, then act on the right: (R_b ∘ R_a)(v) = (v*a)*b.
+pub fn sed_rmul_sequential(
+    a: &[f64; 16], b: &[f64; 16], v: &[f64; 16], out: &![f64; 16]
+) with Mut {
+    var va: [f64; 16] = [0.0; 16]
+    sed_rmul(v, a, &!va)
+    sed_rmul(&va, b, out)
+}
+
+pub fn sed_rmul_composed_nsq(
+    a: &[f64; 16], b: &[f64; 16], v: &[f64; 16]
+) -> f64 with Mut {
+    var out: [f64; 16] = [0.0; 16]
+    sed_rmul_composed(a, b, v, &!out)
+    sed_norm_sq(&out)
+}
+
+pub fn sed_rmul_sequential_nsq(
+    a: &[f64; 16], b: &[f64; 16], v: &[f64; 16]
+) -> f64 with Mut {
+    var out: [f64; 16] = [0.0; 16]
+    sed_rmul_sequential(a, b, v, &!out)
+    sed_norm_sq(&out)
+}
+
+/// Left Moufang discrepancy nsq: a(x(ay)) − ((ax)a)y.
+pub fn sed_moufang_left_nsq(
+    a: &[f64; 16], x: &[f64; 16], y: &[f64; 16]
+) -> f64 with Mut {
+    var ay: [f64; 16] = [0.0; 16]
+    var xay: [f64; 16] = [0.0; 16]
+    var lhs: [f64; 16] = [0.0; 16]
+    var ax: [f64; 16] = [0.0; 16]
+    var axa: [f64; 16] = [0.0; 16]
+    var rhs: [f64; 16] = [0.0; 16]
+    var d: [f64; 16] = [0.0; 16]
+    sed_mul(a, y, &!ay)
+    sed_mul(x, &ay, &!xay)
+    sed_mul(a, &xay, &!lhs)
+    sed_mul(a, x, &!ax)
+    sed_mul(&ax, a, &!axa)
+    sed_mul(&axa, y, &!rhs)
+    sed_vec_sub16(&lhs, &rhs, &!d)
+    sed_norm_sq(&d)
+}
+
+/// Middle Moufang discrepancy nsq: (ax)(ya) − a((xy)a).
+pub fn sed_moufang_middle_nsq(
+    a: &[f64; 16], x: &[f64; 16], y: &[f64; 16]
+) -> f64 with Mut {
+    var ax: [f64; 16] = [0.0; 16]
+    var ya: [f64; 16] = [0.0; 16]
+    var lhs: [f64; 16] = [0.0; 16]
+    var xy: [f64; 16] = [0.0; 16]
+    var xya: [f64; 16] = [0.0; 16]
+    var rhs: [f64; 16] = [0.0; 16]
+    var d: [f64; 16] = [0.0; 16]
+    sed_mul(a, x, &!ax)
+    sed_mul(y, a, &!ya)
+    sed_mul(&ax, &ya, &!lhs)
+    sed_mul(x, y, &!xy)
+    sed_mul(&xy, a, &!xya)
+    sed_mul(a, &xya, &!rhs)
+    sed_vec_sub16(&lhs, &rhs, &!d)
+    sed_norm_sq(&d)
+}
+
+/// Right Moufang discrepancy nsq: ((xa)y)a − x(a(ya)).
+/// Madaros pinned witness a=e1+e10, x=e1, y=e4: left 4, middle 4, right 8.
+pub fn sed_moufang_right_nsq(
+    a: &[f64; 16], x: &[f64; 16], y: &[f64; 16]
+) -> f64 with Mut {
+    var xa: [f64; 16] = [0.0; 16]
+    var xay: [f64; 16] = [0.0; 16]
+    var lhs: [f64; 16] = [0.0; 16]
+    var ya: [f64; 16] = [0.0; 16]
+    var aya: [f64; 16] = [0.0; 16]
+    var rhs: [f64; 16] = [0.0; 16]
+    var d: [f64; 16] = [0.0; 16]
+    sed_mul(x, a, &!xa)
+    sed_mul(&xa, y, &!xay)
+    sed_mul(&xay, a, &!lhs)
+    sed_mul(y, a, &!ya)
+    sed_mul(a, &ya, &!aya)
+    sed_mul(x, &aya, &!rhs)
+    sed_vec_sub16(&lhs, &rhs, &!d)
+    sed_norm_sq(&d)
 }

--- a/tests/run-pass/sedenion_moufang.sio
+++ b/tests/run-pass/sedenion_moufang.sio
@@ -1,0 +1,45 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 0
+//@ description: sedenion Moufang (e1+e10,e1,e4) nsq 4/4/8; octonion embed vanishes
+// Full Test Suite CI uses souc-stage2 (lean_single). Madaros runs this graph.
+
+use algebra::sedenion::{sed_basis}
+use algebra::octonion::{oct_basis}
+use algebra::sedenion_action::{
+    sed_embed_oct, sed_artin_witness_a, sed_artin_witness_v,
+    sed_moufang_left_nsq, sed_moufang_middle_nsq, sed_moufang_right_nsq,
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var a: [f64; 16] = [0.0; 16]
+    var x: [f64; 16] = [0.0; 16]
+    var y: [f64; 16] = [0.0; 16]
+    sed_artin_witness_a(&!a)
+    sed_basis(1, &!x)
+    sed_artin_witness_v(&!y)
+
+    var ok: i64 = 1
+    if abs_f(sed_moufang_left_nsq(&a, &x, &y) - 4.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_moufang_middle_nsq(&a, &x, &y) - 4.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_moufang_right_nsq(&a, &x, &y) - 8.0) > 1.0e-9 { ok = 0 }
+
+    var e1o = oct_basis(1)
+    var e2o = oct_basis(2)
+    var e4o = oct_basis(4)
+    var e1e: [f64; 16] = [0.0; 16]
+    var e2e: [f64; 16] = [0.0; 16]
+    var e4e: [f64; 16] = [0.0; 16]
+    sed_embed_oct(&e1o, &!e1e)
+    sed_embed_oct(&e2o, &!e2e)
+    sed_embed_oct(&e4o, &!e4e)
+    if sed_moufang_left_nsq(&e1e, &e2e, &e4e) > 1.0e-9 { ok = 0 }
+    if sed_moufang_middle_nsq(&e1e, &e2e, &e4e) > 1.0e-9 { ok = 0 }
+    if sed_moufang_right_nsq(&e1e, &e2e, &e4e) > 1.0e-9 { ok = 0 }
+
+    if ok == 1 { 0 } else { 1 }
+}

--- a/tests/run-pass/sedenion_zd_twosided.sio
+++ b/tests/run-pass/sedenion_zd_twosided.sio
@@ -1,0 +1,46 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 0
+//@ description: canonical ZD pair is two-sided as products; sequential nsq 8 both sides
+// Full Test Suite CI uses souc-stage2 (lean_single). Madaros runs this graph.
+
+use algebra::sedenion::{sed_basis}
+use algebra::octonion::{oct_basis}
+use algebra::sedenion_action::{
+    sed_embed_oct, sed_lmul_product_nsq, sed_canonical_zd_pair,
+    sed_lmul_composed_nsq, sed_lmul_sequential_nsq,
+    sed_rmul_composed_nsq, sed_rmul_sequential_nsq,
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var z: [f64; 16] = [0.0; 16]
+    var w: [f64; 16] = [0.0; 16]
+    sed_canonical_zd_pair(&!z, &!w)
+    var e1s: [f64; 16] = [0.0; 16]
+    sed_basis(1, &!e1s)
+
+    var ok: i64 = 1
+    if sed_lmul_product_nsq(&z, &w) > 1.0e-9 { ok = 0 }
+    if sed_lmul_product_nsq(&w, &z) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_lmul_product_nsq(&z, &z) - 4.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_lmul_product_nsq(&w, &w) - 4.0) > 1.0e-9 { ok = 0 }
+    if sed_lmul_composed_nsq(&z, &w, &e1s) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_lmul_sequential_nsq(&z, &w, &e1s) - 8.0) > 1.0e-9 { ok = 0 }
+    if sed_rmul_composed_nsq(&z, &w, &e1s) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_rmul_sequential_nsq(&z, &w, &e1s) - 8.0) > 1.0e-9 { ok = 0 }
+
+    var e1o = oct_basis(1)
+    var e2o = oct_basis(2)
+    var e1e: [f64; 16] = [0.0; 16]
+    var e2e: [f64; 16] = [0.0; 16]
+    sed_embed_oct(&e1o, &!e1e)
+    sed_embed_oct(&e2o, &!e2e)
+    if abs_f(sed_lmul_product_nsq(&e1e, &e2e) - 1.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_lmul_product_nsq(&e2e, &e1e) - 1.0) > 1.0e-9 { ok = 0 }
+
+    if ok == 1 { 0 } else { 1 }
+}


### PR DESCRIPTION
## What

Offer 2 hypothesized a one-sided pair (`w*z ≠ 0`). Madaros says otherwise.

Canonical `z = e3+e10`, `w = e6−e15`:

| quantity | nsq |
|---|---:|
| `z*w` | **0** |
| `w*z` | **0** |
| `z*z`, `w*w` | **4**, **4** |
| left composed `(zw)e1` | **0** |
| left sequential `z(w e1)` | **8** |
| right composed `e1(zw)` | **0** |
| right sequential `(e1 z)w` | **8** |
| embed `e1*e2` and `e2*e1` | **1**, **1** |

Not dim ker `L_z`. Not nilpotent.

Moufang is a corollary of Artin in a unital algebra. Still named as three parenthesizations. Witness `a=e1+e10`, `x=e1`, `y=e4` (not `x=1`, which is Artin again):

| probe | nsq |
|---|---:|
| left / middle / right | **4 / 4 / 8** |
| octonion embed `(e1,e2,e4)` all three | **0** |

## Receipts (Madaros control ELF 100902241 B)

```
ZD_ZW_NSQ 0.000000
ZD_WZ_NSQ 0.000000
ZD_ZZ_NSQ 4.000000
ZD_WW_NSQ 4.000000
ZD_LEFT_SEQUENTIAL_NSQ 8.000000
ZD_RIGHT_SEQUENTIAL_NSQ 8.000000
MOUFANG_SED_LEFT_NSQ 4.000000
MOUFANG_SED_MIDDLE_NSQ 4.000000
MOUFANG_SED_RIGHT_NSQ 8.000000
MOUFANG_OCT_EMBED_* 0.000000
```

Example + test rc=0 (`//@ requires: madaros`).

## Claims-forbidden

New physics; classification of alternative subalgebras; ZD solves g-2; Sounio proved Moufang independently of Artin; dim ker L_z; Madaros is fixed-point-verified.

Do not merge until asked.