### PR TITLE
feat(algebra): name the 4-space ker L_z

### DIFF
--- a/docs/audit/SEDENION_KER_BASIS_2026-08-23.md
+++ b/docs/audit/SEDENION_KER_BASIS_2026-08-23.md
@@ -1,0 +1,72 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.sedenion-ker-basis-2026-08-23
+authority: repo_only
+audience: users
+last_validated: 2026-08-23
+validated_by: grok-cli2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.sedenion-ker-basis-2026-08-23
+-->
+
+# Named 4-space of ker L_z
+
+```text
+Semantic-Lane-ID: sedenion-ker-basis-20260823
+Owner: grok-cli2
+Concept-IDs: SOUNIO-NONASSOCIATIVE-ORDER
+Intent-Preserved: a named spanning set is a measurement of L_z, not a
+  classification of zero-divisors and not Moreno
+Transformation: scan e_i ± e_j; pin the four pair-type hits as
+  generators; rank of the 16×4 matrix is 4; generator 0 is canonical w
+Types-Changed: none
+Effects-Changed: none
+IR-Changed: none
+Claims-Introduced: Sounio computes L_z(g_k)=0 for
+  g = {e6−e15, e4+e13, e5−e12, e7+e14}; span rank 4; L_{e1} nsq 2;
+  the e_i±e_j scan has exactly four hits
+Claims-Forbidden: new physics; unique orthonormal kernel basis;
+  Sounio proved Moreno; ZD solves g-2; Madaros is fixed-point-verified
+Assumptions: Convention X; GE tolerance 1e-9; pair-type scan is not
+  an enumeration of all of ℝ¹⁶
+Write-Set: stdlib/algebra/sedenion_kernel.sio,
+  examples/physics/sedenion_ker_basis.sio,
+  tests/run-pass/sedenion_ker_basis.sio, this file
+Read-Set: docs/audit/SEDENION_KER_LZ_2026-08-23.md
+Positive-Witness: souc run prints span rank 4, all L_z nsq 0,
+  G0 equals w, L_e1 nsq 2
+Negative-Witness: coordinate vectors are not in the kernel; g-2 is
+  not this lane
+Acceptance-Gate: tests/run-pass/sedenion_ker_basis.sio exit 0 under Madaros
+Integration-Target: origin/main
+Authoritative-Only-If: the nsqs and rank are produced by Madaros
+```
+
+## What this is
+
+#2095 measured `dim ker L_z = 4` and `basis-vanish = 0`. This names
+the 4-space. A scan of `e_i ± e_j` (`i < j`) finds **exactly four**
+hits. They are independent (span rank 4). Generator 0 is canonical `w`.
+
+| k | generator | notes |
+|---|---|---|
+| 0 | `e₆ − e₁₅` | canonical `w` |
+| 1 | `e₄ + e₁₃` | |
+| 2 | `e₅ − e₁₂` | |
+| 3 | `e₇ + e₁₄` | |
+
+Each has `‖g‖² = 2`, `L_z(g) = 0`, `L_{e1}(g)` nsq **2** (the unit
+does not annihilate). **Exactly four** is the `e_i ± e_j` (`i < j`)
+scan, not an enumeration of ℝ¹⁶. This is **a** basis of pair-type
+vectors, not uniqueness in ℝ¹⁶.
+
+## Receipts (2026-08-23)
+
+Control ELF `/workspace/sounio/bin/madaros-linux-x86_64` (100902241 B).
+
+Scan: 4 hits, greedy keep 4, final rank 4.
+
+LLM-offload math-review (`/tmp/llm-offload-zA3jCY`):
+
+- xAI grok-4.3: four `[OK]`; one `[TIGHTENABLE]` on "exactly four hits"
+  — already scoped to the pair scan; sentence now says so explicitly.
+- Z.AI: weekly quota exhausted until 2026-08-25 06:34:36.
+- Outcome: **PASS_SINGLE_PROVIDER_DEGRADED**.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -379,6 +379,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.runtime-gc-capability-honesty-2026-08-18 | repo_only | docs/audit/RUNTIME_GC_CAPABILITY_HONESTY_2026-08-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.rust-macro-acceptance-2026-08-20 | repo_only | docs/audit/RUST_MACRO_ACCEPTANCE_2026-08-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-artin-2026-08-23 | repo_only | docs/audit/SEDENION_ARTIN_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.sedenion-ker-basis-2026-08-23 | repo_only | docs/audit/SEDENION_KER_BASIS_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-ker-lz-2026-08-23 | repo_only | docs/audit/SEDENION_KER_LZ_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-zd-action-2026-08-23 | repo_only | docs/audit/SEDENION_ZD_ACTION_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-zd-twosided-moufang-2026-08-23 | repo_only | docs/audit/SEDENION_ZD_TWOSIDED_MOUFANG_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8181,6 +8181,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.sedenion-ker-basis-2026-08-23",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/SEDENION_KER_BASIS_2026-08-23.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.sedenion-ker-lz-2026-08-23",
       "collection": "repo",
       "repo_doc_path": "docs/audit/SEDENION_KER_LZ_2026-08-23.md",

--- a/examples/physics/sedenion_ker_basis.sio
+++ b/examples/physics/sedenion_ker_basis.sio
@@ -1,0 +1,111 @@
+//@ run-pass
+//@ description: named 4-space ker L_z: e6−e15, e4+e13, e5−e12, e7+e14
+//
+// Scan of e_i ± e_j finds exactly these four; they span (rank 4).
+// Generator 0 is canonical w. Each has ||g||²=2, L_z(g)=0,
+// L_{e1}(g) nsq 2. Not a classification. Not Moreno. Not g-2.
+//
+// Run:
+//   export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+//   ./bin/souc run examples/physics/sedenion_ker_basis.sio
+
+use algebra::sedenion::{sed_norm_sq, sed_basis}
+use algebra::sedenion_action::{sed_canonical_zd_pair}
+use algebra::sedenion_kernel::{
+    sed_ker_lz_gen, sed_ker_lz_span_rank, sed_lmul_vec_nsq,
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var z: [f64; 16] = [0.0; 16]
+    var w: [f64; 16] = [0.0; 16]
+    sed_canonical_zd_pair(&!z, &!w)
+    var e1: [f64; 16] = [0.0; 16]
+    sed_basis(1, &!e1)
+
+    var g0: [f64; 16] = [0.0; 16]
+    var g1: [f64; 16] = [0.0; 16]
+    var g2: [f64; 16] = [0.0; 16]
+    var g3: [f64; 16] = [0.0; 16]
+    sed_ker_lz_gen(0, &!g0)
+    sed_ker_lz_gen(1, &!g1)
+    sed_ker_lz_gen(2, &!g2)
+    sed_ker_lz_gen(3, &!g3)
+
+    var dw = 0.0
+    var t: i64 = 0
+    while t < 16 {
+        let x = g0[t] - w[t]
+        dw = dw + x * x
+        t = t + 1
+    }
+    let span = sed_ker_lz_span_rank()
+
+    print("KER_G0_EQ_W_NSQ ")
+    print_f64(dw)
+    print("\nKER_G0_NSQ ")
+    print_f64(sed_norm_sq(&g0))
+    print("\nKER_G1_NSQ ")
+    print_f64(sed_norm_sq(&g1))
+    print("\nKER_G2_NSQ ")
+    print_f64(sed_norm_sq(&g2))
+    print("\nKER_G3_NSQ ")
+    print_f64(sed_norm_sq(&g3))
+    print("\nKER_G0_LZ_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&z, &g0))
+    print("\nKER_G1_LZ_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&z, &g1))
+    print("\nKER_G2_LZ_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&z, &g2))
+    print("\nKER_G3_LZ_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&z, &g3))
+    print("\nKER_G0_E1_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&e1, &g0))
+    print("\nKER_G1_E1_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&e1, &g1))
+    print("\nKER_G2_E1_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&e1, &g2))
+    print("\nKER_G3_E1_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&e1, &g3))
+    print("\nKER_SPAN_RANK ")
+    print_f64(span as f64)
+    print("\n")
+
+    var ok: i64 = 1
+    if dw > 1.0e-9 { ok = 0 }
+    if abs_f(sed_norm_sq(&g0) - 2.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_norm_sq(&g1) - 2.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_norm_sq(&g2) - 2.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_norm_sq(&g3) - 2.0) > 1.0e-9 { ok = 0 }
+    if sed_lmul_vec_nsq(&z, &g0) > 1.0e-9 { ok = 0 }
+    if sed_lmul_vec_nsq(&z, &g1) > 1.0e-9 { ok = 0 }
+    if sed_lmul_vec_nsq(&z, &g2) > 1.0e-9 { ok = 0 }
+    if sed_lmul_vec_nsq(&z, &g3) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_lmul_vec_nsq(&e1, &g0) - 2.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_lmul_vec_nsq(&e1, &g1) - 2.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_lmul_vec_nsq(&e1, &g2) - 2.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_lmul_vec_nsq(&e1, &g3) - 2.0) > 1.0e-9 { ok = 0 }
+    if span != 4 { ok = 0 }
+
+    print("VERDICT_G0_IS_W ")
+    if dw <= 1.0e-9 { print("1\n") } else { print("0\n") }
+    print("VERDICT_ALL_IN_KER_LZ ")
+    if sed_lmul_vec_nsq(&z, &g0) <= 1.0e-9 {
+        if sed_lmul_vec_nsq(&z, &g1) <= 1.0e-9 {
+            if sed_lmul_vec_nsq(&z, &g2) <= 1.0e-9 {
+                if sed_lmul_vec_nsq(&z, &g3) <= 1.0e-9 { print("1\n") } else { print("0\n") }
+            } else { print("0\n") }
+        } else { print("0\n") }
+    } else { print("0\n") }
+    print("VERDICT_SPAN_RANK_4 ")
+    if span == 4 { print("1\n") } else { print("0\n") }
+    print("VERDICT_E1_DOES_NOT_ANNIHILATE ")
+    if abs_f(sed_lmul_vec_nsq(&e1, &g0) - 2.0) <= 1.0e-9 {
+        if abs_f(sed_lmul_vec_nsq(&e1, &g3) - 2.0) <= 1.0e-9 { print("1\n") } else { print("0\n") }
+    } else { print("0\n") }
+
+    if ok == 1 { 0 } else { 1 }
+}

--- a/stdlib/algebra/sedenion_kernel.sio
+++ b/stdlib/algebra/sedenion_kernel.sio
@@ -21,6 +21,15 @@
 // (ker 4 / 16), which uses a different product module. It does
 // not match the slogan "half of 16 is 8".
 //
+// Named 4-space (Madaros scan of e_i ± e_j, 2026-08-23): exactly four
+// pair-type hits, rank 4. Generator 0 is canonical w.
+//   g0 = e6 − e15
+//   g1 = e4 + e13
+//   g2 = e5 − e12
+//   g3 = e7 + e14
+// Each has ||g||² = 2, L_z(g)=0, L_{e1}(g) nsq 2. This is a basis,
+// not a classification, not uniqueness among all of ℝ¹⁶.
+//
 // Claims forbidden: new physics; classification of zero-divisors;
 // Sounio proved Moreno; ZD solves g-2; Madaros is
 // fixed-point-verified. sed_mul remains Mut-only; no ZD effect.
@@ -157,4 +166,57 @@ pub fn sed_lmul_basis_vanish(a: &[f64; 16]) -> i64 with Mut {
         i = i + 1
     }
     n
+}
+
+fn sed_zero16(out: &![f64; 16]) with Mut {
+    var i: i64 = 0
+    while i < 16 {
+        out[i] = 0.0
+        i = i + 1
+    }
+}
+
+/// Pair-type basis of ker L_z found by scanning e_i ± e_j.
+/// k in 0..3. Generator 0 is canonical w = e6 − e15.
+pub fn sed_ker_lz_gen(k: i64, out: &![f64; 16]) with Mut {
+    sed_zero16(out)
+    if k == 0 {
+        out[6] = 1.0
+        out[15] = 0.0 - 1.0
+    }
+    if k == 1 {
+        out[4] = 1.0
+        out[13] = 1.0
+    }
+    if k == 2 {
+        out[5] = 1.0
+        out[12] = 0.0 - 1.0
+    }
+    if k == 3 {
+        out[7] = 1.0
+        out[14] = 1.0
+    }
+}
+
+/// Rank of the 16×4 matrix whose columns are the four generators.
+pub fn sed_ker_lz_span_rank() -> i64 with Mut, Div, Panic {
+    var m: [f64; 256] = [0.0; 256]
+    var c: i64 = 0
+    while c < 4 {
+        var g: [f64; 16] = [0.0; 16]
+        sed_ker_lz_gen(c, &!g)
+        var r: i64 = 0
+        while r < 16 {
+            m[(16 * r + c) as usize] = g[r]
+            r = r + 1
+        }
+        c = c + 1
+    }
+    sed_rank16(&!m)
+}
+
+pub fn sed_lmul_vec_nsq(a: &[f64; 16], v: &[f64; 16]) -> f64 with Mut {
+    var out: [f64; 16] = [0.0; 16]
+    sed_lmul(a, v, &!out)
+    sed_norm_sq(&out)
 }

--- a/tests/run-pass/sedenion_ker_basis.sio
+++ b/tests/run-pass/sedenion_ker_basis.sio
@@ -1,0 +1,47 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 0
+//@ description: ker L_z spanned by e6−e15, e4+e13, e5−e12, e7+e14
+// Full Test Suite CI uses souc-stage2 (lean_single). Madaros runs this graph.
+
+use algebra::sedenion::{sed_norm_sq, sed_basis}
+use algebra::sedenion_action::{sed_canonical_zd_pair}
+use algebra::sedenion_kernel::{
+    sed_ker_lz_gen, sed_ker_lz_span_rank, sed_lmul_vec_nsq,
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var z: [f64; 16] = [0.0; 16]
+    var w: [f64; 16] = [0.0; 16]
+    sed_canonical_zd_pair(&!z, &!w)
+    var e1: [f64; 16] = [0.0; 16]
+    sed_basis(1, &!e1)
+
+    var ok: i64 = 1
+    var k: i64 = 0
+    while k < 4 {
+        var g: [f64; 16] = [0.0; 16]
+        sed_ker_lz_gen(k, &!g)
+        if abs_f(sed_norm_sq(&g) - 2.0) > 1.0e-9 { ok = 0 }
+        if sed_lmul_vec_nsq(&z, &g) > 1.0e-9 { ok = 0 }
+        if abs_f(sed_lmul_vec_nsq(&e1, &g) - 2.0) > 1.0e-9 { ok = 0 }
+        if k == 0 {
+            var dw = 0.0
+            var t: i64 = 0
+            while t < 16 {
+                let x = g[t] - w[t]
+                dw = dw + x * x
+                t = t + 1
+            }
+            if dw > 1.0e-9 { ok = 0 }
+        }
+        k = k + 1
+    }
+    if sed_ker_lz_span_rank() != 4 { ok = 0 }
+
+    if ok == 1 { 0 } else { 1 }
+}


### PR DESCRIPTION
## What

#2095 measured `dim ker L_z = 4` and `basis-vanish = 0`. This names the 4-space.

Scan of `e_i ± e_j` (`i < j`) finds **exactly four** hits. Span rank **4**. Generator 0 is canonical `w`.

| k | generator |
|---|---|
| 0 | `e6 − e15` (`w`) |
| 1 | `e4 + e13` |
| 2 | `e5 − e12` |
| 3 | `e7 + e14` |

Each: `‖g‖² = 2`, `L_z(g) = 0`, `L_{e1}(g)` nsq **2**. Pair-type basis, not uniqueness in ℝ¹⁶. Not Moreno.

## Receipts (Madaros control ELF 100902241 B)

```
KER_G0_EQ_W_NSQ 0.000000
KER_G*_NSQ 2.000000
KER_G*_LZ_NSQ 0.000000
KER_G*_E1_NSQ 2.000000
KER_SPAN_RANK 4.000000
VERDICT_* 1
```

Example + test rc=0 (`//@ requires: madaros`).

## Claims-forbidden

New physics; unique orthonormal kernel basis; Moreno; ZD solves g-2; Madaros is fixed-point-verified.

Do not merge until asked.