### PR TITLE
fix(lower): stop the synthetic Knowledge layout shadowing user field names

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -10422,15 +10422,29 @@ impl Lowerer {
                 // of the table before falling back to the legacy hash path;
                 // partially seeded layouts must not collapse every miss to .0.
                 var sj: i64 = 0
+                // Same Knowledge-preseed shadow as field_idx_from_name_simple:
+                // defer the synthetic layout so a user struct's own field wins.
+                let kname = make_name("Knowledge")
+                var kidx: i64 = -1
                 while sj < (*self.struct_layouts).count {
+                    let sj_is_knowledge = ir_name_eq((*self.struct_layouts).entries[sj as usize].type_name, kname)
                     var fj: i64 = 0
                     while fj < (*self.struct_layouts).entries[sj as usize].field_count {
                         if ir_name_eq(ir_name_at((*self.struct_layouts).entries[sj as usize].fields[fj as usize].name_id), field_name) {
-                            return (*self.struct_layouts).entries[sj as usize].fields[fj as usize].index
+                            if sj_is_knowledge {
+                                if kidx < 0 {
+                                    kidx = (*self.struct_layouts).entries[sj as usize].fields[fj as usize].index
+                                }
+                            } else {
+                                return (*self.struct_layouts).entries[sj as usize].fields[fj as usize].index
+                            }
                         }
                         fj = fj + 1
                     }
                     sj = sj + 1
+                }
+                if kidx >= 0 {
+                    return kidx
                 }
                 if field_name.len <= 0 {
                     return 0
@@ -10455,16 +10469,36 @@ impl Lowerer {
         if n.len == 1 && first_byte >= 48 && first_byte <= 57 {
             return first_byte - 48
         }
+        // The synthetic "Knowledge" layout (ir_register_knowledge_layout) is
+        // preseeded as entry 0, before any user struct is registered, and its
+        // field names — value / variance / confidence — are ordinary user
+        // identifiers. Scanned in table order it shadowed every user struct
+        // carrying one of them, so `arr[i].value` resolved to Knowledge's slot 0
+        // and silently clobbered whatever field really lives there. Defer it:
+        // a user layout always wins, and Knowledge answers only if nothing else
+        // does (genuine Knowledge<T> access through an untyped base).
+        let knowledge_name = make_name("Knowledge")
+        var knowledge_idx: i64 = -1
         var si: i64 = 0
         while si < (*self.struct_layouts).count {
+            let is_knowledge = ir_name_eq((*self.struct_layouts).entries[si as usize].type_name, knowledge_name)
             var fi: i64 = 0
             while fi < (*self.struct_layouts).entries[si as usize].field_count {
                 if ir_name_eq(ir_name_at((*self.struct_layouts).entries[si as usize].fields[fi as usize].name_id), n) {
-                    return (*self.struct_layouts).entries[si as usize].fields[fi as usize].index
+                    if is_knowledge {
+                        if knowledge_idx < 0 {
+                            knowledge_idx = (*self.struct_layouts).entries[si as usize].fields[fi as usize].index
+                        }
+                    } else {
+                        return (*self.struct_layouts).entries[si as usize].fields[fi as usize].index
+                    }
                 }
                 fi = fi + 1
             }
             si = si + 1
+        }
+        if knowledge_idx >= 0 {
+            return knowledge_idx
         }
         // Last-resort legacy compatibility for unregistered dynamic/foreign shapes.
         if n.len <= 0 {

--- a/tests/madaros/source_to_elf/knowledge_field_shadow_exit0.sio
+++ b/tests/madaros/source_to_elf/knowledge_field_shadow_exit0.sio
@@ -1,0 +1,58 @@
+// A user struct field named `value` was silently clobbered by its sibling.
+//
+// `ir_register_knowledge_layout` preseeds a synthetic `Knowledge` layout —
+// value@0, variance@1, confidence@2 — as entry 0 of the struct layout table,
+// before any user struct is registered. `field_idx_from_name_simple` resolves a
+// field *name* to a slot by scanning the whole table in order and taking the
+// first hit in any struct, and that path runs whenever the base is not a typed
+// local: `arr[i].f` reaches it because array locals record a length but no
+// element type.
+//
+// So `ext[0].value` resolved to Knowledge's slot 0 — the same slot as `oid` —
+// and the store overwrote the `oid` written just before it. Both reads then
+// went to slot 0 too, so `value` read back correct while `oid` returned
+// `value`'s bytes: a silent wrong answer at exit 0, with no diagnostic.
+//
+// The trigger was the identifier, not the shape: the same program with the
+// field named `val` was always correct, at any struct size, array length or
+// index form. Guard all three preseeded names.
+//
+// This gate compiles with --native-v2-compile, which is the path that carries
+// the defect; the run-pass suite runs under souc-stage2 and is green either way.
+
+struct Ext {
+    oid: [u8; 20],
+    value: [u8; 512],
+    variance: i64,
+    confidence: i64,
+}
+
+fn zero_ext() -> Ext {
+    Ext { oid: [0; 20], value: [0; 512], variance: 0, confidence: 0 }
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    var ext: [Ext; 4] = [ zero_ext(), zero_ext(), zero_ext(), zero_ext() ]
+
+    var oid_buf: [u8; 20] = [0; 20]
+    oid_buf[0] = 0x55
+    oid_buf[1] = 0x1D
+    var val_buf: [u8; 512] = [0; 512]
+    val_buf[0] = 0xAA
+    val_buf[1] = 0xBB
+
+    var i: i64 = 0
+    ext[i as usize].oid = oid_buf
+    ext[i as usize].value = val_buf
+    ext[i as usize].variance = 7
+    ext[i as usize].confidence = 9
+
+    // Each field must read back its own bytes, not its sibling's.
+    if ext[0].oid[0] as i64 != 85 { return 1 }
+    if ext[0].oid[1] as i64 != 29 { return 1 }
+    if ext[0].value[0] as i64 != 170 { return 1 }
+    if ext[0].value[1] as i64 != 187 { return 1 }
+    if ext[0].variance != 7 { return 1 }
+    if ext[0].confidence != 9 { return 1 }
+    return 0
+}

--- a/tests/madaros/source_to_elf/manifest.tsv
+++ b/tests/madaros/source_to_elf/manifest.tsv
@@ -5,3 +5,4 @@ assert_true	tests/madaros/source_to_elf/assert_true_exit0.sio	0	assert_true_buil
 assert_false	tests/madaros/source_to_elf/assert_false_exit1.sio	1	assert_false_builtin
 assert_literal_true	tests/madaros/source_to_elf/assert_literal_true_exit0.sio	0	assert_literal_true_builtin
 assert_literal_false	tests/madaros/source_to_elf/assert_literal_false_exit1.sio	1	assert_literal_false_builtin
+knowledge_field_shadow	tests/madaros/source_to_elf/knowledge_field_shadow_exit0.sio	0	array_elem_struct_field_name

--- a/tests/run-pass/knowledge_layout_shadows_user_field_name.sio
+++ b/tests/run-pass/knowledge_layout_shadows_user_field_name.sio
@@ -1,0 +1,72 @@
+//@ run-pass
+//@ expect-stdout: oid=85,29 value=170,187 variance=7 confidence=9
+//
+// A user struct field named `value` was silently clobbered by its sibling.
+//
+// `ir_register_knowledge_layout` preseeds a synthetic `Knowledge` layout —
+// value@0, variance@1, confidence@2 — as entry 0 of the struct layout table,
+// before any user struct is registered. `field_idx_from_name_simple` resolves a
+// field *name* to a slot by scanning the whole table in order and taking the
+// first hit in any struct, and that path is what runs whenever the base is not
+// a typed local: `arr[i].f` reaches it because array locals record a length but
+// no element type.
+//
+// So `ext[0].value` resolved to Knowledge's slot 0 — the same slot as `oid` —
+// and `ext[0].value = val_buf` overwrote the `oid` written just before it. Both
+// reads then went to slot 0 too, so `value` read back correct while `oid`
+// returned `value`'s bytes: a silent wrong answer at rc=0, with no diagnostic.
+//
+// The trigger was the identifier, not the shape. The same program with the
+// field named `val` was always correct, at any struct size, array length or
+// index form — which is why size- and index-threshold hypotheses all died.
+//
+// Guard all three preseeded names. Anything reading its sibling's data here
+// means the synthetic layout is shadowing user layouts again.
+//
+// Honest scope: CI runs this suite under souc-stage2, which never carried the
+// defect, so this file is green either way there — it is the readable witness,
+// not the guard. The discriminating gate is the `knowledge_field_shadow` case
+// in tests/madaros/source_to_elf/manifest.tsv, which compiles with Madaros and
+// was measured red before this fix and green after.
+
+struct Ext {
+    oid: [u8; 20],
+    value: [u8; 512],
+    variance: i64,
+    confidence: i64,
+}
+
+fn zero_ext() -> Ext {
+    Ext { oid: [0; 20], value: [0; 512], variance: 0, confidence: 0 }
+}
+
+fn main() with IO {
+    var ext: [Ext; 4] = [ zero_ext(), zero_ext(), zero_ext(), zero_ext() ]
+
+    var oid_buf: [u8; 20] = [0; 20]
+    oid_buf[0] = 0x55
+    oid_buf[1] = 0x1D
+    var val_buf: [u8; 512] = [0; 512]
+    val_buf[0] = 0xAA
+    val_buf[1] = 0xBB
+
+    var i: i64 = 0
+    ext[i as usize].oid = oid_buf
+    ext[i as usize].value = val_buf
+    ext[i as usize].variance = 7
+    ext[i as usize].confidence = 9
+
+    print("oid=")
+    print_int(ext[0].oid[0] as i64)
+    print(",")
+    print_int(ext[0].oid[1] as i64)
+    print(" value=")
+    print_int(ext[0].value[0] as i64)
+    print(",")
+    print_int(ext[0].value[1] as i64)
+    print(" variance=")
+    print_int(ext[0].variance)
+    print(" confidence=")
+    print_int(ext[0].confidence)
+    println("")
+}


### PR DESCRIPTION
A user struct field named `value` was silently clobbered by its sibling. This is the root cause of Finding 24 (`docs/audit/X509_ARRAY_STRUCT_FIELD_CORRUPTION_DISPATCH_2026-08-24.md`), which blocks the X.509 semantic layer's Tasks 6 and 7.

## The defect

`ir_register_knowledge_layout` preseeds a synthetic `Knowledge` layout — `value@0`, `variance@1`, `confidence@2` — as **entry 0** of the struct layout table, before any user struct is registered. `field_idx_from_name_simple` resolves a field *name* to a slot by scanning the whole table in order and taking the first hit in any struct, and that path runs whenever the base is not a typed local: `arr[i].f` reaches it because array locals record a length but no element type.

So `ext[0].value` resolved to Knowledge's slot 0 — the same slot as `oid` — and the store overwrote the `oid` written just before it. Both reads then went to slot 0 too, so `value` read back correct while `oid` returned `value`'s bytes: **a silent wrong answer at exit 0, with no diagnostic**. `field_idx_from_name`'s cross-table fallback carries the identical shadow.

Fix: consult the synthetic layout last. A user layout always wins; `Knowledge` answers only if nothing else does, preserving genuine `Knowledge<T>` access through an untyped base.

## The trigger is the identifier, not the shape

Renaming only the field `value` to `val` makes the program correct at any struct size, array length or index form. Renaming a working program's field to `value` breaks it.

That **refutes the size-threshold framing** in the dispatch, and explains why nine source-level workarounds failed there — none of them changed a name. The dispatch's suggested investigation (compare codegen offsets at passing vs failing scale) points away from the cause; it should be updated.

Black-box bisection first ruled out, by measurement: total size, array length, per-element size, dynamic vs literal index, stack aliasing of the source buffers, interleaved scalar fields, and number of writes into the source buffers. The root cause was then located by a subagent reading the lowerer.

## Measured — three arms built from this base (`7ecec10881`)

| arm | repros | regression gate | full suite |
|---|---|---|---|
| unpatched | corrupt | **FAIL (rc=1)** | 1180 pass / 457 fail |
| hunk 1 only | fixed | PASS | 1173 pass / 464 fail |
| both hunks | fixed | PASS | **1180 pass / 457 fail** |

Fail lists compared **per test, not by count** (the suite flakes on a different test roughly one run in four): unpatched vs both is **zero new failures and zero fixed** — the 456 pre-existing failures are identical.

Hunk 1 alone regresses seven named tests — `lorenz_ball_fixed_explicit_enclosure_imported`, `lorenz_ball_fixed_step_policy_guard_imported`, `test_eisa_backend_v1`, `test_gri30_h2`, `test_gri30_h2_adiabatic`, `test_gri30_h2_adiabatic_delay`, `test_gri30_h2_uq_attribution`. That is what justifies the second hunk, which was inferred rather than measured until that arm was run.

`scripts/ci/madaros_fixed_point_gate.sh` reports `MADAROS_FIXED_POINT_OK` with `MADAROS_BIN` set to the tree's own build.

The 59 `run-pass` tests matching `knowledge|gum` — the population that uses the real `value` field, and the surface this change could plausibly break — fail **identically** before and after: the same 12, with the same exit codes, including the pre-existing `knowledge_array` segfault.

## The guard was proven to discriminate

`tests/madaros/source_to_elf/knowledge_field_shadow_exit0.sio`, registered in that gate's manifest, is **red on the unpatched tree and green on the patched one**. That gate is run by CI (`ci.yml:765`) and compiles with Madaros.

It also fails on the gate's `normal` compile path, not only `--native-v2-compile`, so the defect is not native-v2-specific.

`tests/run-pass/knowledge_layout_shadows_user_field_name.sio` is the readable witness only, and its comment says so: CI runs that suite under `souc-stage2`, which never carried the defect, so it is green either way there.

## Scope beyond X.509

Any Sounio program with a struct field named `value`, `variance` or `confidence` accessed through a non-identifier base is affected. Nothing about DER parsing or byte arrays is required — the field type is irrelevant.

## AI disclosure

Investigated, fixed and verified by an AI coding assistant (Claude). Root cause located with a Fable 5 subagent reading `self-hosted/ir/lower.sio`; all numbers above are measurements from builds on this base, not estimates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)