### PR TITLE
design-system: EpistemicGateCard lane (cursor-1)

### DIFF
--- a/website/src/components/epistemic/EpistemicGateCard.css
+++ b/website/src/components/epistemic/EpistemicGateCard.css
@@ -15,6 +15,39 @@
   min-width: 0;
 }
 
+.egc[data-verdict='TRUSTWORTHY'] {
+  --egc-ink: var(--color-epistemic-verified);
+  --egc-surface: var(--color-epistemic-verified-surface);
+  --egc-border: var(--color-epistemic-verified-border);
+  --egc-text: var(--color-epistemic-verified-text);
+}
+
+.egc[data-verdict='UNBOUNDED'] {
+  --egc-ink: var(--color-epistemic-uncertain);
+  --egc-surface: var(--color-epistemic-uncertain-surface);
+  --egc-border: var(--color-epistemic-uncertain-border);
+  --egc-text: var(--color-epistemic-uncertain-text);
+}
+
+.egc[data-verdict='REFUSED'] {
+  --egc-ink: var(--color-epistemic-refused);
+  --egc-surface: var(--color-epistemic-refused-surface);
+  --egc-border: var(--color-epistemic-refused-border);
+  --egc-text: var(--color-epistemic-refused-text);
+}
+
+.egc-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .egc-header {
   display: flex;
   align-items: flex-start;
@@ -84,10 +117,12 @@
 .egc-step[data-state='ceiling'] {
   border-color: var(--egc-border);
   background: var(--egc-surface);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--egc-ink) 18%, transparent);
 }
 
 .egc-step[data-state='unreached'] {
-  opacity: 0.45;
+  opacity: 0.55;
+  border-style: dashed;
 }
 
 .egc-step-id {
@@ -111,6 +146,10 @@
   font-size: 0.62rem;
   line-height: 1.25;
   color: var(--color-text-tertiary);
+}
+
+.egc-step[data-state='reached'] .egc-step-label {
+  color: var(--color-epistemic-verified-text);
 }
 
 .egc-step[data-state='ceiling'] .egc-step-label {
@@ -149,6 +188,46 @@
   text-decoration: underline;
 }
 
+.egc-link:focus-visible {
+  outline: 2px solid var(--egc-ink);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* Compact — dense panels (e.g. HonestyArgument) */
+.egc[data-size='compact'] {
+  gap: 0.65rem;
+  padding: 0.75rem 0.9rem;
+}
+
+.egc[data-size='compact'] .egc-claim {
+  font-size: 0.72rem;
+}
+
+.egc[data-size='compact'] .egc-ladder {
+  gap: 0.25rem;
+}
+
+.egc[data-size='compact'] .egc-step {
+  padding: 0.35rem 0.25rem;
+}
+
+.egc[data-size='compact'] .egc-step-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.egc[data-size='compact'] .egc-reason {
+  font-size: 0.75rem;
+}
+
 @media (max-width: 720px) {
   .egc-header {
     flex-wrap: wrap;
@@ -156,5 +235,11 @@
 
   .egc-ladder {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .egc-link {
+    transition: none;
   }
 }

--- a/website/src/components/epistemic/EpistemicGateCard.tsx
+++ b/website/src/components/epistemic/EpistemicGateCard.tsx
@@ -1,9 +1,10 @@
-import type { CSSProperties } from 'react';
+import { useId } from 'react';
 import './EpistemicGateCard.css';
 
 export const GATE_LEVELS = ['E0', 'E1', 'E2', 'E3', 'E4', 'E5'] as const;
 export type GateLevel = (typeof GATE_LEVELS)[number];
 export type GateVerdict = 'TRUSTWORTHY' | 'UNBOUNDED' | 'REFUSED';
+export type EpistemicGateCardSize = 'default' | 'compact';
 
 export const GATE_LABEL: Record<GateLevel, string> = {
   E0: 'Syntax',
@@ -14,6 +15,18 @@ export const GATE_LABEL: Record<GateLevel, string> = {
   E5: 'Closed-form Theorem',
 };
 
+export const VERDICT_LABEL: Record<GateVerdict, string> = {
+  TRUSTWORTHY: 'Trustworthy',
+  UNBOUNDED: 'Unbounded',
+  REFUSED: 'Refused',
+};
+
+export const VERDICT_GLYPH: Record<GateVerdict, string> = {
+  TRUSTWORTHY: '◈',
+  UNBOUNDED: '△',
+  REFUSED: '⊘',
+};
+
 export type EpistemicGateCardProps = {
   claim: string;
   ceiling: GateLevel;
@@ -22,42 +35,31 @@ export type EpistemicGateCardProps = {
   sha: string;
   href: string;
   hrefLabel: string;
+  size?: EpistemicGateCardSize;
   className?: string;
 };
 
-const TOKEN: Record<
-  GateVerdict,
-  { ink: string; surface: string; border: string; text: string; glyph: string }
-> = {
-  TRUSTWORTHY: {
-    ink: 'var(--color-epistemic-verified)',
-    surface: 'var(--color-epistemic-verified-surface)',
-    border: 'var(--color-epistemic-verified-border)',
-    text: 'var(--color-epistemic-verified-text)',
-    glyph: '◈',
-  },
-  UNBOUNDED: {
-    ink: 'var(--color-epistemic-uncertain)',
-    surface: 'var(--color-epistemic-uncertain-surface)',
-    border: 'var(--color-epistemic-uncertain-border)',
-    text: 'var(--color-epistemic-uncertain-text)',
-    glyph: '△',
-  },
-  REFUSED: {
-    ink: 'var(--color-epistemic-refused)',
-    surface: 'var(--color-epistemic-refused-surface)',
-    border: 'var(--color-epistemic-refused-border)',
-    text: 'var(--color-epistemic-refused-text)',
-    glyph: '⊘',
-  },
-};
+type StepState = 'reached' | 'ceiling' | 'unreached';
 
-function stepState(level: GateLevel, ceiling: GateLevel): 'reached' | 'ceiling' | 'unreached' {
+function stepState(level: GateLevel, ceiling: GateLevel): StepState {
   const i = GATE_LEVELS.indexOf(level);
   const c = GATE_LEVELS.indexOf(ceiling);
   if (i < c) return 'reached';
   if (i === c) return 'ceiling';
   return 'unreached';
+}
+
+function stepAriaLabel(
+  level: GateLevel,
+  state: StepState,
+  verdict: GateVerdict,
+): string {
+  const label = GATE_LABEL[level];
+  if (state === 'reached') return `${level} ${label}, passed`;
+  if (state === 'ceiling') {
+    return `${level} ${label}, ceiling gate, ${VERDICT_LABEL[verdict].toLowerCase()}`;
+  }
+  return `${level} ${label}, not reached`;
 }
 
 export function EpistemicGateCard({
@@ -68,9 +70,12 @@ export function EpistemicGateCard({
   sha,
   href,
   hrefLabel,
+  size = 'default',
   className,
 }: EpistemicGateCardProps) {
-  const token = TOKEN[verdict];
+  const uid = useId();
+  const claimId = `${uid}-claim`;
+  const summaryId = `${uid}-summary`;
   const classes = ['egc', className].filter(Boolean).join(' ');
 
   return (
@@ -78,26 +83,29 @@ export function EpistemicGateCard({
       className={classes}
       data-verdict={verdict}
       data-ceiling={ceiling}
-      style={
-        {
-          '--egc-ink': token.ink,
-          '--egc-surface': token.surface,
-          '--egc-border': token.border,
-          '--egc-text': token.text,
-        } as CSSProperties
-      }
+      data-size={size}
+      aria-labelledby={`${summaryId} ${claimId}`}
     >
+      <p id={summaryId} className="egc-sr-only">
+        {VERDICT_LABEL[verdict]} at gate {ceiling} ({GATE_LABEL[ceiling]}). {claim}
+      </p>
+
       <header className="egc-header">
-        <p className="egc-claim">{claim}</p>
-        <p className="egc-verdict">
+        <p id={claimId} className="egc-claim">
+          {claim}
+        </p>
+        <p className="egc-verdict" role="status">
           <span className="egc-glyph" aria-hidden="true">
-            {token.glyph}
+            {VERDICT_GLYPH[verdict]}
           </span>
-          {verdict}
+          {VERDICT_LABEL[verdict]}
         </p>
       </header>
 
-      <ol className="egc-ladder" aria-label={`Gate ladder, ceiling ${ceiling}`}>
+      <ol
+        className="egc-ladder"
+        aria-label={`Evidence ladder, ceiling ${ceiling} (${GATE_LABEL[ceiling]})`}
+      >
         {GATE_LEVELS.map((level) => {
           const state = stepState(level, ceiling);
           return (
@@ -106,6 +114,8 @@ export function EpistemicGateCard({
               className="egc-step"
               data-state={state}
               data-verdict={state === 'ceiling' ? verdict : undefined}
+              aria-label={stepAriaLabel(level, state, verdict)}
+              aria-current={state === 'ceiling' ? 'step' : undefined}
             >
               <span className="egc-step-id">{level}</span>
               <span className="egc-step-label">{GATE_LABEL[level]}</span>
@@ -117,8 +127,16 @@ export function EpistemicGateCard({
       <p className="egc-reason">{reason}</p>
 
       <footer className="egc-footer">
-        <code className="egc-sha">{sha}</code>
-        <a className="egc-link" href={href} target="_blank" rel="noopener noreferrer">
+        <code className="egc-sha" aria-label={`Commit ${sha}`}>
+          {sha}
+        </code>
+        <a
+          className="egc-link"
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`${hrefLabel} (opens in new tab)`}
+        >
           {hrefLabel}
         </a>
       </footer>

--- a/website/src/components/epistemic/README.md
+++ b/website/src/components/epistemic/README.md
@@ -1,0 +1,39 @@
+# Epistemic design system (website)
+
+React components for epistemic honesty surfaces on the public site. They consume
+only shared CSS tokens from `website/src/styles/global.css` — no ad hoc hex
+colours in component CSS.
+
+## Token triad
+
+Each epistemic verdict maps to a four-part token set:
+
+| Verdict | Tokens |
+|---------|--------|
+| `TRUSTWORTHY` | `--color-epistemic-verified`, `-surface`, `-border`, `-text` |
+| `UNBOUNDED` | `--color-epistemic-uncertain`, `-surface`, `-border`, `-text` |
+| `REFUSED` | `--color-epistemic-refused`, `-surface`, `-border`, `-text` |
+
+Shared layout tokens: `--color-surface-primary`, `--color-text-primary`,
+`--radius-xl`, `--font-mono`, `--font-sans`.
+
+## EpistemicGateCard
+
+Gate ladder **E0 → E5** with a per-card **ceiling** and **verdict**:
+
+- E0 Syntax · E1 HIR Type · E2 Effect Lattice · E3 GUM Variance Bounds ·
+  E4 Lean 4 Formal Proof · E5 Closed-form Theorem
+
+Used on `/proof` (`EpistemicGateExhibit`) and `/honesty` (`HonestyArgument`).
+
+## Sibling components
+
+- `DiagnosticCodeBlock` — compiler diagnostic with refused styling
+- `EffectLatticeBadge` — effect-set chip
+- `FabricatedDatum` — fifth epistemic state witness
+- `KnowledgeRefusalMeter` — refusal band meter
+
+## Lane
+
+`lane/cursor-1/design-system-epistemic-gate-card-20260824` — token hygiene,
+a11y, and exhibit integration for `EpistemicGateCard`.

--- a/website/src/components/epistemic/README.md
+++ b/website/src/components/epistemic/README.md
@@ -24,6 +24,22 @@ Gate ladder **E0 → E5** with a per-card **ceiling** and **verdict**:
 - E0 Syntax · E1 HIR Type · E2 Effect Lattice · E3 GUM Variance Bounds ·
   E4 Lean 4 Formal Proof · E5 Closed-form Theorem
 
+Verdict tokens bind via `data-verdict` on the root — no inline colour styles.
+
+### Sizes
+
+| `size` | Use |
+|--------|-----|
+| `default` | Playground and standalone exhibits (`/proof`) |
+| `compact` | Dense panels (`HonestyArgument`) — hides step labels visually, keeps `aria-label` on each step |
+
+### Accessibility
+
+- Screen-reader summary + `aria-labelledby` on the card
+- Ladder steps: `aria-current="step"` on the ceiling gate
+- Unreached steps: dashed border (not colour alone)
+- External link: `aria-label` includes “opens in new tab”
+
 Used on `/proof` (`EpistemicGateExhibit`) and `/honesty` (`HonestyArgument`).
 
 ## Sibling components

--- a/website/src/components/honesty/HonestyArgument.astro
+++ b/website/src/components/honesty/HonestyArgument.astro
@@ -140,6 +140,7 @@ const d = copy[locale] ?? copy.en;
           EpistemicGateCard · #1779 · db750980b4
         </figcaption>
         <EpistemicGateCard
+          size="compact"
           claim="EpistemicEffects.lean has subject reduction"
           ceiling="E4"
           verdict="REFUSED"
@@ -163,6 +164,7 @@ const d = copy[locale] ?? copy.en;
           EpistemicGateCard · #1788 · 31adf7b4bc
         </figcaption>
         <EpistemicGateCard
+          size="compact"
           claim="check.sio implements well_typed_value_or_refuse"
           ceiling="E4"
           verdict="UNBOUNDED"
@@ -178,6 +180,7 @@ const d = copy[locale] ?? copy.en;
           EpistemicGateCard · #1801 · 2ab2de46cf
         </figcaption>
         <EpistemicGateCard
+          size="compact"
           claim="abs() + 1 is not i64; empty stub is ud2"
           ceiling="E1"
           verdict="TRUSTWORTHY"
@@ -249,6 +252,7 @@ const d = copy[locale] ?? copy.en;
             EpistemicGateCard · #1825 · CALL named
           </figcaption>
           <EpistemicGateCard
+            size="compact"
             claim="An unspecified CALL is an unknown opcode"
             ceiling="E1"
             verdict="TRUSTWORTHY"
@@ -263,6 +267,7 @@ const d = copy[locale] ?? copy.en;
             EpistemicGateCard · #1823 · witness before the fix
           </figcaption>
           <EpistemicGateCard
+            size="compact"
             claim="Handle reclamation at 2^22 allocations"
             ceiling="E1"
             verdict="REFUSED"


### PR DESCRIPTION
## Summary

- Lane reservada para trabalho no design system do componente `EpistemicGateCard` (`website/src/components/epistemic/`).
- Commit inicial: documentação do contrato de tokens epistémicos e escada E0–E5.
- Branch sincronizada com `main`; PR aberto cedo para visibilidade e CI.

## Estado

- [x] Fast-forward para `main`
- [x] Commit inicial de escopo (README do design system epistémico)
- [ ] Melhorias de tokens, a11y e variantes
- [ ] Validação visual em `/proof` e `/honesty`

## Test plan

- [ ] `cd website && npm run build`
- [ ] Revisão visual em `/proof` e `/honesty` (cards E0–E5, veredictos TRUSTWORTHY / UNBOUNDED / REFUSED)
- [ ] Verificar consumo exclusivo dos tokens `--color-epistemic-*`