### PR TITLE
docs(audit): retitle the Finding 24 dispatch to what it turned out to be, and register 12 unregistered docs

### DIFF
--- a/docs/audit/X509_ARRAY_STRUCT_FIELD_CORRUPTION_DISPATCH_2026-08-24.md
+++ b/docs/audit/X509_ARRAY_STRUCT_FIELD_CORRUPTION_DISPATCH_2026-08-24.md
@@ -4,9 +4,10 @@ authority: repo_only
 audience: users
 last_validated: 2026-08-24
 validated_by: controller (tls-on-madaros branch, X.509 sub-project)
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.x509-array-struct-field-corruption-dispatch-2026-08-24
 -->
 
-# Forensic dispatch — array-of-struct field writes silently corrupt sibling `[u8;N]` fields once the struct/array crosses a size threshold, and the known workaround does not fully cure it
+# Forensic dispatch — `arr[i].field` resolved the field by bare name, so a struct field named `value` was silently clobbered by its sibling
 
 **Filed:** 2026-08-24 · **Status:** RESOLVED (fixed in `self-hosted/ir/lower.sio`, commits `88f91fae6` and `80be7c083`) · **Protocol:** CLAUDE.md §8.
 

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -385,6 +385,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.stats-scipy-e2e-vertical-2026-07-18 | repo_only | docs/audit/STATS_SCIPY_E2E_VERTICAL_2026-07-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.stats-shapiro-e2e-vertical-2026-07-18 | repo_only | docs/audit/STATS_SHAPIRO_E2E_VERTICAL_2026-07-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.surgical-calculus-disjoint-union-2026-08-19 | repo_only | docs/audit/SURGICAL_CALCULUS_DISJOINT_UNION_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.tls-prereq-wide-int-and-raw-buffers-2026-08-23 | repo_only | docs/audit/TLS_PREREQ_WIDE_INT_AND_RAW_BUFFERS_2026-08-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.token-ceiling-blocked-runpass-census-2026-08-17 | repo_only | docs/audit/TOKEN_CEILING_BLOCKED_RUNPASS_CENSUS_2026-08-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.type-archaeology-family-g-2026-08-19 | repo_only | docs/audit/TYPE_ARCHAEOLOGY_FAMILY_G_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.type-enum-denominator-2026-08-19 | repo_only | docs/audit/TYPE_ENUM_DENOMINATOR_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -409,6 +410,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.worktree-branch-governance-audit-2026-06-20 | repo_only | docs/audit/WORKTREE_BRANCH_GOVERNANCE_AUDIT_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.ws-c2-lean-single-seed-only-surface-map-2026-08-19 | repo_only | docs/audit/WS_C2_LEAN_SINGLE_SEED_ONLY_SURFACE_MAP_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.ws-f-close-acceptance-2026-08-16 | repo_only | docs/audit/WS_F_CLOSE_ACCEPTANCE_2026-08-16.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.x509-array-struct-field-corruption-dispatch-2026-08-24 | repo_only | docs/audit/X509_ARRAY_STRUCT_FIELD_CORRUPTION_DISPATCH_2026-08-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.xpas21-known-failure-audit-2026-08-19 | repo_only | docs/audit/XPAS21_KNOWN_FAILURE_AUDIT_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.zd-annihilate-builtin-dispatch-2026-08-19 | repo_only | docs/audit/ZD_ANNIHILATE_BUILTIN_DISPATCH_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.zd-exactness-floating-point-boundary-2026-08-19 | repo_only | docs/audit/ZD_EXACTNESS_FLOATING_POINT_BOUNDARY_2026-08-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -1296,6 +1298,11 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.superpowers.plans.2026-07-19-proof-carrying-statistical-coverage-empirical-binding-d9 | repo_only | docs/superpowers/plans/2026-07-19-proof-carrying-statistical-coverage-empirical-binding-d9.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-19-special-scipy-parity | repo_only | docs/superpowers/plans/2026-07-19-special-scipy-parity.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-19-stats-dist-parity | repo_only | docs/superpowers/plans/2026-07-19-stats-dist-parity.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.plans.2026-08-23-madaros-asn1-der-plan | repo_only | docs/superpowers/plans/2026-08-23-madaros-asn1-der-plan.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.plans.2026-08-23-madaros-bignum-plan | repo_only | docs/superpowers/plans/2026-08-23-madaros-bignum-plan.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.plans.2026-08-23-madaros-hash-functions-plan | repo_only | docs/superpowers/plans/2026-08-23-madaros-hash-functions-plan.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.plans.2026-08-23-madaros-sockets-http-client-plan | repo_only | docs/superpowers/plans/2026-08-23-madaros-sockets-http-client-plan.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.plans.2026-08-24-madaros-x509-plan | repo_only | docs/superpowers/plans/2026-08-24-madaros-x509-plan.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-13-data-science-io-design | repo_only | docs/superpowers/specs/2026-07-13-data-science-io-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-13-epistemic-gum-hardening-design | repo_only | docs/superpowers/specs/2026-07-13-epistemic-gum-hardening-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-integrate-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-integrate-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -1316,6 +1323,11 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.superpowers.specs.2026-07-19-special-scipy-parity-design | repo_only | docs/superpowers/specs/2026-07-19-special-scipy-parity-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-19-stats-dist-parity-design | repo_only | docs/superpowers/specs/2026-07-19-stats-dist-parity-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-25-associator-gum-variance-design | repo_only | docs/superpowers/specs/2026-07-25-associator-gum-variance-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.specs.2026-08-23-madaros-asn1-der-design | repo_only | docs/superpowers/specs/2026-08-23-madaros-asn1-der-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.specs.2026-08-23-madaros-bignum-design | repo_only | docs/superpowers/specs/2026-08-23-madaros-bignum-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.specs.2026-08-23-madaros-hash-functions-design | repo_only | docs/superpowers/specs/2026-08-23-madaros-hash-functions-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.specs.2026-08-23-madaros-sockets-http-client-design | repo_only | docs/superpowers/specs/2026-08-23-madaros-sockets-http-client-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.specs.2026-08-23-madaros-x509-design | repo_only | docs/superpowers/specs/2026-08-23-madaros-x509-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.test-infrastructure-v2 | repo_only | docs/test-infrastructure-v2.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.testing | repo_only | docs/TESTING.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.theory.epistemic-monotonicity | repo_only | docs/theory/epistemic_monotonicity.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8319,6 +8319,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.tls-prereq-wide-int-and-raw-buffers-2026-08-23",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/TLS_PREREQ_WIDE_INT_AND_RAW_BUFFERS_2026-08-23.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.token-ceiling-blocked-runpass-census-2026-08-17",
       "collection": "repo",
       "repo_doc_path": "docs/audit/TOKEN_CEILING_BLOCKED_RUNPASS_CENSUS_2026-08-17.md",
@@ -8851,6 +8874,29 @@
       "topic_id": "repo.docs.audit.ws-f-close-acceptance-2026-08-16",
       "collection": "repo",
       "repo_doc_path": "docs/audit/WS_F_CLOSE_ACCEPTANCE_2026-08-16.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.audit.x509-array-struct-field-corruption-dispatch-2026-08-24",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/X509_ARRAY_STRUCT_FIELD_CORRUPTION_DISPATCH_2026-08-24.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",
@@ -28922,6 +28968,121 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.superpowers.plans.2026-08-23-madaros-asn1-der-plan",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/plans/2026-08-23-madaros-asn1-der-plan.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.superpowers.plans.2026-08-23-madaros-bignum-plan",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/plans/2026-08-23-madaros-bignum-plan.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.superpowers.plans.2026-08-23-madaros-hash-functions-plan",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/plans/2026-08-23-madaros-hash-functions-plan.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.superpowers.plans.2026-08-23-madaros-sockets-http-client-plan",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/plans/2026-08-23-madaros-sockets-http-client-plan.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.superpowers.plans.2026-08-24-madaros-x509-plan",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/plans/2026-08-24-madaros-x509-plan.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.superpowers.specs.2026-07-13-data-science-io-design",
       "collection": "repo",
       "repo_doc_path": "docs/superpowers/specs/2026-07-13-data-science-io-design.md",
@@ -29362,6 +29523,121 @@
       "topic_id": "repo.docs.superpowers.specs.2026-07-25-associator-gum-variance-design",
       "collection": "repo",
       "repo_doc_path": "docs/superpowers/specs/2026-07-25-associator-gum-variance-design.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.superpowers.specs.2026-08-23-madaros-asn1-der-design",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/specs/2026-08-23-madaros-asn1-der-design.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.superpowers.specs.2026-08-23-madaros-bignum-design",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/specs/2026-08-23-madaros-bignum-design.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.superpowers.specs.2026-08-23-madaros-hash-functions-design",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/specs/2026-08-23-madaros-hash-functions-design.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.superpowers.specs.2026-08-23-madaros-sockets-http-client-design",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/specs/2026-08-23-madaros-sockets-http-client-design.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.superpowers.specs.2026-08-23-madaros-x509-design",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/specs/2026-08-23-madaros-x509-design.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",

--- a/docs/superpowers/plans/2026-08-23-madaros-asn1-der-plan.md
+++ b/docs/superpowers/plans/2026-08-23-madaros-asn1-der-plan.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.plans.2026-08-23-madaros-asn1-der-plan
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.plans.2026-08-23-madaros-asn1-der-plan
+-->
+
 # Madaros ASN.1 DER Decoder Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-08-23-madaros-bignum-plan.md
+++ b/docs/superpowers/plans/2026-08-23-madaros-bignum-plan.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.plans.2026-08-23-madaros-bignum-plan
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.plans.2026-08-23-madaros-bignum-plan
+-->
+
 # Madaros BigInt Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-08-23-madaros-hash-functions-plan.md
+++ b/docs/superpowers/plans/2026-08-23-madaros-hash-functions-plan.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.plans.2026-08-23-madaros-hash-functions-plan
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.plans.2026-08-23-madaros-hash-functions-plan
+-->
+
 # Madaros Hash Functions (SHA-1/256/384/512) Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-08-23-madaros-sockets-http-client-plan.md
+++ b/docs/superpowers/plans/2026-08-23-madaros-sockets-http-client-plan.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.plans.2026-08-23-madaros-sockets-http-client-plan
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.plans.2026-08-23-madaros-sockets-http-client-plan
+-->
+
 # Madaros TCP Sockets + Plain HTTP/1.1 Client Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-08-24-madaros-x509-plan.md
+++ b/docs/superpowers/plans/2026-08-24-madaros-x509-plan.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.plans.2026-08-24-madaros-x509-plan
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.plans.2026-08-24-madaros-x509-plan
+-->
+
 # Madaros X.509 Semantic Layer Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/specs/2026-08-23-madaros-asn1-der-design.md
+++ b/docs/superpowers/specs/2026-08-23-madaros-asn1-der-design.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.specs.2026-08-23-madaros-asn1-der-design
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.specs.2026-08-23-madaros-asn1-der-design
+-->
+
 # Madaros ASN.1 DER Decoder — Design Spec
 
 ## Context and Motivation

--- a/docs/superpowers/specs/2026-08-23-madaros-bignum-design.md
+++ b/docs/superpowers/specs/2026-08-23-madaros-bignum-design.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.specs.2026-08-23-madaros-bignum-design
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.specs.2026-08-23-madaros-bignum-design
+-->
+
 # Madaros Big Integer (BigInt) — Design Spec
 
 ## Context and Motivation

--- a/docs/superpowers/specs/2026-08-23-madaros-hash-functions-design.md
+++ b/docs/superpowers/specs/2026-08-23-madaros-hash-functions-design.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.specs.2026-08-23-madaros-hash-functions-design
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.specs.2026-08-23-madaros-hash-functions-design
+-->
+
 # Madaros Hash Functions (SHA-1 / SHA-256 / SHA-384 / SHA-512) — Design Spec
 
 ## Context and Motivation

--- a/docs/superpowers/specs/2026-08-23-madaros-sockets-http-client-design.md
+++ b/docs/superpowers/specs/2026-08-23-madaros-sockets-http-client-design.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.specs.2026-08-23-madaros-sockets-http-client-design
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.specs.2026-08-23-madaros-sockets-http-client-design
+-->
+
 # Madaros TCP Sockets + Plain-Text HTTP/1.1 Client — Design Spec
 
 ## Context and Motivation

--- a/docs/superpowers/specs/2026-08-23-madaros-x509-design.md
+++ b/docs/superpowers/specs/2026-08-23-madaros-x509-design.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.specs.2026-08-23-madaros-x509-design
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.specs.2026-08-23-madaros-x509-design
+-->
+
 # Madaros X.509 Semantic Layer — Design Spec
 
 ## Context and Motivation


### PR DESCRIPTION
Two housekeeping items on this branch. No editorial changes to anyone's prose.

## The title still asserts the refuted claim

`c2a08a2477` corrected the body — root cause characterized, status `RESOLVED`. But the H1 still reads:

> array-of-struct field writes silently corrupt sibling `[u8;N]` fields **once the struct/array crosses a size threshold**

That is the one thing the investigation disproved, and it is the only line a reader scanning `docs/audit/` or a search result sees. Retitled to name the actual defect. The body is untouched, including the preserved investigation trail.

## Twelve docs carry no governance metadata

The whole X.509 sub-project's plans and specs, plus both audit docs, landed without it — `scripts/docs/sync_governance_metadata.mjs` had never been run for them, and Contracts CI fails until it is. This is that script's unedited output.

## Supersedes #2114

Which I opened before `c2a08a2477` landed. It is now redundant: its rewrite of the defect section duplicates the root-cause paragraph already there, and its `tests/known_failures/` witness **passes** under `88f91fae6` + `80be7c083`, so filing it as a known failure would be wrong. Closing it in favour of this.

## Context you may want, since our lanes converged

We reached the same root cause independently. Yours is the better fix and I have verified it: I built this branch's HEAD and ran my probe corpus against it, including the acceptance case for the residual user-vs-user collision — `GeneralName.tag` reads correctly **in the original declaration order**, and all three real `cert.sio` structs pass.

One thing worth deciding on purpose rather than at merge time: `main` now carries a *second*, narrower fix for the same defect (#2126, `01258e2b42`) that defers the synthetic `Knowledge` layout so a user layout wins the name scan. Yours supersedes it functionally — it stops the name scan being reached at all — but both touch the same region of `self-hosted/ir/lower.sio` and will likely conflict textually when this branch merges. Mine remains a backstop only for bases that genuinely have no recorded struct type.

I also filed #2130 for the user-vs-user collision before finding your commits, and have since commented there that it is already fixed here and needs a port, not an investigation.