### PR TITLE
fix(lower): resolve arr[i].field by the element type, not by scanning names

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -10773,6 +10773,27 @@ impl Lowerer {
                         return true
                     }
                 }
+                // The offset half of this lives in field_idx_for_base_ref, and both
+                // used to stop at ExprIdent. Fixing only the offset gives a value
+                // that PRINTS correctly and computes as an integer: with a user
+                // struct spelling `value`, print_f64(ks[0].value) showed 1.000000
+                // while ks[0].value - 1.0 evaluated to 4607182418800017408 -- the
+                // bit pattern of the double 1.0, read as an int because the float
+                // marking never arrived. Same family as the println scalar-kind
+                // loss: the value survives, the kind does not.
+                if (*base_expr).kind == ExprKind::ExprIndex {
+                    match (*base_expr).left {
+                        Some(arr_expr) => {
+                            if (*arr_expr).kind == ExprKind::ExprIdent {
+                                let elem_type = self.lookup_local_struct_type((*arr_expr).name)
+                                if self.field_is_float_for_struct(elem_type, field_name) {
+                                    return true
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
                 false
             }
             _ => false,
@@ -10786,6 +10807,32 @@ impl Lowerer {
                     let type_name = self.lookup_local_struct_type((*base_expr).name)
                     if type_name.len > 0 {
                         return self.field_idx_from_name(type_name, field_name)
+                    }
+                }
+                // `arr[i].field`: the receiver is an index, not an ident, so this
+                // used to fall to the global name scan -- and the scan returns the
+                // FIRST layout carrying that name, whichever it is.
+                //
+                // #2126 fixed one direction of that (the synthetic Knowledge layout
+                // shadowing user structs) by deferring Knowledge. It reversed the
+                // victim rather than removing the ambiguity: with a user struct
+                // holding `value` at slot 1, `ks[i].value` on a [Knowledge<f64>; N]
+                // returned 0.010000 -- the VARIANCE -- where 1.000000 belongs. Both
+                // directions are "first name wins".
+                //
+                // The array's element type is on the local, so ask it. Identity is a
+                // property of (receiver layout, field), not of the lexeme.
+                if (*base_expr).kind == ExprKind::ExprIndex {
+                    match (*base_expr).left {
+                        Some(arr_expr) => {
+                            if (*arr_expr).kind == ExprKind::ExprIdent {
+                                let elem_type = self.lookup_local_struct_type((*arr_expr).name)
+                                if elem_type.len > 0 {
+                                    return self.field_idx_from_name(elem_type, field_name)
+                                }
+                            }
+                        }
+                        _ => {}
                     }
                 }
                 self.field_idx_from_name_simple(field_name)
@@ -13403,6 +13450,38 @@ impl Lowerer {
             Some(ann_ty) => {
                 if (*ann_ty).kind == TypeExprKind::TypeKnowledge {
                     lo = lo.bind_local_struct_type(s.name, make_name("Knowledge"))
+                }
+            }
+            _ => {}
+        }
+        // An ARRAY local records its ELEMENT type, so `arr[i].field` can be
+        // resolved by (layout, field) instead of by scanning every layout for
+        // the name and taking the first hit.
+        //
+        // Without this, member resolution depends on declaration order: with
+        // `struct A { value }` before `struct B { pad, value }`, bs[i].value read
+        // A.value@0 and returned B's pad; swapping the two declarations moved the
+        // error onto A and made as_[1].value read slot 1 of a one-field struct.
+        // #2126 fixed the Knowledge half of this by deferring the synthetic layout,
+        // which reversed the victim -- ks[i].value on [Knowledge<f64>; N] then
+        // returned the variance. Precedence in either direction is still first
+        // name wins; the element type is the missing identity.
+        match s.ty {
+            Some(arr_ty) => {
+                if (*arr_ty).kind == TypeExprKind::TypeArray {
+                    match (*arr_ty).inner {
+                        Some(el) => {
+                            if (*el).kind == TypeExprKind::TypeKnowledge {
+                                lo = lo.bind_local_struct_type(s.name, make_name("Knowledge"))
+                            } else if (*el).kind == TypeExprKind::TypeNamed {
+                                let el_name = ir_path_first_name((*el).path)
+                                if el_name.len > 0 {
+                                    lo = lo.bind_local_struct_type(s.name, el_name)
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
                 }
             }
             _ => {}

--- a/tests/run-pass/field_identity_survives_declaration_order.sio
+++ b/tests/run-pass/field_identity_survives_declaration_order.sio
@@ -1,0 +1,57 @@
+//@ run-pass
+//@ requires: madaros
+//@ expect-stdout: FIELD_IDENTITY_PASS
+
+// Member resolution must not depend on declaration order.
+//
+// `arr[i].field` reaches field_idx_from_name_simple, which scans struct_layouts
+// and returns the FIRST layout carrying that field name. Both structs below
+// have `value`, at different slots, so whichever is registered first used to
+// win for BOTH -- and the loser read the wrong offset:
+//
+//   A then B:   bs[i].value read A.value@0, returning B's pad (111, 333)
+//   B then A:   as_[1].value read slot 1 of a ONE-field struct -- out of bounds
+//
+// #2126 fixed the Knowledge half of this by deferring the synthetic layout,
+// which reversed the victim: ks[i].value on [Knowledge<f64>; N] then returned
+// the VARIANCE, 0.010000 where 1.000000 belongs. Precedence in either
+// direction is still "first name wins".
+//
+// The fix records the array local's ELEMENT type from its declared annotation,
+// so the receiver has an identity to resolve against. Both halves are asserted
+// here: neither struct may be sacrificed for the other, and Knowledge in an
+// array must survive a user struct that spells `value`.
+
+struct A { value: i64 }
+struct B { pad: i64, value: i64 }
+
+fn abs_f(x: f64) -> f64 {
+    if x < 0.0 { return 0.0 - x }
+    return x
+}
+
+fn main() -> i64 with Mut, Panic, Div, Alloc, Epistemic, IO {
+    var as_: [A; 2] = [A { value: 7 }, A { value: 9 }]
+    var bs: [B; 2] = [B { pad: 111, value: 222 }, B { pad: 333, value: 444 }]
+    var ks: [Knowledge<f64>; 2] = [measure(1.0, uncertainty: 0.1), measure(3.0, uncertainty: 0.2)]
+
+    print("as_[1].value="); print_int(as_[1].value); print("\n")
+    print("bs[0].value=");  print_int(bs[0].value);  print("\n")
+    print("bs[1].value=");  print_int(bs[1].value);  print("\n")
+    print("bs[0].pad=");    print_int(bs[0].pad);    print("\n")
+    print("ks[0].value=");  print_f64(ks[0].value);  print("\n")
+    print("ks[1].value=");  print_f64(ks[1].value);  print("\n")
+
+    let ok = as_[1].value == 9
+        && bs[0].value == 222
+        && bs[1].value == 444
+        && bs[0].pad == 111
+        && abs_f(ks[0].value - 1.0) < 1.0e-12
+        && abs_f(ks[1].value - 3.0) < 1.0e-12
+    if ok {
+        print("FIELD_IDENTITY_PASS\n")
+    } else {
+        print("FIELD_IDENTITY_FAIL\n")
+    }
+    0
+}


### PR DESCRIPTION
Closes #2131. Swapping two `struct` declarations changed which type resolved correctly.

```sounio
struct A { value: i64 }            // value@0
struct B { pad: i64, value: i64 }  // value@1
```

| declaration order | `bs[i].value` (B) | `as_[1].value` (A) |
|---|---|---|
| `A` then `B` | **111, 333** — reads B's `pad` | 9 — correct |
| `B` then `A` | 222, 444 — correct | **0** — slot 1 of a **one-field** struct |

## Where it was, precisely

`field_idx_for_base_ref` **already** resolves by receiver identity when the base is a plain identifier — which is why `k.value` on a typed local was never wrong. Only `arr[i].field` reaches the fallback, because the base is an `ExprIndex`. `field_idx_from_name_simple` then scans `struct_layouts` and returns the first layout carrying that name.

#2126 correctly found that the synthetic `Knowledge` layout was winning that scan, and fixed it by deferring `Knowledge`. **That reversed the victim rather than removing the ambiguity**: with a user struct spelling `value` at slot 1, `ks[i].value` on a `[Knowledge<f64>; N]` returned `0.010000` — the *variance* where `1.000000` belongs. Precedence in either direction is still "first name wins".

The element type was simply **not recorded**. An array local now binds it from its declared annotation, and both `base_ref` resolvers accept an indexed receiver.

## Two resolvers — and fixing one is worse than fixing neither

`field_idx_for_base_ref` decides the **offset**. `field_is_float_for_base_ref` decides the **type**. Both stopped at `ExprIdent`. With only the first fixed:

```
print_f64(ks[0].value)   1.000000              <- right slot
ks[0].value - 1.0        4607182418800017408   <- bit pattern of the double 1.0,
                                                  read as an int
```

A value that prints correctly and computes as an integer is far harder to catch than one that is visibly wrong. Same family as the `println` scalar-kind loss: the value survives, the kind does not.

I found this because **the test I wrote to pin the fix failed with the fix applied**. Every printed value was right and the assertions still fell. Adjusting the test would have made it green and shipped half a fix.

## Verified

| | |
|---|---|
| **order independence** | `A`-then-`B` and `B`-then-`A` give byte-identical output — that invariant, not "my case passes", is the claim |
| #2131 | `ks[i].value` `1.000000` / `3.000000`, was `0.010000` / `0.040000` |
| #2126 | `cs`/`ds`/`es` = 22 / 44 / 66, unchanged — no regression on the half that PR fixed |
| arithmetic | `ks[0].value - 1.0` = `0.000000` |
| regression | 260 run-pass tests against a binary built from the same main source: **44 and 44**, zero regressions, zero accidental fixes |

The new test fails on today's main and passes here, and it asserts **both** structs — neither may be sacrificed for the other.

## Two corrections to my own record

On #2126 I wrote that the review's counter-example "does not reproduce". It does. I had tested it against the **pre-merge** binary, where the `Knowledge` layout won first and masked the collision between user layouts. Retracted there.

And my first attempt at this fix did not fire at all — `lookup_local_struct_type` returns nothing for an array local, so there was no element type to resolve against. I built it and measured it before noticing, which is how the real gap surfaced.

## Credit

The architectural claim came from a review by GPT-5.6 relayed by @agourakis82: *member resolution must never depend on global registration order*, and identity is a property of `(receiver layout, field)`, not of the lexeme. Its specific example was right and my refutation of it was wrong.