### PR TITLE
scripts(audit): source-built Madaros pin + wrapper bracket probes

### DIFF
--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/intervention_angle_derived.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/intervention_angle_derived.sio
@@ -1,0 +1,5 @@
+// Probe: focus on Intervention<f64, Derived> (angle form, not bracket).
+// Used with --emit-manifest on the source-built Madaros to test whether
+// the angle path actually produces AstProvDerived.
+fn measure(x: Intervention<f64, Derived>) -> Intervention<f64, Derived> { x }
+fn main() -> i32 { 0 }

--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/intervention_bracket_derived.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/intervention_bracket_derived.sio
@@ -1,0 +1,4 @@
+// Probe: Intervention[f64, Derived] — bracket form, was parse-failing
+// on shipped ELF (13 errors per audit). Test on source-built Madaros.
+fn measure(x: Intervention[f64, Derived]) -> Intervention[f64, Derived> { x }
+fn main() -> i32 { 0 }

--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/intervention_bracket_only.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/intervention_bracket_only.sio
@@ -1,0 +1,4 @@
+// Probe: Intervention[f64] — bracket form with no components.
+// Shipped ELF: parse fail. Test on source-built.
+fn measure(x: Intervention[f64]) -> Intervention[f64] { x }
+fn main() -> i32 { 0 }

--- a/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/validated_bracket_derived.sio
+++ b/docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/validated_bracket_derived.sio
@@ -1,0 +1,4 @@
+// Probe: Validated[f64, Derived] — bracket form.
+// Shipped ELF: parse fail (13 errors per audit). Test on source-built.
+fn measure(x: Validated[f64, Derived]) -> Validated[f64, Derived> { x }
+fn main() -> i32 { 0 }

--- a/scripts/dev/knowledge_annotation_parser_coverage_source_built.sh
+++ b/scripts/dev/knowledge_annotation_parser_coverage_source_built.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# scripts/dev/knowledge_annotation_parser_coverage_source_built.sh
+#
+# Sister pin to scripts/dev/knowledge_annotation_parser_coverage.sh,
+# using a source-built Madaros instead of the shipped ELF. If shipped
+# vs source-built agree on every probe, the audit's "behaviour is the
+# behaviour of the source" claim is grounded in two independent
+# compilers.
+#
+# Scope: this script tests only the wrapper-bracket probes introduced
+# alongside it (intervention_*, validated_bracket_derived). It does not
+# retest the audit's bracket-form `Knowledge` probes — those are
+# handled by the original pin. The angle-form probes (angle_source,
+# angle_literature, angle_input) belong to a different audit addendum
+# and are not exercised here.
+#
+# Usage:
+#   bash scripts/dev/knowledge_annotation_parser_coverage_source_built.sh /path/to/source-built-madaros
+#
+# The pin script intentionally has no fall-back to bin/souc: if the
+# source-built Madaros is missing, the script fails loudly. Mixing the
+# two would defeat the purpose.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+SOUC="${1:-}"
+if [[ -z "$SOUC" ]]; then
+  echo "usage: $0 /path/to/source-built-madaros" >&2
+  exit 2
+fi
+if [[ ! -x "$SOUC" ]]; then
+  echo "error: $SOUC missing or not executable" >&2
+  exit 2
+fi
+
+PROBE_DIR="docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19"
+
+fail=0
+note() { printf '%s\n' "$*"; }
+pin_fail() { printf 'PIN FAIL: %s\n' "$*" >&2; fail=1; }
+
+souc_ver=$(ulimit -s 524288 && env -u SOUC_BIN -u SOUNIO_SOUC_BIN "$SOUC" --version 2>/dev/null | head -1 || true)
+note "SOURCE-BUILT compiler: ${souc_ver:-unknown} path=$SOUC"
+
+check_one() {
+  local file="$1"
+  ( ulimit -s 524288
+    env -u SOUC_BIN -u SOUNIO_SOUC_BIN \
+      SOUNIO_STDLIB_PATH="$ROOT_DIR/stdlib" \
+      "$SOUC" check "$file"
+  ) >/tmp/kcov_sb_check.out 2>&1
+}
+
+# Wrapper bracket closure — three probes that parse-fail on shipped ELF
+# and must parse-fail identically on a source-built Madaros. If they
+# disagree, ELF/source drift is the only remaining explanation.
+sb_fail=(intervention_bracket_only intervention_bracket_derived validated_bracket_derived)
+for name in "${sb_fail[@]}"; do
+  f="$PROBE_DIR/${name}.sio"
+  if [[ ! -f "$f" ]]; then
+    pin_fail "missing source-built fail probe $f"
+    continue
+  fi
+  if check_one "$f"; then
+    pin_fail "source-built fail-probe $name: expected parse/check failure, got check OK"
+  fi
+done
+
+# Wrapper angle form — Intervention<f64, Derived> must check OK on a
+# source-built Madaros. This is the empirical counterpart to the
+# bracket-form failures above: same family, different syntax.
+sb_pass=(intervention_angle_derived)
+for name in "${sb_pass[@]}"; do
+  f="$PROBE_DIR/${name}.sio"
+  if [[ ! -f "$f" ]]; then
+    pin_fail "missing source-built pass probe $f"
+    continue
+  fi
+  if check_one "$f"; then
+    :
+  else
+    pin_fail "source-built pass-probe $name: expected check OK"
+    tail -5 /tmp/kcov_sb_check.out >&2
+  fi
+done
+
+if [[ "$fail" -ne 0 ]]; then
+  note "KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_SOURCE_BUILT: FAIL"
+  exit 1
+fi
+note "KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_SOURCE_BUILT: PASS"
+exit 0


### PR DESCRIPTION
## Scope

A sister pin to `scripts/dev/knowledge_annotation_parser_coverage.sh`, exercising wrapper bracket probes against a source-built Madaros ELF instead of the shipped one. If shipped and source-built disagree on a probe, ELF/source drift is the only remaining explanation for the bracket form failure.

Branch off `origin/main` (842195928a, the green tip after today's 12-PR landing). Single commit, 5 files, +112 lines.

## What's in the diff

- `scripts/dev/knowledge_annotation_parser_coverage_source_built.sh` — sister pin (95 lines)
- `docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/intervention_angle_derived.sio` — pass probe
- `docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/intervention_bracket_only.sio` — fail probe
- `docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/intervention_bracket_derived.sio` — fail probe
- `docs/audit/probes/knowledge-annotation-parser-coverage-2026-08-19/validated_bracket_derived.sio` — fail probe

## Why this is its own PR

The main audit (`docs/audit/KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_2026-08-19.md` on main, 163 lines) has independently absorbed the wrapper bracket finding via the E241 unknown-component-refuse addendum on a different lane's PR. The source-built pin script probes an orthogonal question — does the bracket form fail identically when the compiler is built from current source? — and the four probe files are its required fixtures.

The angle-form `Knowledge` probes (angle_source/angle_literature/angle_input) are scoped out: they belong to a separate audit addendum (the silent-skip discriminator, commit 5d16652a9e on the prior branch) and are not exercised here. The original audit's bracket-form `Knowledge` probes are also out of scope — they are tested by the existing pin.

## Validation

```
$ bash scripts/dev/knowledge_annotation_parser_coverage_source_built.sh /tmp/madaros-source-built
SOURCE-BUILT compiler: Madaros v0.80.0 -- the Sounio self-hosted compiler path=/tmp/madaros-source-built
KNOWLEDGE_ANNOTATION_PARSER_COVERAGE_SOURCE_BUILT: PASS
```

PASS on tip commit (837afa4abc).

## Pin script contract

- No fallback to `bin/souc` — fails loudly if the source-built Madaros is missing, since mixing the two would defeat the purpose.
- Each `sb_fail` probe must parse-fail. Each `sb_pass` probe must check OK.
- If a probe's behaviour diverges from this contract, the script exits non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)