### PR TITLE
feat(algebra): dim ker L_z of canonical sedenion pair is 4

### DIFF
--- a/docs/audit/SEDENION_KER_LZ_2026-08-23.md
+++ b/docs/audit/SEDENION_KER_LZ_2026-08-23.md
@@ -1,0 +1,87 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.sedenion-ker-lz-2026-08-23
+authority: repo_only
+audience: users
+last_validated: 2026-08-23
+validated_by: grok-cli2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.sedenion-ker-lz-2026-08-23
+-->
+
+# Sedenion dim ker L_z — rank-nullity of the canonical pair
+
+```text
+Semantic-Lane-ID: sedenion-ker-lz-20260823
+Owner: grok-cli2
+Concept-IDs: SOUNIO-NONASSOCIATIVE-ORDER
+Intent-Preserved: a kernel dimension is a linear-algebra measurement
+  of L_a, not a physical ontology and not a classification of
+  zero-divisors
+Transformation: build the 16×16 matrix of L_a via sed_mul; rank by
+  Gaussian elimination with partial pivoting; dim ker = 16 − rank;
+  report basis-vanish separately
+Types-Changed: none
+Effects-Changed: none (sed_mul remains Mut-only)
+IR-Changed: none
+Claims-Introduced: Sounio computes rank(L_z)=12 and dim ker L_z=4 on
+  the canonical pair; the same for L_w, R_z, R_w; embed(e1) and e1
+  have rank 16; no standard-basis vector is in ker L_z
+Claims-Forbidden: new physics; Sounio proved Moreno; ZD solves g-2;
+  dim ker is always half the dimension; Madaros is fixed-point-verified;
+  this is the CDElement tower
+Assumptions: Convention X via algebra::sedenion; GE tolerance 1e-9;
+  the CD-tower L4 row (ker 4/16) is a comparison, not this oracle
+Write-Set: stdlib/algebra/sedenion_kernel.sio,
+  examples/physics/sedenion_ker_lz.sio,
+  tests/run-pass/sedenion_ker_lz.sio, this file
+Read-Set: stdlib/algebra/sedenion_action.sio,
+  examples/sedeniontrip_projective_measurement.sio
+Positive-Witness: souc run prints KER_LZ_DIM 4, KER_LZ_RANK 12,
+  KER_LZ_BASIS_VANISH 0, KER_EMBED_E1_DIM 0
+Negative-Witness: counting vanishing L_z(e_i) is not dim ker;
+  g-2 is not this lane
+Acceptance-Gate: tests/run-pass/sedenion_ker_lz.sio exit 0 under Madaros
+Integration-Target: origin/main
+Authoritative-Only-If: the ranks are produced by Madaros running Sounio
+```
+
+## What this is
+
+#2086 showed one vector in the kernel (`z*w=0`). This lane measures
+the dimension. New module: does not touch `sedenion_action.sio`
+(#2093 holds that file).
+
+## Receipts (2026-08-23)
+
+Control ELF `/workspace/sounio/bin/madaros-linux-x86_64` (100902241 B).
+
+| map | rank | dim ker | basis vanish |
+|---|---:|---:|---:|
+| `L_z` | **12** | **4** | **0** |
+| `R_z` | **12** | **4** | — |
+| `L_w` | **12** | **4** | — |
+| `L_{e1}` | **16** | **0** | **0** |
+| `L_{embed(e1)}` | **16** | **0** | — |
+
+The kernel is 4-dimensional and contains **no** coordinate vector
+`e_i`. Counting `z*e_i=0` would have reported 0 and lied. Other
+sparse generators (sums of two basis elements, etc.) are not claimed.
+
+This **agrees** with the L4 row of the CD-tower projective ladder
+(`ker 4 / 16 = 25%`, `e3+e10`). That ladder uses
+`algebra::cayley_dickson`. This lane uses `sed_mul`. Same integer.
+
+This **disagrees** with the slogan that a sedenion zero-divisor has
+an 8-dimensional annihilator. The slogan is not this measurement.
+
+## Claims-forbidden
+
+New physics; Moreno classification; dim ker always n/2; ZD solves
+g-2; Madaros is fixed-point-verified.
+
+LLM-offload math-review (`/tmp/llm-offload-dOO3O6`):
+
+- xAI grok-4.3: five `[OK]`; one `[TIGHTENABLE]` on "basis vanish"
+  over-reading as "no sparse kernel basis" — text now says no
+  coordinate vector, and does not claim other sparse generators.
+- Z.AI: weekly quota exhausted until 2026-08-25 06:34:36.
+- Outcome: **PASS_SINGLE_PROVIDER_DEGRADED**.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -379,6 +379,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.runtime-gc-capability-honesty-2026-08-18 | repo_only | docs/audit/RUNTIME_GC_CAPABILITY_HONESTY_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.rust-macro-acceptance-2026-08-20 | repo_only | docs/audit/RUST_MACRO_ACCEPTANCE_2026-08-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-artin-2026-08-23 | repo_only | docs/audit/SEDENION_ARTIN_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.sedenion-ker-lz-2026-08-23 | repo_only | docs/audit/SEDENION_KER_LZ_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-zd-action-2026-08-23 | repo_only | docs/audit/SEDENION_ZD_ACTION_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.seed-fix-general-lvalue-deref-store-2026-06-24 | repo_only | docs/audit/SEED_FIX_GENERAL_LVALUE_DEREF_STORE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.seed-fix-value-nested-field-store-2026-06-24 | repo_only | docs/audit/SEED_FIX_VALUE_NESTED_FIELD_STORE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8181,6 +8181,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.sedenion-ker-lz-2026-08-23",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/SEDENION_KER_LZ_2026-08-23.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.sedenion-zd-action-2026-08-23",
       "collection": "repo",
       "repo_doc_path": "docs/audit/SEDENION_ZD_ACTION_2026-08-23.md",

--- a/examples/physics/sedenion_ker_lz.sio
+++ b/examples/physics/sedenion_ker_lz.sio
@@ -1,0 +1,98 @@
+//@ run-pass
+//@ description: dim ker L_z of the canonical sedenion pair is 4; octonion embed is 0
+//
+// Rank-nullity of left multiplication on S ≅ R¹⁶. Canonical
+// z=e3+e10: rank 12, dim ker 4, and no standard-basis vector
+// lies in the kernel (vanish count 0). Same numbers for L_w,
+// R_z, R_w. Control: embed(e1) and e1 have rank 16.
+//
+// Agrees with the L4 row of the CD-tower projective ladder
+// (ker 4/16). Disagrees with "half of 16 is 8". Not Moreno.
+// Not dim ker of CDElement. Not g-2.
+//
+// Run:
+//   export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+//   ./bin/souc run examples/physics/sedenion_ker_lz.sio
+
+use algebra::sedenion::{sed_basis}
+use algebra::octonion::{oct_basis}
+use algebra::sedenion_action::{sed_canonical_zd_pair, sed_embed_oct}
+use algebra::sedenion_kernel::{
+    sed_lmul_rank, sed_lmul_ker_dim, sed_lmul_basis_vanish,
+    sed_rmul_rank, sed_rmul_ker_dim,
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var z: [f64; 16] = [0.0; 16]
+    var w: [f64; 16] = [0.0; 16]
+    sed_canonical_zd_pair(&!z, &!w)
+
+    let lz_rank = sed_lmul_rank(&z)
+    let lz_ker = sed_lmul_ker_dim(&z)
+    let lz_van = sed_lmul_basis_vanish(&z)
+    let rz_rank = sed_rmul_rank(&z)
+    let rz_ker = sed_rmul_ker_dim(&z)
+    let lw_rank = sed_lmul_rank(&w)
+    let lw_ker = sed_lmul_ker_dim(&w)
+
+    var e1s: [f64; 16] = [0.0; 16]
+    sed_basis(1, &!e1s)
+    let e1_rank = sed_lmul_rank(&e1s)
+    let e1_ker = sed_lmul_ker_dim(&e1s)
+
+    var e1o = oct_basis(1)
+    var e1e: [f64; 16] = [0.0; 16]
+    sed_embed_oct(&e1o, &!e1e)
+    let emb_rank = sed_lmul_rank(&e1e)
+    let emb_ker = sed_lmul_ker_dim(&e1e)
+
+    print("KER_LZ_RANK ")
+    print_f64(lz_rank as f64)
+    print("\nKER_LZ_DIM ")
+    print_f64(lz_ker as f64)
+    print("\nKER_LZ_BASIS_VANISH ")
+    print_f64(lz_van as f64)
+    print("\nKER_RZ_RANK ")
+    print_f64(rz_rank as f64)
+    print("\nKER_RZ_DIM ")
+    print_f64(rz_ker as f64)
+    print("\nKER_LW_RANK ")
+    print_f64(lw_rank as f64)
+    print("\nKER_LW_DIM ")
+    print_f64(lw_ker as f64)
+    print("\nKER_E1_RANK ")
+    print_f64(e1_rank as f64)
+    print("\nKER_E1_DIM ")
+    print_f64(e1_ker as f64)
+    print("\nKER_EMBED_E1_RANK ")
+    print_f64(emb_rank as f64)
+    print("\nKER_EMBED_E1_DIM ")
+    print_f64(emb_ker as f64)
+    print("\n")
+
+    var ok: i64 = 1
+    if lz_rank != 12 { ok = 0 }
+    if lz_ker != 4 { ok = 0 }
+    if lz_van != 0 { ok = 0 }
+    if rz_rank != 12 { ok = 0 }
+    if rz_ker != 4 { ok = 0 }
+    if lw_rank != 12 { ok = 0 }
+    if lw_ker != 4 { ok = 0 }
+    if e1_rank != 16 { ok = 0 }
+    if e1_ker != 0 { ok = 0 }
+    if emb_rank != 16 { ok = 0 }
+    if emb_ker != 0 { ok = 0 }
+
+    print("VERDICT_KER_LZ_IS_4 ")
+    if lz_ker == 4 { print("1\n") } else { print("0\n") }
+    print("VERDICT_BASIS_NOT_THE_KERNEL ")
+    if lz_van == 0 { print("1\n") } else { print("0\n") }
+    print("VERDICT_OCT_EMBED_INVERTIBLE ")
+    if emb_ker == 0 {
+        if e1_ker == 0 { print("1\n") } else { print("0\n") }
+    } else {
+        print("0\n")
+    }
+
+    if ok == 1 { 0 } else { 1 }
+}

--- a/stdlib/algebra/sedenion_kernel.sio
+++ b/stdlib/algebra/sedenion_kernel.sio
@@ -1,0 +1,160 @@
+// stdlib/algebra/sedenion_kernel.sio
+//
+// Rank-nullity of left multiplication L_a : S → S ≅ R¹⁶.
+// Column k of the matrix is L_a(e_k) = a * e_k, via sed_mul (Convention X).
+// dim ker L_a = 16 − rank(L_a), Gaussian elimination with partial pivoting.
+//
+// This is a measurement, not Moreno, not the CD-tower native-erasure
+// conjecture (that ladder lives in examples/*projective_measurement.sio
+// and uses algebra::cayley_dickson). A miss against that ladder is a
+// reported number, not a silent pin.
+//
+// Control: L_{embed(e1)} and L_{e1} are invertible (rank 16) because
+// octonions are a division algebra and e1 is a unit in S.
+//
+// Basis-vanish count (how many L_a(e_i) have nsq 0) is NOT dim ker.
+//
+// Madaros (control ELF, 2026-08-23) on the canonical pair:
+//   L_z, R_z, L_w, R_w all rank 12, dim ker 4; basis-vanish 0.
+//   L_{e1} and L_{embed(e1)} rank 16, dim ker 0.
+// That matches the L4 row of the CD-tower projective ladder
+// (ker 4 / 16), which uses a different product module. It does
+// not match the slogan "half of 16 is 8".
+//
+// Claims forbidden: new physics; classification of zero-divisors;
+// Sounio proved Moreno; ZD solves g-2; Madaros is
+// fixed-point-verified. sed_mul remains Mut-only; no ZD effect.
+// Not dim ker of the CDElement tower. Not #2093 (two-sided/Moufang).
+
+use algebra::sedenion::{sed_mul, sed_norm_sq, sed_basis}
+use algebra::sedenion_action::{sed_lmul}
+
+fn sed_abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn sed_rank_tol() -> f64 { 1.0e-9 }
+
+/// Row-major 16×16: entry (r,c) at 16*r+c. Column c = L_a(e_c).
+pub fn sed_lmul_matrix(a: &[f64; 16], out: &![f64; 256]) with Mut {
+    var c: i64 = 0
+    while c < 16 {
+        var ek: [f64; 16] = [0.0; 16]
+        sed_basis(c, &!ek)
+        var col: [f64; 16] = [0.0; 16]
+        sed_lmul(a, &ek, &!col)
+        var r: i64 = 0
+        while r < 16 {
+            out[(16 * r + c) as usize] = col[r]
+            r = r + 1
+        }
+        c = c + 1
+    }
+}
+
+/// Row-major 16×16: column c = R_a(e_c) = e_c * a.
+pub fn sed_rmul_matrix(a: &[f64; 16], out: &![f64; 256]) with Mut {
+    var c: i64 = 0
+    while c < 16 {
+        var ek: [f64; 16] = [0.0; 16]
+        sed_basis(c, &!ek)
+        var col: [f64; 16] = [0.0; 16]
+        sed_mul(&ek, a, &!col)
+        var r: i64 = 0
+        while r < 16 {
+            out[(16 * r + c) as usize] = col[r]
+            r = r + 1
+        }
+        c = c + 1
+    }
+}
+
+/// In-place GE with partial pivoting. Returns rank over R at sed_rank_tol.
+pub fn sed_rank16(m: &![f64; 256]) -> i64 with Mut, Div, Panic {
+    let tol = sed_rank_tol()
+    var rank: i64 = 0
+    var row: i64 = 0
+    var col: i64 = 0
+    while col < 16 && row < 16 {
+        var pivot_row: i64 = 0 - 1
+        var best: f64 = tol
+        var r: i64 = row
+        while r < 16 {
+            let av = sed_abs_f(m[(16 * r + col) as usize])
+            if av > best {
+                best = av
+                pivot_row = r
+            }
+            r = r + 1
+        }
+        if pivot_row < 0 {
+            col = col + 1
+        } else {
+            if pivot_row != row {
+                var j: i64 = 0
+                while j < 16 {
+                    let aa = m[(16 * row + j) as usize]
+                    let bb = m[(16 * pivot_row + j) as usize]
+                    m[(16 * row + j) as usize] = bb
+                    m[(16 * pivot_row + j) as usize] = aa
+                    j = j + 1
+                }
+            }
+            let piv = m[(16 * row + col) as usize]
+            var rr: i64 = row + 1
+            while rr < 16 {
+                let factor = m[(16 * rr + col) as usize] / piv
+                var j: i64 = col
+                while j < 16 {
+                    let nv = m[(16 * rr + j) as usize]
+                        - factor * m[(16 * row + j) as usize]
+                    m[(16 * rr + j) as usize] = nv
+                    j = j + 1
+                }
+                rr = rr + 1
+            }
+            rank = rank + 1
+            row = row + 1
+            col = col + 1
+        }
+    }
+    rank
+}
+
+pub fn sed_lmul_rank(a: &[f64; 16]) -> i64 with Mut, Div, Panic {
+    var m: [f64; 256] = [0.0; 256]
+    sed_lmul_matrix(a, &!m)
+    sed_rank16(&!m)
+}
+
+pub fn sed_lmul_ker_dim(a: &[f64; 16]) -> i64 with Mut, Div, Panic {
+    16 - sed_lmul_rank(a)
+}
+
+pub fn sed_rmul_rank(a: &[f64; 16]) -> i64 with Mut, Div, Panic {
+    var m: [f64; 256] = [0.0; 256]
+    sed_rmul_matrix(a, &!m)
+    sed_rank16(&!m)
+}
+
+pub fn sed_rmul_ker_dim(a: &[f64; 16]) -> i64 with Mut, Div, Panic {
+    16 - sed_rmul_rank(a)
+}
+
+/// How many basis vectors satisfy ||L_a(e_i)||² ≤ tol. Not dim ker.
+pub fn sed_lmul_basis_vanish(a: &[f64; 16]) -> i64 with Mut {
+    let tol = sed_rank_tol()
+    var n: i64 = 0
+    var i: i64 = 0
+    while i < 16 {
+        var ek: [f64; 16] = [0.0; 16]
+        var out: [f64; 16] = [0.0; 16]
+        sed_basis(i, &!ek)
+        sed_lmul(a, &ek, &!out)
+        if sed_norm_sq(&out) <= tol {
+            n = n + 1
+        }
+        i = i + 1
+    }
+    n
+}

--- a/tests/run-pass/sedenion_ker_lz.sio
+++ b/tests/run-pass/sedenion_ker_lz.sio
@@ -1,0 +1,41 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 0
+//@ description: dim ker L_z = 4, rank 12, basis vanish 0; embed(e1) ker 0
+// Full Test Suite CI uses souc-stage2 (lean_single). Madaros runs this graph.
+
+use algebra::sedenion::{sed_basis}
+use algebra::octonion::{oct_basis}
+use algebra::sedenion_action::{sed_canonical_zd_pair, sed_embed_oct}
+use algebra::sedenion_kernel::{
+    sed_lmul_rank, sed_lmul_ker_dim, sed_lmul_basis_vanish,
+    sed_rmul_rank, sed_rmul_ker_dim,
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var z: [f64; 16] = [0.0; 16]
+    var w: [f64; 16] = [0.0; 16]
+    sed_canonical_zd_pair(&!z, &!w)
+
+    var ok: i64 = 1
+    if sed_lmul_rank(&z) != 12 { ok = 0 }
+    if sed_lmul_ker_dim(&z) != 4 { ok = 0 }
+    if sed_lmul_basis_vanish(&z) != 0 { ok = 0 }
+    if sed_rmul_rank(&z) != 12 { ok = 0 }
+    if sed_rmul_ker_dim(&z) != 4 { ok = 0 }
+    if sed_lmul_rank(&w) != 12 { ok = 0 }
+    if sed_lmul_ker_dim(&w) != 4 { ok = 0 }
+
+    var e1s: [f64; 16] = [0.0; 16]
+    sed_basis(1, &!e1s)
+    if sed_lmul_rank(&e1s) != 16 { ok = 0 }
+    if sed_lmul_ker_dim(&e1s) != 0 { ok = 0 }
+
+    var e1o = oct_basis(1)
+    var e1e: [f64; 16] = [0.0; 16]
+    sed_embed_oct(&e1o, &!e1e)
+    if sed_lmul_rank(&e1e) != 16 { ok = 0 }
+    if sed_lmul_ker_dim(&e1e) != 0 { ok = 0 }
+
+    if ok == 1 { 0 } else { 1 }
+}


### PR DESCRIPTION
## What

#2086 showed one vector in the kernel. This measures the dimension.

New module `stdlib/algebra/sedenion_kernel.sio`. Does **not** touch `sedenion_action.sio` (#2093).

16×16 Gaussian elimination on `L_a(e_k) = a*e_k` via `sed_mul` (Convention X).

| map | rank | dim ker | basis vanish |
|---|---:|---:|---:|
| `L_z` | **12** | **4** | **0** |
| `R_z` | **12** | **4** | — |
| `L_w` | **12** | **4** | — |
| `L_{e1}` / `L_{embed(e1)}` | **16** | **0** | **0** |

No coordinate vector lies in ker `L_z`. Counting `z*e_i=0` would have reported 0 and lied.

Agrees with the L4 row of the CD-tower projective ladder (`ker 4/16`, different product module). Disagrees with the slogan that a sedenion zero-divisor has an 8-dimensional annihilator. That slogan is not this measurement.

## Receipts (Madaros control ELF 100902241 B)

```
KER_LZ_RANK 12.000000
KER_LZ_DIM 4.000000
KER_LZ_BASIS_VANISH 0.000000
KER_EMBED_E1_DIM 0.000000
VERDICT_KER_LZ_IS_4 1
VERDICT_BASIS_NOT_THE_KERNEL 1
VERDICT_OCT_EMBED_INVERTIBLE 1
```

Example + test rc=0 (`//@ requires: madaros`).

## Claims-forbidden

New physics; Moreno classification; dim ker always n/2; ZD solves g-2; Madaros is fixed-point-verified.

Do not merge until asked.