### PR TITLE
feat(algebra): name the 4-space ker L_w

### DIFF
--- a/docs/audit/SEDENION_KER_LW_BASIS_2026-08-24.md
+++ b/docs/audit/SEDENION_KER_LW_BASIS_2026-08-24.md
@@ -1,0 +1,77 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.sedenion-ker-lw-basis-2026-08-24
+authority: repo_only
+audience: users
+last_validated: 2026-08-24
+validated_by: grok-cli2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.sedenion-ker-lw-basis-2026-08-24
+-->
+
+# Named 4-space of ker L_w
+
+```text
+Semantic-Lane-ID: sedenion-ker-lw-basis-20260824
+Owner: grok-cli2
+Concept-IDs: SOUNIO-NONASSOCIATIVE-ORDER
+Intent-Preserved: a named spanning set of ker L_w is a measurement,
+  not a classification of zero-divisors
+Transformation: scan e_i ± e_j under L_w; pin four pair-type hits;
+  generator 0 is canonical z; span rank 4
+Types-Changed: none
+Effects-Changed: none
+IR-Changed: none
+Claims-Introduced: Sounio computes L_w(h_k)=0 for
+  h = {e3+e10, e2−e11, e4−e13, e5+e12}; span rank 4; L_{e1} nsq 2;
+  pair scan has exactly four hits
+Claims-Forbidden: new physics; unique orthonormal basis; Moreno;
+  complementary in R^16; ZD solves g-2; Madaros is
+  fixed-point-verified
+Assumptions: Convention X; GE tolerance 1e-9; pair-type scan is not
+  an enumeration of all of ℝ¹⁶
+Write-Set: stdlib/algebra/sedenion_kernel.sio,
+  examples/physics/sedenion_ker_lw_basis.sio,
+  tests/run-pass/sedenion_ker_lw_basis.sio, this file
+Read-Set: docs/audit/SEDENION_KER_BASIS_2026-08-23.md,
+  docs/audit/SEDENION_KER_LW_2026-08-23.md
+Positive-Witness: souc run prints span rank 4, all L_w nsq 0,
+  H0 equals z, L_e1 nsq 2
+Negative-Witness: g-2 is not this lane
+Acceptance-Gate: tests/run-pass/sedenion_ker_lw_basis.sio exit 0
+  under Madaros
+Integration-Target: origin/main
+Authoritative-Only-If: the nsqs and rank are produced by Madaros
+```
+
+## What this is
+
+#2096 named `ker L_z`. #2100 showed `ker L_z ∩ ker L_w = {0}`.
+This names `ker L_w`. The scan of all 240 vectors `e_i ± e_j`
+(`i < j`, both signs) finds **exactly four** hits. That family is
+exhaustive; ℝ¹⁶ is not. Span GE rank **4** at tolerance 1e-9.
+Generator 0 is canonical `z`. Computationally witnessed.
+
+| k | generator |
+|---|---|
+| 0 | `e₃ + e₁₀` (`z`) |
+| 1 | `e₂ − e₁₁` |
+| 2 | `e₄ − e₁₃` |
+| 3 | `e₅ + e₁₂` |
+
+The L_z basis used `e₄+e₁₃` and `e₅−e₁₂` — the **other sign** of
+the same pairs. Pair-type basis, not uniqueness in ℝ¹⁶.
+`L_z(h_k)` is nonzero on each generator (consistent with
+`ker L_z ∩ ker L_w = {0}` from #2100).
+
+## Receipts (2026-08-24)
+
+Control ELF `/workspace/sounio/bin/madaros-linux-x86_64` (100902241 B).
+
+LLM-offload math-review (`/tmp/llm-offload-gbAIi1`):
+
+- xAI grok-4.3: `[OVERREACH]` on treating numerical L_w=0 / rank 4 as
+  algebraic — text now says computationally witnessed, GE 1e-9;
+  `[OVERREACH]` on "exactly four" — scoped to the 240 pair-type
+  vectors; `[TIGHTENABLE]` intersection — example/test require
+  `L_z(h_k)` nonzero.
+- Z.AI: weekly quota exhausted until 2026-08-25 06:34:36.
+- Outcome: **PASS_SINGLE_PROVIDER_DEGRADED**.

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -389,6 +389,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.sedenion-ker-basis-2026-08-23 | repo_only | docs/audit/SEDENION_KER_BASIS_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-ker-intersect-2026-08-23 | repo_only | docs/audit/SEDENION_KER_INTERSECT_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-ker-lw-2026-08-23 | repo_only | docs/audit/SEDENION_KER_LW_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.sedenion-ker-lw-basis-2026-08-24 | repo_only | docs/audit/SEDENION_KER_LW_BASIS_2026-08-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-ker-lz-2026-08-23 | repo_only | docs/audit/SEDENION_KER_LZ_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-zd-action-2026-08-23 | repo_only | docs/audit/SEDENION_ZD_ACTION_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sedenion-zd-twosided-moufang-2026-08-23 | repo_only | docs/audit/SEDENION_ZD_TWOSIDED_MOUFANG_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8411,6 +8411,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.sedenion-ker-lw-basis-2026-08-24",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/SEDENION_KER_LW_BASIS_2026-08-24.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.sedenion-ker-lz-2026-08-23",
       "collection": "repo",
       "repo_doc_path": "docs/audit/SEDENION_KER_LZ_2026-08-23.md",

--- a/examples/physics/sedenion_ker_lw_basis.sio
+++ b/examples/physics/sedenion_ker_lw_basis.sio
@@ -1,0 +1,113 @@
+//@ run-pass
+//@ description: named 4-space ker L_w: e3+e10, e2−e11, e4−e13, e5+e12
+//
+// Scan of e_i ± e_j finds exactly these four; they span (rank 4).
+// Generator 0 is canonical z. Each has ||h||²=2, L_w(h)=0,
+// L_{e1}(h) nsq 2. Disjoint from ker L_z. Not Moreno. Not g-2.
+//
+// Run:
+//   export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+//   ./bin/souc run examples/physics/sedenion_ker_lw_basis.sio
+
+use algebra::sedenion::{sed_norm_sq, sed_basis}
+use algebra::sedenion_action::{sed_canonical_zd_pair}
+use algebra::sedenion_kernel::{
+    sed_ker_lw_gen, sed_ker_lw_span_rank, sed_lmul_vec_nsq,
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var z: [f64; 16] = [0.0; 16]
+    var w: [f64; 16] = [0.0; 16]
+    sed_canonical_zd_pair(&!z, &!w)
+    var e1: [f64; 16] = [0.0; 16]
+    sed_basis(1, &!e1)
+
+    var h0: [f64; 16] = [0.0; 16]
+    var h1: [f64; 16] = [0.0; 16]
+    var h2: [f64; 16] = [0.0; 16]
+    var h3: [f64; 16] = [0.0; 16]
+    sed_ker_lw_gen(0, &!h0)
+    sed_ker_lw_gen(1, &!h1)
+    sed_ker_lw_gen(2, &!h2)
+    sed_ker_lw_gen(3, &!h3)
+
+    var dz = 0.0
+    var t: i64 = 0
+    while t < 16 {
+        let x = h0[t] - z[t]
+        dz = dz + x * x
+        t = t + 1
+    }
+    let span = sed_ker_lw_span_rank()
+
+    print("KERW_H0_EQ_Z_NSQ ")
+    print_f64(dz)
+    print("\nKERW_H0_NSQ ")
+    print_f64(sed_norm_sq(&h0))
+    print("\nKERW_H1_NSQ ")
+    print_f64(sed_norm_sq(&h1))
+    print("\nKERW_H2_NSQ ")
+    print_f64(sed_norm_sq(&h2))
+    print("\nKERW_H3_NSQ ")
+    print_f64(sed_norm_sq(&h3))
+    print("\nKERW_H0_LW_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&w, &h0))
+    print("\nKERW_H1_LW_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&w, &h1))
+    print("\nKERW_H2_LW_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&w, &h2))
+    print("\nKERW_H3_LW_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&w, &h3))
+    print("\nKERW_H0_E1_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&e1, &h0))
+    print("\nKERW_H1_E1_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&e1, &h1))
+    print("\nKERW_H2_E1_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&e1, &h2))
+    print("\nKERW_H3_E1_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&e1, &h3))
+    print("\nKERW_SPAN_RANK ")
+    print_f64(span as f64)
+    print("\nKERW_H0_LZ_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&z, &h0))
+    print("\nKERW_H1_LZ_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&z, &h1))
+    print("\nKERW_H2_LZ_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&z, &h2))
+    print("\nKERW_H3_LZ_NSQ ")
+    print_f64(sed_lmul_vec_nsq(&z, &h3))
+    print("\n")
+
+    var ok: i64 = 1
+    if dz > 1.0e-9 { ok = 0 }
+    if abs_f(sed_norm_sq(&h0) - 2.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_norm_sq(&h1) - 2.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_norm_sq(&h2) - 2.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_norm_sq(&h3) - 2.0) > 1.0e-9 { ok = 0 }
+    if sed_lmul_vec_nsq(&w, &h0) > 1.0e-9 { ok = 0 }
+    if sed_lmul_vec_nsq(&w, &h1) > 1.0e-9 { ok = 0 }
+    if sed_lmul_vec_nsq(&w, &h2) > 1.0e-9 { ok = 0 }
+    if sed_lmul_vec_nsq(&w, &h3) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_lmul_vec_nsq(&e1, &h0) - 2.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_lmul_vec_nsq(&e1, &h1) - 2.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_lmul_vec_nsq(&e1, &h2) - 2.0) > 1.0e-9 { ok = 0 }
+    if abs_f(sed_lmul_vec_nsq(&e1, &h3) - 2.0) > 1.0e-9 { ok = 0 }
+    if span != 4 { ok = 0 }
+    if sed_lmul_vec_nsq(&z, &h0) <= 1.0e-9 { ok = 0 }
+    if sed_lmul_vec_nsq(&z, &h1) <= 1.0e-9 { ok = 0 }
+    if sed_lmul_vec_nsq(&z, &h2) <= 1.0e-9 { ok = 0 }
+    if sed_lmul_vec_nsq(&z, &h3) <= 1.0e-9 { ok = 0 }
+
+    print("VERDICT_H0_IS_Z ")
+    if dz <= 1.0e-9 { print("1\n") } else { print("0\n") }
+    print("VERDICT_ALL_IN_KER_LW ")
+    if sed_lmul_vec_nsq(&w, &h3) <= 1.0e-9 { print("1\n") } else { print("0\n") }
+    print("VERDICT_SPAN_RANK_4 ")
+    if span == 4 { print("1\n") } else { print("0\n") }
+
+    if ok == 1 { 0 } else { 1 }
+}

--- a/stdlib/algebra/sedenion_kernel.sio
+++ b/stdlib/algebra/sedenion_kernel.sio
@@ -30,6 +30,14 @@
 // Each has ||g||² = 2, L_z(g)=0, L_{e1}(g) nsq 2. This is a basis,
 // not a classification, not uniqueness among all of ℝ¹⁶.
 //
+// Named 4-space of ker L_w (scan 2026-08-24): exactly four pair-type
+// hits, rank 4. Generator 0 is canonical z.
+//   h0 = e3 + e10
+//   h1 = e2 − e11
+//   h2 = e4 − e13
+//   h3 = e5 + e12
+// Disjoint from the L_z 4-space (intersection {0}, #2100).
+//
 // Claims forbidden: new physics; classification of zero-divisors;
 // Sounio proved Moreno; ZD solves g-2; Madaros is
 // fixed-point-verified. sed_mul remains Mut-only; no ZD effect.
@@ -219,4 +227,41 @@ pub fn sed_lmul_vec_nsq(a: &[f64; 16], v: &[f64; 16]) -> f64 with Mut {
     var out: [f64; 16] = [0.0; 16]
     sed_lmul(a, v, &!out)
     sed_norm_sq(&out)
+}
+
+/// Pair-type basis of ker L_w. k in 0..3. Generator 0 is canonical z.
+pub fn sed_ker_lw_gen(k: i64, out: &![f64; 16]) with Mut {
+    sed_zero16(out)
+    if k == 0 {
+        out[3] = 1.0
+        out[10] = 1.0
+    }
+    if k == 1 {
+        out[2] = 1.0
+        out[11] = 0.0 - 1.0
+    }
+    if k == 2 {
+        out[4] = 1.0
+        out[13] = 0.0 - 1.0
+    }
+    if k == 3 {
+        out[5] = 1.0
+        out[12] = 1.0
+    }
+}
+
+pub fn sed_ker_lw_span_rank() -> i64 with Mut, Div, Panic {
+    var m: [f64; 256] = [0.0; 256]
+    var c: i64 = 0
+    while c < 4 {
+        var g: [f64; 16] = [0.0; 16]
+        sed_ker_lw_gen(c, &!g)
+        var r: i64 = 0
+        while r < 16 {
+            m[(16 * r + c) as usize] = g[r]
+            r = r + 1
+        }
+        c = c + 1
+    }
+    sed_rank16(&!m)
 }

--- a/tests/run-pass/sedenion_ker_lw_basis.sio
+++ b/tests/run-pass/sedenion_ker_lw_basis.sio
@@ -1,0 +1,48 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 0
+//@ description: ker L_w spanned by e3+e10, e2−e11, e4−e13, e5+e12
+// Full Test Suite CI uses souc-stage2 (lean_single). Madaros runs this graph.
+
+use algebra::sedenion::{sed_norm_sq, sed_basis}
+use algebra::sedenion_action::{sed_canonical_zd_pair}
+use algebra::sedenion_kernel::{
+    sed_ker_lw_gen, sed_ker_lw_span_rank, sed_lmul_vec_nsq,
+}
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var z: [f64; 16] = [0.0; 16]
+    var w: [f64; 16] = [0.0; 16]
+    sed_canonical_zd_pair(&!z, &!w)
+    var e1: [f64; 16] = [0.0; 16]
+    sed_basis(1, &!e1)
+
+    var ok: i64 = 1
+    var k: i64 = 0
+    while k < 4 {
+        var h: [f64; 16] = [0.0; 16]
+        sed_ker_lw_gen(k, &!h)
+        if abs_f(sed_norm_sq(&h) - 2.0) > 1.0e-9 { ok = 0 }
+        if sed_lmul_vec_nsq(&w, &h) > 1.0e-9 { ok = 0 }
+        if abs_f(sed_lmul_vec_nsq(&e1, &h) - 2.0) > 1.0e-9 { ok = 0 }
+        if sed_lmul_vec_nsq(&z, &h) <= 1.0e-9 { ok = 0 }
+        if k == 0 {
+            var dz = 0.0
+            var t: i64 = 0
+            while t < 16 {
+                let x = h[t] - z[t]
+                dz = dz + x * x
+                t = t + 1
+            }
+            if dz > 1.0e-9 { ok = 0 }
+        }
+        k = k + 1
+    }
+    if sed_ker_lw_span_rank() != 4 { ok = 0 }
+
+    if ok == 1 { 0 } else { 1 }
+}


### PR DESCRIPTION
## What

#2096 named `ker L_z`. #2100 showed intersection `{0}`. This names `ker L_w`.

Scan of all 240 vectors `e_i ± e_j` (`i < j`, both signs): **exactly four** hits. GE span rank **4**. Generator 0 is canonical `z`. Computationally witnessed.

| k | generator |
|---|---|
| 0 | `e3 + e10` (`z`) |
| 1 | `e2 − e11` |
| 2 | `e4 − e13` |
| 3 | `e5 + e12` |

`ker L_z` used `e4+e13` and `e5−e12` — the **other sign** of the same pairs. Each: `‖h‖²=2`, `L_w(h)=0`, `L_{e1}` nsq **2**, `L_z(h)` nsq in `{4,8}` (not in `ker L_z`).

## Receipts (Madaros control ELF 100902241 B)

```
KERW_H0_EQ_Z_NSQ 0.000000
KERW_H*_NSQ 2.000000
KERW_H*_LW_NSQ 0.000000
KERW_H*_E1_NSQ 2.000000
KERW_SPAN_RANK 4.000000
KERW_H*_LZ_NSQ 4/4/8/8
```

Example + test rc=0 (`//@ requires: madaros`).

## Claims-forbidden

New physics; unique orthonormal basis; Moreno; complementary in R^16; ZD solves g-2.

Do not merge until asked.