### PR TITLE
feat(algebra): ker L_z equals ker R_z for canonical z

### DIFF
--- a/docs/audit/SEDENION_KER_INTERSECT_2026-08-23.md
+++ b/docs/audit/SEDENION_KER_INTERSECT_2026-08-23.md
@@ -1,0 +1,67 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.sedenion-ker-intersect-2026-08-23
+authority: repo_only
+audience: users
+last_validated: 2026-08-23
+validated_by: grok-cli2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.sedenion-ker-intersect-2026-08-23
+-->
+
+# Two-sided annihilator of canonical z — intersection dim 4
+
+```text
+Semantic-Lane-ID: sedenion-ker-intersect-20260823
+Owner: grok-cli2
+Concept-IDs: SOUNIO-NONASSOCIATIVE-ORDER
+Intent-Preserved: equal left/right kernels for this z is a
+  measurement, not a classification of zero-divisors
+Transformation: map the named ker L_z basis through R_z; rank of
+  those four images is 0; intersection dim = 4 − 0 = 4
+Types-Changed: none
+Effects-Changed: none
+IR-Changed: none
+Claims-Introduced: Sounio computes v*z=0 for each of the four
+  pair-type generators; R-image rank 0; dim(ker L_z ∩ ker R_z)=4;
+  dim ker R_z=4, so the two kernels coincide for this z
+Claims-Forbidden: new physics; every sedenion ZD has ker L = ker R;
+  Moreno; ZD solves g-2; Madaros is fixed-point-verified
+Assumptions: Convention X; named basis from #2096; GE tolerance 1e-9
+Write-Set: stdlib/algebra/sedenion_annihilator.sio,
+  examples/physics/sedenion_ker_intersect.sio,
+  tests/run-pass/sedenion_ker_intersect.sio, this file
+Read-Set: stdlib/algebra/sedenion_kernel.sio,
+  docs/audit/SEDENION_KER_BASIS_2026-08-23.md
+Positive-Witness: souc run prints INTERSECT_DIM 4, R_IMAGE_RANK 0,
+  each K L 0 R 0 RE1 2
+Negative-Witness: L_{e1} / R_{e1} do not annihilate; g-2 is not
+  this lane
+Acceptance-Gate: tests/run-pass/sedenion_ker_intersect.sio exit 0
+  under Madaros
+Integration-Target: origin/main after #2096
+Authoritative-Only-If: the nsqs and ranks are produced by Madaros
+```
+
+## What this is
+
+#2093 showed the *pair* `(z,w)` is two-sided. #2095 showed
+`dim ker L_z = dim ker R_z = 4`. #2096 named a basis of `ker L_z`.
+Those facts do not decide whether the two 4-spaces are the same.
+
+A vector `Σ a_k g_k` in `ker L_z` lies in `ker R_z` iff
+`Σ a_k R_z(g_k) = 0`. Each column `R_z(g_k)` has nsq **0** (the
+16×4 matrix is the zero matrix, not merely rank-deficient). Rank
+**0**. Intersection dimension is **4**. Combined with
+`dim ker R_z = 4`, `ker L_z = ker R_z` **for this z**.
+
+Not a statement about every zero-divisor.
+
+## Receipts (2026-08-23)
+
+Control ELF `/workspace/sounio/bin/madaros-linux-x86_64` (100902241 B).
+
+LLM-offload math-review (`/tmp/llm-offload-L7pkqp`):
+
+- xAI grok-4.3: three `[OK]`; one `[TIGHTENABLE]` on reporting only rank 0
+  — text now states each column nsq is 0 (zero matrix).
+- Z.AI: weekly quota exhausted until 2026-08-25 06:34:36.
+- Outcome: **PASS_SINGLE_PROVIDER_DEGRADED**.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -380,6 +380,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.rust-macro-acceptance-2026-08-20 | repo_only | docs/audit/RUST_MACRO_ACCEPTANCE_2026-08-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-artin-2026-08-23 | repo_only | docs/audit/SEDENION_ARTIN_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-ker-basis-2026-08-23 | repo_only | docs/audit/SEDENION_KER_BASIS_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.sedenion-ker-intersect-2026-08-23 | repo_only | docs/audit/SEDENION_KER_INTERSECT_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-ker-lz-2026-08-23 | repo_only | docs/audit/SEDENION_KER_LZ_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-zd-action-2026-08-23 | repo_only | docs/audit/SEDENION_ZD_ACTION_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-zd-twosided-moufang-2026-08-23 | repo_only | docs/audit/SEDENION_ZD_TWOSIDED_MOUFANG_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8204,6 +8204,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.sedenion-ker-intersect-2026-08-23",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/SEDENION_KER_INTERSECT_2026-08-23.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.sedenion-ker-lz-2026-08-23",
       "collection": "repo",
       "repo_doc_path": "docs/audit/SEDENION_KER_LZ_2026-08-23.md",

--- a/examples/physics/sedenion_ker_intersect.sio
+++ b/examples/physics/sedenion_ker_intersect.sio
@@ -1,0 +1,79 @@
+//@ run-pass
+//@ description: ker L_z ∩ ker R_z has dim 4; named 4-space is two-sided for z
+//
+// The four pair-type generators of ker L_z also satisfy v*z = 0.
+// Rank of columns R_z(g_k) is 0, so intersection dim = 4 − 0 = 4.
+// Combined with dim ker R_z = 4, the two kernels coincide for this z.
+// Not every zero-divisor. Not Moreno. Not g-2.
+//
+// Run:
+//   export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+//   ./bin/souc run examples/physics/sedenion_ker_intersect.sio
+
+use algebra::sedenion::{sed_basis}
+use algebra::sedenion_action::{sed_canonical_zd_pair}
+use algebra::sedenion_kernel::{sed_ker_lz_gen, sed_lmul_vec_nsq, sed_rmul_ker_dim}
+use algebra::sedenion_annihilator::{
+    sed_rmul_vec_nsq, sed_ker_z_rimage_rank, sed_ker_z_intersect_dim,
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var z: [f64; 16] = [0.0; 16]
+    var w: [f64; 16] = [0.0; 16]
+    sed_canonical_zd_pair(&!z, &!w)
+    var e1: [f64; 16] = [0.0; 16]
+    sed_basis(1, &!e1)
+
+    var ok: i64 = 1
+    var k: i64 = 0
+    while k < 4 {
+        var g: [f64; 16] = [0.0; 16]
+        sed_ker_lz_gen(k, &!g)
+        let ln = sed_lmul_vec_nsq(&z, &g)
+        let rn = sed_rmul_vec_nsq(&g, &z)
+        let en = sed_rmul_vec_nsq(&g, &e1)
+        print("K ")
+        print_f64(k as f64)
+        print(" L ")
+        print_f64(ln)
+        print(" R ")
+        print_f64(rn)
+        print(" RE1 ")
+        print_f64(en)
+        print("\n")
+        if ln > 1.0e-9 { ok = 0 }
+        if rn > 1.0e-9 { ok = 0 }
+        if abs_f(en - 2.0) > 1.0e-9 { ok = 0 }
+        k = k + 1
+    }
+
+    let img = sed_ker_z_rimage_rank()
+    let dim = sed_ker_z_intersect_dim()
+    let rker = sed_rmul_ker_dim(&z)
+    print("R_IMAGE_RANK ")
+    print_f64(img as f64)
+    print("\nINTERSECT_DIM ")
+    print_f64(dim as f64)
+    print("\nKER_RZ_DIM ")
+    print_f64(rker as f64)
+    print("\n")
+
+    if img != 0 { ok = 0 }
+    if dim != 4 { ok = 0 }
+    if rker != 4 { ok = 0 }
+
+    print("VERDICT_ALL_FOUR_TWOSIDED ")
+    if ok == 1 { print("1\n") } else { print("0\n") }
+    print("VERDICT_INTERSECTION_DIM_4 ")
+    if dim == 4 { print("1\n") } else { print("0\n") }
+    print("VERDICT_KERNELS_COINCIDE ")
+    if dim == 4 {
+        if rker == 4 { print("1\n") } else { print("0\n") }
+    } else { print("0\n") }
+
+    if ok == 1 { 0 } else { 1 }
+}

--- a/stdlib/algebra/sedenion_annihilator.sio
+++ b/stdlib/algebra/sedenion_annihilator.sio
@@ -1,0 +1,48 @@
+// stdlib/algebra/sedenion_annihilator.sio
+//
+// Two-sided annihilator of the canonical z: ker L_z ∩ ker R_z.
+// The four pair-type generators of ker L_z (#2096) are a basis of that
+// 4-space. Map coefficients through R_z: columns R_z(g_k). If that
+// 16×4 matrix has rank r, dim(intersection) = 4 − r.
+//
+// Madaros (2026-08-23): each R_z(g_k)=0, r=0, intersection dim 4.
+// Combined with dim ker R_z = 4 (#2095), ker L_z = ker R_z as subspaces
+// for this z. Not a statement about every zero-divisor.
+//
+// Claims forbidden: new physics; classification; ZD solves g-2;
+// Madaros is fixed-point-verified; every sedenion ZD has equal
+// left/right kernels. sed_mul remains Mut-only.
+
+use algebra::sedenion::{sed_mul, sed_norm_sq, sed_zd_z}
+use algebra::sedenion_kernel::{sed_ker_lz_gen, sed_rank16}
+
+pub fn sed_rmul_vec_nsq(v: &[f64; 16], a: &[f64; 16]) -> f64 with Mut {
+    var out: [f64; 16] = [0.0; 16]
+    sed_mul(v, a, &!out)
+    sed_norm_sq(&out)
+}
+
+/// Rank of the 16×4 matrix with columns R_z(g_k), g_k the named basis.
+pub fn sed_ker_z_rimage_rank() -> i64 with Mut, Div, Panic {
+    var z: [f64; 16] = [0.0; 16]
+    sed_zd_z(&!z)
+    var m: [f64; 256] = [0.0; 256]
+    var k: i64 = 0
+    while k < 4 {
+        var g: [f64; 16] = [0.0; 16]
+        sed_ker_lz_gen(k, &!g)
+        var rz: [f64; 16] = [0.0; 16]
+        sed_mul(&g, &z, &!rz)
+        var r: i64 = 0
+        while r < 16 {
+            m[(16 * r + k) as usize] = rz[r]
+            r = r + 1
+        }
+        k = k + 1
+    }
+    sed_rank16(&!m)
+}
+
+pub fn sed_ker_z_intersect_dim() -> i64 with Mut, Div, Panic {
+    4 - sed_ker_z_rimage_rank()
+}

--- a/tests/run-pass/sedenion_ker_intersect.sio
+++ b/tests/run-pass/sedenion_ker_intersect.sio
@@ -1,0 +1,40 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 0
+//@ description: ker L_z ∩ ker R_z dim 4; each named generator has v*z=0
+// Full Test Suite CI uses souc-stage2 (lean_single). Madaros runs this graph.
+
+use algebra::sedenion::{sed_basis}
+use algebra::sedenion_action::{sed_canonical_zd_pair}
+use algebra::sedenion_kernel::{sed_ker_lz_gen, sed_lmul_vec_nsq, sed_rmul_ker_dim}
+use algebra::sedenion_annihilator::{
+    sed_rmul_vec_nsq, sed_ker_z_rimage_rank, sed_ker_z_intersect_dim,
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var z: [f64; 16] = [0.0; 16]
+    var w: [f64; 16] = [0.0; 16]
+    sed_canonical_zd_pair(&!z, &!w)
+    var e1: [f64; 16] = [0.0; 16]
+    sed_basis(1, &!e1)
+
+    var ok: i64 = 1
+    var k: i64 = 0
+    while k < 4 {
+        var g: [f64; 16] = [0.0; 16]
+        sed_ker_lz_gen(k, &!g)
+        if sed_lmul_vec_nsq(&z, &g) > 1.0e-9 { ok = 0 }
+        if sed_rmul_vec_nsq(&g, &z) > 1.0e-9 { ok = 0 }
+        if abs_f(sed_rmul_vec_nsq(&g, &e1) - 2.0) > 1.0e-9 { ok = 0 }
+        k = k + 1
+    }
+    if sed_ker_z_rimage_rank() != 0 { ok = 0 }
+    if sed_ker_z_intersect_dim() != 4 { ok = 0 }
+    if sed_rmul_ker_dim(&z) != 4 { ok = 0 }
+
+    if ok == 1 { 0 } else { 1 }
+}


### PR DESCRIPTION
## What

Stacked on #2096. The named 4-space of `ker L_z` is asked whether it sits in `ker R_z`.

Each generator `g_k` has `g_k * z = 0` (nsq 0). The 16×4 matrix with columns `R_z(g_k)` is the **zero matrix** (rank 0), not merely rank-deficient. Intersection dim = 4 − 0 = **4**. Combined with `dim ker R_z = 4`, `ker L_z = ker R_z` **for this z**.

`R_{e1}(g_k)` nsq **2** (control).

Not every zero-divisor. Not Moreno. Not g-2.

## Receipts (Madaros control ELF 100902241 B)

```
K 0..3 L 0 R 0 RE1 2
R_IMAGE_RANK 0.000000
INTERSECT_DIM 4.000000
KER_RZ_DIM 4.000000
VERDICT_KERNELS_COINCIDE 1
```

Example + test rc=0 (`//@ requires: madaros`).

## Merge

Merge **#2096 first**, then retarget this PR at `main` (or merge this into the #2096 branch). Do not merge until asked.