### PR TITLE
fix(ir): classify a/b as an FO transfer so imported division keeps variance (#1706)

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -8833,6 +8833,17 @@ impl Lowerer {
                                     return lo.fo_xfer_set(name, 3, 0.0, ir_empty_name())
                                 }
                             }
+                            // p0 / p1 -- kind 7. Deliberately NOT accepting the
+                            // swapped (li == 1 && ri == 0) form the mul/add arms
+                            // allow: division is not commutative, and the apply side
+                            // takes arg0 as the numerator. Matching `p1 / p0` here
+                            // would silently compute the derivative of the reciprocal
+                            // expression, which is worse than leaving it unregistered.
+                            if (*e).bin_op == BinaryOp::OpDiv {
+                                if nparams >= 2 && li == 0 && ri == 1 {
+                                    return lo.fo_xfer_set(name, 7, 0.0, ir_empty_name())
+                                }
+                            }
                         }
                         _ => {}
                     }
@@ -9062,6 +9073,24 @@ impl Lowerer {
             let aval1 = lo.fo_lower_nth_arg_value(args, 1)
             lo = aval1.0
             lo = lo.fo_combine_sens_mul(s0, s1, val0, aval1.1)
+            return lo.fo_emit_var_from_sens()
+        }
+        // kind 7: `f(a, b) = a / b`. Mirrors kind 4 exactly, except the combiner is
+        // the quotient rule instead of the product rule. fo_combine_sens_div already
+        // existed for the INLINE algebra (`variance_of(a / b)` written out in the
+        // caller); this makes the same rule reachable when the division is behind an
+        // imported helper -- which is why fo_div2 in stdlib/epistemic/fo.sio missed
+        // while fo_mul2, one line away, hit (#1706).
+        //
+        // ORDER MATTERS: d/da (a/b) = 1/b and d/db (a/b) = -a/b^2, so unlike mul and
+        // add the two arguments are NOT interchangeable. s0/arg0 is the numerator.
+        if kind == 7 {
+            let dval0 = lo.fo_lower_nth_arg_value(args, 0)
+            lo = dval0.0
+            let dnum = dval0.1
+            let dval1 = lo.fo_lower_nth_arg_value(args, 1)
+            lo = dval1.0
+            lo = lo.fo_combine_sens_div(s0, s1, dnum, dval1.1)
             return lo.fo_emit_var_from_sens()
         }
         (lo.fo_clear_expr_sens(), -1)

--- a/tests/run-pass/gum_fo_imported_div_variance.sio
+++ b/tests/run-pass/gum_fo_imported_div_variance.sio
@@ -1,0 +1,47 @@
+//@ run-pass
+//@ requires: madaros
+//@ expect-stdout: GUM_FO_IMPORTED_DIV_OK
+
+// #1706: an imported `a / b` helper erased first-order variance while the
+// `a * b` helper one line away in the same file preserved it. #1939 fixed the
+// ORDERING (imported helpers register in time); division was still not a
+// classified shape, so fo_div2 kept missing where fo_mul2 hit.
+//
+// Var(a/b) with independent a, b:  (1/b)^2 Var(a) + (a/b^2)^2 Var(b)
+//   a = 6.0 +/- 0.3,  b = 2.0 +/- 0.1
+//   = 0.25*0.09 + (6/4)^2*0.01 = 0.0225 + 0.0225 = 0.045
+//
+// The peel is the control: writing `x / y` inline always worked. The point is
+// that routing it through an imported helper now agrees.
+
+use epistemic::fo::{fo_div2, fo_mul2}
+
+fn abs_f(v: f64) -> f64 {
+    if v < 0.0 { return 0.0 - v }
+    return v
+}
+
+fn main() with IO, Mut, Div, Epistemic {
+    let ka: Knowledge<f64> = measure(6.0, uncertainty: 0.3)
+    let kb: Knowledge<f64> = measure(2.0, uncertainty: 0.1)
+    let x = ka.value
+    let y = kb.value
+
+    let v_imp_div = variance_of(fo_div2(x, y))
+    let v_peel_div = variance_of(x / y)
+    let v_imp_mul = variance_of(fo_mul2(x, y))
+    let v_peel_mul = variance_of(x * y)
+
+    print("imp_div="); print_f64(v_imp_div); print("\n")
+    print("peel_div="); print_f64(v_peel_div); print("\n")
+    print("imp_mul="); print_f64(v_imp_mul); print("\n")
+    print("peel_mul="); print_f64(v_peel_mul); print("\n")
+
+    if abs_f(v_imp_div - v_peel_div) < 1.0e-9
+        && abs_f(v_imp_div - 0.045) < 1.0e-9
+        && abs_f(v_imp_mul - v_peel_mul) < 1.0e-9 {
+        print("GUM_FO_IMPORTED_DIV_OK\n")
+    } else {
+        print("GUM_FO_IMPORTED_DIV_FAIL\n")
+    }
+}


### PR DESCRIPTION
`fo_div2(a, b) = a / b` in `stdlib/epistemic/fo.sio` erased first-order variance while `fo_mul2(a, b) = a * b`, **one line above it**, preserved it. The FO transfer classifier accepted only identity, `lit*x`, `a+b` and `a*b` — division was never a classified shape, so any call through an imported division helper fell back to a silent `0.0`.

Follow-on to #1939, which closed the *ordering* half of #1706's defect 2 (imported helpers now register in time). Division was the next thing in the way.

## The quotient rule already existed

`fo_combine_sens_div` has been in the tree for the **inline** algebra — `variance_of(a / b)` spelled out in the caller always worked. This change only makes it reachable when the division sits behind a helper. Kind 7 mirrors kind 4 exactly, swapping the product-rule combiner for the quotient one. **29 lines, insertions only.**

## Argument order is load-bearing here

Unlike kinds 3 and 4, the arguments are **not** interchangeable: `d/da (a/b) = 1/b` but `d/db (a/b) = -a/b²`. The mul and add arms accept either parameter order; this one accepts only `p0 / p1`. Matching `p1 / p0` would silently compute the derivative of the reciprocal expression — worse than leaving it unregistered.

## Measured

New test, A/B against unmodified `main`:

| | `imp_div` | verdict |
|---|---|---|
| unmodified `main` | `0.000000` | `GUM_FO_IMPORTED_DIV_FAIL` |
| with this change | **`0.045000`** | `GUM_FO_IMPORTED_DIV_OK` |

`0.045` is not merely "equal to the peel" — it is the closed form worked out in the test header: `(1/b)²·Var(a) + (a/b²)²·Var(b)` = `0.0225 + 0.0225`, for `a = 6.0 ± 0.3`, `b = 2.0 ± 0.1`. And `peel_div` reads `0.045` on **both** trees, which places the defect at the helper boundary and nowhere else.

## Verification

- **per-test A/B** over 48 `gum`/`epistemic`/`variance`/`knowledge` tests: **exactly one test flips** — the new one — and nothing regresses
- **fixed-point ratchet**: `MADAROS_FIXED_POINT_OK` on both arms
- **`madaros_full_gate`**: PASS on both arms
- the new test **discriminates**: it FAILS on unmodified `main`

One note on method: an aggregate sweep first showed **+2** where I expected +1. The per-test diff showed that second point was suite flakiness — the same base tree scored 30, then 29, across two runs of the same binary. Aggregates are not attributable in this repo; the per-test diff is. (That instability is itself only visible because #1531 armed the assertions.)

## Scope

This closes the **division shape only**. #1706's remaining classifier holes are **arity ≥ 3** (which #1939 explicitly declares open), `ExprIf` bodies, and calls nested inside a binary. The 14 `madaros_gum_fo_*` entries **stay** in `tests/vacuous_expect_baseline.txt` — none of them flips on division alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)