### PR TITLE
P_z preserving-basis helper (Jordan subalgebra) + full-basis unlearning demo

### DIFF
--- a/docs/research/cd-tower-automorphism-freeze.md
+++ b/docs/research/cd-tower-automorphism-freeze.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.cd-tower-automorphism-freeze
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/stdlib/algebra/sedenion_kernel.sio
+++ b/stdlib/algebra/sedenion_kernel.sio
@@ -256,6 +256,35 @@ pub fn sed_ker_lz_preserves(a: &[f64; 16]) -> i64 with Mut {
     1
 }
 
+/// The preserving-multiplier subspace P_z, packed as six consecutive 16-vectors
+/// (row-major: vector j at out[16*j .. 16*j+15]).
+///
+///   P_z = span{ e0, e2, e3, e8, e10, e11 }   (dim 6)
+///
+/// Computed structure of P_z (exact, CD-k4 table):
+///   - it is exactly {a : sed_ker_lz_preserves(a) = 1} — membership is the
+///     support test "a has no component outside {0,2,3,8,10,11}";
+///   - it is NOT the centralizer of z (only e0 commutes with z) and NOT an
+///     associative subalgebra (not closed under *), BUT it IS closed under the
+///     Jordan product a∘b = (ab+ba)/2 — a special-Jordan subalgebra;
+///   - preservation composes: applying any sequence of P_z multipliers keeps
+///     ker L_z invariant (b*(a*x) ∈ ker if a,b preserve), independent of P_z's
+///     product structure. So "privacy-preserving operation" is a decidable,
+///     composition-closed, type-level policy — the backing for an
+///     ExactlyPrivate `*`-preservation rule.
+/// z-specific: a different z gives a different 6-dim Jordan P_z (verified for
+/// z=e3+e10 and w=e6−e15). This is the canonical (z = e3+e10) policy.
+pub fn sed_ker_lz_preserving_basis(out: &![f64; 96]) with Mut {
+    var i: i64 = 0
+    while i < 96 { out[i] = 0.0; i = i + 1 }
+    out[0]        = 1.0   // e0  (identity)
+    out[16 + 2]   = 1.0   // e2
+    out[32 + 3]   = 1.0   // e3   (in z's support)
+    out[48 + 8]   = 1.0   // e8
+    out[64 + 10]  = 1.0   // e10  (in z's support)
+    out[80 + 11]  = 1.0   // e11
+}
+
 /// Rank of the 16×4 matrix whose columns are the four generators.
 pub fn sed_ker_lz_span_rank() -> i64 with IO, Mut, Div, Panic {
     var m: [f64; 256] = [0.0; 256]

--- a/tests/run-pass/exactly_private_preserving_basis.sio
+++ b/tests/run-pass/exactly_private_preserving_basis.sio
@@ -1,0 +1,98 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 0
+//@ description: P_z preserving-multiplier subspace — spans exactly the preserving set, is Jordan-closed, agrees with sed_ker_lz_preserves; the type-level backing for an ExactlyPrivate *-preservation rule
+// Full Test Suite CI uses souc-stage2 (lean_single). Madaros runs this graph.
+//
+// Backs the ExactlyPrivate<T> composition rule (dispatch
+// docs/audit/EXACTLY_PRIVATE_TYPE_KER_WIRING_DISPATCH_2026-08-24.md, ACCEPTED):
+// "a preserves ExactlyPrivate iff a ∈ P_z". This witnesses P_z = span{e0,e2,e3,
+// e8,e10,e11} is (1) exactly the preserving set, (2) Jordan-closed, (3) a linear
+// subspace — so the policy is a decidable, composition-closed, type-level check.
+
+use algebra::sedenion::{sed_mul, sed_basis}
+use algebra::sedenion_kernel::{sed_ker_lz_preserving_basis, sed_ker_lz_preserves}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    var ok: i64 = 1
+
+    var pb: [f64; 96] = [0.0; 96]
+    sed_ker_lz_preserving_basis(&!pb)
+
+    // (1) every spanning vector of P_z preserves ker L_z
+    var j: i64 = 0
+    while j < 6 {
+        var v: [f64; 16] = [0.0; 16]
+        var i: i64 = 0
+        while i < 16 { v[i] = pb[(j * 16 + i) as usize]; i = i + 1 }
+        if sed_ker_lz_preserves(&v) != 1 { ok = 0 }
+        j = j + 1
+    }
+
+    // and vectors OUTSIDE P_z do not preserve
+    var e1: [f64; 16] = [0.0; 16]; sed_basis(1, &!e1)
+    var e4: [f64; 16] = [0.0; 16]; sed_basis(4, &!e4)
+    if sed_ker_lz_preserves(&e1) != 0 { ok = 0 }
+    if sed_ker_lz_preserves(&e4) != 0 { ok = 0 }
+
+    // (2) P_z is a LINEAR subspace: a combo of members preserves; mixing a
+    //     non-member breaks it.
+    var e2: [f64; 16] = [0.0; 16]; sed_basis(2, &!e2)
+    var e8: [f64; 16] = [0.0; 16]; sed_basis(8, &!e8)
+    var e11: [f64; 16] = [0.0; 16]; sed_basis(11, &!e11)
+    var combo: [f64; 16] = [0.0; 16]
+    var mixed: [f64; 16] = [0.0; 16]
+    var t: i64 = 0
+    while t < 16 {
+        combo[t] = e2[t] + e8[t] + e11[t]     // all in P_z
+        mixed[t] = e1[t] + e2[t]              // e1 not in P_z
+        t = t + 1
+    }
+    if sed_ker_lz_preserves(&combo) != 1 { ok = 0 }
+    if sed_ker_lz_preserves(&mixed) != 0 { ok = 0 }
+
+    // (3) JORDAN-CLOSED: a∘b = a*b + b*a stays inside P_z (support ⊆
+    //     {0,2,3,8,10,11}). P_z is NOT closed under * alone — this is the
+    //     special-Jordan structure. Test all pairs of the 6 spanning vectors.
+    var ja: i64 = 0
+    while ja < 6 {
+        var a: [f64; 16] = [0.0; 16]
+        var ii: i64 = 0
+        while ii < 16 { a[ii] = pb[(ja * 16 + ii) as usize]; ii = ii + 1 }
+        var jb: i64 = 0
+        while jb < 6 {
+            var b: [f64; 16] = [0.0; 16]
+            ii = 0
+            while ii < 16 { b[ii] = pb[(jb * 16 + ii) as usize]; ii = ii + 1 }
+            var ab: [f64; 16] = [0.0; 16]
+            var ba: [f64; 16] = [0.0; 16]
+            sed_mul(&a, &b, &!ab)
+            sed_mul(&b, &a, &!ba)
+            // any Jordan component a∘b outside {0,2,3,8,10,11} must be zero
+            ii = 0
+            while ii < 16 {
+                if ab[ii] + ba[ii] != 0.0 {
+                    var inP: i64 = 0
+                    if ii == 0 { inP = 1 }
+                    if ii == 2 { inP = 1 }
+                    if ii == 3 { inP = 1 }
+                    if ii == 8 { inP = 1 }
+                    if ii == 10 { inP = 1 }
+                    if ii == 11 { inP = 1 }
+                    if inP == 0 { ok = 0 }   // nonzero component outside P_z
+                }
+                ii = ii + 1
+            }
+            jb = jb + 1
+        }
+        ja = ja + 1
+    }
+
+    if ok == 1 {
+        print("P_z: spans preserving set / linear subspace / Jordan-closed PASS\n")
+        0
+    } else {
+        print("P_z PRESERVING BASIS FAIL\n")
+        1
+    }
+}

--- a/tests/run-pass/zd_unlearning_full_basis.sio
+++ b/tests/run-pass/zd_unlearning_full_basis.sio
@@ -1,0 +1,73 @@
+//@ run-pass
+//@ requires: madaros
+//@ exit-code: 0
+//@ description: machine-unlearning with a 4-generator contribution — the old 2-of-4 projection leaves g1/g2 residual, the fixed stdlib forget_contribution (4-of-4) erases it exactly
+// Full Test Suite CI uses souc-stage2 (lean_single). Madaros runs this graph.
+//
+// examples/zd_machine_unlearning.sio uses an INLINE 2-vector projection (g0,g3)
+// and places Alice only on those two generators, so it never exercises the full
+// kernel. This test constructs a contribution that spans all four generators and
+// shows the difference the #2111 fix makes:
+//   OLD (2-of-4, replicated inline): Alice's g1/g2 components SURVIVE forgetting.
+//   NEW (stdlib forget_contribution): the whole contribution is erased, exact.
+// Integer coefficients ⇒ exact comparisons.
+
+use algebra::sedenion::{sed_norm_sq}
+use privacy::exactly_private::{forget_contribution}
+
+fn main() -> i64 with IO, Mut, Div, Panic, ZD {
+    var ok: i64 = 1
+
+    // kernel generators
+    var g0: [f64; 16] = [0.0; 16]; g0[6] = 1.0;  g0[15] = 0.0 - 1.0
+    var g1: [f64; 16] = [0.0; 16]; g1[4] = 1.0;  g1[13] = 1.0
+    var g2: [f64; 16] = [0.0; 16]; g2[5] = 1.0;  g2[12] = 0.0 - 1.0
+    var g3: [f64; 16] = [0.0; 16]; g3[7] = 1.0;  g3[14] = 1.0
+
+    // Bob = retained model (non-kernel), Alice = user contribution across ALL 4
+    // generators: 3 g0 + 2 g1 + 5 g2 + 1 g3. W_full = Bob + Alice.
+    var bob: [f64; 16] = [0.0; 16]; bob[0] = 1.0            // e0, non-kernel
+    var w_full: [f64; 16] = [0.0; 16]
+    var i: i64 = 0
+    while i < 16 {
+        w_full[i] = bob[i] + 3.0*g0[i] + 2.0*g1[i] + 5.0*g2[i] + 1.0*g3[i]
+        i = i + 1
+    }
+
+    // OLD method (2-of-4): project out only g0 and g3 (g_k·g_k = 2 ⇒ ·0.5).
+    var c0 = 0.0; var c3 = 0.0
+    i = 0
+    while i < 16 { c0 = c0 + w_full[i]*g0[i]; c3 = c3 + w_full[i]*g3[i]; i = i + 1 }
+    c0 = c0 * 0.5; c3 = c3 * 0.5
+    var old_forget: [f64; 16] = [0.0; 16]
+    i = 0
+    while i < 16 { old_forget[i] = w_full[i] - c0*g0[i] - c3*g3[i]; i = i + 1 }
+    // residual vs Bob = what the OLD method failed to forget (should be 2 g1 + 5 g2)
+    var old_leak: [f64; 16] = [0.0; 16]
+    i = 0
+    while i < 16 { old_leak[i] = old_forget[i] - bob[i]; i = i + 1 }
+    let old_leak_nsq = sed_norm_sq(&old_leak)   // 2 g1 + 5 g2: 2·(4) + 2·(25) = 58
+
+    // NEW method: the fixed 4-of-4 stdlib forget.
+    let new_forget = forget_contribution(&w_full)
+    var new_leak: [f64; 16] = [0.0; 16]
+    i = 0
+    while i < 16 { new_leak[i] = new_forget[i] - bob[i]; i = i + 1 }
+    let new_leak_nsq = sed_norm_sq(&new_leak)   // exactly Bob recovered ⇒ 0
+
+    print("OLD (2-of-4) leak nsq = "); print(old_leak_nsq); print("  (g1/g2 survive)\n")
+    print("NEW (4-of-4) leak nsq = "); print(new_leak_nsq); print("  (exact erasure)\n")
+
+    // the bug: old method leaves exactly 2 g1 + 5 g2 (norm² 58)
+    if old_leak_nsq != 58.0 { ok = 0 }
+    // the fix: nothing of Alice survives
+    if new_leak_nsq != 0.0 { ok = 0 }
+
+    if ok == 1 {
+        print("ZD UNLEARNING FULL-BASIS: fix erases 4-generator contribution PASS\n")
+        0
+    } else {
+        print("ZD UNLEARNING FULL-BASIS FAIL\n")
+        1
+    }
+}


### PR DESCRIPTION
Runtime input for codex-2's ExactlyPrivate<T> `*`-preservation rule (dispatch ACCEPTED).

**`sed_ker_lz_preserving_basis`** — the six spanning vectors of the preserving-multiplier subspace `P_z = span{e0,e2,e3,e8,e10,e11}` (canonical z=e3+e10). Computed structure (exact): P_z is exactly `{a : sed_ker_lz_preserves(a)=1}`, is **not** the centralizer and **not** an associative subalgebra, but **is** a special-Jordan subalgebra (closed under `a∘b=(ab+ba)/2`), and preservation **composes**. So the `*`-rule's witness is a decidable, composition-closed, type-level membership — the canonical kernel-policy P codex-2 asked to nominalize (z-specific; verified for z and w).

**`exactly_private_preserving_basis.sio`** — witnesses P_z spans the preserving set, is a linear subspace, is Jordan-closed, and agrees with `sed_ker_lz_preserves`.

**`zd_unlearning_full_basis.sio`** — demonstrates the #2111 fix on a 4-generator contribution: the old inline 2-of-4 projection leaks `norm²=58` (surviving 2g1+5g2), the fixed 4-of-4 `forget_contribution` erases exactly (`0`).

Verified on current-source main Madaros. Runtime only (stdlib); compiler-side stays codex-2's. 🤖 Generated with [Claude Code](https://claude.com/claude-code)