### PR TITLE
fix(ci): a receipt must survive the squash merge that lands it

### DIFF
--- a/scripts/ci/madaros_receipt_gate.sh
+++ b/scripts/ci/madaros_receipt_gate.sh
@@ -73,7 +73,24 @@ if ! git rev-parse --verify -q "${claimed_commit}^{commit}" >/dev/null 2>&1; the
   fi
 else
   if ! git merge-base --is-ancestor "$claimed_commit" HEAD 2>/dev/null; then
+    # A squash merge collapses a branch into one new commit, so a receipt
+    # written on the branch names a commit that never lands on the target.
+    # The bytes did arrive; only the commit id was rewritten. Distinguishing
+    # that from a false provenance claim needs evidence, not tolerance: accept
+    # only when the commit the receipt names carried the SAME artifact blob
+    # that HEAD carries. A receipt pointing at an unrelated commit still fails.
+    claimed_blob="$(git rev-parse -q --verify "$claimed_commit:$claimed_artifact" 2>/dev/null || true)"
+    head_blob="$(git rev-parse -q --verify "HEAD:$claimed_artifact" 2>/dev/null || true)"
+    if [[ -n "$claimed_blob" && "$claimed_blob" == "$head_blob" ]]; then
+      delivered="$(git log -1 --format=%H -- "$claimed_artifact" 2>/dev/null)"
+      echo "  receipt: source=$claimed_commit is not in this history -- squash merge rewrote it"
+      echo "  receipt: it carried the same $claimed_artifact blob ($claimed_blob), delivered here by ${delivered:-unknown}"
+      claimed_commit="${delivered:-$claimed_commit}"
+    else
+      echo "  receipt names $claimed_commit, whose $claimed_artifact blob is ${claimed_blob:-absent}"
+      echo "  HEAD carries ${head_blob:-absent} -- these are different artifacts, not a rewritten commit"
     gate_fail "receipt source_commit=$claimed_commit is not an ancestor of HEAD — the receipt describes a tree this branch is not on"
+    fi
   fi
   behind="$(git rev-list --count "${claimed_commit}..HEAD" 2>/dev/null || echo '?')"
   echo "  receipt: gate=$claimed_gate result=$claimed_result source=$claimed_commit (${behind} commits behind HEAD)"


### PR DESCRIPTION
main is red at `d4f445eeab` with:

```
MADAROS_RECEIPT_GATE_FAIL: receipt source_commit=a61cabcc6e... is not an ancestor of HEAD
```

#2099 was squash-merged. The receipt it carried was written while the work was a branch, so it names a commit that never landed. The gate was right that the commit is absent and wrong to conclude the receipt is false — the bytes arrived, only the commit id was rewritten.

This is structural, not incidental: **any** receipt written on a branch and landed by squash hits this. The writer cannot fix it, because it does not know the merge strategy.

## What changed

When the named commit is not an ancestor, the gate now asks whether that commit carried the *same artifact blob* HEAD carries. Same blob → the commit was rewritten, accept and report both the rewrite and the commit that actually delivered the artifact. Different blob → still a hard failure. The sha256 check downstream is untouched and remains load-bearing.

## Controls

| receipt names | in history | blob | verdict |
|---|---|---|---|
| `a61cabcc6e` | squashed away | `5bfd57c7` = HEAD | **pass**, rewrite reported |
| `e4a308f1be` | squashed away | `c43aa51e` ≠ HEAD | **fail**, "different artifacts, not a rewritten commit" |

The first negative control was invalid on the first attempt: it used a fabricated 40-character sha, so the gate rejected it as "not a commit in this repository" and never entered the new branch. Redone with the resolved sha.