### PR TITLE
fix(harness): honour expect-stdout-contains; fail unknown expect-* keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,10 @@ jobs:
         run: python3 scripts/ci/ci_watch_receipt_selftest.py
       - name: Madaros changed-test selector self-test
         run: bash scripts/ci/madaros_changed_tests_selftest.sh
+      # Honour expect-stdout-contains and refuse invented expect-* keys.
+      # A gate that no workflow names is invisible tomorrow (ratchet #1972).
+      - name: Test-suite annotation self-test
+        run: bash scripts/ci/test_suite_annotation_selftest.sh
       - name: Madaros v2 ENIR gate stack
         run: |
           # Shadow stack: ENIR work must not change codegen/ABI/runtime.

--- a/docs/test-infrastructure-v2.md
+++ b/docs/test-infrastructure-v2.md
@@ -2,7 +2,7 @@
 topic_id: repo.docs.test-infrastructure-v2
 authority: repo_only
 audience: users
-last_validated: 2026-03-07
+last_validated: 2026-08-24
 validated_by: A2
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.test-infrastructure-v2
 -->
@@ -43,6 +43,7 @@ All annotations use the `//@` prefix in the test file header:
 | `//@ ignore` | Skip this test entirely |
 | `//@ check-only` | Only compile, don't execute (for run-pass tests) |
 | `//@ expect-stdout: PATTERN` | Expected output pattern in stdout |
+| `//@ expect-stdout-contains: PATTERN` | Substring that must appear in stdout (run-pass) |
 | `//@ error-pattern: PATTERN` | Expected error message pattern |
 
 ### New Annotations (V2)
@@ -69,6 +70,12 @@ All annotations use the `//@` prefix in the test file header:
 |---------|-------------|
 | `gpu` | Requires GPU support |
 | `llvm` | Requires LLVM backend |
+
+Unknown `expect-*` / `expected-*` header keys fail the test. The runner used
+to skip them, so `//@ expect-stdout-contains:` asserted nothing: a run-pass
+file that printed `FAIL` and exited 0 still went green. `skip-if` and
+`requires` already fail closed on unrecognised values; stdout assertions now
+match that contract.
 
 ## Test Result Categories
 

--- a/scripts/ci/test_suite_annotation_selftest.sh
+++ b/scripts/ci/test_suite_annotation_selftest.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Harness self-test for //@ expect-stdout-contains and unknown expect-* keys.
+#
+# The control the defect requires: a garbage marker must go red. If this
+# script stays green while a mutated marker still passes, the bug is back.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+HARNESS="$ROOT_DIR/scripts/dev/run_sio_test_suite_v2.sh"
+HELLO="$ROOT_DIR/tests/run-pass/hello.sio"
+REAL_ONE="$ROOT_DIR/tests/run-pass/struct_array_elem_method_dispatch.sio"
+
+fail() { echo "TEST_SUITE_ANNOTATION_SELFTEST_FAIL: $*" >&2; exit 1; }
+
+[[ -f "$HARNESS" ]] || fail "harness missing: $HARNESS"
+[[ -f "$HELLO" ]] || fail "hello fixture missing"
+[[ -f "$REAL_ONE" ]] || fail "control fixture missing: $REAL_ONE"
+
+bash -n "$HARNESS"
+
+# Shape check: payload extraction must stay parameter-expansion, not quoted =~.
+# The previous vacuous-regex bug made every expect-stdout assertion match
+# the empty string. Reintroducing that shape for -contains would reimplement it.
+if grep -nE '\[\[ "\$line" =~ "//@ expect-stdout-contains:\\ ' "$HARNESS" >/dev/null; then
+    fail "expect-stdout-contains extraction uses quoted =~ (vacuous-regex shape)"
+fi
+grep -Fq 'expect-stdout-contains: "*' "$HARNESS" \
+    || fail "harness does not prefix-match //@ expect-stdout-contains:"
+grep -Fq 'unknown annotation:' "$HARNESS" \
+    || fail "harness does not fail closed on unknown expect-* keys"
+
+TMP="$(mktemp -d /tmp/sounio-ann-selftest.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+run_list() {
+    local list="$1"
+    # Unset CI so a one-file selection is allowed. Do not load the full-suite
+    # known-failure manifest (that path is junit + no filter only, but be explicit).
+    SOUNIO_TEST_KNOWN_FAILURES_FILE="" \
+        bash "$HARNESS" --test-list "$list" --jobs 1 --verbose
+}
+
+expect_rc() {
+    local want="$1"
+    local log="$2"
+    shift 2
+    set +e
+    "$@" >"$log" 2>&1
+    local rc=$?
+    set -e
+    [[ "$rc" -eq "$want" ]] || {
+        echo "----- log -----" >&2
+        cat "$log" >&2
+        fail "expected exit $want, got $rc"
+    }
+}
+
+# --- 1. Live contains: hello prints "Hello, Sounio!" ---
+cp "$HELLO" "$TMP/hello_contains.sio"
+# Insert the assertion after the existing //@ run-pass line.
+awk '
+    NR==1 { print; print "//@ expect-stdout-contains: Hello, Sounio!"; next }
+    { print }
+' "$HELLO" > "$TMP/hello_contains.sio"
+printf '%s\n' "$TMP/hello_contains.sio" > "$TMP/list_pass.txt"
+expect_rc 0 "$TMP/pass.log" run_list "$TMP/list_pass.txt"
+grep -Fq "PASS" "$TMP/pass.log" || fail "live contains marker did not PASS"
+
+# --- 2. Garbage marker on one of the original 11 must go red ---
+awk '
+    { sub(/^\/\/@ expect-stdout-contains: .*/, "//@ expect-stdout-contains: THIS_MARKER_IS_GARBAGE") }
+    { print }
+' "$REAL_ONE" > "$TMP/garbage.sio"
+grep -Fq 'THIS_MARKER_IS_GARBAGE' "$TMP/garbage.sio" \
+    || fail "failed to rewrite control fixture marker"
+printf '%s\n' "$TMP/garbage.sio" > "$TMP/list_garbage.txt"
+expect_rc 1 "$TMP/garbage.log" run_list "$TMP/list_garbage.txt"
+grep -Fq "missing stdout contains: THIS_MARKER_IS_GARBAGE" "$TMP/garbage.log" \
+    || fail "garbage marker did not fail with missing stdout contains"
+
+# --- 3. Unknown expect-* key must fail before it can pass vacuously ---
+awk '
+    NR==1 { print; print "//@ expect-stdout-not-a-thing: Hello, Sounio!"; next }
+    { print }
+' "$HELLO" > "$TMP/unknown.sio"
+printf '%s\n' "$TMP/unknown.sio" > "$TMP/list_unknown.txt"
+expect_rc 1 "$TMP/unknown.log" run_list "$TMP/list_unknown.txt"
+grep -Fq "unknown annotation: expect-stdout-not-a-thing" "$TMP/unknown.log" \
+    || fail "unknown expect-* key was not rejected"
+
+echo "TEST_SUITE_ANNOTATION_SELFTEST_PASS"

--- a/scripts/dev/run_sio_test_suite_v2.sh
+++ b/scripts/dev/run_sio_test_suite_v2.sh
@@ -12,12 +12,16 @@
 #   //@ ignore                — skip this test
 #   //@ check-only            — compile only, do not execute
 #   //@ expect-stdout: X      — stdout must contain X (run-pass only)
+#   //@ expect-stdout-contains: X — stdout must contain X (run-pass only)
 #   //@ error-pattern: X      — stderr/stdout must contain X (compile-fail only)
 #   //@ known-failure: REASON — documented accepted failure
 #   //@ skip-if: CONDITION    — conditional skip (e.g., skip-if: no-gpu)
 #   //@ requires: FEATURE     — feature dependency (e.g., requires: gpu)
 #   //@ flaky                 — known flaky test
 #   //@ timeout: SECONDS      — override default timeout
+#
+# Unknown `expect-*` / `expected-*` header keys fail the test. They used to
+# be skipped silently, so `expect-stdout-contains` asserted nothing.
 #
 # Usage:
 #   bash scripts/run_sio_test_suite_v2.sh [--filter PATTERN] [--verbose] [--format junit] [--jobs N]
@@ -249,11 +253,33 @@ run_test() {
     local skip_if=""
     local requires=""
     local known_reason=""
+    local unknown_expect=""
     
     # Parse annotations
     while IFS= read -r line; do
         if [[ ! "$line" =~ ^[[:space:]]*//@\  && ! "$line" =~ ^[[:space:]]*//\  && ! "$line" =~ ^[[:space:]]*$ ]]; then
             break
+        fi
+        # Fail closed on invented stdout assertions. `expect-stdout-contains`
+        # was silently ignored because the harness only extracted
+        # `expect-stdout:`; the same hole would swallow `expected-output` or
+        # `expect-stdout-has`. Key extraction is identifier-only; the payload
+        # is still read by parameter expansion below (the vacuous-regex bug).
+        local expect_line="${line%"${line##*[![:space:]]}"}"
+        expect_line="${expect_line#"${expect_line%%[![:space:]]*}"}"
+        expect_line="${expect_line%$'\r'}"
+        if [[ "$expect_line" == "//@ expect"* || "$expect_line" == "//@ expected"* ]]; then
+            local expect_key="${expect_line#//@ }"
+            expect_key="${expect_key%%:*}"
+            expect_key="${expect_key%% *}"
+            case "$expect_key" in
+                expect-stdout|expect-stdout-contains) ;;
+                *)
+                    if [[ -z "$unknown_expect" ]]; then
+                        unknown_expect="$expect_key"
+                    fi
+                    ;;
+            esac
         fi
         case "$line" in
             *"//@ run-pass"*) is_run_pass=true ;;
@@ -301,6 +327,11 @@ run_test() {
 
     # Check filter
     if ! test_matches_filter "$basename"; then
+        return
+    fi
+
+    if [[ -n "$unknown_expect" ]]; then
+        echo "{\"status\":\"fail\",\"category\":\"fail\",\"name\":\"$basename\",\"relfile\":\"$rel_file\",\"time\":0,\"output\":\"unknown annotation: $unknown_expect (expected: expect-stdout|expect-stdout-contains)\",\"idx\":$idx}" > "$output_file"
         return
     fi
     
@@ -357,6 +388,7 @@ run_test() {
     
     # Read expected patterns
     local expect_stdout=()
+    local expect_stdout_contains=()
     local error_patterns=()
     while IFS= read -r line; do
         if [[ ! "$line" =~ ^[[:space:]]*//@\  && ! "$line" =~ ^[[:space:]]*//\  && ! "$line" =~ ^[[:space:]]*$ ]]; then
@@ -372,6 +404,9 @@ run_test() {
         # metacharacter class to get this wrong for either annotation.
         if [[ "$line" == "//@ expect-stdout: "* ]]; then
             expect_stdout+=("${line#*//@ expect-stdout: }")
+        fi
+        if [[ "$line" == "//@ expect-stdout-contains: "* ]]; then
+            expect_stdout_contains+=("${line#*//@ expect-stdout-contains: }")
         fi
         if [[ "$line" == "//@ error-pattern: "* ]]; then
             error_patterns+=("${line#*//@ error-pattern: }")
@@ -422,6 +457,15 @@ run_test() {
                     break
                 fi
             done
+            if [[ $exit_code -eq 0 ]]; then
+                for pattern in "${expect_stdout_contains[@]}"; do
+                    if ! grep -qF -- "$pattern" <<<"$output"; then
+                        exit_code=1
+                        test_output="missing stdout contains: $pattern"
+                        break
+                    fi
+                done
+            fi
         fi
         
     elif $is_compile_fail; then

--- a/tests/known_failures/hardened_diagnostics_full_suite.txt
+++ b/tests/known_failures/hardened_diagnostics_full_suite.txt
@@ -24,9 +24,6 @@ tests/compile-fail/door1_too_many_globals_1025.sio
 tests/compile-fail/door1_too_many_locals_1025.sio
 tests/compile-fail/parser_card_a_const_dim_name_checker_boundary.sio
 tests/run-pass/audit_trail_basic.sio
-tests/run-pass/darwin_compartments_coronary_smc_smoke.sio
-tests/run-pass/darwin_pd_bergman_smoke.sio
-tests/run-pass/darwin_pd_coronary_smc_smoke.sio
 tests/run-pass/darwin_sema_sc_depot_smoke.sio
 tests/run-pass/knowledge_array.sio
 tests/run-pass/linalg_decomp.sio
@@ -107,8 +104,15 @@ tests/compile-fail/invariant_diff1_not_comparable.sio
 # entry claims, so dropping the entry would trade a stale xfail for a green that
 # asserts nothing. Mutation evidence in the commit message.
 #   knowledge_array.sio                     prints KNOWLEDGE_ARRAY_FAIL and still exits 0
-#   darwin_compartments_coronary_smc_smoke  ditto; //@ expect-stdout-contains is
-#   darwin_pd_coronary_smc_smoke            not an annotation the harness reads
+#   darwin_sema_sc_depot_smoke.sio          still typechecks fail (private
+#                                           SemaglutideScenario fields / E175).
+#                                           Three neighbours (compartments,
+#                                           pd_bergman, pd_coronary_smc) were
+#                                           dropped 2026-08-24: they print their
+#                                           PASS marker and the harness now
+#                                           honours //@ expect-stdout-contains,
+#                                           so a green result is no longer
+#                                           vacuous.
 #   rapamycin_iso_budget.sio                "PASS" is printed unconditionally
 #   pbpk28_struct_return.sio                asserts exit 0 only; cl_central unchecked
 #   tests/stdlib/epistemic/test_kaxi_fuse   prints kaxi_fuse: FAIL and still exits 0

--- a/tests/run-pass/box_all_read_forms.sio
+++ b/tests/run-pass/box_all_read_forms.sio
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ expected-output: BOXMATRIX OK
+//@ expect-stdout-contains: BOXMATRIX OK
 // Regression witness for Box<T> auto-deref. The no-field call at the end guards
 // against copying LowerLocalStack while consulting Box inner-layout metadata.
 // label_id transport is not a fix: Box<T> is not marked is_ref, so the broken

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -97,8 +97,8 @@ Example:
 ```
 
 The test runner understands the existing `//@ run-pass`, `//@ compile-fail`,
-`//@ check-only`, `//@ expect-stdout`, `//@ error-pattern`, and `//@ ignore`
-annotations.
+`//@ check-only`, `//@ expect-stdout`, `//@ expect-stdout-contains`,
+`//@ error-pattern`, and `//@ ignore` annotations.
 
 ## Resources
 

--- a/tools/mcp/sounio_mcp/test.py
+++ b/tools/mcp/sounio_mcp/test.py
@@ -81,15 +81,33 @@ async def _run_one(souc: Path, path: Path) -> tuple[str, dict[str, Any] | None]:
 
     result = await run_command([souc, "run", path], timeout_sec=30)
     expected_stdout = ann.get("expect-stdout", [""])[0]
-    if result.returncode == 0 and (not expected_stdout or expected_stdout in result.stdout):
-        return "passed", None
-    return "failed", {
-        "name": name,
-        "stdout": result.stdout,
-        "stderr": result.stderr,
-        "expected": expected_stdout or "exit 0",
-        "got": f"exit {result.returncode}",
-    }
+    expected_contains = [m for m in ann.get("expect-stdout-contains", []) if m]
+    if result.returncode != 0:
+        return "failed", {
+            "name": name,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "expected": expected_stdout or (expected_contains[0] if expected_contains else "exit 0"),
+            "got": f"exit {result.returncode}",
+        }
+    if expected_stdout and expected_stdout not in result.stdout:
+        return "failed", {
+            "name": name,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "expected": expected_stdout,
+            "got": f"exit {result.returncode}",
+        }
+    for marker in expected_contains:
+        if marker not in result.stdout:
+            return "failed", {
+                "name": name,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "expected": marker,
+                "got": f"exit {result.returncode}",
+            }
+    return "passed", None
 
 
 async def sounio_test(


### PR DESCRIPTION
## Decision

**Route 1 plus fail-closed on other unknown `expect-*` / `expected-*` keys.** Implement `//@ expect-stdout-contains:` as a substring match, and refuse invented stdout-assertion names instead of skipping them.

Route 2 (convert the 11 to `expect-stdout:` and reject every unknown `//@` key) would have worked for the suite runner — that runner already treats `expect-stdout` as substring (`grep -qF`). It is the wrong cut:

1. The authors chose a *different* annotation. That is not a typo of `expect-stdout`. `scripts/ci/run_pass_output_gate.sh` treats `expect-stdout` as an exact line; converting would drag these tests onto that contract without anyone asking.
2. Rejecting *every* unknown `//@` key is a 249-file `typecheck-fail` war plus a pile of prose `//@ METHOD …` comments. That is a different dispatch.
3. Precedent in *this* runner is already fail-closed on unknown `skip-if` and `requires` values (e947a33dd0). Stdout assertions now match that contract, scoped to the `expect-*` family that was actually silent.

## The control (the deliverable)

`scripts/ci/test_suite_annotation_selftest.sh`:

- live marker on `hello.sio` → PASS
- rewrite `struct_array_elem_method_dispatch.sio` (one of the original 11) so the marker is `THIS_MARKER_IS_GARBAGE` → **FAIL** `missing stdout contains: THIS_MARKER_IS_GARBAGE`
- `//@ expect-stdout-not-a-thing:` → **FAIL** `unknown annotation:`

If the garbage marker stays green, the bug is back. Measured green on this tree: `TEST_SUITE_ANNOTATION_SELFTEST_PASS`.

Extraction is the same parameter-expansion prefix match as `expect-stdout`, not quoted `=~`. That quoted-regex shape previously made every stdout assertion match the empty string; using it for `-contains` would have reimplemented the bug.

## Vacuous count (the finding)

**0 of the 11 would have failed the live assertion for a missing marker** on this tree (`c90e6cd7d3` binaries).

They already printed their PASS strings whenever they exited 0. The defect was still loaded: most of these mains `return` after printing `FAIL` with no non-zero exit, so a science miss would have stayed green. The garbage-marker control is what makes the assertion real, not today's green.

| File | Madaros | lean_single |
|---|---|---|
| `darwin_pd_coronary_smc_smoke` | PASS (marker present) | PASS |
| `darwin_pd_bergman_smoke` | PASS | PASS |
| `darwin_compartments_coronary_smc_smoke` | PASS | PASS |
| `darwin_venlafaxine_xr_matrix_smoke` | PASS | PASS |
| `darwin_pbpk28_smoke` | PASS | PASS |
| `darwin_tmdd_fkbp12_smoke` | PASS | PASS |
| `darwin_tmdd_glp1r_smoke` | PASS | PASS |
| `struct_array_elem_method_dispatch` | PASS | PASS |
| `struct_array_field_name_collision_dispatch` | PASS | PASS |
| `darwin_venlafaxine_xr_pgx_smoke` | FAIL E175 (private `vfx_scenario_init`) | PASS (marker present) |
| `darwin_sema_sc_depot_smoke` | FAIL E175 / private fields | FAIL typecheck (private `SemaglutideScenario` fields) |

Engine: this worktree `bin/souc` / `bin/souc-lean-single-x86_64`, `SOUNIO_STDLIB_PATH` pinned here. Do not quote a run that inherited `SOUC_BIN=/workspace/sounio/bin/souc` from the control worktree.

## Also in this PR

- `box_all_read_forms.sio` used `//@ expected-output:` (same silent class, in the suite glob). Renamed to `expect-stdout-contains`. PASS under this Madaros with the assertion live.
- Dropped three `known_failures` entries (`darwin_compartments_coronary_smc_smoke`, `darwin_pd_bergman_smoke`, `darwin_pd_coronary_smc_smoke`) that were *retained because the annotation was unread*. They now assert. `darwin_sema_sc_depot_smoke` stays (real typecheck failure).
- MCP `sounio_test` honours `expect-stdout-contains` as well.

## Left on the floor (not this dispatch)

- `tests/native-v2/handle_reclamation_below_capacity.sio` still has `expected-output` — not in the suite glob, so fail-closed does not see it.
- `tests/multimodule/visibility_basename_collision_main.sio` has `expect-error:` — same, not in the glob.
- Broad unknown-`//@` rejection (`typecheck-fail` is already implemented; 249 files would go red if it were not).

## Commands

```bash
SOUC_BIN=$PWD/bin/souc SOUNIO_TEST_SOUC_BIN=$PWD/bin/souc \
  SOUNIO_STDLIB_PATH=$PWD/stdlib \
  bash scripts/ci/test_suite_annotation_selftest.sh
# TEST_SUITE_ANNOTATION_SELFTEST_PASS
```
