### PR TITLE
fix(offload): the fan-out loses a provider silently; make math-review reachable

### DIFF
--- a/.claude/offload-routing.md
+++ b/.claude/offload-routing.md
@@ -19,9 +19,22 @@ The wrapper prepends a task-specific system prompt from `.claude/offload-tasks/<
 | `scaffold` | `deepseek` | `qwen`, `grok-code` | Spec → boilerplate (.sio, SQL, ETL, LaTeX) |
 | `review` | `deepseek` | `xai`, `qwen` | Devil's-advocate code/paper review |
 | `paraphrase` | `minimax` (needs key) | `qwen`, `deepseek` | Cover letters, abstract polishing |
-| `math-review` | `xai zai` fan-out (Grok 4.3 + Z.AI GLM) | `xai-fast`, `qwen`, `mistral` | Math / algebra / stats audit — **default is now a two-provider fan-out for every agent** |
+| `math-review` | `xai zai local` fan-out | `xai-fast`, `qwen`, `mistral` | Math / algebra / stats audit — **three-way, so one outage still leaves two independent opinions** |
 
 > **Default math review (2026-07-07):** `bin/llm-offload -t math-review` fans out to **xai (grok-4.3)** and **zai (Z.AI GLM-5.2)** automatically — an independent second opinion is the standard, not opt-in. Z.AI needs `ZAI_API_KEY` (or `ZHIPU_API_KEY`); without it the tool runs xai alone and prints a SKIPPED notice for Z.AI. The default response cap is 8,192 tokens; deep audits must opt in with `OFFLOAD_MAX_TOKENS`. Run `bin/llm-offload --status` to see loaded keys.
+
+> **Third leg added 2026-08-24.** The two-provider default degrades to ONE whenever either
+> vendor is down, silently — the run still exits 0 and prints a review. On 2026-08-24 zai
+> returned `1310 Weekly/Monthly Limit Exhausted` and six math reviews were logged as
+> single-provider before anyone noticed the policy standard was not being met. `local` is now
+> the third leg: it is the on-prem gateway (`LOCAL_LLM_URL`/`LOCAL_LLM_MODEL`), it needs no
+> vendor account, and `.claude/AGENT_OFFLOAD_POLICY.md` M1 already accepts a local leg for this
+> purpose. Verified the same day on a real Lean diff: it independently checked the arithmetic and
+> the negative control rather than echoing the prompt.
+>
+> **It is a weaker leg than a second frontier vendor, not a substitute for one.** When zai
+> recovers you get three; treat `local` as the floor that keeps the standard reachable, and
+> prefer `--raw <prompt> xai zai` style fan-outs for anything referee-bound.
 
 ```bash
 # Outline -> prose

--- a/bin/llm-offload
+++ b/bin/llm-offload
@@ -23,7 +23,15 @@
 #   scaffold     -> deepseek (code-strong)
 #   review       -> deepseek (code) or xai/grok (math/blunt)
 #   paraphrase   -> minimax  (Anthropic-compat) [requires MINIMAX_API_KEY]
-#   math-review  -> xai zai  (fan-out: Grok 4.3 + Z.AI GLM — independent second opinion; default for all agents)
+#   math-review  -> xai zai local  (three-way fan-out; one outage still leaves two
+#                  independent opinions.  `local` = the on-prem gateway, LOCAL_LLM_*)
+#
+# LOCAL endpoints: providers `local` and `local2` speak to any OpenAI-compatible server
+# (Ollama / vLLM / llama.cpp / LM Studio).  Configure LOCAL_LLM_URL (INCLUDING the /v1 prefix)
+# and LOCAL_LLM_MODEL, and optionally LOCAL2_* for a second, independent local model —
+# `-p "local local2"` then satisfies the two-provider review policy without any hosted API.
+# Set OFFLOAD_TIMEOUT higher for local reasoning models; a curl timeout writes an EMPTY file,
+# which reads exactly like a provider error.
 
 set -euo pipefail
 
@@ -38,7 +46,13 @@ default_provider_for() {
         scaffold)    echo "deepseek" ;;
         review)      echo "deepseek" ;;
         paraphrase)  echo "minimax" ;;
-        math-review) echo "xai zai" ;;   # fan-out default: Grok 4.3 + Z.AI GLM (independent providers)
+        # Fan-out default.  Three providers, not two, so ONE outage still leaves an
+        # independent second opinion: `local` is the on-prem gateway, and the policy
+        # (.claude/AGENT_OFFLOAD_POLICY.md M1) accepts a local leg for exactly this.
+        # Measured 2026-08-24: zai returns 1310 Weekly/Monthly Limit Exhausted, and
+        # with a two-provider default that silently degraded every math review that
+        # day to a single vendor.
+        math-review) echo "xai zai local" ;;
         *)           echo "" ;;
     esac
 }

--- a/scripts/mcp/llm-offload.sh
+++ b/scripts/mcp/llm-offload.sh
@@ -9,6 +9,10 @@
 #   xai|grok     — Grok 4.3 (primary adversarial math/review lane)
 #   xai-fast     — Grok 4.1 Fast Reasoning (lower-latency fallback)
 #   zai|glm      — Z.AI GLM-5.2 direct (independent math/review provider)
+#   local        — a LOCAL OpenAI-compatible endpoint (Ollama/vLLM/llama.cpp/LM Studio):
+#                  set LOCAL_LLM_URL (with the /v1 prefix) and LOCAL_LLM_MODEL
+#   local2       — a second local endpoint (LOCAL2_LLM_URL / LOCAL2_LLM_MODEL), so a
+#                  two-local fan-out can satisfy the two-provider review policy
 #   grok-code    — Grok Code Fast 1 (fast code tasks)
 #   groq         — Llama 3.3 70B on Groq (fast inference)
 #   gemini       — Gemini 2.5 Pro via OpenRouter (1M ctx, best long-context)
@@ -59,7 +63,10 @@ call_openai_compat() {
         esac
     fi
     echo "  -> Sending to $name ($model, max=$max_tok)..."
-    curl -s -m 180 "$url/chat/completions" \
+    # Local reasoning models are slow; give them room rather than losing the leg.
+    local _tmo="${OFFLOAD_TIMEOUT:-180}"
+    case "$name" in Local*) _tmo="${OFFLOAD_TIMEOUT:-600}" ;; esac
+    curl -s -m "$_tmo" "$url/chat/completions" \
         -H "Authorization: Bearer $key" \
         -H "Content-Type: application/json" \
         -d "$(jq -n --arg model "$model" --arg prompt "$PROMPT" --argjson maxtok "$max_tok" '{
@@ -67,7 +74,13 @@ call_openai_compat() {
             messages: [{role: "user", content: $prompt}],
             max_tokens: $maxtok,
             temperature: 0.7
-        }')" > "$outfile" 2>&1
+        }')" > "$outfile" 2>&1 || true
+    # `|| true` is load-bearing under `set -e`: curl exits non-zero on a TIMEOUT or a
+    # connection failure (unlike an HTTP error, where it exits 0 with a JSON body), and
+    # without it the whole background subshell dies right here — no "<- name: ERROR" line,
+    # no mention of the provider at all.  The fan-out then prints a clean Results section
+    # and exits 0 having silently lost a leg.  Measured 2026-08-24 with a local reasoning
+    # model that needed longer than the 180 s cap.
 
     # Prefer .content; fall back to .reasoning_content for reasoning models
     # (e.g. Z.AI GLM-5.x) that leave .content empty. Treat empty output as error.
@@ -75,7 +88,11 @@ call_openai_compat() {
         jq -r 'if (.choices[0].message.content // "") != "" then .choices[0].message.content else .choices[0].message.reasoning_content end' "$outfile" > "${outfile%.json}.md"
         echo "  <- $name: DONE ($(wc -c < "${outfile%.json}.md") bytes)"
     else
-        echo "  <- $name: ERROR (see $outfile)"
+        if [[ ! -s "$outfile" ]]; then
+            echo "  <- $name: EMPTY after ${_tmo}s — timeout or unreachable endpoint (raise OFFLOAD_TIMEOUT)"
+        else
+            echo "  <- $name: ERROR (see $outfile)"
+        fi
     fi
 }
 
@@ -143,6 +160,25 @@ run_provider() {
         minimax)
             [[ -n "${MINIMAX_API_KEY:-}" ]] && \
             call_openai_compat "MiniMax M2.7" "https://api.minimax.io/v1" "$MINIMAX_API_KEY" "MiniMax-M2.7" "$OUTDIR/minimax.json"
+            ;;
+        local|local1|local2)
+            # LOCAL endpoints (Ollama / vLLM / llama.cpp / LM Studio — all OpenAI-compatible).
+            # Configure with LOCAL_LLM_URL (must end in the OpenAI-compatible prefix, e.g.
+            # http://host:11434/v1) and LOCAL_LLM_MODEL.  LOCAL_LLM_KEY is optional; most local
+            # servers ignore it but curl still needs a bearer, so it defaults to "local".
+            # A SECOND endpoint can be given as LOCAL2_LLM_URL / LOCAL2_LLM_MODEL, so that a
+            # fan-out of two independent local models satisfies the two-provider review policy.
+            local _u _m _k _tag
+            if [[ "$p" == "local2" ]]; then
+                _u="${LOCAL2_LLM_URL:-}"; _m="${LOCAL2_LLM_MODEL:-}"; _k="${LOCAL2_LLM_KEY:-local}"; _tag="local2"
+            else
+                _u="${LOCAL_LLM_URL:-}"; _m="${LOCAL_LLM_MODEL:-}"; _k="${LOCAL_LLM_KEY:-local}"; _tag="local"
+            fi
+            if [[ -n "$_u" && -n "$_m" ]]; then
+                call_openai_compat "Local $_m" "$_u" "$_k" "$_m" "$OUTDIR/$_tag.json"
+            else
+                echo "  <- Local ($_tag): SKIPPED (set ${_tag^^}_LLM_URL and ${_tag^^}_LLM_MODEL; URL must include the /v1 prefix)"
+            fi
             ;;
         *)
             echo "  ?? Unknown provider: $p"


### PR DESCRIPTION
The mandatory math-review degraded from two providers to one, and printed a clean report while
doing it. Four changes, in order of how much they matter.

### 1. `|| true` on the curl — the one that actually bites

Under `set -euo pipefail`, curl exits non-zero on a **timeout or connection failure** — unlike an
HTTP error, where it exits 0 with a JSON body. So the background subshell died at that line: no
`<- name: ERROR`, no mention of the provider at all. The fan-out then printed a tidy `=== Results
===` section and **exited 0 having lost a leg**.

That asymmetry is why zai's quota error was visible all day while a timed-out leg was invisible.

### 2. `EMPTY` is not `ERROR`

A zero-byte output now reports `EMPTY after Ns — timeout or unreachable endpoint (raise
OFFLOAD_TIMEOUT)`. The script's own header already warned that a curl timeout *"writes an EMPTY
file, which reads exactly like a provider error"*; now the code says so too.

Verified with `OFFLOAD_TIMEOUT=5` — previously silence, now the line.

### 3. Local legs get 600 s, not the 180 s cap

Local reasoning models are slow, and the cap was cutting them off — which is what produced the
silent loss in §1. Still overridable with `OFFLOAD_TIMEOUT`.

### 4. The `math-review` default is `xai zai local`

Three legs instead of two, so **one outage still leaves an independent second opinion**. Carries a
cherry-pick of `33333e9aa3` (local/local2 provider support, 30 lines) which was never on `main` —
without it the new default prints `?? Unknown provider: local` and degrades to exactly the failure
it is meant to fix.

### Why — measured 2026-08-24

| route | error | fixable by |
|---|---|---|
| Z.AI | `1310 Weekly/Monthly Limit Exhausted`, resets 08-25 06:34 | time |
| DeepSeek | `Authentication Fails, api key ****8cec is invalid` | a new key |
| Groq | `Invalid API Key` | a new key |
| OpenRouter | `This account never purchased credits` — takes qwen, mistral, gemini, llama, cohere | credits |

Six math reviews were logged that day as single-provider, with the policy standard recorded as
**unmet**. It was reachable the whole time: `local` and `local2` were configured and live, and
`.claude/AGENT_OFFLOAD_POLICY.md` M1 already accepts a local leg. I had not tested them — I tested
seven hosted routes and the local gateway with models I substituted myself, never the two the
keyfile already configures for this purpose.

### Verified on a real Lean diff, with zai still down

| | |
|---|---|
| before | 1 opinion, and no line at all for the lost leg |
| after | **2 substantive opinions** (grok + local) |

The local leg independently checked the arithmetic and the negative control's reasoning
(`8ⁱ·[j,3]₂ = 8/3`, non-integer ⇒ irrepresentable) rather than echoing the prompt.

### Scope note

`local` is a **weaker** leg than a second frontier vendor, and `offload-routing.md` now says so:
it is the floor that keeps the standard reachable, not a substitute. When zai recovers the default
gives three. For referee-bound work, prefer an explicit two-vendor fan-out.

This PR does not fix the keys — credits and new API keys are account actions.
