### PR TITLE
feat(algebra): ker L_z ∩ ker L_w is {0}

### DIFF
--- a/docs/audit/SEDENION_KER_LW_2026-08-23.md
+++ b/docs/audit/SEDENION_KER_LW_2026-08-23.md
@@ -1,0 +1,73 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.sedenion-ker-lw-2026-08-23
+authority: repo_only
+audience: users
+last_validated: 2026-08-23
+validated_by: grok-cli2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.sedenion-ker-lw-2026-08-23
+-->
+
+# ker L_z ∩ ker L_w is {0}
+
+```text
+Semantic-Lane-ID: sedenion-ker-lw-20260823
+Owner: grok-cli2
+Concept-IDs: SOUNIO-NONASSOCIATIVE-ORDER
+Intent-Preserved: two 4-dimensional kernels of a pair are not assumed
+  equal; intersection is measured
+Transformation: restrict L_w to the named ker L_z basis; rank 4
+  implies intersection dim 0
+Types-Changed: none
+Effects-Changed: none
+IR-Changed: none
+Claims-Introduced: Sounio computes L_w(g_k) nsq in {4,8} on the four
+  generators (none zero); L_w(z)=0; rank(L_w on ker L_z)=4;
+  dim(ker L_z ∩ ker L_w)=0
+Claims-Forbidden: new physics; complementary in R^16; every ZD pair
+  has disjoint kernels; Moreno; ZD solves g-2; Madaros is
+  fixed-point-verified
+Assumptions: Convention X; named basis from #2096; GE tolerance 1e-9
+Write-Set: stdlib/algebra/sedenion_annihilator.sio,
+  examples/physics/sedenion_ker_lw.sio,
+  tests/run-pass/sedenion_ker_lw.sio, this file
+Read-Set: docs/audit/SEDENION_KER_INTERSECT_2026-08-23.md
+Positive-Witness: souc run prints INTERSECT_LZ_LW_DIM 0,
+  LW_ON_LZ_RANK 4, LW_ON_Z 0, WW_NSQ 4
+Negative-Witness: g-2 is not this lane
+Acceptance-Gate: tests/run-pass/sedenion_ker_lw.sio exit 0 under Madaros
+Integration-Target: origin/main
+Authoritative-Only-If: the nsqs and ranks are produced by Madaros
+```
+
+## What this is
+
+#2097 showed `ker L_z = ker R_z` for canonical `z`. The same question
+for `w` is a different 4-space: `w*w` has nsq 4, so `w ∉ ker L_w`,
+while `w ∈ ker L_z`. The spaces cannot coincide.
+
+The remaining number is the intersection. Restriction of `L_w` to the
+named `ker L_z` basis has GE rank **4** (the four images are linearly
+independent at tolerance 1e-9, not merely each nonzero), so
+`dim(ker L_z ∩ ker L_w) = 0`. Computationally witnessed, not a Lean
+identity.
+
+`z` itself lives in `ker L_w` (and `ker R_w`), not in `ker L_z`.
+
+## Receipts (2026-08-23)
+
+Control ELF `/workspace/sounio/bin/madaros-linux-x86_64` (100902241 B).
+
+| k | `L_w(g_k)` nsq |
+|---|---:|
+| 0 (`w`) | **4** |
+| 1 | **8** |
+| 2 | **8** |
+| 3 | **4** |
+
+LLM-offload math-review (`/tmp/llm-offload-AF1P4G`):
+
+- xAI grok-4.3: three `[OK]`; `[TIGHTENABLE]` that nonzero nsqs are not
+  full rank — rank 4 is GE of the four images; `[OVERREACH]` if treated
+  as a Lean identity — text now says computationally witnessed.
+- Z.AI: weekly quota exhausted until 2026-08-25 06:34:36.
+- Outcome: **PASS_SINGLE_PROVIDER_DEGRADED**.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -382,6 +382,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.sedenion-artin-2026-08-23 | repo_only | docs/audit/SEDENION_ARTIN_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-ker-basis-2026-08-23 | repo_only | docs/audit/SEDENION_KER_BASIS_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-ker-intersect-2026-08-23 | repo_only | docs/audit/SEDENION_KER_INTERSECT_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.sedenion-ker-lw-2026-08-23 | repo_only | docs/audit/SEDENION_KER_LW_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-ker-lz-2026-08-23 | repo_only | docs/audit/SEDENION_KER_LZ_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-zd-action-2026-08-23 | repo_only | docs/audit/SEDENION_ZD_ACTION_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-zd-twosided-moufang-2026-08-23 | repo_only | docs/audit/SEDENION_ZD_TWOSIDED_MOUFANG_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8250,6 +8250,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.sedenion-ker-lw-2026-08-23",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/SEDENION_KER_LW_2026-08-23.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.sedenion-ker-lz-2026-08-23",
       "collection": "repo",
       "repo_doc_path": "docs/audit/SEDENION_KER_LZ_2026-08-23.md",

--- a/examples/physics/sedenion_ker_lw.sio
+++ b/examples/physics/sedenion_ker_lw.sio
@@ -1,0 +1,84 @@
+//@ run-pass
+//@ description: ker L_z ∩ ker L_w is 0; the two 4-spaces are distinct
+//
+// w is in ker L_z and not in ker L_w (w*w nsq 4). z is in ker L_w
+// and not in ker L_z (z*z nsq 4). Restriction of L_w to the named
+// ker L_z basis has rank 4, so the intersection is {0}.
+// Not the same 4-space. Not every ZD. Not g-2.
+//
+// Run:
+//   export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+//   ./bin/souc run examples/physics/sedenion_ker_lw.sio
+
+use algebra::sedenion::{sed_norm_sq}
+use algebra::sedenion_action::{sed_canonical_zd_pair}
+use algebra::sedenion_kernel::{sed_ker_lz_gen, sed_lmul_vec_nsq, sed_lmul_ker_dim}
+use algebra::sedenion_annihilator::{
+    sed_rmul_vec_nsq, sed_ker_lw_on_lz_rank, sed_ker_lz_lw_intersect_dim,
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var z: [f64; 16] = [0.0; 16]
+    var w: [f64; 16] = [0.0; 16]
+    sed_canonical_zd_pair(&!z, &!w)
+
+    var ok: i64 = 1
+    var k: i64 = 0
+    while k < 4 {
+        var g: [f64; 16] = [0.0; 16]
+        sed_ker_lz_gen(k, &!g)
+        let ln = sed_lmul_vec_nsq(&w, &g)
+        print("K ")
+        print_f64(k as f64)
+        print(" LW ")
+        print_f64(ln)
+        print("\n")
+        if ln <= 1.0e-9 { ok = 0 }
+        k = k + 1
+    }
+
+    let zz = sed_lmul_vec_nsq(&z, &z)
+    let ww = sed_lmul_vec_nsq(&w, &w)
+    let lwz = sed_lmul_vec_nsq(&w, &z)
+    let rwz = sed_rmul_vec_nsq(&z, &w)
+    let img = sed_ker_lw_on_lz_rank()
+    let dim = sed_ker_lz_lw_intersect_dim()
+    let wker = sed_lmul_ker_dim(&w)
+
+    print("ZZ_NSQ ")
+    print_f64(zz)
+    print("\nWW_NSQ ")
+    print_f64(ww)
+    print("\nLW_ON_Z ")
+    print_f64(lwz)
+    print("\nRW_ON_Z ")
+    print_f64(rwz)
+    print("\nLW_ON_LZ_RANK ")
+    print_f64(img as f64)
+    print("\nINTERSECT_LZ_LW_DIM ")
+    print_f64(dim as f64)
+    print("\nKER_LW_DIM ")
+    print_f64(wker as f64)
+    print("\n")
+
+    if abs_f(zz - 4.0) > 1.0e-9 { ok = 0 }
+    if abs_f(ww - 4.0) > 1.0e-9 { ok = 0 }
+    if lwz > 1.0e-9 { ok = 0 }
+    if rwz > 1.0e-9 { ok = 0 }
+    if img != 4 { ok = 0 }
+    if dim != 0 { ok = 0 }
+    if wker != 4 { ok = 0 }
+
+    print("VERDICT_NOT_THE_SAME_SPACE ")
+    if abs_f(ww - 4.0) <= 1.0e-9 { print("1\n") } else { print("0\n") }
+    print("VERDICT_INTERSECTION_ZERO ")
+    if dim == 0 { print("1\n") } else { print("0\n") }
+    print("VERDICT_Z_IN_KER_LW ")
+    if lwz <= 1.0e-9 { print("1\n") } else { print("0\n") }
+
+    if ok == 1 { 0 } else { 1 }
+}

--- a/stdlib/algebra/sedenion_annihilator.sio
+++ b/stdlib/algebra/sedenion_annihilator.sio
@@ -9,11 +9,15 @@
 // Combined with dim ker R_z = 4 (#2095), ker L_z = ker R_z as subspaces
 // for this z. Not a statement about every zero-divisor.
 //
+// ker L_w is a different 4-space: w is in ker L_z but w*w has nsq 4,
+// so w is not in ker L_w. z is in ker L_w. Restriction of L_w to the
+// named ker L_z basis has rank 4, so ker L_z ∩ ker L_w = {0}.
+//
 // Claims forbidden: new physics; classification; ZD solves g-2;
 // Madaros is fixed-point-verified; every sedenion ZD has equal
 // left/right kernels. sed_mul remains Mut-only.
 
-use algebra::sedenion::{sed_mul, sed_norm_sq, sed_zd_z}
+use algebra::sedenion::{sed_mul, sed_norm_sq, sed_zd_z, sed_zd_w}
 use algebra::sedenion_kernel::{sed_ker_lz_gen, sed_rank16}
 
 pub fn sed_rmul_vec_nsq(v: &[f64; 16], a: &[f64; 16]) -> f64 with Mut {
@@ -45,4 +49,29 @@ pub fn sed_ker_z_rimage_rank() -> i64 with Mut, Div, Panic {
 
 pub fn sed_ker_z_intersect_dim() -> i64 with Mut, Div, Panic {
     4 - sed_ker_z_rimage_rank()
+}
+
+/// Rank of L_w restricted to the named ker L_z basis. Columns L_w(g_k).
+pub fn sed_ker_lw_on_lz_rank() -> i64 with Mut, Div, Panic {
+    var w: [f64; 16] = [0.0; 16]
+    sed_zd_w(&!w)
+    var m: [f64; 256] = [0.0; 256]
+    var k: i64 = 0
+    while k < 4 {
+        var g: [f64; 16] = [0.0; 16]
+        sed_ker_lz_gen(k, &!g)
+        var lw: [f64; 16] = [0.0; 16]
+        sed_mul(&w, &g, &!lw)
+        var r: i64 = 0
+        while r < 16 {
+            m[(16 * r + k) as usize] = lw[r]
+            r = r + 1
+        }
+        k = k + 1
+    }
+    sed_rank16(&!m)
+}
+
+pub fn sed_ker_lz_lw_intersect_dim() -> i64 with Mut, Div, Panic {
+    4 - sed_ker_lw_on_lz_rank()
 }

--- a/tests/run-pass/sedenion_ker_lw.sio
+++ b/tests/run-pass/sedenion_ker_lw.sio
@@ -1,0 +1,36 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 0
+//@ description: ker L_z ∩ ker L_w is {0}; L_w on named L_z basis has rank 4
+// Full Test Suite CI uses souc-stage2 (lean_single). Madaros runs this graph.
+
+use algebra::sedenion_action::{sed_canonical_zd_pair}
+use algebra::sedenion_kernel::{sed_ker_lz_gen, sed_lmul_vec_nsq, sed_lmul_ker_dim}
+use algebra::sedenion_annihilator::{sed_ker_lw_on_lz_rank, sed_ker_lz_lw_intersect_dim}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var z: [f64; 16] = [0.0; 16]
+    var w: [f64; 16] = [0.0; 16]
+    sed_canonical_zd_pair(&!z, &!w)
+
+    var ok: i64 = 1
+    var k: i64 = 0
+    while k < 4 {
+        var g: [f64; 16] = [0.0; 16]
+        sed_ker_lz_gen(k, &!g)
+        if sed_lmul_vec_nsq(&w, &g) <= 1.0e-9 { ok = 0 }
+        k = k + 1
+    }
+    if abs_f(sed_lmul_vec_nsq(&z, &z) - 4.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_lmul_vec_nsq(&w, &w) - 4.0) > 1.0e-9 { ok = 0 }
+    if sed_lmul_vec_nsq(&w, &z) > 1.0e-9 { ok = 0 }
+    if sed_ker_lw_on_lz_rank() != 4 { ok = 0 }
+    if sed_ker_lz_lw_intersect_dim() != 0 { ok = 0 }
+    if sed_lmul_ker_dim(&w) != 4 { ok = 0 }
+
+    if ok == 1 { 0 } else { 1 }
+}


### PR DESCRIPTION
## What

#2096/#2097 (now on main): named 4-space of `ker L_z`, and `ker L_z = ker R_z` for canonical `z`.

Is `ker L_w` the same 4-space? **No.** `w*w` nsq 4, so `w ∉ ker L_w` while `w ∈ ker L_z`.

Intersection: restriction of `L_w` to the named `ker L_z` basis has GE rank **4**, so `dim(ker L_z ∩ ker L_w) = 0`. Computationally witnessed.

`z` lives in `ker L_w` (and `ker R_w`), not in `ker L_z`.

| k | `L_w(g_k)` nsq |
|---|---:|
| 0 (`w`) | **4** |
| 1 | **8** |
| 2 | **8** |
| 3 | **4** |

## Receipts (Madaros control ELF 100902241 B)

```
LW_ON_LZ_RANK 4.000000
INTERSECT_LZ_LW_DIM 0.000000
LW_ON_Z 0.000000
WW_NSQ 4.000000
VERDICT_INTERSECTION_ZERO 1
```

Example + test rc=0 (`//@ requires: madaros`).

## Claims-forbidden

New physics; complementary in R^16; every ZD pair has disjoint kernels; Moreno; ZD solves g-2.

Do not merge until asked.